### PR TITLE
Default Polymorphic.on_generic_type_mismatch to warn; add env-var override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+#### Behavior changes
+
+- **`Polymorphic(on_generic_type_mismatch=...)` default is now `"warn"`** (was `"raise"`). Generic-type mismatches detected at validation time — including inside `SubClass[...]` annotations — now emit a `UserWarning` by default instead of raising `ValidationError`. Set `STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=raise` to restore the previous behavior, or `=ignore` to suppress the warning entirely. An explicit non-`None` value passed to `Polymorphic(...)` always overrides the env var. The emitted warning now includes the env-var suppression hint.
+
 ## [0.5.5] — 2026-04-09
 
 ### SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.5.6] — 2026-04-19
+
 ### SDK
 
 #### Behavior changes

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,54 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.5.6 — Softer default for generic-type-mismatch handling
+
+`Polymorphic(on_generic_type_mismatch=...)` — the option that controls what
+happens when the best-effort generic-args compatibility check inside
+`SubClass[...]` annotations fires — now defaults to `"warn"` instead of
+`"raise"`. The same default applies transitively to plain `SubClass[T]`
+annotations and to `TaskLoads[T]`-driven dispatch, which all flow through
+`Polymorphic()`.
+
+### Why
+
+The compatibility check is heuristic and occasionally produces false positives
+on patterns that are safe in context (different origins without a mapper,
+nested `Annotated[...]`, etc.). A hard `ValidationError` on every such case
+was too strict for what is ultimately an informational signal. A warning
+surfaces the same information without blocking otherwise-valid code.
+
+### Env var override: `STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH`
+
+The mode can now be controlled globally via
+`STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH`. Accepted values are `"raise"`,
+`"warn"`, or `"ignore"`. Any other value raises a clear `ValueError`.
+Resolution order:
+
+1. Explicit non-`None` arg on `Polymorphic(...)` — always wins.
+2. Env var.
+3. Fallback to `"warn"`.
+
+Resolution happens at validation time, so toggling the env var takes effect
+live (useful with `monkeypatch.setenv(...)` in tests).
+
+### Migration
+
+- **Tolerate the warnings** (do nothing) — new default.
+- **Silence them entirely** — `export STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=ignore`.
+- **Restore the old strict behavior** — `export STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=raise`.
+- **Per-field override** — pass `Polymorphic(on_generic_type_mismatch="raise")` (or `"warn"` / `"ignore"`) explicitly; that wins over the env var.
+
+The emitted warning now carries a suppression hint so users encountering it
+know how to silence it:
+
+```
+UserWarning: Value of type LoadsIntTask is not compatible with expected type
+... (suppress by setting STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=ignore)
+```
+
+---
+
 ## v0.5.5 — Customizable Modal Builder and Runner
 
 The Modal integration now uses subclassable `Builder` and `Runner` classes

--- a/lib/stardag/src/stardag/polymorphic.py
+++ b/lib/stardag/src/stardag/polymorphic.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import types
 import typing
 import warnings
@@ -453,19 +454,52 @@ class PolymorphicRoot(StardagBaseModel):
         return cls.__type_id__.namespace
 
 
