### PR TITLE
Support user-defined generic task classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 #### New features
 
-- **Generic task classes can now be instantiated directly.** Previously, declaring `class MyGeneric[T](Task[...]): ...` registered the class, but instantiating it (either bare as `MyGeneric(...)` or parameterized as `MyGeneric[int](...)`) raised `AttributeError: __type_id__` during serialization. The registration filter has been narrowed to only skip parameterized generic aliases (e.g. `Task[int]`) and classes explicitly marked `__stardag_abstract__ = True`; user-defined generic tasks now get their own `__type_id__`. The internal abstract bases `Task`, `LoadableTask`, and `TargetTask` carry the marker so their current unregistered status is preserved.
+- **Generic task classes can now be instantiated directly.** Previously, a user-defined generic task (e.g. `class MyGeneric(Task[list[T]], Generic[T]): ...`) was silently skipped during polymorphic registration because any class with unresolved `__parameters__` was excluded. With no `__type_id__` attached, the first `model_dump()` raised `AttributeError: __type_id__`. The registration filter has been narrowed to only skip parameterized generic aliases (e.g. `Task[int]`) and classes explicitly marked `__stardag_abstract__ = True`; user-defined generic tasks now get their own `__type_id__`. The internal abstract bases `Task`, `LoadableTask`, and `TargetTask` carry the marker so their current unregistered status is preserved.
 - **`SubClass[T]` field annotations now accept `TypeVar`s bound to a `PolymorphicRoot` subclass.** A generic task can declare e.g. `field: SubClass[T]` where `T = TypeVar("T", bound=MyRoot)`; the schema is built using the TypeVar's bound for the generic form and re-built strictly for each parameterized form. Unbounded `TypeVar`s still raise a clear `TypeError` at schema-build time.
 
 #### Notes
 
-- TypeVars on a generic `Task` remain a **static-typing convenience** — runtime behavior (serializer, target selection, etc.) is fixed at class-definition time. If different type parameters need different runtime behavior, define a concrete subclass (`class MyInt(MyGeneric[int]): pass`) — concrete subclasses get their own `__type_id__` and distinct task id.
+- TypeVars on a generic `Task` remain a **static-typing convenience** — runtime behavior (serializer, target selection, etc.) is fixed at class-definition time. If different type parameters need different runtime behavior, define a concrete subclass (e.g. `class MyInt(MyGeneric[int]): pass`) — concrete subclasses get their own `__type_id__` and distinct task id.
 
 ## [0.5.6] — 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.5.7] — 2026-04-19
+
+### SDK
+
+#### New features
+
+- **Generic task classes can now be instantiated directly.** Previously, declaring `class MyGeneric[T](Task[...]): ...` registered the class, but instantiating it (either bare as `MyGeneric(...)` or parameterized as `MyGeneric[int](...)`) raised `AttributeError: __type_id__` during serialization. The registration filter has been narrowed to only skip parameterized generic aliases (e.g. `Task[int]`) and classes explicitly marked `__stardag_abstract__ = True`; user-defined generic tasks now get their own `__type_id__`. The internal abstract bases `Task`, `LoadableTask`, and `TargetTask` carry the marker so their current unregistered status is preserved.
+- **`SubClass[T]` field annotations now accept `TypeVar`s bound to a `PolymorphicRoot` subclass.** A generic task can declare e.g. `field: SubClass[T]` where `T = TypeVar("T", bound=MyRoot)`; the schema is built using the TypeVar's bound for the generic form and re-built strictly for each parameterized form. Unbounded `TypeVar`s still raise a clear `TypeError` at schema-build time.
+
+#### Notes
+
+- TypeVars on a generic `Task` remain a **static-typing convenience** — runtime behavior (serializer, target selection, etc.) is fixed at class-definition time. If different type parameters need different runtime behavior, define a concrete subclass (`class MyInt(MyGeneric[int]): pass`) — concrete subclasses get their own `__type_id__` and distinct task id.
+
 ## [0.5.6] — 2026-04-19
 
 ### SDK

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,99 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.5.7 — Support for user-defined generic task classes
+
+User-defined generic tasks can now be declared and instantiated directly —
+two long-standing blockers have been removed without introducing any new
+wire format or hash dependency.
+
+### Unblocker 1: generic tasks get a `__type_id__`
+
+Previously, any class with unresolved `__parameters__` was skipped during
+polymorphic registration. That meant a user-defined generic task like
+
+```python
+class MyGenericTask[ItemT](sd.Task[list[ItemT]]):
+    deps: list[sd.TaskLoads[ItemT]]
+    def run(self):
+        self._save([d.load() for d in self.deps])
+
+MyGenericTask(deps=[...])  # AttributeError: __type_id__
+```
+
+failed at the first `model_dump()`. The registration filter now only skips
+**parameterized generic aliases** (`Task[int]`, not real classes) and
+classes explicitly marked `__stardag_abstract__ = True`. `Task`,
+`LoadableTask`, and `TargetTask` carry the marker, so their current
+unregistered status is preserved. Any user-defined generic task is
+registered under its own name and works end-to-end.
+
+### Unblocker 2: `SubClass[T]` inside generic tasks
+
+A generic task that wants to dispatch polymorphically on its TypeVar can
+now declare:
+
+```python
+from typing import TypeVar
+import stardag as sd
+from stardag.polymorphic import PolymorphicRoot, SubClass
+
+class ParamsBase(PolymorphicRoot): ...
+ParamT = TypeVar("ParamT", bound=ParamsBase)
+
+class MyGenericTask(sd.Task[int], Generic[ParamT]):
+    params: SubClass[ParamT]
+    # ...
+```
+
+Previously, the `SubClass[T]` annotation raised `TypeError: Polymorphic()
+can only be used with PolymorphicRoot subclasses` at class-body time
+because the TypeVar itself isn't a `PolymorphicRoot`. The schema builder
+now treats a TypeVar as its `__bound__` for the generic form; Pydantic
+re-invokes it with the concrete type for each parameterized form
+(`MyGenericTask[Concrete]`), which narrows validation strictly. Unbounded
+TypeVars still raise a clear `TypeError` at schema-build time.
+
+### What remains class-definition-time
+
+A TypeVar on a generic `Task` is a **static-typing convenience**. Runtime
+behavior — serializer selection, target path, validators — is baked in at
+class-definition time. If you need _different_ runtime behavior for
+different type parameters (e.g. a distinct serializer for `MyTask[int]`
+vs `MyTask[str]`), define a concrete subclass:
+
+```python
+class MyInt(MyGeneric[int]): pass
+```
+
+Concrete subclasses get their own `__type_id__` and hash distinctly;
+parameterized aliases (`MyGeneric[int]`) do not — they share the generic
+class's `__type_id__` and hash identically to the bare form. This is an
+intentional invariant: **different `__type_id__` ⇔ different class with
+different runtime behavior**.
+
+### What this release does NOT do
+
+An earlier iteration of this branch also pickle-transferred resolved type
+args in the serialized payload (under `__type_args`), so distinct
+parameterizations like `MyGeneric[int](...)` and `MyGeneric[str](...)`
+hashed distinctly and round-tripped back to the parameterized class. We
+decided against that path:
+
+- It coupled task id stability to pickle output, which is version-
+  sensitive (task ids could drift across Python minor versions).
+- The `Task` machinery already draws the runtime-behavior line at
+  concrete subclasses (parameterized aliases don't get their own
+  serializer anyway). Introducing a finer hash granularity than the
+  behavior granularity would be a surprise, not an asset.
+- Users who genuinely need per-parameterization ids have a clear,
+  already-supported path: concrete subclass.
+
+If this tradeoff doesn't hold for a future use case, the pickle-transfer
+design is recoverable from the PR history.
+
+---
+
 ## v0.5.6 — Softer default for generic-type-mismatch handling
 
 `Polymorphic(on_generic_type_mismatch=...)` — the option that controls what

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -14,16 +14,22 @@ wire format or hash dependency.
 
 ### Unblocker 1: generic tasks get a `__type_id__`
 
