### PR TITLE
Fix build_sequential resolving yielded deps' requires() chain (#118)

### DIFF
--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -408,6 +408,27 @@ def _run_task_sequential(
     on_registry_failure: OnRegistryFailure = "raise",
 ) -> None:
     """Run a single task in sequential mode, handling dynamic deps."""
+    # Ensure static requires() are complete before running this task. When the
+    # outer build loop schedules a ready task this is a no-op (its deps are
+    # already in completion_cache), but it's required when this function is
+    # called recursively for a dynamically-yielded dep whose requires() chain
+    # has not been built yet (see issue #118).
+    for static_dep in flatten_task_struct(task.requires()):
+        if static_dep.id not in completion_cache:
+            _run_task_sequential(
+                static_dep,
+                completion_cache,
+                all_tasks,
+                build_id,
+                registry,
+                dual_run_default,
+                discover,
+                task_count,
+                on_registry_failure,
+            )
+            if task_count is not None:
+                task_count.succeeded += 1
+
     registry.task_start(build_id, task)
 
     has_run = _has_custom_run(task)
@@ -793,6 +814,24 @@ async def _run_task_sequential_aio(
     on_registry_failure: OnRegistryFailure = "raise",
 ) -> None:
     """Run a single task in async sequential mode, handling dynamic deps."""