+ON_GENERIC_TYPE_MISMATCH_ENV_VAR = "STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH"
+_DEFAULT_ON_GENERIC_TYPE_MISMATCH: OnGenericTypeMismatch = "warn"
+
+
+def _resolve_on_generic_type_mismatch(
+    explicit: OnGenericTypeMismatch | None,
+) -> OnGenericTypeMismatch:
+    """Resolve the on-mismatch mode from explicit arg, env var, or default.
+
+    Explicit (non-None) arg always wins. Otherwise reads
+    ``STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH``, falling back to
+    ``"warn"`` when unset.
+    """
+    if explicit is not None:
+        return explicit
+    env_val = os.environ.get(ON_GENERIC_TYPE_MISMATCH_ENV_VAR)
+    if env_val is None:
+        return _DEFAULT_ON_GENERIC_TYPE_MISMATCH
+    allowed = typing.get_args(OnGenericTypeMismatch)
+    if env_val not in allowed:
+        raise ValueError(
+            f"Invalid value for env var {ON_GENERIC_TYPE_MISMATCH_ENV_VAR}: "
+            f"{env_val!r}. Expected one of {allowed}."
+        )
+    return typing.cast(OnGenericTypeMismatch, env_val)
+
+
 class Polymorphic:
     """Pydantic annotation for polymorphic validation of PolymorphicRoot subclasses.
 
     Args:
-        on_type_mismatch: Behavior when generic type args don't match.
-            - "raise" (default): Raise a ValidationError
-            - "warn": Log a warning but accept the value
-            - "ignore": Silently accept the value
+        on_generic_type_mismatch: Behavior when generic type args don't match.
+            - ``"raise"``: Raise a ValidationError
+            - ``"warn"``: Emit a warning but accept the value
+            - ``"ignore"``: Silently accept the value
+            - ``None`` (default): Resolve at validation time from env var
+              ``STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH``; if that env
+              var is unset, fall back to ``"warn"``. An explicit non-None
+              value always overrides the env var.
     """
+
+    on_generic_type_mismatch: OnGenericTypeMismatch | None
 
     def __init__(
         self,
-        on_generic_type_mismatch: OnGenericTypeMismatch = "raise",
+        on_generic_type_mismatch: OnGenericTypeMismatch | None = None,
     ) -> None:
         self.on_generic_type_mismatch = on_generic_type_mismatch
 
@@ -491,7 +525,7 @@ class Polymorphic:
             pydantic_meta.get("origin") if pydantic_meta else None
         ) or source_type
 
-        on_generic_type_mismatch = self.on_generic_type_mismatch
+        explicit_on_mismatch = self.on_generic_type_mismatch
 
         def dispatch(v: Any, info):
             if isinstance(v, base_origin):
@@ -504,10 +538,18 @@ class Polymorphic:
                         f"Value of type {type(v).__name__} is not compatible with "
                         f"expected type {source_type}: {error_msg}"
                     )
-                    if on_generic_type_mismatch == "raise":
+                    on_mismatch = _resolve_on_generic_type_mismatch(
+                        explicit_on_mismatch
+                    )
+                    if on_mismatch == "raise":
                         raise ValueError(message)
-                    elif on_generic_type_mismatch == "warn":
-                        warnings.warn(message, UserWarning, stacklevel=2)
+                    elif on_mismatch == "warn":
+                        warnings.warn(
+                            f"{message} (suppress by setting "
+                            f"{ON_GENERIC_TYPE_MISMATCH_ENV_VAR}=ignore)",
+                            UserWarning,
+                            stacklevel=2,
+                        )
                 return v
 
             if not isinstance(v, dict):

--- a/lib/stardag/tests/test__core/test_task_loads.py
+++ b/lib/stardag/tests/test__core/test_task_loads.py
@@ -12,6 +12,18 @@ from stardag.utils.testing.generic import assert_serialize_validate_roundtrip
 
 auto_namespace(__name__)  # Avoid collisions in task registry
 
+
+@pytest.fixture
+def raise_on_mismatch(monkeypatch):
+    """Force ``on_generic_type_mismatch="raise"`` via env var for this test.
+
+    Used by pre-existing tests that assert a ``ValidationError`` is raised on
+    type mismatch — now that the default has moved to ``"warn"``, they need to
+    opt back in.
+    """
+    monkeypatch.setenv("STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH", "raise")
+
+
 # =============================================================================
 # TargetTask classes for testing SubClass[TargetTask[...]] directly
 # =============================================================================
@@ -291,7 +303,9 @@ def test_task_loads_compatible_types(task_instance, description):
         ),
     ],
 )
-def test_task_loads_type_mismatch(container_cls, task_instance, description):
+def test_task_loads_type_mismatch(
+    container_cls, task_instance, description, raise_on_mismatch
+):
     """Test that incompatible Task types are rejected by TaskLoads."""
     with pytest.raises(ValidationError):
         container_cls(task=task_instance)  # pyright: ignore[reportArgumentType]
@@ -303,7 +317,7 @@ def test_task_loads_accepts_bare_loadable_task():
     assert_serialize_validate_roundtrip(ContainerTaskLoadsStr, container)
 
 