-Previously, any class with unresolved `__parameters__` was skipped during
-polymorphic registration. That meant a user-defined generic task like
+Previously, any class with unresolved `__parameters__` was silently skipped
+during polymorphic registration — so no `__type_id__` was attached. That
+meant a user-defined generic task like
 
 ```python
-class MyGenericTask[ItemT](sd.Task[list[ItemT]]):
+from typing import Generic, TypeVar
+import stardag as sd
+
+ItemT = TypeVar("ItemT")
+
+class MyGenericTask(sd.Task[list[ItemT]], Generic[ItemT]):
     deps: list[sd.TaskLoads[ItemT]]
     def run(self):
         self._save([d.load() for d in self.deps])
 
-MyGenericTask(deps=[...])  # AttributeError: __type_id__
+MyGenericTask(deps=[...])  # AttributeError: __type_id__ (at model_dump)
 ```
 
 failed at the first `model_dump()`. The registration filter now only skips
@@ -39,7 +45,7 @@ A generic task that wants to dispatch polymorphically on its TypeVar can
 now declare:
 
 ```python
-from typing import TypeVar
+from typing import Generic, TypeVar
 import stardag as sd
 from stardag.polymorphic import PolymorphicRoot, SubClass
 

--- a/lib/stardag/src/stardag/_core/base_task.py
+++ b/lib/stardag/src/stardag/_core/base_task.py
@@ -499,6 +499,8 @@ class LoadableTask(BaseTask, abc.ABC, Generic[LoadedT_co]):
     the ``run``/``run_aio`` pattern on ``BaseTask``).
     """
 
+    __stardag_abstract__: ClassVar[bool] = True
+
     def load(self) -> LoadedT_co:
         """Load the output of this task (sync).
 
@@ -543,6 +545,8 @@ class TargetTask(BaseTask, Generic[TargetType]):
     with automatic serialization and filesystem target management) rather than
     using ``TargetTask`` directly.
     """
+
+    __stardag_abstract__: ClassVar[bool] = True
 
     def complete(self) -> bool:
         """Check if the task is complete."""

--- a/lib/stardag/src/stardag/_core/task.py
+++ b/lib/stardag/src/stardag/_core/task.py
@@ -1,5 +1,6 @@
 import abc
 import typing
+from typing import ClassVar
 
 from stardag._core.base_task import BaseTask, LoadableTask, TargetTask
 from stardag._core.validate import LoadValidator, get_validators, run_validators
@@ -115,6 +116,8 @@ class Task(
     # <stardag.target.serialize.JSONSerializer at 0x1064e4710>
     ```
     """
+
+    __stardag_abstract__: ClassVar[bool] = True
 
     @classmethod
     def __map_generic_args_to_ancestor__(

--- a/lib/stardag/src/stardag/polymorphic.py
+++ b/lib/stardag/src/stardag/polymorphic.py
@@ -595,9 +595,26 @@ class Polymorphic:
     ):
         _ = handler(source_type)  # ensure schema exists
 
-        # require source_type to be a PolymorphicRoot subclass
-        if not isinstance(source_type, type) or not issubclass(
-            source_type, PolymorphicRoot
+        # Resolve TypeVars to their bound so that generic Pydantic models can
+        # declare fields like ``field: SubClass[T]`` where ``T`` is a TypeVar
+        # bound to a PolymorphicRoot subclass. At schema-build time for the
+        # generic class, source_type is the TypeVar; at schema-build time for
+        # the parameterized form (``MyModel[Concrete]``), Pydantic re-invokes
+        # this method with the concrete class, so the TypeVar branch only
+        # shapes the generic-form schema.
+        resolved_source = source_type
+        if isinstance(source_type, TypeVar):
+            bound = source_type.__bound__
+            if not (isinstance(bound, type) and issubclass(bound, PolymorphicRoot)):
+                raise TypeError(
+                    "Polymorphic() used with a TypeVar requires the TypeVar "
+                    f"to be bound to a PolymorphicRoot subclass; got "
+                    f"TypeVar {source_type!r} with bound {bound!r}"
+                )
+            resolved_source = bound
+
+        if not isinstance(resolved_source, type) or not issubclass(
+            resolved_source, PolymorphicRoot
         ):
             raise TypeError(
                 "Polymorphic() can only be used with PolymorphicRoot subclasses"
@@ -605,10 +622,10 @@ class Polymorphic:
 
         # For parameterized generics like Task[LoadableTarget[str]], get the origin class
         # (Task) for isinstance checks, but keep source_type for generic args checking
-        pydantic_meta = getattr(source_type, "__pydantic_generic_metadata__", None)
+        pydantic_meta = getattr(resolved_source, "__pydantic_generic_metadata__", None)
         base_origin: type[PolymorphicRoot] = (
             pydantic_meta.get("origin") if pydantic_meta else None
-        ) or source_type
+        ) or resolved_source
 
         explicit_on_mismatch = self.on_generic_type_mismatch
 
@@ -616,12 +633,12 @@ class Polymorphic:
             if isinstance(v, base_origin):
                 # Best-effort generic args check for already-instantiated values
                 is_compatible, error_msg = _check_generic_args_compatibility(
-                    source_type, type(v)
+                    resolved_source, type(v)
                 )
                 if not is_compatible:
                     message = (
                         f"Value of type {type(v).__name__} is not compatible with "
-                        f"expected type {source_type}: {error_msg}"
+                        f"expected type {resolved_source}: {error_msg}"
                     )
                     on_mismatch = _resolve_on_generic_type_mismatch(
                         explicit_on_mismatch

--- a/lib/stardag/src/stardag/polymorphic.py
+++ b/lib/stardag/src/stardag/polymorphic.py
@@ -1,9 +1,12 @@
+import base64
 import logging
 import os
 import types
 import typing
 import warnings
 from dataclasses import dataclass
+from pickle import dumps as pickle_dumps
+from pickle import loads as pickle_loads
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -163,6 +166,25 @@ def _check_generic_args_compatibility(
 
 NAMESPACE_KEY = "__namespace"
 NAME_KEY = "__name"
+TYPE_ARGS_KEY = "__type_args"
+
+
+def _encode_type_args(args: tuple[Any, ...]) -> str:
+    return base64.b64encode(pickle_dumps(args)).decode("ascii")
+
+
+def _decode_type_args(encoded: str) -> tuple[Any, ...]:
+    return pickle_loads(base64.b64decode(encoded))
+
+
+def _contains_typevar(annotation: Any) -> bool:
+    """Recursively detect unresolved ``TypeVar``s inside a type annotation."""
+    if isinstance(annotation, TypeVar):
+        return True
+    for sub in get_args(annotation):
+        if _contains_typevar(sub):
+            return True
+    return False
 
 
 @dataclass(frozen=True)
@@ -311,6 +333,24 @@ def is_generic_model(cls: Type[BaseModel]) -> bool:
     return False
 
 
+def _is_parameterized_generic_alias(cls: Type[BaseModel]) -> bool:
+    """True for parameterized generic aliases like ``Task[int]``.
+
+    These aren't real classes and must never be registered: the concrete subclass
+    that extends them (``class MyTask(Task[int]): pass``) is what carries the id.
+    """
+    return bool(cls.__pydantic_generic_metadata__.get("origin"))
+
+
+def _is_stardag_abstract(cls: type) -> bool:
+    """True if this class is explicitly marked as an abstract stardag base.
+
+    Only honored when set directly on the class (via ``cls.__dict__``), not
+    inherited — so user subclasses of abstract bases still get registered.
+    """
+    return cls.__dict__.get("__stardag_abstract__", False) is True
+
+
 _TPolymorphicRoot = TypeVar("_TPolymorphicRoot", bound="PolymorphicRoot")
 _TBaseModel = TypeVar("_TBaseModel", bound=StardagBaseModel)
 
@@ -363,6 +403,19 @@ class PolymorphicRoot(StardagBaseModel):
         # narrow + safety: only allow subclasses of the annotated base
         if not issubclass(sub, cls):
             raise TypeError(f"Registered class {sub} is not a subclass of {cls}")
+
+        # If type args travelled with the payload (parameterized-at-call-site
+        # generic), re-parameterize the registered class so the resulting
+        # instance carries the correct ``__orig_class__``.
+        type_args_encoded = extra.get(TYPE_ARGS_KEY)
+        if type_args_encoded is not None:
+            sub_params = sub.__pydantic_generic_metadata__.get("parameters") or ()
+            if sub_params:
+                args = tuple(_decode_type_args(type_args_encoded))
+                if len(args) == 1:
+                    sub = sub[args[0]]  # type: ignore[index]
+                elif len(args) > 1:
+                    sub = sub[args]  # type: ignore[index]
         return sub  # type: ignore[return-value]
 
     @classmethod
@@ -394,7 +447,11 @@ class PolymorphicRoot(StardagBaseModel):
                 for base in cls.__mro__
                 if PolymorphicRoot in getattr(base, "__bases__", ())
             )
-            if cls is not family and not is_generic_model(cls):
+            if (
+                cls is not family
+                and not _is_parameterized_generic_alias(cls)
+                and not _is_stardag_abstract(cls)
+            ):
                 cls.__type_id__ = family._registry().add(
                     cls,
                     name_override=name_override,
@@ -424,12 +481,39 @@ class PolymorphicRoot(StardagBaseModel):
         """Always add discriminator keys. This runs for all subclasses too."""
         if isinstance(data, dict):
             tid = self.__class__.__type_id__
-            data = {
+            header: dict[str, Any] = {
                 NAMESPACE_KEY: tid.namespace,
                 NAME_KEY: tid.name,
-                **data,
             }
+            type_args = self._get_transferable_type_args()
+            if type_args is not None:
+                header[TYPE_ARGS_KEY] = _encode_type_args(type_args)
+            data = {**header, **data}
         return data
+
+    def _get_transferable_type_args(self) -> tuple | None:
+        """Concrete generic type args that need to travel with this instance.
+
+        Returns the args tuple when the instance was produced from a
+        parameterized-at-call-site generic (e.g. ``TestGeneric[int](...)``) and
+        the registry-resolvable class still carries unresolved type parameters
+        without those args. Returns ``None`` for concrete named subclasses —
+        their ``__name`` discriminator already fully determines the class.
+        """
+        orig_class = getattr(self, "__orig_class__", None)
+        if orig_class is None:
+            return None
+        args = get_args(orig_class)
+        if not args:
+            return None
+        if any(_contains_typevar(a) for a in args):
+            return None
+        cls = self.__class__
+        meta = cls.__pydantic_generic_metadata__
+        origin = meta.get("origin") or cls
+        if not origin.__pydantic_generic_metadata__.get("parameters"):
+            return None
+        return args
 
     @classmethod
     def _before_validate(cls, payload: Any, info: ValidationInfo) -> Any:
@@ -440,6 +524,7 @@ class PolymorphicRoot(StardagBaseModel):
         payload = dict(payload)
         payload.pop(NAMESPACE_KEY, None)
         payload.pop(NAME_KEY, None)
+        payload.pop(TYPE_ARGS_KEY, None)
 
         return payload
 

--- a/lib/stardag/src/stardag/polymorphic.py
+++ b/lib/stardag/src/stardag/polymorphic.py
@@ -1,12 +1,9 @@
-import base64
 import logging
 import os
 import types
 import typing
 import warnings
 from dataclasses import dataclass
-from pickle import dumps as pickle_dumps
-from pickle import loads as pickle_loads
 from typing import (
     TYPE_CHECKING,
     Annotated,
@@ -166,25 +163,6 @@ def _check_generic_args_compatibility(
 
 NAMESPACE_KEY = "__namespace"
 NAME_KEY = "__name"
-TYPE_ARGS_KEY = "__type_args"
-
-
-def _encode_type_args(args: tuple[Any, ...]) -> str:
-    return base64.b64encode(pickle_dumps(args)).decode("ascii")
-
-
-def _decode_type_args(encoded: str) -> tuple[Any, ...]:
-    return pickle_loads(base64.b64decode(encoded))
-
-
-def _contains_typevar(annotation: Any) -> bool:
-    """Recursively detect unresolved ``TypeVar``s inside a type annotation."""
-    if isinstance(annotation, TypeVar):
-        return True
-    for sub in get_args(annotation):
-        if _contains_typevar(sub):
-            return True
-    return False
 
 
 @dataclass(frozen=True)
@@ -403,19 +381,6 @@ class PolymorphicRoot(StardagBaseModel):
         # narrow + safety: only allow subclasses of the annotated base
         if not issubclass(sub, cls):
             raise TypeError(f"Registered class {sub} is not a subclass of {cls}")
-
-        # If type args travelled with the payload (parameterized-at-call-site
-        # generic), re-parameterize the registered class so the resulting
-        # instance carries the correct ``__orig_class__``.
-        type_args_encoded = extra.get(TYPE_ARGS_KEY)
-        if type_args_encoded is not None:
-            sub_params = sub.__pydantic_generic_metadata__.get("parameters") or ()
-            if sub_params:
-                args = tuple(_decode_type_args(type_args_encoded))
-                if len(args) == 1:
-                    sub = sub[args[0]]  # type: ignore[index]
-                elif len(args) > 1:
-                    sub = sub[args]  # type: ignore[index]
         return sub  # type: ignore[return-value]
 
     @classmethod
@@ -481,39 +446,12 @@ class PolymorphicRoot(StardagBaseModel):
         """Always add discriminator keys. This runs for all subclasses too."""
         if isinstance(data, dict):
             tid = self.__class__.__type_id__
-            header: dict[str, Any] = {
+            data = {
                 NAMESPACE_KEY: tid.namespace,
                 NAME_KEY: tid.name,
+                **data,
             }
-            type_args = self._get_transferable_type_args()
-            if type_args is not None:
-                header[TYPE_ARGS_KEY] = _encode_type_args(type_args)
-            data = {**header, **data}
         return data
-
-    def _get_transferable_type_args(self) -> tuple | None:
-        """Concrete generic type args that need to travel with this instance.
-
-        Returns the args tuple when the instance was produced from a
-        parameterized-at-call-site generic (e.g. ``TestGeneric[int](...)``) and
-        the registry-resolvable class still carries unresolved type parameters
-        without those args. Returns ``None`` for concrete named subclasses —
-        their ``__name`` discriminator already fully determines the class.
-        """
-        orig_class = getattr(self, "__orig_class__", None)
-        if orig_class is None:
-            return None
-        args = get_args(orig_class)
-        if not args:
-            return None
-        if any(_contains_typevar(a) for a in args):
-            return None
-        cls = self.__class__
-        meta = cls.__pydantic_generic_metadata__
-        origin = meta.get("origin") or cls
-        if not origin.__pydantic_generic_metadata__.get("parameters"):
-            return None
-        return args
 
     @classmethod
     def _before_validate(cls, payload: Any, info: ValidationInfo) -> Any:
@@ -524,7 +462,6 @@ class PolymorphicRoot(StardagBaseModel):
         payload = dict(payload)
         payload.pop(NAMESPACE_KEY, None)
         payload.pop(NAME_KEY, None)
-        payload.pop(TYPE_ARGS_KEY, None)
 
         return payload
 

--- a/lib/stardag/tests/test__core/test_task.py
+++ b/lib/stardag/tests/test__core/test_task.py
@@ -1,7 +1,10 @@
 import json
 import typing
 
+import pytest
+
 from stardag import Task, auto_namespace, get_default_relpath
+from stardag.polymorphic import PolymorphicRoot as _PolymorphicRoot
 from stardag.target import DirectorySerializable, FileSerializable
 from stardag.target._base import DirectoryTarget
 from stardag.target.serialize import (
@@ -463,3 +466,147 @@ class TestGenericTypeArgTransfer:
         dumped = task.model_dump(mode="json")
         assert "__type_args" not in dumped
         assert dumped["__name"] == "IntParamTask"
+
+
+class _TypeVarRoundTripBase(_PolymorphicRoot):
+    """Module-level PolymorphicRoot family used by the round-trip test below.
+
+    The pickle-transfer mechanism needs module-level classes (pickle can't
+    find locally-defined ones by qualname), so this base and its subclass
+    must live at module scope.
+    """
+
+    pass
+
+
+class _TypeVarRoundTripConcrete(_TypeVarRoundTripBase):
+    payload: int = 0
+
+
+class TestGenericTaskWithSubClassField:
+    """A generic task can use a ``TypeVar`` bound to a ``PolymorphicRoot`` as a
+    ``SubClass[...]`` field annotation, so the polymorphic base narrows with the
+    task's type parameter.
+
+    Pattern:
+
+        class BaseParam(PolymorphicRoot):
+            ...
+
+        ParamT = TypeVar("ParamT", bound=BaseParam)
+
+        class GenericTask(Task[...], Generic[ParamT]):
+            param: SubClass[ParamT]
+
+        GenericTask[ConcreteParam](param=ConcreteParam(), ...)
+
+    The generic form builds a schema using the TypeVar's bound as the dispatch
+    target (so ``GenericTask(param=...)`` accepts any ``BaseParam`` subclass).
+    Pydantic re-invokes schema construction for each parameterized form,
+    narrowing the dispatch to the concrete type.
+    """
+
+    def test_generic_class_with_subclass_typevar_field_can_be_declared(self):
+        """Previously raised ``TypeError: Polymorphic() can only be used with
+        PolymorphicRoot subclasses`` at class-body evaluation because source_type
+        was the unresolved TypeVar."""
+        from stardag.polymorphic import PolymorphicRoot, SubClass
+
+        class BaseParam(PolymorphicRoot):
+            pass
+
+        ParamT = typing.TypeVar("ParamT", bound=BaseParam)
+
+        class GenericTask(Task[int], typing.Generic[ParamT]):
+            param: SubClass[ParamT]
+            value: int
+
+            def run(self):
+                self._save(self.value)
+
+        assert hasattr(GenericTask, "__type_id__")
+        assert GenericTask.__type_id__.name == "GenericTask"
+
+    def test_narrowing_rejects_wrong_concrete_subclass(self):
+        """``GenericTask[ConcreteA](param=ConcreteB())`` is rejected by Pydantic's
+        strict schema for the parameterized form."""
+        from pydantic import ValidationError
+
+        from stardag.polymorphic import PolymorphicRoot, SubClass
+
+        class BaseParam(PolymorphicRoot):
+            pass
+
+        class ConcreteA(BaseParam):
+            a: int = 1
+
+        class ConcreteB(BaseParam):
+            b: int = 2
+
+        ParamT = typing.TypeVar("ParamT", bound=BaseParam)
+
+        class GenericTask(Task[int], typing.Generic[ParamT]):
+            param: SubClass[ParamT]
+            value: int
+
+            def run(self):
+                self._save(self.value)
+
+        # Correct parameterization: accepted.
+        ok = GenericTask[ConcreteA](param=ConcreteA(a=5), value=1)
+        assert isinstance(ok.param, ConcreteA)
+
+        # Mismatched concrete: rejected.
+        with pytest.raises(ValidationError):
+            GenericTask[ConcreteA](param=ConcreteB(), value=1)  # type: ignore[arg-type]
+
+    def test_round_trip_preserves_typevar_parameterization(self):
+        """Serialize + dispatch on ``SubClass[BaseTask]`` reconstructs the
+        parameterized class; the ``SubClass[ParamT]`` field still resolves
+        polymorphically inside.
+
+        Uses module-level classes for the polymorphic family because the
+        pickle-transferred ``__type_args`` need qualname-addressable types.
+        """
+        from pydantic import TypeAdapter
+
+        from stardag import BaseTask
+        from stardag.polymorphic import SubClass
+
+        ParamT = typing.TypeVar("ParamT", bound=_TypeVarRoundTripBase)
+
+        class _RTGenericTask(Task[int], typing.Generic[ParamT]):
+            param: SubClass[ParamT]
+            value: int
+
+            def run(self):
+                self._save(self.value)
+
+        original = _RTGenericTask[_TypeVarRoundTripConcrete](
+            param=_TypeVarRoundTripConcrete(payload=7), value=3
+        )
+        dumped = original.model_dump(mode="json")
+        assert "__type_args" in dumped
+
+        adapter = TypeAdapter(SubClass[BaseTask])
+        restored = adapter.validate_python(dumped)
+        assert type(restored).__name__ == "_RTGenericTask[_TypeVarRoundTripConcrete]"
+        assert isinstance(restored, _RTGenericTask)
+        assert isinstance(restored.param, _TypeVarRoundTripConcrete)
+        assert restored.id == original.id
+
+    def test_typevar_without_polymorphic_bound_raises(self):
+        """A TypeVar without a PolymorphicRoot bound can't drive polymorphic
+        dispatch — declaring such a field must raise at schema-build time."""
+        from stardag.polymorphic import SubClass
+
+        ParamT = typing.TypeVar("ParamT")  # no bound
+
+        with pytest.raises(TypeError, match="TypeVar"):
+
+            class GenericTask(Task[int], typing.Generic[ParamT]):
+                param: SubClass[ParamT]  # type: ignore[type-var]
+                value: int
+
+                def run(self):
+                    self._save(self.value)

--- a/lib/stardag/tests/test__core/test_task.py
+++ b/lib/stardag/tests/test__core/test_task.py
@@ -483,6 +483,22 @@ class _TypeVarRoundTripConcrete(_TypeVarRoundTripBase):
     payload: int = 0
 
 
+# Module-level family for ``test_nested_typevar_inside_taskloads_of_parameterized_type``
+# (same rationale as above — pickle-transferred ``__type_args`` need
+# qualname-addressable types, and types referenced inside field annotations
+# for a generic model also need to be resolvable at schema-build time).
+class _NestedBaseParam(_PolymorphicRoot):
+    pass
+
+
+class _NestedConcreteA(_NestedBaseParam):
+    a: int = 1
+
+
+class _NestedConcreteB(_NestedBaseParam):
+    b: int = 2
+
+
 class TestGenericTaskWithSubClassField:
     """A generic task can use a ``TypeVar`` bound to a ``PolymorphicRoot`` as a
     ``SubClass[...]`` field annotation, so the polymorphic base narrows with the
