### PR TITLE
Fix modal >=1.4 import error: remove modal.gpu.GPU_T

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.5.4] — 2026-04-08
+
+### SDK
+
+#### Bug fixes
+
+- **Fix `modal >= 1.4` compatibility**: Remove import of `modal.gpu.GPU_T` which was deleted in modal 1.4. `FunctionSettings.gpu` now uses `str | list[str]` directly. (#113)
+
 ## [0.5.3] — 2026-04-05
 
 ### SDK

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,14 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.5.4 — Fix modal >= 1.4 compatibility
+
+`import stardag.integration.modal` broke on `modal >= 1.4` due to the removed
+`modal.gpu` module. The `GPU_T` type is replaced with `str | list[str]`, which
+is what the modal 1.x API actually accepts.
+
+---
+
 ## v0.5.3 — Secret masking for auth credentials
 
 `RegistryAuth.api_key` and `RegistryAuth.access_token` now use Pydantic

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -41,7 +41,6 @@ import pathlib
 import typing
 
 import modal
-from modal.gpu import GPU_T
 
 import traceback as tb_module
 
@@ -262,7 +261,7 @@ class FunctionSettings(typing.TypedDict, total=False):
     """
 
     image: typing.Required[modal.Image]
-    gpu: GPU_T | list[GPU_T]
+    gpu: str | list[str]
     cpu: float | tuple[float, float]
     memory: int | tuple[int, int]
     timeout: int

--- a/lib/stardag/tests/test_integration/test_modal/test_import.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_import.py
@@ -1,0 +1,47 @@
+"""Test that stardag.integration.modal imports successfully.
+
+Regression test for https://github.com/stardag-dev/stardag/issues/113
+where `from modal.gpu import GPU_T` broke on modal >= 1.4 because the
+`modal.gpu` module was removed.
+"""
+
+import pytest
+
+try:
+    import modal  # noqa: F401
+except ImportError:
+    pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+
+def test_modal_integration_import():
+    """Importing stardag.integration.modal should not raise."""
+    from stardag.integration.modal import FunctionSettings, StardagApp
+
+    assert FunctionSettings is not None
+    assert StardagApp is not None
+
+
+def test_function_settings_gpu_accepts_string():
+    """FunctionSettings.gpu should accept str values (modal 1.x API)."""
+    import modal
+
+    from stardag.integration.modal import FunctionSettings
+
+    settings = FunctionSettings(
+        image=modal.Image.debian_slim(),
+        gpu="A10G",
+    )
+    assert settings.get("gpu") == "A10G"
+
+
+def test_function_settings_gpu_accepts_list():
+    """FunctionSettings.gpu should accept list[str] values."""
+    import modal
+
+    from stardag.integration.modal import FunctionSettings
+
+    settings = FunctionSettings(
+        image=modal.Image.debian_slim(),
+        gpu=["A10G", "T4"],
+    )
+    assert settings.get("gpu") == ["A10G", "T4"]


### PR DESCRIPTION
Fixes #113

## Summary

`modal.gpu.GPU_T` was removed in modal 1.4. Replace with `str | list[str]` which is the actual type the modal 1.x API accepts for GPU specifications.

The import was at module level so `import stardag.integration.modal` failed immediately on modal >= 1.4, even if GPUs were never used.

## Changes

- Remove `from modal.gpu import GPU_T` from `_app.py`
- Replace `gpu: GPU_T | list[GPU_T]` with `gpu: str | list[str]` in `FunctionSettings`
- Add regression tests: import check + GPU string/list type verification

## Test plan

- [x] Pre-commit hooks pass (ruff, pyright)
- [x] New tests pass with modal 1.3.3 (venv) and verified import failure on modal 1.4.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)