### PR TITLE
Add async generator support for dynamic deps in build system

### DIFF
--- a/lib/stardag/src/stardag/_core/decorator.py
+++ b/lib/stardag/src/stardag/_core/decorator.py
@@ -129,6 +129,15 @@ class _FunctionTask(Task[LoadedT], typing.Generic[LoadedT, _PWrapped]):
         result = await self.call_aio(**await self._get_inputs_aio())  # type: ignore
         await self._save_aio(result)
 
+    async def run_aio(self) -> None:
+        """Async execution path — used when the decorated function is async."""
+        if not self._is_async:
+            # Sync function: just run synchronously
+            self.run()
+            return
+        result = await self.call_aio(**await self._get_inputs_aio())  # type: ignore
+        await self.target().save_aio(result)
+
     def _get_inputs(self) -> _PWrapped.kwargs:  # type: ignore
         """Resolve dependency inputs synchronously.
 

--- a/lib/stardag/src/stardag/_core/decorator.py
+++ b/lib/stardag/src/stardag/_core/decorator.py
@@ -221,6 +221,14 @@ def task(
 
         is_async = inspect.iscoroutinefunction(_func)
 
+        # Reject generator functions — dynamic dependencies require the class API
+        if inspect.isgeneratorfunction(_func) or inspect.isasyncgenfunction(_func):
+            raise TypeError(
+                f"@task does not support generator functions (got {_func.__name__}). "
+                "Dynamic dependencies require the class-based Task API — "
+                "implement run()/run_aio() as a generator method on a Task subclass."
+            )
+
         signature = inspect.signature(_func)
         return_type = signature.return_annotation
         if return_type == inspect.Parameter.empty:

--- a/lib/stardag/src/stardag/_core/decorator.py
+++ b/lib/stardag/src/stardag/_core/decorator.py
@@ -129,15 +129,6 @@ class _FunctionTask(Task[LoadedT], typing.Generic[LoadedT, _PWrapped]):
         result = await self.call_aio(**await self._get_inputs_aio())  # type: ignore
         await self._save_aio(result)
 
-    async def run_aio(self) -> None:
-        """Async execution path — used when the decorated function is async."""
-        if not self._is_async:
-            # Sync function: just run synchronously
-            self.run()
-            return
-        result = await self.call_aio(**await self._get_inputs_aio())  # type: ignore
-        await self.target().save_aio(result)
-
     def _get_inputs(self) -> _PWrapped.kwargs:  # type: ignore
         """Resolve dependency inputs synchronously.
 

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -9,10 +9,11 @@ This module contains:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from enum import StrEnum
-from typing import Generator, Literal, Protocol, Sequence
+from typing import AsyncGenerator, Generator, Literal, Protocol, Sequence, Union
 from uuid import UUID
 
 from stardag import (
@@ -225,9 +226,15 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
         self._thread_pool: ThreadPoolExecutor | None = None
         self._process_pool: ProcessPoolExecutor | None = None
 
-        # Track suspended generators (task_id -> generator)
+        # Track suspended generators (task_id -> sync or async generator)
         # For in-process execution where we can suspend and resume
-        self._suspended_generators: dict[UUID, Generator[TaskStruct, None, None]] = {}
+        self._suspended_generators: dict[
+            UUID,
+            Union[
+                Generator[TaskStruct, None, None],
+                AsyncGenerator[TaskStruct, None],
+            ],
+        ] = {}
 
         # Track tasks pending re-execution (task_id -> True)
         # For cross-process/remote execution: when task yields incomplete deps,
@@ -270,6 +277,9 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
         """
         # Check if we're resuming a suspended generator (in-process dynamic deps)
         if task.id in self._suspended_generators:
+            gen = self._suspended_generators[task.id]
+            if hasattr(gen, "__anext__"):
+                return await self._resume_generator_aio(task)
             return self._resume_generator(task)
 
         # Check if task is pending re-execution (cross-process dynamic deps)
@@ -281,13 +291,18 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
 
         try:
             result = await self._execute_task(task, mode)
-            return self._handle_result(task, result)
+            return await self._handle_result(task, result)
         except Exception as e:
             return e
 
     async def _execute_task(
         self, task: BaseTask, mode: ExecutionMode
-    ) -> Generator[TaskStruct, None, None] | TaskStruct | None:
+    ) -> (
+        Generator[TaskStruct, None, None]
+        | AsyncGenerator[TaskStruct, None]
+        | TaskStruct
+        | None
+    ):
         """Execute task in appropriate context.
 
         Returns:
@@ -299,6 +314,10 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
         if mode == ExecutionMode.ASYNC_MAIN_LOOP:
             assert self._async_semaphore is not None
             async with self._async_semaphore:
+                # Async generator functions (dynamic deps) can't be awaited —
+                # call without await to get the async generator object.
+                if inspect.isasyncgenfunction(type(task).run_aio):
+                    return task.run_aio()  # type: ignore[return-value]
                 return await task.run_aio()
 
         elif mode == ExecutionMode.SYNC_THREAD:
@@ -322,18 +341,23 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
         else:
             raise ValueError(f"Unsupported execution mode: {mode}")
 
-    def _handle_result(
+    async def _handle_result(
         self,
         task: BaseTask,
-        result: Generator[TaskStruct, None, None] | TaskStruct | None,
+        result: Generator[TaskStruct, None, None]
+        | AsyncGenerator[TaskStruct, None]
+        | TaskStruct
+        | None,
     ) -> None | TaskStruct:
         """Handle task execution result.
 
-        Handles three cases:
+        Handles four cases:
         1. None: Task completed normally.
-        2. Generator: Task has dynamic deps and is suspended (in-process execution).
+        2. Generator: Task has sync dynamic deps and is suspended (in-process).
            Store generator and return first yielded deps.
-        3. TaskStruct: Task has dynamic deps but cannot be suspended (cross-process
+        3. AsyncGenerator: Task has async dynamic deps and is suspended (in-process).
+           Store generator and return first yielded deps.
+        4. TaskStruct: Task has dynamic deps but cannot be suspended (cross-process
            or remote execution). Return deps directly; task will be re-executed
            when deps complete (idempotent re-execution).
 
@@ -343,28 +367,25 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
             # Task completed normally
             return None
 
-        # Check if result is a generator (dynamic deps, in-process)
-        # Use hasattr to check for generator protocol
+        # Check if result is an async generator (dynamic deps from run_aio)
+        if hasattr(result, "__anext__"):
+            agen: AsyncGenerator[TaskStruct, None] = result  # type: ignore[assignment]
+            return await self._handle_generator_aio(task, agen)
+
+        # Check if result is a sync generator (dynamic deps, in-process)
         if hasattr(result, "__next__"):
-            # Cast to Generator for type checker - we've verified it has __next__
             gen: Generator[TaskStruct, None, None] = result  # type: ignore[assignment]
             return self._handle_generator(task, gen)
 
         # Result is TaskStruct (dynamic deps from process/remote execution)
-        # Task yielded these deps but they weren't complete, so the task
-        # returned early (idempotent re-execution pattern). Mark task as pending
-        # re-execution - it will be re-executed from scratch after deps complete.
-        # On re-execution, the generator will drive forward past the yield
-        # because the deps are now complete.
         self._pending_reexecution.add(task.id)
-        # Cast to TaskStruct for type checker - we've verified it's not a generator
         task_struct: TaskStruct = result  # type: ignore[assignment]
         return task_struct
 
     def _handle_generator(
         self, task: BaseTask, gen: Generator[TaskStruct, None, None]
     ) -> None | TaskStruct:
-        """Handle a generator from task execution."""
+        """Handle a sync generator from task execution."""
         try:
             yielded = next(gen)
             # Store generator for resumption
@@ -374,16 +395,47 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
             # Generator completed without yielding
             return None
 
+    async def _handle_generator_aio(
+        self, task: BaseTask, agen: AsyncGenerator[TaskStruct, None]
+    ) -> None | TaskStruct:
+        """Handle an async generator from task execution."""
+        try:
+            yielded = await anext(agen)
+            # Store async generator for resumption
+            self._suspended_generators[task.id] = agen
+            return yielded
+        except StopAsyncIteration:
+            # Async generator completed without yielding
+            return None
+
     def _resume_generator(self, task: BaseTask) -> None | TaskStruct | Exception:
-        """Resume a suspended generator."""
+        """Resume a suspended sync generator."""
         gen = self._suspended_generators[task.id]
 
         try:
-            yielded = next(gen)
+            yielded = next(gen)  # type: ignore[arg-type]
             # Still more dynamic deps
             return yielded
         except StopIteration:
             # Generator completed
+            del self._suspended_generators[task.id]
+            return None
+        except Exception as e:
+            del self._suspended_generators[task.id]
+            return e
+
+    async def _resume_generator_aio(
+        self, task: BaseTask
+    ) -> None | TaskStruct | Exception:
+        """Resume a suspended async generator."""
+        agen = self._suspended_generators[task.id]
+
+        try:
+            yielded = await anext(agen)  # type: ignore[arg-type]
+            # Still more dynamic deps
+            return yielded
+        except StopAsyncIteration:
+            # Async generator completed
             del self._suspended_generators[task.id]
             return None
         except Exception as e:

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -7,8 +7,10 @@ Intended for debugging and testing, not production use.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import time
+import typing
 from typing import Literal
 from uuid import UUID
 
@@ -634,7 +636,12 @@ async def _run_task_sequential_aio(
     # Determine how to run
     if has_run_aio:
         # Async-only or Dual - use async
-        result = await task.run_aio()
+        # Check if run_aio is an async generator function (dynamic deps).
+        # Async generators can't be awaited — call without await to get the generator.
+        if inspect.isasyncgenfunction(type(task).run_aio):
+            result = task.run_aio()  # type: ignore[assignment]
+        else:
+            result = await task.run_aio()
     elif has_run:
         # Sync-only
         if sync_run_default == "thread":
@@ -645,9 +652,9 @@ async def _run_task_sequential_aio(
     else:
         raise ValueError(f"Task {task} has no run method")
 
-    # Handle generator (dynamic deps)
+    # Handle generator (dynamic deps) — sync or async
     if result is not None and hasattr(result, "__next__"):
-        gen = result
+        gen: typing.Generator = result  # type: ignore[assignment]
         while True:
             try:
                 yielded = next(gen)
@@ -674,6 +681,29 @@ async def _run_task_sequential_aio(
 
             except StopIteration:
                 break
+
+    elif result is not None and hasattr(result, "__anext__"):
+        agen = typing.cast(typing.AsyncGenerator, result)
+        async for yielded in agen:
+            dynamic_deps = flatten_task_struct(yielded)
+
+            # Discover and build dynamic deps
+            for dep in dynamic_deps:
+                if dep.id not in all_tasks:
+                    all_tasks[dep.id] = dep
+                    for sub_dep in flatten_task_struct(dep.requires()):
+                        if sub_dep.id not in all_tasks:
+                            all_tasks[sub_dep.id] = sub_dep
+
+                if dep.id not in completion_cache:
+                    await _run_task_sequential_aio(
+                        dep,
+                        completion_cache,
+                        all_tasks,
+                        build_id,
+                        registry,
+                        sync_run_default,
+                    )
 
     completion_cache.add(task.id)
     await registry.task_complete_aio(build_id, task)

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -619,6 +619,27 @@ async def build_sequential_aio(
         )
 
 
+async def _iter_dynamic_deps(
+    result: typing.Any,
+) -> typing.AsyncGenerator[typing.Any, None]:
+    """Iterate dynamic deps from a task run result (sync generator, async generator, or None).
+
+    Normalizes the three cases into a single async iteration:
+    - Sync generator (__next__): wraps with next() calls
+    - Async generator (__anext__): iterates with async for
+    - None / non-generator: yields nothing
+    """
+    if result is not None and hasattr(result, "__anext__"):
+        async for value in result:
+            yield value
+    elif result is not None and hasattr(result, "__next__"):
+        while True:
+            try:
+                yield next(result)  # type: ignore[arg-type]
+            except StopIteration:
+                break
+
+
 async def _run_task_sequential_aio(
     task: BaseTask,
     completion_cache: set[UUID],
@@ -653,57 +674,26 @@ async def _run_task_sequential_aio(
         raise ValueError(f"Task {task} has no run method")
 
     # Handle generator (dynamic deps) — sync or async
-    if result is not None and hasattr(result, "__next__"):
-        gen: typing.Generator = result  # type: ignore[assignment]
-        while True:
-            try:
-                yielded = next(gen)
-                dynamic_deps = flatten_task_struct(yielded)
+    async for yielded in _iter_dynamic_deps(result):
+        dynamic_deps = flatten_task_struct(yielded)
 
-                # Discover and build dynamic deps
-                for dep in dynamic_deps:
-                    if dep.id not in all_tasks:
-                        all_tasks[dep.id] = dep
-                        # Recursively discover
-                        for sub_dep in flatten_task_struct(dep.requires()):
-                            if sub_dep.id not in all_tasks:
-                                all_tasks[sub_dep.id] = sub_dep
+        # Discover and build dynamic deps
+        for dep in dynamic_deps:
+            if dep.id not in all_tasks:
+                all_tasks[dep.id] = dep
+                for sub_dep in flatten_task_struct(dep.requires()):
+                    if sub_dep.id not in all_tasks:
+                        all_tasks[sub_dep.id] = sub_dep
 
-                    if dep.id not in completion_cache:
-                        await _run_task_sequential_aio(
-                            dep,
-                            completion_cache,
-                            all_tasks,
-                            build_id,
-                            registry,
-                            sync_run_default,
-                        )
-
-            except StopIteration:
-                break
-
-    elif result is not None and hasattr(result, "__anext__"):
-        agen = typing.cast(typing.AsyncGenerator, result)
-        async for yielded in agen:
-            dynamic_deps = flatten_task_struct(yielded)
-
-            # Discover and build dynamic deps
-            for dep in dynamic_deps:
-                if dep.id not in all_tasks:
-                    all_tasks[dep.id] = dep
-                    for sub_dep in flatten_task_struct(dep.requires()):
-                        if sub_dep.id not in all_tasks:
-                            all_tasks[sub_dep.id] = sub_dep
-
-                if dep.id not in completion_cache:
-                    await _run_task_sequential_aio(
-                        dep,
-                        completion_cache,
-                        all_tasks,
-                        build_id,
-                        registry,
-                        sync_run_default,
-                    )
+            if dep.id not in completion_cache:
+                await _run_task_sequential_aio(
+                    dep,
+                    completion_cache,
+                    all_tasks,
+                    build_id,
+                    registry,
+                    sync_run_default,
+                )
 
     completion_cache.add(task.id)
     await registry.task_complete_aio(build_id, task)

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -43,7 +43,7 @@ import typing
 import modal
 from modal.gpu import GPU_T
 
-from stardag import BaseTask, TaskStruct, build
+from stardag import BaseTask, TaskStruct, build, flatten_task_struct
 from stardag.build import BuildExitStatus, TaskExecutorABC
 from stardag.config import clear_config_cache, config_provider, load_config
 from stardag.integration.modal._target import (
@@ -420,27 +420,79 @@ async def _prefect_build(
     logger.info(f"Completed building root task {repr(task)}")
 
 
-def _run(task: BaseTask):
+def _run(task: BaseTask) -> TaskStruct | None:
+    """Execute a task on a Modal worker, handling dynamic dependencies.
+
+    Like ``_run_task_in_process`` in the concurrent executor, generators cannot
+    be persisted across remote calls. We use idempotent re-execution:
+
+    1. Run the task (sync or async) to get the result
+    2. If it's a generator, drive it forward while yielded deps are complete
+    3. If yielded deps are NOT complete, return them as TaskStruct
+    4. The ModalTaskExecutor marks the task for re-execution after deps are built
+    5. On re-execution, previously incomplete deps are now complete, so the
+       generator advances past those yields
+
+    Returns:
+        None if task completed, or TaskStruct of incomplete dynamic deps.
+    """
+    import asyncio
+    import inspect
+
+    from stardag._core.base_task import _has_custom_run, _has_custom_run_aio
+
     _setup_logging()
     logger.info(f"Running task: {repr(task)}")
     try:
-        # Use run_aio for async tasks (those with custom run_aio but no custom run).
-        # BaseTask.run() already falls back to asyncio.run(run_aio()) for async-only
-        # tasks, so task.run() would work too, but calling run_aio explicitly is
-        # cleaner and avoids the overhead of the fallback detection.
-        from stardag._core.base_task import _has_custom_run, _has_custom_run_aio
+        has_run = _has_custom_run(task)
+        has_run_aio = _has_custom_run_aio(task)
 
-        if _has_custom_run_aio(task) and not _has_custom_run(task):
-            import asyncio
-
+        if has_run_aio and not has_run:
+            # Async-only task — handle async generators in the event loop
+            if inspect.isasyncgenfunction(type(task).run_aio):
+                return asyncio.run(_drive_async_generator(task))
             asyncio.run(task.run_aio())
-        else:
-            task.run()
+            return None
+
+        # Sync task — run and drive sync generator if returned
+        result = task.run()
+        return _drive_sync_generator(result)
     except Exception as e:
         logger.exception(f"Error running task: {repr(task)} - {e}")
         raise
 
-    logger.info(f"Completed running task: {repr(task)}")
+
+def _drive_sync_generator(result: typing.Any) -> TaskStruct | None:
+    """Drive a sync generator result, returning incomplete deps as TaskStruct."""
+    if result is None:
+        return None
+
+    if not hasattr(result, "__next__"):
+        return result  # type: ignore[return-value]
+
+    try:
+        while True:
+            yielded = next(result)  # type: ignore[arg-type]
+            deps = flatten_task_struct(yielded)
+            incomplete = [dep for dep in deps if not dep.complete()]
+            if incomplete:
+                return tuple(deps)  # type: ignore[return-value]
+    except StopIteration:
+        return None
+
+
+async def _drive_async_generator(task: BaseTask) -> TaskStruct | None:
+    """Drive an async generator run_aio, returning incomplete deps as TaskStruct."""
+    agen = task.run_aio()
+    try:
+        async for yielded in agen:  # type: ignore[union-attr]
+            deps = flatten_task_struct(yielded)
+            incomplete = [dep for dep in deps if not dep.complete()]
+            if incomplete:
+                return tuple(deps)  # type: ignore[return-value]
+    except StopAsyncIteration:
+        pass
+    return None
 
 
 def _setup_logging():

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -34,6 +34,8 @@ Example usage:
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
 import logging
 import os
@@ -44,6 +46,7 @@ import modal
 from modal.gpu import GPU_T
 
 from stardag import BaseTask, TaskStruct, build, flatten_task_struct
+from stardag._core.base_task import _has_custom_run, _has_custom_run_aio
 from stardag.build import BuildExitStatus, TaskExecutorABC
 from stardag.config import clear_config_cache, config_provider, load_config
 from stardag.integration.modal._target import (
@@ -436,11 +439,6 @@ def _run(task: BaseTask) -> TaskStruct | None:
     Returns:
         None if task completed, or TaskStruct of incomplete dynamic deps.
     """
-    import asyncio
-    import inspect
-
-    from stardag._core.base_task import _has_custom_run, _has_custom_run_aio
-
     _setup_logging()
     logger.info(f"Running task: {repr(task)}")
     try:

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -424,7 +424,18 @@ def _run(task: BaseTask):
     _setup_logging()
     logger.info(f"Running task: {repr(task)}")
     try:
-        task.run()
+        # Use run_aio for async tasks (those with custom run_aio but no custom run).
+        # BaseTask.run() already falls back to asyncio.run(run_aio()) for async-only
+        # tasks, so task.run() would work too, but calling run_aio explicitly is
+        # cleaner and avoids the overhead of the fallback detection.
+        from stardag._core.base_task import _has_custom_run, _has_custom_run_aio
+
+        if _has_custom_run_aio(task) and not _has_custom_run(task):
+            import asyncio
+
+            asyncio.run(task.run_aio())
+        else:
+            task.run()
     except Exception as e:
         logger.exception(f"Error running task: {repr(task)} - {e}")
         raise

--- a/lib/stardag/src/stardag/utils/testing/helper_tasks.py
+++ b/lib/stardag/src/stardag/utils/testing/helper_tasks.py
@@ -155,3 +155,29 @@ class DynamicDiamondTask(Task[str]):
             yield dep
 
         self._save(f"{self.name}:{_execution_counts[key]}")
+
+
+class AsyncDynamicDiamondTask(Task[str]):
+    """Async task with dynamic deps that tracks execution for diamond tests.
+
+    Uses async generator run_aio() to yield dynamic dependencies.
+    """
+
+    name: str
+    test_id: str
+    static_task_deps: tuple["AsyncDynamicDiamondTask", ...] = ()
+    dynamic_task_deps: tuple["AsyncDynamicDiamondTask", ...] = ()
+
+    def requires(self):
+        return self.static_task_deps
+
+    async def run_aio(self):  # type: ignore[override]
+        global _execution_counts
+        key = f"{self.test_id}:{self.name}"
+        _execution_counts[key] = _execution_counts.get(key, 0) + 1
+
+        # Yield dynamic deps (async generator)
+        for dep in self.dynamic_task_deps:
+            yield dep
+
+        await self._save_aio(f"{self.name}:{_execution_counts[key]}")

--- a/lib/stardag/tests/test__core/test_decorator.py
+++ b/lib/stardag/tests/test__core/test_decorator.py
@@ -236,3 +236,25 @@ async def test_call_aio_raises_on_sync_func():
 
     with pytest.raises(TypeError, match="cannot be used with a sync function"):
         await sync_add.call_aio(a=1, b=2)
+
+
+# --- Generator rejection tests ---
+
+
+def test_sync_generator_rejected():
+    """Sync generator functions should be rejected by @task."""
+    with pytest.raises(TypeError, match="does not support generator functions"):
+
+        @task
+        def gen_func(a: int) -> int:  # type: ignore[reportInvalidTypeForm]
+            yield a  # type: ignore[misc]
+            return a
+
+
+def test_async_generator_rejected():
+    """Async generator functions should be rejected by @task."""
+    with pytest.raises(TypeError, match="does not support generator functions"):
+
+        @task
+        async def async_gen_func(a: int) -> int:  # type: ignore[reportInvalidTypeForm]
+            yield a  # type: ignore[misc]

--- a/lib/stardag/tests/test_build/test_concurrent.py
+++ b/lib/stardag/tests/test_build/test_concurrent.py
@@ -33,6 +33,7 @@ from stardag.utils.testing.dynamic_deps_dag import (
     get_dynamic_deps_dag,
 )
 from stardag.utils.testing.helper_tasks import (
+    AsyncDynamicDiamondTask,
     AsyncOnlyTask,
     DiamondTask,
     DynamicDiamondTask,
@@ -660,6 +661,86 @@ class TestDiamondPatternsConcurrent:
         assert get_execution_count("complex_conc", "21") == 1
         assert get_execution_count("complex_conc", "1") == 1
         assert get_execution_count("complex_conc", "0") == 1
+
+
+# ============================================================================
+# Test: Async Dynamic Dependencies (Concurrent)
+# ============================================================================
+
+
+class TestAsyncDynamicDepsConcurrent:
+    """Tests for async dynamic dependencies with concurrent build."""
+
+    @pytest.mark.asyncio
+    async def test_async_dynamic_diamond(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileSystemTarget],
+        noop_registry,
+    ):
+        """Async dynamic diamond pattern with build_aio.
+
+        parent (static: [dyn_task, shared])
+           |
+        dyn_task (dynamic: [shared])
+           |
+        shared (appears in both paths)
+        """
+        reset_execution_counts()
+
+        shared = AsyncDynamicDiamondTask(name="shared", test_id="async_conc1")
+        dyn_task = AsyncDynamicDiamondTask(
+            name="dyn_task",
+            test_id="async_conc1",
+            dynamic_task_deps=(shared,),
+        )
+        parent = AsyncDynamicDiamondTask(
+            name="parent",
+            test_id="async_conc1",
+            static_task_deps=(dyn_task, shared),
+        )
+
+        summary = await build_aio([parent], registry=noop_registry)
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert get_execution_count("async_conc1", "shared") == 1
+        assert get_execution_count("async_conc1", "dyn_task") == 1
+        assert get_execution_count("async_conc1", "parent") == 1
+
+    @pytest.mark.asyncio
+    async def test_async_complex_dynamic_diamond(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileSystemTarget],
+        noop_registry,
+    ):
+        """Complex async dynamic pattern with concurrent build."""
+        reset_execution_counts()
+
+        t20 = AsyncDynamicDiamondTask(name="20", test_id="async_complex_conc")
+        t21 = AsyncDynamicDiamondTask(name="21", test_id="async_complex_conc")
+        t30 = AsyncDynamicDiamondTask(name="30", test_id="async_complex_conc")
+        shared_31 = AsyncDynamicDiamondTask(name="31", test_id="async_complex_conc")
+
+        dyn_and_static = AsyncDynamicDiamondTask(
+            name="1",
+            test_id="async_complex_conc",
+            static_task_deps=(t20, t21),
+            dynamic_task_deps=(t30, shared_31),
+        )
+        parent = AsyncDynamicDiamondTask(
+            name="0",
+            test_id="async_complex_conc",
+            static_task_deps=(dyn_and_static, shared_31),
+        )
+
+        summary = await build_aio([parent], registry=noop_registry)
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert get_execution_count("async_complex_conc", "31") == 1
+        assert get_execution_count("async_complex_conc", "30") == 1
+        assert get_execution_count("async_complex_conc", "20") == 1
+        assert get_execution_count("async_complex_conc", "21") == 1
+        assert get_execution_count("async_complex_conc", "1") == 1
+        assert get_execution_count("async_complex_conc", "0") == 1
 
 
 # ============================================================================

--- a/lib/stardag/tests/test_build/test_sequential.py
+++ b/lib/stardag/tests/test_build/test_sequential.py
@@ -19,6 +19,7 @@ from stardag.build import (
 from stardag.registry import NoOpRegistry
 from stardag.target import InMemoryFileSystemTarget
 from stardag.utils.testing.helper_tasks import (
+    AsyncDynamicDiamondTask,
     AsyncOnlyTask,
     DiamondTask,
     DualTask,
@@ -399,3 +400,90 @@ class TestDiamondPatternsSequential:
         assert get_execution_count("complex_seq", "21") == 1
         assert get_execution_count("complex_seq", "1") == 1
         assert get_execution_count("complex_seq", "0") == 1
+
+
+# ============================================================================
+# Test: Async Dynamic Dependencies (Sequential)
+# ============================================================================
+
+
+class TestAsyncDynamicDepsSequential:
+    """Tests for async dynamic dependencies using class-based Task API."""
+
+    @pytest.mark.asyncio
+    async def test_async_dynamic_diamond(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileSystemTarget],
+        noop_registry,
+    ):
+        """Async dynamic diamond pattern with build_sequential_aio.
+
+        parent (static: [dyn_task, shared])
+           |
+        dyn_task (dynamic: [shared])
+           |
+        shared (appears in both paths)
+        """
+        reset_execution_counts()
+
+        shared = AsyncDynamicDiamondTask(name="shared", test_id="async_dyn1")
+        dyn_task = AsyncDynamicDiamondTask(
+            name="dyn_task",
+            test_id="async_dyn1",
+            dynamic_task_deps=(shared,),
+        )
+        parent = AsyncDynamicDiamondTask(
+            name="parent",
+            test_id="async_dyn1",
+            static_task_deps=(dyn_task, shared),
+        )
+
+        summary = await build_sequential_aio([parent], registry=noop_registry)
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert get_execution_count("async_dyn1", "shared") == 1
+        assert get_execution_count("async_dyn1", "dyn_task") == 1
+        assert get_execution_count("async_dyn1", "parent") == 1
+
+    @pytest.mark.asyncio
+    async def test_async_complex_dynamic_diamond(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileSystemTarget],
+        noop_registry,
+    ):
+        """Complex async dynamic pattern matching the sync test.
+
+        parent (static: [dyn_and_static, shared_31])
+           |
+        dyn_and_static (static: [t20, t21], dynamic: [t30, shared_31])
+           |
+        shared_31 appears in both parent's static and dyn_and_static's dynamic
+        """
+        reset_execution_counts()
+
+        t20 = AsyncDynamicDiamondTask(name="20", test_id="async_complex")
+        t21 = AsyncDynamicDiamondTask(name="21", test_id="async_complex")
+        t30 = AsyncDynamicDiamondTask(name="30", test_id="async_complex")
+        shared_31 = AsyncDynamicDiamondTask(name="31", test_id="async_complex")
+
+        dyn_and_static = AsyncDynamicDiamondTask(
+            name="1",
+            test_id="async_complex",
+            static_task_deps=(t20, t21),
+            dynamic_task_deps=(t30, shared_31),
+        )
+        parent = AsyncDynamicDiamondTask(
+            name="0",
+            test_id="async_complex",
+            static_task_deps=(dyn_and_static, shared_31),
+        )
+
+        summary = await build_sequential_aio([parent], registry=noop_registry)
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert get_execution_count("async_complex", "31") == 1
+        assert get_execution_count("async_complex", "30") == 1
+        assert get_execution_count("async_complex", "20") == 1
+        assert get_execution_count("async_complex", "21") == 1
+        assert get_execution_count("async_complex", "1") == 1
+        assert get_execution_count("async_complex", "0") == 1


### PR DESCRIPTION
## Summary

- Build sequential and concurrent executors now handle **async generators** from `run_aio()` for dynamic dependencies (class-based Task API)
- `@task` decorator rejects generator functions with a clear error message pointing users to the class-based API
- Modal `_run` function now supports async-only tasks via `asyncio.run(run_aio())`
- New `AsyncDynamicDiamondTask` test helper and async dynamic deps tests for both sequential and concurrent build paths

## Context

The build system previously only handled **sync generators** (`__next__`) for dynamic dependencies. When a class-based task's `run_aio()` is an async generator (yielding `TaskStruct` deps), the build system would fail because `await` doesn't work on async generators. This PR adds `inspect.isasyncgenfunction()` detection and `async for` iteration alongside the existing sync generator handling.

The `@task` decorator API is intentionally kept simple — dynamic dependencies are complex and better served by the class-based API where type annotations and generator patterns are more natural.

## Changes

| File | Change |
|------|--------|
| `build/_sequential.py` | Detect async generator `run_aio`, iterate with `async for` |
| `build/_concurrent.py` | `_handle_result` (now async), `_handle_generator_aio`, `_resume_generator_aio`, updated typing |
| `_core/decorator.py` | Reject generator/async generator functions with `TypeError` |
| `integration/modal/_app.py` | `_run` detects async-only tasks, uses `asyncio.run(run_aio())` |
| `utils/testing/helper_tasks.py` | New `AsyncDynamicDiamondTask` class |
| `tests/test__core/test_decorator.py` | Generator rejection tests |
| `tests/test_build/test_sequential.py` | Async dynamic diamond tests |
| `tests/test_build/test_concurrent.py` | Async dynamic diamond tests |

## Test plan

- [x] All 71 existing + new tests pass (`test_decorator.py`, `test_sequential.py`, `test_concurrent.py`)
- [x] Pyright passes with 0 errors
- [ ] Modal integration test (requires Modal test setup — tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)