@@ -610,3 +626,125 @@ class TestGenericTaskWithSubClassField:
 
                 def run(self):
                     self._save(self.value)
+
+    def test_nested_typevar_inside_taskloads_of_parameterized_type(self):
+        """TypeVar appears *inside* a parameterized loadable type inside
+        ``TaskLoads[...]``, alongside a direct ``SubClass[T]`` field.
+
+        This is the compound pattern from real-world code: one field drives
+        dispatch on the TypeVar directly, another field takes a loadable whose
+        loaded type is itself parameterized by the same TypeVar:
+
+            class GenericTask(Task[...], Generic[T]):
+                loader: TaskLoads[LoaderBase[T]]
+                param:  SubClass[T]
+
+        Asserts end-to-end:
+          - schema build succeeds for the generic form
+          - parameterized instances construct correctly
+          - distinct parameterizations produce distinct ids
+          - round-trip through ``SubClass[BaseTask]`` preserves parameterization
+          - direct ``SubClass[T]`` field narrows strictly via Pydantic
+          - the heuristic ``on_generic_type_mismatch`` check traverses nested
+            generics and warns on a wrong-concrete loader (default is
+            ``"warn"``; ``STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=raise``
+            promotes it to a hard error)
+        """
+        from pydantic import TypeAdapter, ValidationError
+
+        from stardag import BaseTask, LoadableTask, TaskLoads
+        from stardag.polymorphic import SubClass
+
+        # Stand-in for the loaded value type — a plain generic class
+        # parameterized by the same param family. Mirrors the real pattern
+        # where ``TaskLoads[LoadedValue[T]]`` means "a LoadableTask whose
+        # loaded value is a ``LoadedValue[T]``", so the TypeVar ``T``
+        # appears nested inside ``TaskLoads[...]``.
+        ValueT_inner = typing.TypeVar("ValueT_inner", bound=_NestedBaseParam)
+
+        class _NestedLoadedValue(typing.Generic[ValueT_inner]):
+            def __init__(self, tag: str = "") -> None:
+                self.tag = tag
+
+        class _NestedLoaderForA(LoadableTask[_NestedLoadedValue[_NestedConcreteA]]):
+            def complete(self) -> bool:
+                return True
+
+            def load(self) -> _NestedLoadedValue[_NestedConcreteA]:
+                return _NestedLoadedValue("for-a")
+
+            def run(self):
+                pass
+
+        class _NestedLoaderForB(LoadableTask[_NestedLoadedValue[_NestedConcreteB]]):
+            def complete(self) -> bool:
+                return True
+
+            def load(self) -> _NestedLoadedValue[_NestedConcreteB]:
+                return _NestedLoadedValue("for-b")
+
+            def run(self):
+                pass
+
+        # The generic task: TypeVar appears at two positions — nested inside
+        # ``TaskLoads[_NestedLoadedValue[T]]`` and directly inside
+        # ``SubClass[T]``.
+        ParamT = typing.TypeVar("ParamT", bound=_NestedBaseParam)
+
+        class _NestedGenericTask(Task[int], typing.Generic[ParamT]):
+            loader: TaskLoads[_NestedLoadedValue[ParamT]]
+            param: SubClass[ParamT]
+            value: int
+
+            def run(self):
+                self._save(self.value)
+
+        # --- schema build succeeded ---
+        assert hasattr(_NestedGenericTask, "__type_id__")
+
+        # --- correct construction works ---
+        ok_a = _NestedGenericTask[_NestedConcreteA](
+            loader=_NestedLoaderForA(),
+            param=_NestedConcreteA(a=5),
+            value=1,
+        )
+        assert isinstance(ok_a.loader, _NestedLoaderForA)
+        assert isinstance(ok_a.param, _NestedConcreteA)
+
+        # --- distinct parameterizations → distinct ids ---
+        ok_b = _NestedGenericTask[_NestedConcreteB](
+            loader=_NestedLoaderForB(),
+            param=_NestedConcreteB(b=7),
+            value=1,
+        )
+        assert ok_a.id != ok_b.id
+
+        # --- round-trip preserves parameterization ---
+        dumped = ok_a.model_dump(mode="json")
+        assert "__type_args" in dumped
+        restored = TypeAdapter(SubClass[BaseTask]).validate_python(dumped)
+        assert isinstance(restored, _NestedGenericTask)
+        assert type(restored).__name__ == "_NestedGenericTask[_NestedConcreteA]"
+        assert restored.id == ok_a.id
+
+        # --- direct SubClass[T] field narrows strictly via Pydantic ---
+        with pytest.raises(ValidationError):
+            _NestedGenericTask[_NestedConcreteA](
+                loader=_NestedLoaderForB(),  # type: ignore[arg-type]
+                param=_NestedConcreteB(),  # type: ignore[arg-type]  # wrong: SubClass[_NestedConcreteA]
+                value=1,
+            )
+
+        # --- nested generic-args mismatch in ``TaskLoads[LoadedValue[T]]`` is
+        # caught by the heuristic check and surfaces under the default
+        # ``on_generic_type_mismatch="warn"`` mode: value is still accepted
+        # but a UserWarning is emitted. Setting
+        # ``STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=raise`` would promote
+        # it to a ValidationError.
+        with pytest.warns(UserWarning, match="not compatible"):
+            warned = _NestedGenericTask[_NestedConcreteA](
+                loader=_NestedLoaderForB(),  # type: ignore[arg-type]
+                param=_NestedConcreteA(a=1),
+                value=1,
+            )
+        assert isinstance(warned.loader, _NestedLoaderForB)