-def test_task_loads_rejects_bare_loadable_task_type_mismatch():
+def test_task_loads_rejects_bare_loadable_task_type_mismatch(raise_on_mismatch):
     """TaskLoads[str] should reject LoadableTask[int] (type mismatch)."""
     with pytest.raises(ValidationError):
         ContainerTaskLoadsStr(task=BareLoadableInt())  # pyright: ignore[reportArgumentType]
@@ -321,7 +335,7 @@ def test_annotated_field_compatible():
     assert_serialize_validate_roundtrip(ContainerWithAnnotatedField, container)
 
 
-def test_annotated_field_mismatch():
+def test_annotated_field_mismatch(raise_on_mismatch):
     """Annotated[TaskLoads[...], ...] should also catch type mismatches."""
     with pytest.raises(ValidationError):
         ContainerWithAnnotatedField(task=TaskInt())  # pyright: ignore[reportArgumentType]
@@ -350,7 +364,7 @@ def test_subclass_annotation_compatible():
     assert_serialize_validate_roundtrip(ContainerWithSubClass, container)
 
 
-def test_subclass_annotation_mismatch():
+def test_subclass_annotation_mismatch(raise_on_mismatch):
     """SubClass[TargetTask[...]] should catch type mismatches."""
     with pytest.raises(ValidationError) as exc_info:
         ContainerWithSubClass(task=LoadsIntTask())  # pyright: ignore[reportArgumentType]
@@ -424,9 +438,51 @@ def test_on_type_mismatch_ignore():
     assert isinstance(container.task, LoadsIntTask)
 
 
-def test_on_type_mismatch_raise_is_default():
-    """on_type_mismatch='raise' is the default behavior for SubClass[TargetTask[...]]."""
+def test_on_type_mismatch_warn_is_default(monkeypatch):
+    """Default behavior (no explicit arg, no env var) is 'warn'."""
+    monkeypatch.delenv("STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH", raising=False)
+    with pytest.warns(UserWarning, match="LoadsIntTask.*not compatible"):
+        container = ContainerWithSubClass(task=LoadsIntTask())  # pyright: ignore[reportArgumentType]
+    assert isinstance(container.task, LoadsIntTask)
+
+
+def test_on_type_mismatch_env_var_raise(monkeypatch):
+    """Env var 'raise' makes SubClass mismatches raise when no explicit arg set."""
+    monkeypatch.setenv("STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH", "raise")
     with pytest.raises(ValidationError):
+        ContainerWithSubClass(task=LoadsIntTask())  # pyright: ignore[reportArgumentType]
+
+
+def test_on_type_mismatch_env_var_ignore(monkeypatch):
+    """Env var 'ignore' silences mismatches when no explicit arg set."""
+    monkeypatch.setenv("STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH", "ignore")
+    container = ContainerWithSubClass(task=LoadsIntTask())  # pyright: ignore[reportArgumentType]
+    assert isinstance(container.task, LoadsIntTask)
+
+
+def test_on_type_mismatch_explicit_arg_overrides_env_var(monkeypatch):
+    """Explicit non-None arg always beats the env var."""
+    monkeypatch.setenv("STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH", "raise")
+    # ContainerWithIgnoreOnMismatch uses Polymorphic(on_generic_type_mismatch="ignore"),
+    # which must win over env var "raise".
+    container = ContainerWithIgnoreOnMismatch(task=LoadsIntTask())  # pyright: ignore[reportArgumentType]
+    assert isinstance(container.task, LoadsIntTask)
+
+
+def test_on_type_mismatch_invalid_env_var_raises(monkeypatch):
+    """Invalid env var value raises at mismatch-evaluation time."""
+    monkeypatch.setenv("STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH", "bogus")
+    with pytest.raises(ValueError, match="Invalid value for env var"):
+        ContainerWithSubClass(task=LoadsIntTask())  # pyright: ignore[reportArgumentType]
+
+
+def test_on_type_mismatch_warning_mentions_env_var(monkeypatch):
+    """Warning message includes the env-var suppression hint."""
+    monkeypatch.delenv("STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH", raising=False)
+    with pytest.warns(
+        UserWarning,
+        match=r"STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=ignore",
+    ):
         ContainerWithSubClass(task=LoadsIntTask())  # pyright: ignore[reportArgumentType]
 
 
