### PR TITLE
Async generator support for dynamic deps + Modal re-exec (replaces #84)

### DIFF
--- a/lib/stardag/src/stardag/_core/decorator.py
+++ b/lib/stardag/src/stardag/_core/decorator.py
@@ -221,6 +221,14 @@ def task(
 
         is_async = inspect.iscoroutinefunction(_func)
 
+        # Reject generator functions — dynamic dependencies require the class API
+        if inspect.isgeneratorfunction(_func) or inspect.isasyncgenfunction(_func):
+            raise TypeError(
+                f"@task does not support generator functions (got {_func.__name__}). "
+                "Dynamic dependencies require the class-based Task API — "
+                "implement run()/run_aio() as a generator method on a Task subclass."
+            )
+
         signature = inspect.signature(_func)
         return_type = signature.return_annotation
         if return_type == inspect.Parameter.empty:

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -9,11 +9,12 @@ This module contains:
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import traceback as tb_module
 from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from enum import StrEnum
-from typing import Generator, Literal, Protocol, Sequence
+from typing import AsyncGenerator, Generator, Literal, Protocol, Sequence, Union
 from uuid import UUID
 
 from stardag import (
@@ -229,9 +230,15 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
         self._thread_pool: ThreadPoolExecutor | None = None
         self._process_pool: ProcessPoolExecutor | None = None
 
-        # Track suspended generators (task_id -> generator)
+        # Track suspended generators (task_id -> sync or async generator)
         # For in-process execution where we can suspend and resume
-        self._suspended_generators: dict[UUID, Generator[TaskStruct, None, None]] = {}
+        self._suspended_generators: dict[
+            UUID,
+            Union[
+                Generator[TaskStruct, None, None],
+                AsyncGenerator[TaskStruct, None],
+            ],
+        ] = {}
 
         # Track tasks pending re-execution (task_id -> True)
         # For cross-process/remote execution: when task yields incomplete deps,
@@ -274,6 +281,9 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
         """
         # Check if we're resuming a suspended generator (in-process dynamic deps)
         if task.id in self._suspended_generators:
+            gen = self._suspended_generators[task.id]
+            if hasattr(gen, "__anext__"):
+                return await self._resume_generator_aio(task)
             return self._resume_generator(task)
 
         # Check if task is pending re-execution (cross-process dynamic deps)
@@ -285,7 +295,7 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
 
         try:
             result = await self._execute_task(task, mode)
-            return self._handle_result(task, result)
+            return await self._handle_result(task, result)
         except Exception as e:
             return TaskExecutionError(
                 exception=e,
@@ -294,18 +304,28 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
 
     async def _execute_task(
         self, task: BaseTask, mode: ExecutionMode
-    ) -> Generator[TaskStruct, None, None] | TaskStruct | None:
+    ) -> (
+        Generator[TaskStruct, None, None]
+        | AsyncGenerator[TaskStruct, None]
+        | TaskStruct
+        | None
+    ):
         """Execute task in appropriate context.
 
         Returns:
             - None: Task completed with no dynamic dependencies.
-            - Generator: Task has dynamic deps and is suspended in current process.
+            - Generator: Task has sync dynamic deps and is suspended in-process.
+            - AsyncGenerator: Task has async dynamic deps and is suspended in-process.
             - TaskStruct: Task has dynamic deps but cannot be suspended (e.g., ran
                 in subprocess). Task will be re-executed when deps complete.
         """
         if mode == ExecutionMode.ASYNC_MAIN_LOOP:
             assert self._async_semaphore is not None
             async with self._async_semaphore:
+                # Async generator functions (dynamic deps in run_aio) must not
+                # be awaited — calling the bound method returns the generator.
+                if inspect.isasyncgenfunction(type(task).run_aio):
+                    return task.run_aio()  # type: ignore[return-value]
                 return await task.run_aio()
 
         elif mode == ExecutionMode.SYNC_THREAD:
@@ -329,31 +349,37 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
         else:
             raise ValueError(f"Unsupported execution mode: {mode}")
 
-    def _handle_result(
+    async def _handle_result(
         self,
         task: BaseTask,
-        result: Generator[TaskStruct, None, None] | TaskStruct | None,
+        result: Generator[TaskStruct, None, None]
+        | AsyncGenerator[TaskStruct, None]
+        | TaskStruct
+        | None,
     ) -> None | TaskStruct:
         """Handle task execution result.
 
-        Handles three cases:
+        Handles four cases:
         1. None: Task completed normally.
-        2. Generator: Task has dynamic deps and is suspended (in-process execution).
+        2. Generator: Task has sync dynamic deps and is suspended (in-process).
            Store generator and return first yielded deps.
-        3. TaskStruct: Task has dynamic deps but cannot be suspended (cross-process
+        3. AsyncGenerator: Task has async dynamic deps and is suspended (in-process).
+           Store generator and return first yielded deps.
+        4. TaskStruct: Task has dynamic deps but cannot be suspended (cross-process
            or remote execution). Return deps directly; task will be re-executed
            when deps complete (idempotent re-execution).
 
         Note: This method does not make any registry calls.
         """
         if result is None:
-            # Task completed normally
             return None
 
-        # Check if result is a generator (dynamic deps, in-process)
-        # Use hasattr to check for generator protocol
+        # Async generator takes precedence (also has __aiter__, not __next__)
+        if hasattr(result, "__anext__"):
+            agen: AsyncGenerator[TaskStruct, None] = result  # type: ignore[assignment]
+            return await self._handle_generator_aio(task, agen)
+
         if hasattr(result, "__next__"):
-            # Cast to Generator for type checker - we've verified it has __next__
             gen: Generator[TaskStruct, None, None] = result  # type: ignore[assignment]
             return self._handle_generator(task, gen)
 
@@ -364,35 +390,60 @@ class HybridConcurrentTaskExecutor(TaskExecutorABC):
         # On re-execution, the generator will drive forward past the yield
         # because the deps are now complete.
         self._pending_reexecution.add(task.id)
-        # Cast to TaskStruct for type checker - we've verified it's not a generator
         task_struct: TaskStruct = result  # type: ignore[assignment]
         return task_struct
 
     def _handle_generator(
         self, task: BaseTask, gen: Generator[TaskStruct, None, None]
     ) -> None | TaskStruct:
-        """Handle a generator from task execution."""
+        """Handle a sync generator from task execution."""
         try:
             yielded = next(gen)
-            # Store generator for resumption
             self._suspended_generators[task.id] = gen
             return yielded
         except StopIteration:
-            # Generator completed without yielding
+            return None
+
+    async def _handle_generator_aio(
+        self, task: BaseTask, agen: AsyncGenerator[TaskStruct, None]
+    ) -> None | TaskStruct:
+        """Handle an async generator from task execution."""
+        try:
+            yielded = await agen.__anext__()
+            self._suspended_generators[task.id] = agen
+            return yielded
+        except StopAsyncIteration:
             return None
 
     def _resume_generator(
         self, task: BaseTask
     ) -> None | TaskStruct | TaskExecutionError:
-        """Resume a suspended generator."""
+        """Resume a suspended sync generator."""
         gen = self._suspended_generators[task.id]
 
         try:
-            yielded = next(gen)
-            # Still more dynamic deps
+            yielded = next(gen)  # type: ignore[arg-type]
             return yielded
         except StopIteration:
-            # Generator completed
+            del self._suspended_generators[task.id]
+            return None
+        except Exception as e:
+            del self._suspended_generators[task.id]
+            return TaskExecutionError(
+                exception=e,
+                traceback="".join(tb_module.format_exception(e)),
+            )
+
+    async def _resume_generator_aio(
+        self, task: BaseTask
+    ) -> None | TaskStruct | TaskExecutionError:
+        """Resume a suspended async generator."""
+        agen = self._suspended_generators[task.id]
+
+        try:
+            yielded = await agen.__anext__()  # type: ignore[union-attr]
+            return yielded
+        except StopAsyncIteration:
             del self._suspended_generators[task.id]
             return None
         except Exception as e:

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -17,10 +17,11 @@ breaks the sync contract.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import time
 from collections.abc import Awaitable, Sequence
-from typing import Callable, Literal
+from typing import Any, AsyncIterator, Callable, Literal
 from uuid import UUID
 
 from stardag import (
@@ -839,6 +840,28 @@ async def build_sequential_aio(
         )
 
 
+async def _iter_dynamic_deps(result: Any) -> AsyncIterator[Any]:
+    """Iterate yielded dynamic deps from a sync or async generator run result.
+
+    Normalizes the three cases into a single async iteration:
+    - None / non-generator: yields nothing
+    - Sync generator (``__next__``): wraps with ``next()`` calls
+    - Async generator (``__anext__``): iterates with ``async for``
+    """
+    if result is None:
+        return
+    if hasattr(result, "__anext__"):
+        async for value in result:
+            yield value
+        return
+    if hasattr(result, "__next__"):
+        while True:
+            try:
+                yield next(result)
+            except StopIteration:
+                return
+
+
 async def _run_task_sequential_aio(
     task: BaseTask,
     completion_cache: set[UUID],
@@ -877,8 +900,12 @@ async def _run_task_sequential_aio(
 
     # Determine how to run
     if has_run_aio:
-        # Async-only or Dual - use async
-        result = await task.run_aio()
+        # Async generators (dynamic deps via `async def run_aio: yield ...`)
+        # cannot be awaited — calling the bound method returns the generator.
+        if inspect.isasyncgenfunction(type(task).run_aio):
+            result: Any = task.run_aio()
+        else:
+            result = await task.run_aio()
     elif has_run:
         # Sync-only
         if sync_run_default == "thread":
@@ -889,38 +916,31 @@ async def _run_task_sequential_aio(
     else:
         raise ValueError(f"Task {task} has no run method")
 
-    # Handle generator (dynamic deps)
-    if result is not None and hasattr(result, "__next__"):
-        gen = result
-        while True:
-            try:
-                yielded = next(gen)
-                dynamic_deps = flatten_task_struct(yielded)
+    # Handle dynamic deps — unified across sync and async generators
+    async for yielded in _iter_dynamic_deps(result):
+        dynamic_deps = flatten_task_struct(yielded)
 
-                # discover() is the runtime wrapper from build_sequential_aio: it
-                # recurses into requires(), and registers any previously-complete
-                # tasks it surfaces (so they appear in the build's task list even
-                # though they were first seen after the initial registration pass).
-                for dep in dynamic_deps:
-                    await discover(dep)
+        # discover() is the runtime wrapper from build_sequential_aio: it
+        # recurses into requires(), and registers any previously-complete
+        # tasks it surfaces (so they appear in the build's task list even
+        # though they were first seen after the initial registration pass).
+        for dep in dynamic_deps:
+            await discover(dep)
 
-                    if dep.id not in completion_cache:
-                        await _run_task_sequential_aio(
-                            dep,
-                            completion_cache,
-                            all_tasks,
-                            build_id,
-                            registry,
-                            sync_run_default,
-                            discover,
-                            task_count,
-                            on_registry_failure,
-                        )
-                        if task_count is not None:
-                            task_count.succeeded += 1
-
-            except StopIteration:
-                break
+            if dep.id not in completion_cache:
+                await _run_task_sequential_aio(
+                    dep,
+                    completion_cache,
+                    all_tasks,
+                    build_id,
+                    registry,
+                    sync_run_default,
+                    discover,
+                    task_count,
+                    on_registry_failure,
+                )
+                if task_count is not None:
+                    task_count.succeeded += 1
 
     completion_cache.add(task.id)
     await registry.task_complete_aio(build_id, task)

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -406,9 +406,12 @@ class RunFunction(typing.Protocol):
 
     This function is called remotely on Modal to execute a single task.
     It receives a task instance and returns either ``None`` (task completed)
-    or a ``TaskStruct`` of dynamic dependencies that were not yet complete
-    (for idempotent re-execution — the task will be re-invoked after those
-    deps are built).
+    or the ``TaskStruct`` yielded at the first incomplete dynamic-deps yield
+    (which may include deps that are already complete — the caller is
+    expected to filter if that matters). This enables idempotent
+    re-execution: the build system schedules the yielded deps, then
+    re-invokes the task. On re-execution the generator advances past
+    previously-yielded batches whose deps are now complete.
 
     The default implementation (``Runner``) handles sync, async, and dynamic
     deps tasks. Custom implementations can subclass ``Runner`` to override
@@ -559,12 +562,25 @@ class Runner(RunFunction):
     def run(self, task: BaseTask) -> None | TaskStruct:
         """Default run logic — handles sync, async, and dynamic deps tasks.
 
+        Dispatch policy:
+
+        - **Async-only** (``run_aio`` defined, ``run`` not overridden):
+          async generator ``run_aio`` is driven via ``_drive_async_generator``;
+          otherwise ``asyncio.run(task.run_aio())``.
+        - **Sync-only and dual** (``run`` defined, with or without ``run_aio``):
+          ``task.run()`` is called. If it returns a sync generator it is
+          driven via ``_drive_sync_generator``. Dual tasks intentionally
+          prefer the sync path here because the Modal worker invocation is
+          itself synchronous — if you need async execution for a dual task,
+          implement it in ``run()`` (e.g. via ``asyncio.run`` internally).
+
         Generators cannot be serialized across the Modal boundary, so we
-        mirror ``_run_task_in_process``: drive the generator forward while
-        yielded deps are complete, and return the first batch of incomplete
-        deps as a ``TaskStruct``. The ``ModalTaskExecutor`` will build those
-        deps and re-invoke this function — on re-execution the generator
-        advances past previously-yielded completions.
+        mirror ``_run_task_in_process``: drive forward while yielded batches
+        are fully complete, and at the first yield with any incomplete dep
+        return the entire yielded ``TaskStruct``. The ``ModalTaskExecutor``
+        builds those deps (filtering for incomplete ones) and re-invokes this
+        function — on re-execution the generator advances past the
+        now-complete batch.
         """
         has_run_aio = _has_custom_run_aio(task)
         has_run = _has_custom_run(task)
@@ -576,14 +592,26 @@ class Runner(RunFunction):
             asyncio.run(task.run_aio())
             return None
 
-        # Sync (or dual) task — run and drive generator if returned
+        # Sync (or dual) task — run and drive generator if returned.
+        # Dual tasks deliberately take the sync path; see method docstring.
         return _drive_sync_generator(task.run())
 
 
 def _drive_sync_generator(
     result: None | typing.Generator[TaskStruct, None, None] | TaskStruct,
 ) -> None | TaskStruct:
-    """Drive a sync generator result, returning incomplete deps as TaskStruct."""
+    """Drive a sync generator result for idempotent re-execution.
+
+    Advances the generator past yield batches whose deps are all complete.
+    Stops at the first yield with any incomplete dep and returns that yield's
+    full ``TaskStruct`` (which may also include already-complete deps — the
+    caller is expected to filter for incomplete ones when scheduling). If
+    the generator completes, returns ``None``.
+
+    If ``result`` is ``None`` (no dynamic deps) returns ``None``. If
+    ``result`` is already a ``TaskStruct`` (unusual but possible when a
+    user's ``run()`` returns deps directly) it is returned as-is.
+    """
     if result is None:
         return None
     if not hasattr(result, "__next__"):
@@ -603,7 +631,13 @@ def _drive_sync_generator(
 
 
 async def _drive_async_generator(task: BaseTask) -> None | TaskStruct:
-    """Drive an async generator ``run_aio``, returning incomplete deps as TaskStruct."""
+    """Drive an async generator ``run_aio`` for idempotent re-execution.
+
+    Same contract as ``_drive_sync_generator``: advances past fully-complete
+    yield batches and returns the first batch that contains any incomplete
+    dep as a ``TaskStruct`` (may include already-complete deps). Returns
+    ``None`` when the generator finishes.
+    """
     agen = typing.cast(
         typing.AsyncGenerator[TaskStruct, None],
         task.run_aio(),  # type: ignore[assignment]

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -34,6 +34,8 @@ Example usage:
 
 from __future__ import annotations
 
+import asyncio
+import inspect
 import json
 import logging
 import os
@@ -43,7 +45,8 @@ import typing
 
 import modal
 
-from stardag import BaseTask, TaskStruct, build
+from stardag import BaseTask, TaskStruct, build, flatten_task_struct
+from stardag._core.base_task import _has_custom_run, _has_custom_run_aio
 from stardag.build import BuildExitStatus, TaskExecutionError, TaskExecutorABC
 from stardag.build._base import BuildSummary
 from stardag.config import clear_config_cache, config_provider, load_config
@@ -402,20 +405,21 @@ class RunFunction(typing.Protocol):
     """Protocol for the function registered as Modal "worker_*" functions.
 
     This function is called remotely on Modal to execute a single task.
-    It receives a task instance and should call ``task.run()``.
+    It receives a task instance and returns either ``None`` (task completed)
+    or a ``TaskStruct`` of dynamic dependencies that were not yet complete
+    (for idempotent re-execution — the task will be re-invoked after those
+    deps are built).
 
-    The default implementation (``Runner``) calls ``task.run()`` with
-    logging. Custom implementations can subclass ``Runner`` to override
-    ``setup()``/``teardown()``, or implement this protocol directly.
+    The default implementation (``Runner``) handles sync, async, and dynamic
+    deps tasks. Custom implementations can subclass ``Runner`` to override
+    ``setup()``/``teardown()``/``run()``, or implement this protocol directly.
 
     Any module-level code in the module where a custom run function is
     defined will execute inside the Modal container before the function is
     called — use this for container-level setup (imports, config, etc.).
     """
 
-    def __call__(
-        self, task: BaseTask
-    ) -> None | typing.Generator[TaskStruct, None, None]: ...
+    def __call__(self, task: BaseTask) -> None | TaskStruct: ...
 
 
 # --- Default build/run implementations, with overridable methods ---
@@ -533,11 +537,14 @@ class Runner(RunFunction):
         if exception:
             logger.error(f"Task {repr(task)} raised an exception: {repr(exception)}")
 
-    def __call__(
-        self, task: BaseTask
-    ) -> None | typing.Generator[TaskStruct, None, None]:
-        """Core logic to execute a single task."""
-        result: None | typing.Generator[TaskStruct, None, None] = None
+    def __call__(self, task: BaseTask) -> None | TaskStruct:
+        """Core logic to execute a single task.
+
+        Returns ``None`` when the task completed, or a ``TaskStruct`` of
+        dynamic dependencies that were not yet complete (idempotent
+        re-execution pattern — see ``run``).
+        """
+        result: None | TaskStruct = None
         exception: Exception | None = None
         try:
             self.setup(task)
@@ -549,9 +556,67 @@ class Runner(RunFunction):
             self.teardown(task, exception)
         return result
 
-    def run(self, task: BaseTask) -> None | typing.Generator[TaskStruct, None, None]:
-        """Default run logic - simply call task.run()."""
-        return task.run()
+    def run(self, task: BaseTask) -> None | TaskStruct:
+        """Default run logic — handles sync, async, and dynamic deps tasks.
+
+        Generators cannot be serialized across the Modal boundary, so we
+        mirror ``_run_task_in_process``: drive the generator forward while
+        yielded deps are complete, and return the first batch of incomplete
+        deps as a ``TaskStruct``. The ``ModalTaskExecutor`` will build those
+        deps and re-invoke this function — on re-execution the generator
+        advances past previously-yielded completions.
+        """
+        has_run_aio = _has_custom_run_aio(task)
+        has_run = _has_custom_run(task)
+
+        if has_run_aio and not has_run:
+            # Async-only task
+            if inspect.isasyncgenfunction(type(task).run_aio):
+                return asyncio.run(_drive_async_generator(task))
+            asyncio.run(task.run_aio())
+            return None
+
+        # Sync (or dual) task — run and drive generator if returned
+        return _drive_sync_generator(task.run())
+
+
+def _drive_sync_generator(
+    result: None | typing.Generator[TaskStruct, None, None] | TaskStruct,
+) -> None | TaskStruct:
+    """Drive a sync generator result, returning incomplete deps as TaskStruct."""
+    if result is None:
+        return None
+    if not hasattr(result, "__next__"):
+        # Already a TaskStruct (unusual, but handle it)
+        return typing.cast(TaskStruct, result)
+
+    gen = typing.cast(typing.Generator[TaskStruct, None, None], result)
+    try:
+        while True:
+            yielded = next(gen)
+            deps = flatten_task_struct(yielded)
+            incomplete = [dep for dep in deps if not dep.complete()]
+            if incomplete:
+                return tuple(deps)
+    except StopIteration:
+        return None
+
+
+async def _drive_async_generator(task: BaseTask) -> None | TaskStruct:
+    """Drive an async generator ``run_aio``, returning incomplete deps as TaskStruct."""
+    agen = typing.cast(
+        typing.AsyncGenerator[TaskStruct, None],
+        task.run_aio(),  # type: ignore[assignment]
+    )
+    try:
+        async for yielded in agen:
+            deps = flatten_task_struct(yielded)
+            incomplete = [dep for dep in deps if not dep.complete()]
+            if incomplete:
+                return tuple(deps)
+    except StopAsyncIteration:
+        pass
+    return None
 
 
 _default_build = Builder()

--- a/lib/stardag/src/stardag/testing/modal/_tasks.py
+++ b/lib/stardag/src/stardag/testing/modal/_tasks.py
@@ -4,6 +4,8 @@ These tasks are defined inside the stardag package (not in tests/) so they
 can be deserialized in Modal containers that install stardag from local source.
 """
 
+import asyncio
+
 import stardag as sd
 
 
@@ -17,3 +19,58 @@ def make_range(limit: int) -> list[int]:
 def sum_list(values: sd.Depends[list[int]]) -> int:
     """Return sum of input list."""
     return sum(values)
+
+
+# --- Class-based tasks exercising Runner.run() branches ---
+
+
+class AsyncDoubleTask(sd.Task[int]):
+    """Async-only task: only implements ``run_aio``.
+
+    Exercises ``Runner.run()``'s async-only branch
+    (``asyncio.run(task.run_aio())``).
+    """
+
+    input_task: sd.TaskLoads[int]
+
+    def requires(self):
+        return self.input_task
+
+    async def run_aio(self) -> None:
+        val = await self.input_task.load_aio()
+        await asyncio.sleep(0.01)
+        await self._save_aio(val * 2)
+
+
+class SyncDynamicRangeSumTask(sd.Task[int]):
+    """Sync generator dynamic deps: yields a task, then reads it.
+
+    Exercises ``Runner.run()``'s sync-generator path via
+    ``_drive_sync_generator``. Generators cannot be pickled across the Modal
+    boundary, so the first invocation returns the yielded dep as a
+    ``TaskStruct``; the task is re-invoked after that dep is built.
+    """
+
+    limit: int
+
+    def run(self):
+        range_task = make_range(limit=self.limit)
+        yield range_task
+        values = range_task.load()
+        self._save(sum(values))
+
+
+class AsyncDynamicRangeSumTask(sd.Task[int]):
+    """Async generator dynamic deps: yields a task, then reads it.
+
+    Exercises ``Runner.run()``'s async-generator path via
+    ``_drive_async_generator``.
+    """
+
+    limit: int
+
+    async def run_aio(self):  # type: ignore[override]
+        range_task = make_range(limit=self.limit)
+        yield range_task
+        values = await range_task.load_aio()
+        await self._save_aio(sum(values))

--- a/lib/stardag/src/stardag/utils/testing/helper_tasks.py
+++ b/lib/stardag/src/stardag/utils/testing/helper_tasks.py
@@ -155,3 +155,41 @@ class DynamicDiamondTask(Task[str]):
             yield dep
 
         self._save(f"{self.name}:{_execution_counts[key]}")
+
+
+class AsyncDynamicDiamondTask(Task[str]):
+    """Async task with dynamic deps that tracks execution for diamond tests.
+
+    Uses an async generator ``run_aio`` to yield dynamic dependencies.
+    """
+
+    name: str
+    test_id: str
+    static_task_deps: tuple["AsyncDynamicDiamondTask", ...] = ()
+    dynamic_task_deps: tuple["AsyncDynamicDiamondTask", ...] = ()
+
+    def requires(self):
+        return self.static_task_deps
+
+    async def run_aio(self):  # type: ignore[override]
+        global _execution_counts
+        key = f"{self.test_id}:{self.name}"
+        _execution_counts[key] = _execution_counts.get(key, 0) + 1
+
+        # CONTRACT: static requires() must be complete at the start of run.
+        for static_dep in self.static_task_deps:
+            if not static_dep.complete():
+                raise AssertionError(
+                    f"Static requires contract violated! Dep {static_dep} is not "
+                    f"complete at the start of {self}.run_aio()."
+                )
+
+        for dep in self.dynamic_task_deps:
+            yield dep
+            if not dep.complete():
+                raise AssertionError(
+                    f"Dynamic deps contract violated! Dep {dep} is not complete "
+                    f"after yield in {self}.run_aio()."
+                )
+
+        self._save(f"{self.name}:{_execution_counts[key]}")

--- a/lib/stardag/tests/test__core/test_decorator.py
+++ b/lib/stardag/tests/test__core/test_decorator.py
@@ -236,3 +236,29 @@ async def test_call_aio_raises_on_sync_func():
 
     with pytest.raises(TypeError, match="cannot be used with a sync function"):
         await sync_add.call_aio(a=1, b=2)
+
+
+# --- Generator rejection tests ---
+
+
+def test_sync_generator_rejected():
+    """Sync generator functions should be rejected by @task.
+
+    Dynamic dependencies require the class-based Task API where run()/run_aio()
+    can be a generator method. The decorator API is intentionally kept simple.
+    """
+    with pytest.raises(TypeError, match="does not support generator functions"):
+
+        @task
+        def gen_func(a: int) -> int:  # type: ignore[reportInvalidTypeForm]
+            yield a  # type: ignore[misc]
+            return a
+
+
+def test_async_generator_rejected():
+    """Async generator functions should be rejected by @task."""
+    with pytest.raises(TypeError, match="does not support generator functions"):
+
+        @task
+        async def async_gen_func(a: int) -> int:  # type: ignore[reportInvalidTypeForm]
+            yield a  # type: ignore[misc]

--- a/lib/stardag/tests/test_build/test_sequential.py
+++ b/lib/stardag/tests/test_build/test_sequential.py
@@ -28,6 +28,7 @@ from stardag.utils.testing.dynamic_deps_dag import (
     assert_dynamic_deps_task_complete_recursive,
 )
 from stardag.utils.testing.helper_tasks import (
+    AsyncDynamicDiamondTask,
     AsyncOnlyTask,
     DiamondTask,
     DualTask,
@@ -610,6 +611,86 @@ class TestDynamicDepsWithRequiresRegistryBookkeeping:
             f"calls: {leaf_calls}"
         )
         assert "task_complete" in leaf_calls
+
+
+# ============================================================================
+# Test: Async-generator dynamic deps (yield from `async def run_aio`)
+#
+# Parameterized across build_sequential_aio and build_aio so the async-gen
+# handling is exercised for both executors.
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "build_aio_fn",
+    [build_sequential_aio, build_aio],
+    ids=["sequential", "concurrent"],
+)
+class TestAsyncDynamicDeps:
+    @pytest.mark.asyncio
+    async def test_async_dynamic_diamond(
+        self,
+        build_aio_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        noop_registry,
+    ):
+        """Async dynamic diamond pattern.
+
+        parent (static: [dyn_task, shared])
+           |
+        dyn_task (dynamic: [shared])
+           |
+        shared (appears in both paths)
+        """
+        reset_execution_counts()
+        test_id = f"async_dyn_{build_aio_fn.__name__}"
+
+        shared = AsyncDynamicDiamondTask(name="shared", test_id=test_id)
+        dyn_task = AsyncDynamicDiamondTask(
+            name="dyn_task", test_id=test_id, dynamic_task_deps=(shared,)
+        )
+        parent = AsyncDynamicDiamondTask(
+            name="parent", test_id=test_id, static_task_deps=(dyn_task, shared)
+        )
+
+        summary = await build_aio_fn([parent], registry=noop_registry)
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert get_execution_count(test_id, "shared") == 1
+        assert get_execution_count(test_id, "dyn_task") == 1
+        assert get_execution_count(test_id, "parent") == 1
+
+    @pytest.mark.asyncio
+    async def test_async_yielded_dep_with_static_requires(
+        self,
+        build_aio_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        noop_registry,
+    ):
+        """Async generator: yielded dep's requires() chain must be resolved.
+
+        Same contract as issue #118 but exercised through ``async def run_aio: yield``.
+        """
+        reset_execution_counts()
+        test_id = f"async_req_{build_aio_fn.__name__}"
+
+        leaf = AsyncDynamicDiamondTask(name="leaf", test_id=test_id)
+        middle = AsyncDynamicDiamondTask(
+            name="middle", test_id=test_id, static_task_deps=(leaf,)
+        )
+        orch = AsyncDynamicDiamondTask(
+            name="orch", test_id=test_id, dynamic_task_deps=(middle,)
+        )
+
+        summary = await build_aio_fn([orch], registry=noop_registry)
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert leaf.complete()
+        assert middle.complete()
+        assert orch.complete()
+        assert get_execution_count(test_id, "leaf") == 1
+        assert get_execution_count(test_id, "middle") == 1
+        assert get_execution_count(test_id, "orch") == 1
 
 
 # ============================================================================

--- a/lib/stardag/tests/test_integration/test_modal/test__app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__app.py
@@ -35,7 +35,13 @@ try:
         get_default_volume_mount_path,
     )
     from stardag.integration.modal._config import with_stardag_on_image
-    from stardag.testing.modal._tasks import make_range, sum_list
+    from stardag.testing.modal._tasks import (
+        AsyncDoubleTask,
+        AsyncDynamicRangeSumTask,
+        SyncDynamicRangeSumTask,
+        make_range,
+        sum_list,
+    )
 
     # check if logged in and volume exists
     try:
@@ -280,54 +286,25 @@ class TestEndToEndBuild:
     """End-to-end test: build a DAG through the deployed Modal app.
 
     This exercises the full Builder/Runner flow:
-    1. Delete any existing targets on the Modal volume
+    1. ``isolated_modal_target_root`` points the ``default`` target root at
+       a unique subpath on the Modal volume (no pre-existing targets).
     2. build_remote() calls the deployed "build" function (Builder.__call__)
     3. Builder creates ModalTaskExecutor and runs stardag.build()
     4. ModalTaskExecutor dispatches each task to "worker_default" (Runner.__call__)
     5. Runner calls task.run(), which writes output to the Modal volume
     6. Load results locally via the Modal volume remote filesystem API
+    7. Fixture recursively deletes the subpath on teardown.
 
     Tasks are defined in stardag.testing.modal._tasks (inside the stardag
     package) so they can be deserialized in the Modal container.
     """
 
-    @pytest.fixture(autouse=True)
-    def setup_target_roots(self):
-        """Set target roots to the Modal volume so local load() works."""
-        from stardag.testing import target_roots_override
-
-        target_roots = {"default": f"modalvol://{VOLUME_NAME}/{ROOT_DEFAULT}"}
-        with target_roots_override(target_roots):
-            yield
-
-    @staticmethod
-    def _delete_targets_on_volume(*tasks):
-        """Delete task target files from the Modal volume."""
-        import stardag as sd
-        from stardag.integration.modal._target import get_volume_name_and_path
-
-        volume = modal.Volume.from_name(VOLUME_NAME)
-        all_tasks = list(tasks)
-        for task in tasks:
-            all_tasks.extend(sd.flatten_task_struct(task.requires()))
-
-        for task in all_tasks:
-            uri = task.target().uri
-            _, in_vol_path = get_volume_name_and_path(uri)
-            try:
-                volume.remove_file(in_vol_path)
-            except Exception:
-                pass  # file doesn't exist — fine
-
-    def test_build_and_load_result(self):
+    def test_build_and_load_result(self, isolated_modal_target_root):
         """Build a DAG through Modal, then load the result locally."""
         from stardag.build._base import BuildSummary
 
         root = sum_list(values=make_range(limit=5))
-
-        # Delete existing targets so the build actually executes all tasks
-        self._delete_targets_on_volume(root)
-        assert not root.target().exists(), "Target should not exist before build"
+        assert not root.target().exists()
 
         # Build remotely through Modal
         result = stardag_app.build_remote(root)
@@ -341,3 +318,112 @@ class TestEndToEndBuild:
         # Load results locally via Modal volume remote filesystem API
         assert root.target().exists()
         assert root.target().load() == 10  # sum(range(5)) = 0+1+2+3+4
+
+
+@pytest.fixture
+def isolated_modal_target_root():
+    """Wipe the test target-root subtree on the Modal volume before & after a test.
+
+    The target root is baked into the Modal app at deploy time as a Secret
+    (``STARDAG_TARGET_ROOTS__DEFAULT``), so client-side ``target_roots_override``
+    does not propagate to remote containers. Instead we:
+
+    1. Before the test: recursively delete everything under
+       ``stardag/root/default`` on the Modal volume, and override local
+       target roots so ``task.target().exists()`` and ``.load()`` see the
+       same state as the remote container.
+    2. After the test: recursively delete the subtree again.
+
+    This is the Modal analogue of ``stardag.testing.test_harness``:
+    independent of which tasks a test builds (including dynamic deps), the
+    subtree is guaranteed empty pre-test and cleaned post-test. Any test
+    running after this one also starts from a clean subtree.
+    """
+    from stardag.testing import target_roots_override
+
+    target_roots = {"default": f"modalvol://{VOLUME_NAME}/{ROOT_DEFAULT}"}
+    volume = modal.Volume.from_name(VOLUME_NAME)
+
+    def _wipe():
+        try:
+            volume.remove_file(ROOT_DEFAULT, recursive=True)
+        except Exception:
+            pass  # path didn't exist — fine
+
+    _wipe()
+    with target_roots_override(target_roots):
+        yield target_roots
+    _wipe()
+
+
+class TestEndToEndDynamicDepsBuild:
+    """End-to-end tests verifying Runner.run()'s handling of async tasks and
+    dynamic deps across the Modal boundary.
+
+    Generators cannot be pickled, so ``Runner.run()`` drives them and returns
+    a ``TaskStruct`` of incomplete yielded deps for idempotent re-execution.
+    The ``ModalTaskExecutor`` builds those deps and re-invokes the task.
+
+    Every test uses ``isolated_modal_target_root`` to start from a clean
+    subpath on the Modal volume — no cross-test state, including dynamically
+    discovered tasks that a walk-from-requires() cleanup approach would miss.
+    """
+
+    # Distinct limits per test method — Modal worker containers cache the
+    # volume mount across invocations within a pytest run, so a ``make_range``
+    # file from one test can still be visible to a warm container after the
+    # volume-wipe fixture runs. Different params → different task IDs →
+    # different file paths → no cross-test cache hits.
+
+    def test_async_only_task_build(self, isolated_modal_target_root):
+        """Async-only class-based task (``run_aio`` only) — Runner uses ``asyncio.run``."""
+        from stardag.build._base import BuildSummary
+
+        limit = 7
+        source = sum_list(values=make_range(limit=limit))
+        root = AsyncDoubleTask(input_task=source)
+        assert not root.target().exists()
+
+        result = stardag_app.build_remote(root)
+        assert isinstance(result, BuildSummary)
+        # 3 tasks: make_range, sum_list, AsyncDoubleTask
+        assert result.task_count.succeeded == 3, (
+            f"Expected 3 succeeded, got {result.task_count}"
+        )
+        assert root.target().exists()
+        assert root.target().load() == sum(range(limit)) * 2
+
+    def test_sync_dynamic_deps_build(self, isolated_modal_target_root):
+        """Sync generator dynamic deps — Runner drives via re-execution."""
+        from stardag.build._base import BuildSummary
+
+        limit = 11
+        root = SyncDynamicRangeSumTask(limit=limit)
+        assert not root.target().exists()
+
+        result = stardag_app.build_remote(root)
+        assert isinstance(result, BuildSummary)
+        # 2 tasks succeed: make_range (dynamically discovered) and the root.
+        # The root is re-executed on Modal when the dyn dep becomes available,
+        # but each task is counted once at final completion.
+        assert result.task_count.succeeded == 2, (
+            f"Expected 2 succeeded, got {result.task_count}"
+        )
+        assert root.target().exists()
+        assert root.target().load() == sum(range(limit))
+
+    def test_async_dynamic_deps_build(self, isolated_modal_target_root):
+        """Async generator dynamic deps — Runner drives via ``_drive_async_generator``."""
+        from stardag.build._base import BuildSummary
+
+        limit = 13
+        root = AsyncDynamicRangeSumTask(limit=limit)
+        assert not root.target().exists()
+
+        result = stardag_app.build_remote(root)
+        assert isinstance(result, BuildSummary)
+        assert result.task_count.succeeded == 2, (
+            f"Expected 2 succeeded, got {result.task_count}"
+        )
+        assert root.target().exists()
+        assert root.target().load() == sum(range(limit))

--- a/lib/stardag/tests/test_integration/test_modal/test_runner.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_runner.py
@@ -1,0 +1,165 @@
+"""Unit tests for ``Runner.run()`` dispatch behavior.
+
+These tests do NOT require a real Modal account — they exercise ``Runner.run``
+against local in-memory targets to verify the sync / async-only / sync-generator
+/ async-generator dispatch branches and the ``TaskStruct`` return value for
+idempotent re-execution.
+
+For the end-to-end Modal round-trip (Runner invoked inside a Modal container),
+see ``test__app.py::TestEndToEndBuild`` and ``TestEndToEndDynamicDepsBuild``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import modal  # noqa: F401
+except ImportError:
+    pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+from stardag.integration.modal._app import Runner
+from stardag.testing.modal._tasks import (
+    AsyncDoubleTask,
+    AsyncDynamicRangeSumTask,
+    SyncDynamicRangeSumTask,
+    make_range,
+    sum_list,
+)
+
+
+@pytest.fixture
+def runner() -> Runner:
+    return Runner()
+
+
+class TestRunnerSyncTask:
+    """Sync-only task: ``run()`` executes, returns None."""
+
+    def test_sync_task_returns_none(self, runner: Runner, default_in_memory_fs_target):
+        task = make_range(limit=3)
+        result = runner(task)
+        assert result is None
+        assert task.complete()
+        assert task.target().load() == [0, 1, 2]
+
+    def test_sync_task_with_static_dep(
+        self, runner: Runner, default_in_memory_fs_target
+    ):
+        # Pre-build the static dep so sum_list can execute
+        range_task = make_range(limit=4)
+        runner(range_task)
+        assert range_task.complete()
+
+        total = sum_list(values=range_task)
+        result = runner(total)
+        assert result is None
+        assert total.target().load() == 6  # 0+1+2+3
+
+
+class TestRunnerAsyncOnlyTask:
+    """Async-only task: ``run_aio()`` is driven via ``asyncio.run``."""
+
+    def test_async_only_task_returns_none(
+        self, runner: Runner, default_in_memory_fs_target
+    ):
+        # Pre-build the input
+        input_task = make_range(limit=5)  # produces list
+        runner(input_task)
+        # Use a task where the single numeric input is trivially available:
+        # Wrap make_range's output in a simple int producer.
+        source = sum_list(values=input_task)
+        runner(source)
+        assert source.complete()
+
+        doubler = AsyncDoubleTask(input_task=source)
+        result = runner(doubler)
+        assert result is None
+        assert doubler.complete()
+        assert doubler.target().load() == 20  # sum(range(5)) * 2
+
+
+class TestRunnerSyncDynamicDeps:
+    """Sync generator dynamic deps: first invocation returns the yielded TaskStruct.
+
+    Verifies the idempotent re-execution contract — generators can't cross
+    the Modal boundary, so ``Runner.run()`` drives the generator forward and
+    returns the first yield whose deps aren't all complete.
+    """
+
+    def test_first_invocation_returns_yielded_deps(
+        self, runner: Runner, default_in_memory_fs_target
+    ):
+        task = SyncDynamicRangeSumTask(limit=4)
+        result = runner(task)
+
+        # The yielded dep (make_range(limit=4)) was incomplete — expect the
+        # TaskStruct yield to be returned for the executor to build.
+        assert result is not None
+        # Result is the tuple/struct of yielded deps. For this task, a single
+        # task is yielded, so flatten should find it.
+        import stardag as sd
+
+        deps = sd.flatten_task_struct(result)
+        assert len(deps) == 1
+        assert deps[0].id == make_range(limit=4).id
+        # Task itself should NOT be complete yet (it was suspended)
+        assert not task.complete()
+
+    def test_re_execution_completes_task(
+        self, runner: Runner, default_in_memory_fs_target
+    ):
+        task = SyncDynamicRangeSumTask(limit=4)
+        # First invocation — yields deps (idempotent re-exec contract)
+        first = runner(task)
+        assert first is not None
+
+        # Build the yielded deps (mimics what ModalTaskExecutor would do)
+        import stardag as sd
+
+        for dep in sd.flatten_task_struct(first):
+            if not dep.complete():
+                runner(dep)
+
+        # Re-invoke the task — generator re-runs, past the yield now that the
+        # dep is complete.
+        second = runner(task)
+        assert second is None
+        assert task.complete()
+        assert task.target().load() == 6  # sum(range(4))
+
+
+class TestRunnerAsyncDynamicDeps:
+    """Async generator dynamic deps: first invocation returns the yielded TaskStruct."""
+
+    def test_first_invocation_returns_yielded_deps(
+        self, runner: Runner, default_in_memory_fs_target
+    ):
+        task = AsyncDynamicRangeSumTask(limit=5)
+        result = runner(task)
+
+        assert result is not None
+        import stardag as sd
+
+        deps = sd.flatten_task_struct(result)
+        assert len(deps) == 1
+        assert deps[0].id == make_range(limit=5).id
+        assert not task.complete()
+
+    def test_re_execution_completes_task(
+        self, runner: Runner, default_in_memory_fs_target
+    ):
+        task = AsyncDynamicRangeSumTask(limit=5)
+        first = runner(task)
+        assert first is not None
+
+        import stardag as sd
+
+        for dep in sd.flatten_task_struct(first):
+            if not dep.complete():
+                runner(dep)
+
+        second = runner(task)
+        assert second is None
+        assert task.complete()
+        assert task.target().load() == 10  # sum(range(5))


### PR DESCRIPTION
## Summary

Replaces [#84](https://github.com/stardag-dev/stardag/pull/84) (which was significantly behind `main`). Rebased onto the issue #118 fix in #119 so the requires-chain resolution also covers the new async-generator branch.

- **Async generator support for dynamic deps** — both executors now accept `async def run_aio(self): yield ...` in addition to sync `def run(self): yield ...`.
- **Modal worker re-exec** — `Runner.run()` drives generators and returns a `TaskStruct` of incomplete deps (generators aren't pickleable across the Modal boundary). Mirrors `_run_task_in_process`.
- **@task decorator rejects generator functions** — dynamic deps require the class-based Task API; the decorator API is intentionally kept simple.

## Changes

| File | Change |
|------|--------|
| `build/_concurrent.py` | Detect async generators (`inspect.isasyncgenfunction`), suspend/resume via parallel `_handle_generator_aio` / `_resume_generator_aio`. `_handle_result` becomes async. |
| `build/_sequential.py` | New `_iter_dynamic_deps` helper unifies sync + async generator iteration. The `_run_task_sequential_aio` dynamic-deps loop uses it. Requires-chain fix from #119 applies here. |
| `_core/decorator.py` | `@task` raises `TypeError` on sync/async generator functions with a message pointing to the class-based API. |
| `integration/modal/_app.py` | `Runner.run()` default handles async tasks via `asyncio.run(run_aio())` and drives generators (sync + async) to return `TaskStruct`. New `_drive_sync_generator` / `_drive_async_generator` helpers. `RunFunction` protocol return type updated. |
| `utils/testing/helper_tasks.py` | New `AsyncDynamicDiamondTask` helper with static and dynamic deps contract assertions. |
| `tests/test__core/test_decorator.py` | Generator rejection tests. |
| `tests/test_build/test_sequential.py` | `TestAsyncDynamicDeps` parameterized across `build_sequential_aio` and `build_aio` — covers the async-gen dynamic diamond and the async-gen equivalent of the issue #118 requires-chain scenario. |

## Dependencies

- **Depends on #119** (issue #118 fix). This PR is currently targeted at that branch; once #119 merges to main, this will be retargeted at main.

## Test plan

- [x] All 455 existing + new tests pass (excluding Modal integration tests which need a real Modal account)
- [x] Pyright passes with 0 errors
- [x] Pre-commit (ruff, ruff format, prettier) clean
- [ ] Modal integration test (requires Modal test setup — tracked separately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)