--- a/lib/stardag/tests/test__core/test_task.py
+++ b/lib/stardag/tests/test__core/test_task.py
@@ -396,84 +396,11 @@ class TestDirectGenericInstantiation:
         )
 
 
-class TestGenericTypeArgTransfer:
-    """Parameterized-at-call-site generics (``TestGeneric[int](...)``) transfer
-    their resolved type args in the serialized payload so distinct parameteriza-
-    tions get distinct ids and round-trip back to the correct parameterized class.
-    """
-
-    def test_distinct_parameterizations_have_distinct_ids(self):
-        ItemT = typing.TypeVar("ItemT")
-
-        class ParamTask(Task[list[ItemT]], typing.Generic[ItemT]):
-            items: list[ItemT]
-
-            def run(self):
-                self._save(list(self.items))
-
-        int_task: ParamTask[int] = ParamTask[int](items=[])
-        str_task: ParamTask[str] = ParamTask[str](items=[])
-        bare = ParamTask(items=[])
-
-        assert int_task.id != str_task.id
-        assert int_task.id != bare.id
-        assert str_task.id != bare.id
-
-    def test_round_trip_preserves_parameterization(self):
-        from pydantic import TypeAdapter
-
-        from stardag import BaseTask
-        from stardag.polymorphic import SubClass
-
-        ItemT = typing.TypeVar("ItemT")
-
-        class ParamTask(Task[list[ItemT]], typing.Generic[ItemT]):
-            items: list[ItemT]
-
-            def run(self):
-                self._save(list(self.items))
-
-        original: ParamTask[int] = ParamTask[int](items=[1, 2, 3])
-        dumped = original.model_dump(mode="json")
-
-        # Wire format carries the pickled type args.
-        assert "__type_args" in dumped
-
-        adapter = TypeAdapter(SubClass[BaseTask])
-        restored = adapter.validate_python(dumped)
-
-        # Class reconstructed with correct parameterization.
-        assert type(restored).__name__ == "ParamTask[int]"
-        assert typing.get_args(getattr(restored, "__orig_class__")) == (int,)
-        # Id survives round-trip.
-        assert restored.id == original.id
-
-    def test_concrete_subclass_skips_type_arg_transfer(self):
-        """``class Concrete(Gen[int])`` does not emit ``__type_args`` — its name
-        discriminator already determines the class fully."""
-        ItemT = typing.TypeVar("ItemT")
-
-        class ParamTask(Task[list[ItemT]], typing.Generic[ItemT]):
-            items: list[ItemT]
-
-            def run(self):
-                self._save(list(self.items))
-
-        class IntParamTask(ParamTask[int]):
-            pass
-
-        task = IntParamTask(items=[1, 2])
-        dumped = task.model_dump(mode="json")
-        assert "__type_args" not in dumped
-        assert dumped["__name"] == "IntParamTask"
-
-
 class _TypeVarRoundTripBase(_PolymorphicRoot):
