### PR TITLE
Cleanup decorator api `relpath` args

### DIFF
--- a/examples/ml_pipeline/class_api.py
+++ b/examples/ml_pipeline/class_api.py
@@ -39,16 +39,8 @@ class Dump(ExamplesMLPipelineBase[pd.DataFrame]):
     )
 
     @property
-    def _relpath(self) -> str:
-        return "/".join(
-            [
-                self.get_namespace().replace(".", "/"),
-                self.get_family(),
-                f"v{self.version}",
-                self.date.isoformat(),
-                f"{self.snapshot_slug}.csv",  # TODO extension and format
-            ]
-        )
+    def _relpath_extra(self) -> str:
+        return f"{self.date.isoformat()}/{self.snapshot_slug}"
 
     def run(self):
         if not self.date == base.utc_today():

--- a/examples/ml_pipeline/decorator_api.py
+++ b/examples/ml_pipeline/decorator_api.py
@@ -21,15 +21,9 @@ base_task = partial(task, version="0")
 
 
 @base_task(
-    relpath=lambda self: "/".join(
-        [
-            self.get_namespace().replace(".", "/"),
-            self.get_family(),
-            f"v{self.version}",
-            self.date.isoformat(),  # type: ignore
-            f"{self.snapshot_slug}.csv",  # type: ignore # TODO extension and format
-        ]
-    )
+    relpath={
+        "extra": lambda self: f"{self.date.isoformat()}/{self.snapshot_slug}"  # type: ignore
+    }
 )
 def dump(
     date: datetime.date = base.utc_today(),

--- a/examples/task_api_three_levels.py
+++ b/examples/task_api_three_levels.py
@@ -10,13 +10,11 @@ from stardag.task_parameter import TaskLoads
 def decorator_api(limit: int) -> TaskLoads[int]:
     from stardag.decorator import Depends, task
 
-    # @task(family="Range")  # TODO
-    @task
+    @task(family="Range")
     def get_range(limit: int) -> list[int]:
         return list(range(limit))
 
-    # @task(family="Sum")  # TODO
-    @task
+    @task(family="Sum")
     def get_sum(integers: Depends[list[int]]) -> int:
         return sum(integers)
 
@@ -52,7 +50,6 @@ def base_task_api(limit: int) -> TaskLoads[int]:
     def default_relpath(task: Task) -> str:
         return "/".join(
             [
-                task.get_namespace().replace(".", "/"),
                 task.get_family(),
                 task.task_id[:2],
                 task.task_id[2:4],

--- a/src/stardag/decorator.py
+++ b/src/stardag/decorator.py
@@ -82,6 +82,7 @@ class RelpathSettings(typing.TypedDict):
 def task(
     _func: typing.Callable[_PWrapped, LoadedT],
     *,
+    family: str | None = None,
     version: str = "0",
     relpath: RelpathSettings | _RelpathOverride | None = None,
 ) -> typing.Type[_FunctionTask[LoadedT, _PWrapped]]: ...
@@ -90,6 +91,7 @@ def task(
 @typing.overload
 def task(
     *,
+    family: str | None = None,
     version: str = "0",
     relpath: RelpathSettings | _RelpathOverride | None = None,
 ) -> _TaskWrapper: ...
@@ -98,7 +100,8 @@ def task(
 def task(
     _func: typing.Callable[_PWrapped, LoadedT] | None = None,
     *,
-    version: str = "0",
+    family: str | None = None,
+    version: str | None = None,
     relpath: RelpathSettings | _RelpathOverride | None = None,
 ) -> typing.Type[_FunctionTask[LoadedT, _PWrapped]] | _TaskWrapper:
     def wrapper(
@@ -115,7 +118,7 @@ def task(
             raise ValueError("All arguments must have annotations")
 
         task_class = create_model(
-            _func.__name__,
+            family or _func.__name__,
             __base__=_FunctionTask[return_type, _PWrapped],
             __module__=_func.__module__,
             version=(str | None, version),
@@ -128,7 +131,7 @@ def task(
             },
         )
         task_class._func = _func
-        task_class.__version__ = "0"
+        task_class.__version__ = version
 
         # extra properties
         if relpath is not None:

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -35,9 +35,8 @@ def test_with_params(default_in_memory_fs_target):
 
     @task(
         version="1",
-        relpath_base="add_task",
         relpath=lambda self: (
-            f"{self._relpath_base}/add2/v{self.version}/"
+            f"add_task/add2/v{self.version}/"
             f"{val_or_id(self.a)}_{val_or_id(self.b)}/"  # type: ignore
             "result.txt"
         ),

--- a/tests/test_decorator.py
+++ b/tests/test_decorator.py
@@ -10,8 +10,8 @@ def test_basic(default_in_memory_fs_target):
     def add(a: int, b: int) -> int:
         return a + b
 
-    assert add.__version__ == "0"
-    assert add.model_fields["version"].default == "0"
+    assert add.__version__ is None
+    assert add.model_fields["version"].default is None
 
     add_b_task = add(a=2, b=3)
     add_task = add(a=1, b=add_b_task)
@@ -43,6 +43,9 @@ def test_with_params(default_in_memory_fs_target):
     )
     def add2(a: int, b: int) -> int:
         return a + b
+
+    assert add2.__version__ == "1"
+    assert add2.model_fields["version"].default == "1"
 
     add_b_task = add2(a=2, b=3)
     add_task = add2(a=1, b=add_b_task)


### PR DESCRIPTION
- cleanup decorator api `relpath` args
- make three levels exampel identical (add `family` as argument to `@task`)
- default to no version in decorator api for consistency
- fix bug in that current version was hardcoded in decorator api