+    # Ensure static requires() are complete before running this task — see the
+    # matching comment and issue #118 reference in _run_task_sequential.
+    for static_dep in flatten_task_struct(task.requires()):
+        if static_dep.id not in completion_cache:
+            await _run_task_sequential_aio(
+                static_dep,
+                completion_cache,
+                all_tasks,
+                build_id,
+                registry,
+                sync_run_default,
+                discover,
+                task_count,
+                on_registry_failure,
+            )
+            if task_count is not None:
+                task_count.succeeded += 1
+
     await registry.task_start_aio(build_id, task)
 
     has_run = _has_custom_run(task)

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -213,24 +213,49 @@ def build_sequential(
     # We also call task_complete to mark them as done — otherwise they remain in
     # PENDING state in the registry (e.g. WrapperTasks that are complete because
     # their deps are complete, but were never explicitly run).
-    for task in previously_completed_tasks:
-        try:
-            registry.task_register(build_id, task)
-        except Exception as reg_err:
-            handle_registry_error(
-                reg_err,
-                f"Failed to register previously completed task {task.id}",
-                on_registry_failure,
-            )
-            continue
-        try:
-            registry.task_complete(build_id, task)
-        except Exception as reg_err:
-            handle_registry_error(
-                reg_err,
-                f"Failed to mark previously completed task {task.id} as complete",
-                on_registry_failure,
-            )
+    registered_previously_completed_count = 0
+
+    def register_pending_previously_completed() -> None:
+        """Register and complete any previously-completed tasks not yet sent to the registry.
+
+        Drains ``previously_completed_tasks`` starting from the last registered
+        index. Called both for the initial bulk registration and after any
+        runtime ``discover()`` call that might newly surface a complete task
+        (e.g. the static dep of a dynamically yielded task).
+        """
+        nonlocal registered_previously_completed_count
+        while registered_previously_completed_count < len(previously_completed_tasks):
+            pc_task = previously_completed_tasks[registered_previously_completed_count]
+            registered_previously_completed_count += 1
+            try:
+                registry.task_register(build_id, pc_task)
+            except Exception as reg_err:
+                handle_registry_error(
+                    reg_err,
+                    f"Failed to register previously completed task {pc_task.id}",
+                    on_registry_failure,
+                )
+                continue
+            try:
+                registry.task_complete(build_id, pc_task)
+            except Exception as reg_err:
+                handle_registry_error(
+                    reg_err,
+                    f"Failed to mark previously completed task {pc_task.id} as complete",
+                    on_registry_failure,
+                )
+
+    register_pending_previously_completed()
+
+    def runtime_discover(task: BaseTask) -> None:
+        """``discover()`` wrapper used after the initial registration pass.
+
+        Registers any previously-completed tasks that ``discover()`` surfaces
+        at runtime (e.g. when processing a dynamically yielded task's
+        ``requires()`` chain).
+        """
+        discover(task)
+        register_pending_previously_completed()
 
     def acquire_lock_sync(task: BaseTask) -> LockAcquisitionResult:
         """Acquire lock synchronously with retry/backoff."""
@@ -350,7 +375,7 @@ def build_sequential(
                     build_id,
                     registry,
                     dual_run_default,
-                    discover,
+                    runtime_discover,
                     task_count,
                     on_registry_failure,
                 )
@@ -413,7 +438,14 @@ def _run_task_sequential(
     # already in completion_cache), but it's required when this function is
     # called recursively for a dynamically-yielded dep whose requires() chain
     # has not been built yet (see issue #118).
+    #
+    # Go through discover() (the runtime wrapper in build_sequential) so that:
+    # - task_count.discovered is updated when we first walk into a subgraph,
+    # - any newly-surfaced already-complete deps get a registry
+    #   task_register + task_complete pair (they missed the initial bulk
+    #   registration because they were only found at runtime).
     for static_dep in flatten_task_struct(task.requires()):
+        discover(static_dep)
         if static_dep.id not in completion_cache:
             _run_task_sequential(
                 static_dep,
@@ -462,31 +494,11 @@ def _run_task_sequential(
                 # function used for static deps, so task_count.discovered
                 # is properly incremented and sub-deps are fully recursed.
                 for dep in dynamic_deps:
-                    was_known = dep.id in all_tasks
+                    # discover() is the runtime wrapper from build_sequential: it
+                    # recurses into requires(), and registers any previously-complete
+                    # tasks it surfaces (so they appear in the build's task list even
+                    # though they were first seen after the initial registration pass).
                     discover(dep)
-
-                    # A dynamic dep that was newly discovered and already complete
-                    # won't be caught by the initial "register previously completed"
-                    # loop (which runs before the build loop). Register it now so it
-                    # appears correctly in the registry for this build.
-                    if not was_known and dep.id in completion_cache:
-                        try:
-                            registry.task_register(build_id, dep)
-                        except Exception as reg_err:
-                            handle_registry_error(
-                                reg_err,
-                                f"Failed to register dynamic previously-completed task {dep.id}",
-                                on_registry_failure,
-                            )
-                            continue
-                        try:
-                            registry.task_complete(build_id, dep)
-                        except Exception as reg_err:
-                            handle_registry_error(
-                                reg_err,
-                                f"Failed to mark dynamic previously-completed task {dep.id} as complete",
-                                on_registry_failure,
-                            )
 
                     if dep.id not in completion_cache:
                         _run_task_sequential(
@@ -617,24 +629,49 @@ async def build_sequential_aio(
     # We also call task_complete_aio to mark them as done — otherwise they remain in
     # PENDING state in the registry (e.g. WrapperTasks that are complete because
     # their deps are complete, but were never explicitly run).
-    for task in previously_completed_tasks:
-        try:
-            await registry.task_register_aio(build_id, task)
-        except Exception as reg_err:
-            handle_registry_error(
-                reg_err,
-                f"Failed to register previously completed task {task.id}",
-                on_registry_failure,
-            )
-            continue
-        try:
-            await registry.task_complete_aio(build_id, task)
-        except Exception as reg_err:
-            handle_registry_error(
-                reg_err,
-                f"Failed to mark previously completed task {task.id} as complete",
-                on_registry_failure,
-            )
+    registered_previously_completed_count = 0
+
+    async def register_pending_previously_completed_aio() -> None:
+        """Register and complete previously-completed tasks not yet sent to the registry.
+
+        Drains ``previously_completed_tasks`` starting from the last registered
+        index. Called for the initial bulk registration and after any runtime
+        ``discover()`` call that might surface a new complete task (e.g. the
+        static dep of a dynamically yielded task).
+        """
+        nonlocal registered_previously_completed_count
+        while registered_previously_completed_count < len(previously_completed_tasks):
+            pc_task = previously_completed_tasks[registered_previously_completed_count]
+            registered_previously_completed_count += 1
+            try:
+                await registry.task_register_aio(build_id, pc_task)
+            except Exception as reg_err:
+                handle_registry_error(
+                    reg_err,
+                    f"Failed to register previously completed task {pc_task.id}",
+                    on_registry_failure,
+                )
+                continue
+            try:
+                await registry.task_complete_aio(build_id, pc_task)
+            except Exception as reg_err:
+                handle_registry_error(
+                    reg_err,
+                    f"Failed to mark previously completed task {pc_task.id} as complete",
+                    on_registry_failure,
+                )
+
+    await register_pending_previously_completed_aio()
+
+    async def runtime_discover_aio(task: BaseTask) -> None:
+        """``discover()`` wrapper used after the initial registration pass.
+
+        Registers any previously-completed tasks that ``discover()`` surfaces
+        at runtime (e.g. when processing a dynamically yielded task's
+        ``requires()`` chain).
+        """
+        await discover(task)
+        await register_pending_previously_completed_aio()
 
     async def acquire_lock_aio(task: BaseTask) -> LockAcquisitionResult:
         """Acquire lock asynchronously with retry/backoff."""
@@ -756,7 +793,7 @@ async def build_sequential_aio(
                     build_id,
                     registry,
                     sync_run_default,
-                    discover,
+                    runtime_discover_aio,
                     task_count,
                     on_registry_failure,
                 )
@@ -817,6 +854,7 @@ async def _run_task_sequential_aio(
     # Ensure static requires() are complete before running this task — see the
     # matching comment and issue #118 reference in _run_task_sequential.
     for static_dep in flatten_task_struct(task.requires()):
+        await discover(static_dep)
         if static_dep.id not in completion_cache:
             await _run_task_sequential_aio(
                 static_dep,
@@ -859,35 +897,12 @@ async def _run_task_sequential_aio(
                 yielded = next(gen)
                 dynamic_deps = flatten_task_struct(yielded)
 
-                # Discover and build dynamic deps using the same discover()
-                # function used for static deps, so task_count.discovered
-                # is properly incremented and sub-deps are fully recursed.
+                # discover() is the runtime wrapper from build_sequential_aio: it
+                # recurses into requires(), and registers any previously-complete
+                # tasks it surfaces (so they appear in the build's task list even
+                # though they were first seen after the initial registration pass).
                 for dep in dynamic_deps:
-                    was_known = dep.id in all_tasks
                     await discover(dep)
-
-                    # A dynamic dep that was newly discovered and already complete
-                    # won't be caught by the initial "register previously completed"
-                    # loop (which runs before the build loop). Register it now so it
-                    # appears correctly in the registry for this build.
-                    if not was_known and dep.id in completion_cache:
-                        try:
-                            await registry.task_register_aio(build_id, dep)
-                        except Exception as reg_err:
-                            handle_registry_error(
-                                reg_err,
-                                f"Failed to register dynamic previously-completed task {dep.id}",
-                                on_registry_failure,
-                            )
-                            continue
-                        try:
-                            await registry.task_complete_aio(build_id, dep)
-                        except Exception as reg_err:
-                            handle_registry_error(
-                                reg_err,
-                                f"Failed to mark dynamic previously-completed task {dep.id} as complete",
-                                on_registry_failure,
-                            )
 
                     if dep.id not in completion_cache:
                         await _run_task_sequential_aio(

--- a/lib/stardag/src/stardag/utils/testing/dynamic_deps_dag.py
+++ b/lib/stardag/src/stardag/utils/testing/dynamic_deps_dag.py
@@ -18,6 +18,17 @@ class DynamicDepsTask(Task[str]):
         return self.static_deps
 
     def run(self):  # type: ignore
+        # CONTRACT: When run() is called, static requires MUST be complete.
+        # This holds regardless of whether the task was discovered statically
+        # or yielded as a dynamic dep by another task (see issue #118).
+        for dep in self.static_deps:
+            if not dep.complete():  # type: ignore
+                raise AssertionError(
+                    f"Static requires contract violated! Dep {dep} is not complete "
+                    f"at the start of {self}.run(). The build system must resolve "
+                    f"task.requires() before executing the task."
+                )
+
         if self.dynamic_deps:
             # Yield all dynamic deps at once
             yield self.dynamic_deps

--- a/lib/stardag/tests/test_build/test_sequential.py
+++ b/lib/stardag/tests/test_build/test_sequential.py
@@ -13,6 +13,8 @@ import pytest
 from stardag.build import (
     BuildExitStatus,
     FailMode,
+    build,
+    build_aio,
     build_sequential,
     build_sequential_aio,
 )
@@ -21,6 +23,10 @@ from uuid import UUID
 from stardag.artifact import Artifact, MarkdownArtifact
 from stardag.registry import NoOpRegistry, registry_provider
 from stardag.target import InMemoryFileTarget
+from stardag.utils.testing.dynamic_deps_dag import (
+    DynamicDepsTask,
+    assert_dynamic_deps_task_complete_recursive,
+)
 from stardag.utils.testing.helper_tasks import (
     AsyncOnlyTask,
     DiamondTask,
@@ -465,6 +471,88 @@ class TestDiamondPatternsSequential:
         assert get_execution_count("complex_seq", "21") == 1
         assert get_execution_count("complex_seq", "1") == 1
         assert get_execution_count("complex_seq", "0") == 1
+
+
+# ============================================================================
+# Test: Dynamically-yielded deps with their own requires() chain (issue #118)
+#
+# Parameterized across build_sequential and build (and the aio variants) so the
+# same contract is verified for both executors. Before the fix for issue #118,
+# build_sequential ran yielded tasks directly without first resolving their
+# requires(), while build (concurrent) did not.
+#
+# DynamicDepsTask enforces (via assertions in run()) that static requires are
+# complete at the start of run, so these tests fail loudly on the bug.
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "build_fn",
+    [build_sequential, build],
+    ids=["sequential", "concurrent"],
+)
+class TestDynamicDepsWithRequiresSync:
+    def test_yielded_dep_with_static_requires(
+        self,
+        build_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        noop_registry,
+    ):
+        """Reproduces issue #118.
+
+        Orchestrator yields Middle, and Middle has Leaf as a static require.
+        Build systems must resolve Middle.requires() (i.e. build Leaf) before
+        running Middle.
+        """
+        leaf = DynamicDepsTask(value="leaf")
+        middle = DynamicDepsTask(value="middle", static_deps=(leaf,))
+        orchestrator = DynamicDepsTask(value="orch", dynamic_deps=(middle,))
+
+        summary = build_fn([orchestrator], registry=noop_registry)
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert_dynamic_deps_task_complete_recursive(orchestrator, True)
+
+    def test_yielded_dep_with_nested_requires(
+        self,
+        build_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        noop_registry,
+    ):
+        """Yielded task has a multi-level static requires chain."""
+        grand = DynamicDepsTask(value="grand")
+        leaf = DynamicDepsTask(value="leaf", static_deps=(grand,))
+        middle = DynamicDepsTask(value="middle", static_deps=(leaf,))
+        orchestrator = DynamicDepsTask(value="orch", dynamic_deps=(middle,))
+
+        summary = build_fn([orchestrator], registry=noop_registry)
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert_dynamic_deps_task_complete_recursive(orchestrator, True)
+
+
+@pytest.mark.parametrize(
+    "build_aio_fn",
+    [build_sequential_aio, build_aio],
+    ids=["sequential", "concurrent"],
+)
+class TestDynamicDepsWithRequiresAio:
+    @pytest.mark.asyncio
+    async def test_yielded_dep_with_static_requires(
+        self,
+        build_aio_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        noop_registry,
+    ):
+        """Async variant of the issue #118 regression test."""
+        leaf = DynamicDepsTask(value="leaf_aio")
+        middle = DynamicDepsTask(value="middle_aio", static_deps=(leaf,))
+        orchestrator = DynamicDepsTask(value="orch_aio", dynamic_deps=(middle,))
+
+        summary = await build_aio_fn([orchestrator], registry=noop_registry)
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert_dynamic_deps_task_complete_recursive(orchestrator, True)
 
 
 # ============================================================================

--- a/lib/stardag/tests/test_build/test_sequential.py
+++ b/lib/stardag/tests/test_build/test_sequential.py
@@ -555,6 +555,63 @@ class TestDynamicDepsWithRequiresAio:
         assert_dynamic_deps_task_complete_recursive(orchestrator, True)
 
 
+class TestDynamicDepsWithRequiresRegistryBookkeeping:
+    """Registry bookkeeping for static deps newly discovered via a dynamic-dep chain.
+
+    When a task is yielded dynamically and its ``requires()`` references a task
+    that was already complete on disk before the build started, that static
+    dep is only discovered at runtime. It should still get a ``task_register``
+    + ``task_complete`` event so it shows up in the build's task list — mirrors
+    the existing handling for dynamically yielded previously-complete tasks.
+    """
+
+    def test_static_dep_of_dynamic_dep_pre_complete(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        # Pre-build leaf so it's already complete on disk.
+        leaf = DynamicDepsTask(value="pre_leaf")
+        build_sequential([leaf], registry=NoOpRegistry())
+        assert leaf.complete()
+
+        middle = DynamicDepsTask(value="pre_middle", static_deps=(leaf,))
+        orchestrator = DynamicDepsTask(value="pre_orch", dynamic_deps=(middle,))
+
+        tracking = TrackingRegistry()
+        summary = build_sequential([orchestrator], registry=tracking)
+        assert summary.status == BuildExitStatus.SUCCESS
+
+        leaf_calls = tracking.calls_for(leaf.id)
+        assert "task_register" in leaf_calls, (
+            f"Pre-complete static dep of a dynamic dep was not registered; "
+            f"calls: {leaf_calls}"
+        )
+        assert "task_complete" in leaf_calls
+
+    @pytest.mark.asyncio
+    async def test_static_dep_of_dynamic_dep_pre_complete_aio(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        leaf = DynamicDepsTask(value="pre_leaf_aio")
+        await build_sequential_aio([leaf], registry=NoOpRegistry())
+        assert leaf.complete()
+
+        middle = DynamicDepsTask(value="pre_middle_aio", static_deps=(leaf,))
+        orchestrator = DynamicDepsTask(value="pre_orch_aio", dynamic_deps=(middle,))
+
+        tracking = TrackingRegistry()
+        summary = await build_sequential_aio([orchestrator], registry=tracking)
+        assert summary.status == BuildExitStatus.SUCCESS
+
+        leaf_calls = tracking.calls_for(leaf.id)
+        assert "task_register" in leaf_calls, (
+            f"Pre-complete static dep of a dynamic dep was not registered; "
+            f"calls: {leaf_calls}"
+        )
+        assert "task_complete" in leaf_calls
+
+
 # ============================================================================
 # Test: Registry communication for previously-completed tasks
 # ============================================================================


### PR DESCRIPTION
## Summary

- Fix [#118](https://github.com/stardag-dev/stardag/issues/118): `build_sequential` (and `build_sequential_aio`) called `_run_task_sequential` directly on a dynamically yielded task, skipping any `requires()` that task declared. The concurrent `build()` didn't have this bug because its scheduler waits for all deps (static + dynamic) to complete before dispatching a task.
- Resolve static `requires()` at the top of `_run_task_sequential` / `_run_task_sequential_aio` — a no-op for the outer build loop (deps are already in `completion_cache`) but required for recursive calls from the dynamic deps handler.
- Extend `DynamicDepsTask`'s contract assertions so static deps must be complete at the start of `run()`, symmetric with the existing post-yield assertion.
- Add `TestDynamicDepsWithRequires{Sync,Aio}` parameterized across `build_sequential`/`build` and `build_sequential_aio`/`build_aio` so the same contract is covered for both executors.

## Test plan

- [x] New tests fail on `main` for the `sequential` parameter and pass for `concurrent` — confirming the bug and that the fix targets the right code path
- [x] After the fix, all 6 new tests pass
- [x] Full `tests/` suite passes (449 tests, excluding Modal integration which needs a real account)
- [x] Issue #118's exact minimal repro now succeeds
- [x] Pre-commit (ruff, ruff format, pyright) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)