-    """Module-level PolymorphicRoot family used by the round-trip test below.
+    """Module-level PolymorphicRoot family for ``test_round_trip_lands_on_bare_generic_class``.
 
-    The pickle-transfer mechanism needs module-level classes (pickle can't
-    find locally-defined ones by qualname), so this base and its subclass
-    must live at module scope.
+    Kept at module scope so both sides of the round-trip can find the class
+    via its qualname during polymorphic dispatch.
     """
 
     pass
@@ -484,9 +411,7 @@ class _TypeVarRoundTripConcrete(_TypeVarRoundTripBase):
 
 
 # Module-level family for ``test_nested_typevar_inside_taskloads_of_parameterized_type``
-# (same rationale as above — pickle-transferred ``__type_args`` need
-# qualname-addressable types, and types referenced inside field annotations
-# for a generic model also need to be resolvable at schema-build time).
+# (same rationale as above — qualname-addressable so dispatch round-trips).
 class _NestedBaseParam(_PolymorphicRoot):
     pass
 
@@ -576,13 +501,16 @@ class TestGenericTaskWithSubClassField:
         with pytest.raises(ValidationError):
             GenericTask[ConcreteA](param=ConcreteB(), value=1)  # type: ignore[arg-type]
 
-    def test_round_trip_preserves_typevar_parameterization(self):
-        """Serialize + dispatch on ``SubClass[BaseTask]`` reconstructs the
-        parameterized class; the ``SubClass[ParamT]`` field still resolves
-        polymorphically inside.
+    def test_round_trip_lands_on_bare_generic_class(self):
+        """Serialize + dispatch on ``SubClass[BaseTask]`` lands on the *bare*
+        generic class (not ``Gen[Concrete]``) — parameterization info is not
+        carried across the wire, because the framework treats runtime behavior
+        as class-definition-time (concrete subclass → own ``__type_id__``).
 
-        Uses module-level classes for the polymorphic family because the
-        pickle-transferred ``__type_args`` need qualname-addressable types.
+        Inner polymorphic fields (here ``SubClass[ParamT]``) still resolve
+        correctly via their own discriminators on the receiver, and the
+        round-tripped id matches the original's id because both sides dump
+        to the same structural payload.
         """
         from pydantic import TypeAdapter
 