@@ -499,7 +555,7 @@ def test_task_loads_annotated_accepts_generic_wrapper():
     assert isinstance(container.task, GenericWrapperTask)
 
 
-def test_task_loads_annotated_rejects_type_mismatch():
+def test_task_loads_annotated_rejects_type_mismatch(raise_on_mismatch):
     """Task[int] should still be rejected by TaskLoads[Annotated[str, ...]]."""
     with pytest.raises(ValidationError):
         ContainerTaskLoadsAnnotatedStr(task=TaskInt())  # pyright: ignore[reportArgumentType]

--- a/lib/stardag/tests/test__core/test_task_loads.py
+++ b/lib/stardag/tests/test__core/test_task_loads.py
@@ -470,9 +470,14 @@ def test_on_type_mismatch_explicit_arg_overrides_env_var(monkeypatch):
 
 
 def test_on_type_mismatch_invalid_env_var_raises(monkeypatch):
-    """Invalid env var value raises at mismatch-evaluation time."""
+    """Invalid env var value surfaces as a Pydantic ValidationError.
+
+    The helper raises ``ValueError``, which Pydantic wraps into a
+    ``ValidationError`` at validator boundary. Assert on the wrapping type
+    (not its ``ValueError`` base) so the test documents the real contract.
+    """
     monkeypatch.setenv("STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH", "bogus")
-    with pytest.raises(ValueError, match="Invalid value for env var"):
+    with pytest.raises(ValidationError, match="Invalid value for env var"):
         ContainerWithSubClass(task=LoadsIntTask())  # pyright: ignore[reportArgumentType]
 
 


### PR DESCRIPTION
## Summary

`Polymorphic(on_generic_type_mismatch=...)` — the option that controls what happens when the best-effort generic-args compatibility check inside `SubClass[...]` annotations fires — previously defaulted to `"raise"`. In practice the compatibility check produces some false positives (patterns that are safe in context but trip the check), and a hard `ValidationError` is heavy-handed for what is ultimately a heuristic. This PR softens the default and makes the mode overridable via an env var.

## Behavior

The default changes from `"raise"` to `"warn"`. The resolution order is:

1. **Explicit non-`None` arg** on `Polymorphic(...)` — always wins.
2. **Env var** `STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH` — accepts `"raise"`, `"warn"`, or `"ignore"`; any other value raises a clear `ValueError`.
3. **Fallback:** `"warn"`.

Resolution happens at dispatch time, so setting/unsetting the env var takes effect live without rebuilding schemas (plays nicely with `monkeypatch.setenv(...)` in tests).

The emitted `UserWarning` now carries a suppression hint:

```
Value of type LoadsIntTask is not compatible with expected type ... (suppress by setting STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=ignore)
```

## Migration

- **Tolerate the warnings** (do nothing) — new default.
- **Silence them entirely** — `export STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=ignore`.
- **Restore the old strict behavior** — `export STARDAG_POLYMORPHIC_ON_GENERIC_TYPE_MISMATCH=raise`.
- **Per-field override** — `Polymorphic(on_generic_type_mismatch="raise")` still takes precedence over the env var.

## Tests

- Pre-existing mismatch tests that asserted `ValidationError` now opt into raise mode via a `raise_on_mismatch` fixture (cleaner than reorganizing them around the new default — those tests document "mismatch is caught", and the env var path is the documented strict mode).
- New tests cover: default `"warn"`, env var `"raise"` / `"ignore"` / invalid value, explicit arg overriding env var, and the presence of the env-var suppression hint in the warning text.

Full suite: 435 passing (`uv run pytest tests/ --ignore=tests/test_integration/test_modal`). Pre-commit clean (ruff + ruff format + pyright).

## Test plan

- [x] `uv run pytest lib/stardag/tests/test__core/test_task_loads.py` — all green
- [x] Full stardag suite (excluding modal integration which needs live creds) — 435 passed
- [x] Pre-commit: ruff, ruff format, pyright
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)