@@ -602,13 +530,18 @@ class TestGenericTaskWithSubClassField:
             param=_TypeVarRoundTripConcrete(payload=7), value=3
         )
         dumped = original.model_dump(mode="json")
-        assert "__type_args" in dumped
+        # No pickle of type args on the wire.
+        assert "__type_args" not in dumped
 
         adapter = TypeAdapter(SubClass[BaseTask])
         restored = adapter.validate_python(dumped)
-        assert type(restored).__name__ == "_RTGenericTask[_TypeVarRoundTripConcrete]"
+
+        # Bare generic class, not ``_RTGenericTask[_TypeVarRoundTripConcrete]``.
+        assert type(restored) is _RTGenericTask
+        # Inner polymorphic field resolved correctly via its own discriminator.
         assert isinstance(restored, _RTGenericTask)
         assert isinstance(restored.param, _TypeVarRoundTripConcrete)
+        # Id round-trips because payloads are structurally identical on both sides.
         assert restored.id == original.id
 
     def test_typevar_without_polymorphic_bound_raises(self):
@@ -642,8 +575,14 @@ class TestGenericTaskWithSubClassField:
         Asserts end-to-end:
           - schema build succeeds for the generic form
           - parameterized instances construct correctly
-          - distinct parameterizations produce distinct ids
-          - round-trip through ``SubClass[BaseTask]`` preserves parameterization
+          - distinct instances produce distinct ids when their *field values*
+            differ (type parameters do not enter the hash — different
+            parameterizations with identical field values would collide by
+            design; use a concrete subclass if you need per-parameterization
+            ids / runtime behavior)
+          - round-trip through ``SubClass[BaseTask]`` lands on the bare
+            generic class (no pickle of type args on the wire) with the
+            inner polymorphic field resolved and the id preserved
           - direct ``SubClass[T]`` field narrows strictly via Pydantic
           - the heuristic ``on_generic_type_mismatch`` check traverses nested
             generics and warns on a wrong-concrete loader (default is
@@ -711,7 +650,9 @@ class TestGenericTaskWithSubClassField:
         assert isinstance(ok_a.loader, _NestedLoaderForA)
         assert isinstance(ok_a.param, _NestedConcreteA)
 
-        # --- distinct parameterizations → distinct ids ---
+        # --- distinct field values → distinct ids ---
+        # (parameterization alone does not enter the hash; field-value differ-
+        # ences do.)
         ok_b = _NestedGenericTask[_NestedConcreteB](
             loader=_NestedLoaderForB(),
             param=_NestedConcreteB(b=7),
@@ -719,12 +660,12 @@ class TestGenericTaskWithSubClassField:
         )
         assert ok_a.id != ok_b.id
 
-        # --- round-trip preserves parameterization ---
+        # --- round-trip lands on the bare generic class ---
         dumped = ok_a.model_dump(mode="json")
-        assert "__type_args" in dumped
+        assert "__type_args" not in dumped
         restored = TypeAdapter(SubClass[BaseTask]).validate_python(dumped)
+        assert type(restored) is _NestedGenericTask
         assert isinstance(restored, _NestedGenericTask)
-        assert type(restored).__name__ == "_NestedGenericTask[_NestedConcreteA]"
         assert restored.id == ok_a.id
 
         # --- direct SubClass[T] field narrows strictly via Pydantic ---

--- a/lib/stardag/tests/test__core/test_task.py
+++ b/lib/stardag/tests/test__core/test_task.py
@@ -330,3 +330,136 @@ class TestDirectoryTarget:
         loaded = task.load()
         assert isinstance(loaded, _DirData)
         assert loaded.data == {"result": 1}
+
+
+class TestDirectGenericInstantiation:
+    """Generic user tasks can be instantiated directly without a concrete subclass.
+
+    Prior behavior required ``class Concrete(Generic[int]): pass`` boilerplate when
+    the type parameter was only meant as a type-hint convenience — direct
+    instantiation raised ``AttributeError: __type_id__`` at serialization time.
+    """
+
+    def test_direct_instantiation_of_user_generic_task(
+        self, default_in_memory_fs_target
+    ):
+        ItemT = typing.TypeVar("ItemT")
+
+        class GenericListTask(Task[list[ItemT]], typing.Generic[ItemT]):
+            items: list[ItemT]
+
+            def run(self):
+                self._save(list(self.items))
+
+        task: GenericListTask[int] = GenericListTask(items=[1, 2, 3])
+
+        # Serialization works (previously failed with AttributeError: __type_id__)
+        dumped = task.model_dump(mode="json")
+        assert dumped["items"] == [1, 2, 3]
+
+        # Deterministic id works (depends on model_dump with hash context)
+        assert task.id is not None
+
+        # Build + load round-trip works
+        task.run()
+        assert task.complete()
+        assert task.load() == [1, 2, 3]
+
+    def test_generic_task_has_type_id(self):
+        ItemT = typing.TypeVar("ItemT")
+
+        class RegisteredGeneric(Task[ItemT], typing.Generic[ItemT]):
+            value: int
+
+            def run(self):
+                self._save(self.value)  # type: ignore[arg-type]
+
+        assert hasattr(RegisteredGeneric, "__type_id__")
+        assert RegisteredGeneric.__type_id__.name == "RegisteredGeneric"
+
+    def test_parameterized_alias_does_not_get_registered(self):
+        """``Task[int]`` must not grab its own type id — only user classes do."""
+        ItemT = typing.TypeVar("ItemT")
+
+        class MyGeneric(Task[ItemT], typing.Generic[ItemT]):
+            value: int
+
+            def run(self):
+                self._save(self.value)  # type: ignore[arg-type]
+
+        alias = MyGeneric[int]
+        assert not hasattr(alias, "__type_id__") or (
+            alias.__type_id__ is MyGeneric.__type_id__
+        )
+
+
+class TestGenericTypeArgTransfer:
+    """Parameterized-at-call-site generics (``TestGeneric[int](...)``) transfer
+    their resolved type args in the serialized payload so distinct parameteriza-
+    tions get distinct ids and round-trip back to the correct parameterized class.
+    """
+
+    def test_distinct_parameterizations_have_distinct_ids(self):
+        ItemT = typing.TypeVar("ItemT")
+
+        class ParamTask(Task[list[ItemT]], typing.Generic[ItemT]):
+            items: list[ItemT]
+
+            def run(self):
+                self._save(list(self.items))
+
+        int_task: ParamTask[int] = ParamTask[int](items=[])
+        str_task: ParamTask[str] = ParamTask[str](items=[])
+        bare = ParamTask(items=[])
+
+        assert int_task.id != str_task.id
+        assert int_task.id != bare.id
+        assert str_task.id != bare.id
+
+    def test_round_trip_preserves_parameterization(self):
+        from pydantic import TypeAdapter
+
+        from stardag import BaseTask
+        from stardag.polymorphic import SubClass
+
+        ItemT = typing.TypeVar("ItemT")
+
+        class ParamTask(Task[list[ItemT]], typing.Generic[ItemT]):
+            items: list[ItemT]
+
+            def run(self):
+                self._save(list(self.items))
+
+        original: ParamTask[int] = ParamTask[int](items=[1, 2, 3])
+        dumped = original.model_dump(mode="json")
+
+        # Wire format carries the pickled type args.
+        assert "__type_args" in dumped
+
+        adapter = TypeAdapter(SubClass[BaseTask])
+        restored = adapter.validate_python(dumped)
+
+        # Class reconstructed with correct parameterization.
+        assert type(restored).__name__ == "ParamTask[int]"
+        assert typing.get_args(getattr(restored, "__orig_class__")) == (int,)
+        # Id survives round-trip.
+        assert restored.id == original.id
+
+    def test_concrete_subclass_skips_type_arg_transfer(self):
+        """``class Concrete(Gen[int])`` does not emit ``__type_args`` — its name
+        discriminator already determines the class fully."""
+        ItemT = typing.TypeVar("ItemT")
+
+        class ParamTask(Task[list[ItemT]], typing.Generic[ItemT]):
+            items: list[ItemT]
+
+            def run(self):
+                self._save(list(self.items))
+
+        class IntParamTask(ParamTask[int]):
+            pass
+
+        task = IntParamTask(items=[1, 2])
+        dumped = task.model_dump(mode="json")
+        assert "__type_args" not in dumped
+        assert dumped["__name"] == "IntParamTask"

--- a/lib/stardag/tests/test_polymorphic.py
+++ b/lib/stardag/tests/test_polymorphic.py
@@ -122,6 +122,7 @@ def test_smoke():
     expected_animal_type_id_to_class = {
         TypeId(namespace="", name="Dog"): Dog,
         TypeId(namespace="", name="Cat"): Cat,
+        TypeId(namespace="", name="BirdBase"): BirdBase,
         TypeId(namespace="", name="Parrot"): Parrot,
         TypeId(namespace="", name="Sparrow"): Sparrow,
     }


### PR DESCRIPTION
## Background

User-defined generic tasks have two long-standing blockers that force users into boilerplate concrete subclasses even when a TypeVar is purely a static-typing convenience.

**Blocker 1:** Any class with unresolved `__parameters__` was skipped during polymorphic registration. So:
```python
class MyGen[T](sd.Task[list[T]]):
    deps: list[sd.TaskLoads[T]]
    def run(self): self._save([d.load() for d in self.deps])

MyGen(deps=[...])  # AttributeError: __type_id__ (at model_dump)
```
Workaround was a throwaway `class MyInt(MyGen[int]): pass` just to get the class registered.

**Blocker 2:** Declaring `field: SubClass[T]` where `T = TypeVar("T", bound=SomeRoot)` raised `TypeError: Polymorphic() can only be used with PolymorphicRoot subclasses` at class-body time, because the TypeVar itself isn't a `PolymorphicRoot`. This pattern is needed for generic tasks that dispatch polymorphically on their TypeVar (e.g. `predictor: TaskLoads[PredictorABC[T]]` alongside `predict_params: SubClass[T]`).

## What this PR actually lands

Two small, surgical changes — **zero new wire format, zero new hash dependency**.

### 1. Narrow the generic-registration filter

`polymorphic.py:_is_parameterized_generic_alias` + `_is_stardag_abstract` replace the blanket `is_generic_model()` exclusion. Parameterized aliases (`Task[int]`) and classes explicitly marked `__stardag_abstract__ = True` are still skipped; user-defined generic tasks are now registered under their own name.

Marks `Task`, `LoadableTask`, `TargetTask` with `__stardag_abstract__ = True` to preserve their existing unregistered status.

### 2. TypeVar-bound handling in `Polymorphic.__get_pydantic_core_schema__`

When `source_type` is a `TypeVar` with a `PolymorphicRoot` bound, the schema is built using the bound for the generic form. Pydantic re-invokes the method with the concrete type for each parameterized form, which narrows validation strictly. Unbounded TypeVars still raise a clear `TypeError`.

## Guiding invariant

> **Different `__type_id__` ⇔ different class with different runtime behavior.**

A TypeVar on a generic `Task` is a static-typing convenience; runtime behavior (serializer selection, target path, validators) is baked in at class-definition time. If different type parameters need different runtime behavior, define a concrete subclass:
```python
class MyInt(MyGeneric[int]): pass  # own __type_id__, own serializer, distinct hash
```
Parameterized aliases (`MyGeneric[int]`) share the generic's `__type_id__` and hash — which aligns with the fact that they also share the generic's runtime behavior.

## Side-track explored: pickle-transfer of type args (dropped)

An earlier version of this branch also pickle-transferred resolved type args in the serialized payload (under `__type_args`), so `MyGen[int](...)` and `MyGen[str](...)` hashed distinctly and round-tripped back to the parameterized class. We decided against it. Summarized in the v0.5.7 release notes and recoverable from the intermediate commits on this branch if a future use case justifies it. Key reasons:

- Coupled task id stability to pickle output, which is version-sensitive.
- The `Task` machinery already draws the runtime-behavior line at concrete subclasses (parameterized aliases don't get their own `_serializer` anyway). Finer hash granularity than behavior granularity = surprise, not asset.
- The concrete-subclass path already covers any use case that genuinely needs per-parameterization ids.

Intermediate commits on this branch (`d5dba0a`, `b8ffea6`) contain the pickle-transfer design + a test scenario using it, for future reference.

## Test coverage

`TestDirectGenericInstantiation` (3 tests):
- Unparameterized generic task can be instantiated, serialized, built, loaded.
- Generic class gets its own `__type_id__`.
- Parameterized aliases (`Gen[int]`) do NOT get registered (only the bare class does).

`TestGenericTaskWithSubClassField` (5 tests):
- Generic class with `SubClass[TypeVar]` field can be declared (was `TypeError` before).
- `Gen[ConcreteA](param=ConcreteB())` is rejected by Pydantic's narrowed schema.
- Round-trip via `SubClass[BaseTask]` lands on the bare generic class; inner polymorphic fields resolve; id preserved.
- Unbounded TypeVar raises a clear `TypeError`.
- Compound pattern with nested TypeVar (`TaskLoads[LoadedValue[T]]` + `SubClass[T]`) — all the above plus Pydantic's strict narrowing on the direct `SubClass[T]` field and the heuristic check warning on a wrong-concrete nested loader.

Full suite: **443 passing** (net −3 from removed `TestGenericTypeArgTransfer`). Pre-commit clean.

## Release

Marked for v0.5.7. See `CHANGELOG.md` and `RELEASE_NOTES.md`.

## Test plan

- [x] `uv run pytest lib/stardag/tests/` — 443 passing
- [x] Pre-commit: ruff, ruff format, pyright all green on touched files
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)