### PR TITLE
Draft v0.5.8 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.5.8] — 2026-04-20
+
+### SDK
+
+#### Bug fixes
+
+- **`build_sequential` now resolves dynamically-yielded tasks' `requires()` chain.** Previously `build_sequential` (and `build_sequential_aio`) could execute a task yielded from a `run()` generator without first building that task's own static `requires()`, causing it to fail when it tried to `load()` a dep that was never built. The concurrent `build()` already handled this correctly; the sequential executor now matches. ([#118](https://github.com/stardag-dev/stardag/issues/118), [#119](https://github.com/stardag-dev/stardag/pull/119))
+
+#### New features
+
+- **Async generator dynamic dependencies.** `async def run_aio(self): yield ...` is now a supported form for declaring dynamic deps on the class-based Task API — the build system detects async generators via `inspect.isasyncgenfunction` and drives them with `async for`. Both sequential and concurrent executors support it, and the Modal integration handles it via idempotent re-execution. ([#120](https://github.com/stardag-dev/stardag/pull/120))
+- **Modal integration: dynamic-deps tasks can now run remotely.** `Runner.run()` now drives sync and async generators and returns a `TaskStruct` of yielded deps for idempotent re-execution (generators cannot be pickled across the Modal boundary). Async-only tasks (`run_aio` without `run`) are executed via `asyncio.run`. ([#120](https://github.com/stardag-dev/stardag/pull/120))
+
+#### Minor breaking change
+
+- **`@task` decorator rejects generator functions.** Declaring `@task`-decorated functions as generators (`yield`) or async generators now raises `TypeError` at decoration time, with an error message pointing to the class-based Task API. Dynamic dependencies were never well-supported by the decorator API — the class-based API is the intended path and always has been. If you relied on this (undocumented) behavior, migrate the function to a `Task` subclass with a generator `run()` / `run_aio()` method. ([#120](https://github.com/stardag-dev/stardag/pull/120))
+
+#### Notes
+
+- The sequential executor's handling of previously-complete dependencies surfaced at runtime (e.g. static deps of a dynamically-yielded task that happen to already be on disk) is more consistent — a `runtime_discover()` wrapper ensures they receive `task_register` + `task_complete` events so they appear in the build's task list in the Registry. Previously they could be silently excluded.
+- Known limitation: `StardagApp.build_remote` does not yet support passing runtime configuration overrides to the remote build/worker containers — target roots and other config are baked into the deployed Modal app via Secrets. Tracked as [#121](https://github.com/stardag-dev/stardag/issues/121).
+
 ## [0.5.7] — 2026-04-19
 
 ### SDK

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -81,7 +81,7 @@ handle tasks that yielded dynamic deps. `Runner.run()` now drives generators
 (sync and async) in the worker container and returns a `TaskStruct` of
 yielded deps. The build system builds those deps and re-invokes the task —
 on re-execution the generator advances past the previously-yielded batch.
-This mirrors the existing behaviour of `_run_task_in_process` for the
+This mirrors the existing behavior of `_run_task_in_process` for the
 subprocess executor.
 
 Async-only tasks (`run_aio` without `run`) are now also supported in Modal:
@@ -93,7 +93,9 @@ Generator and async-generator functions are no longer accepted by the
 `@task` decorator:
 
 ```python
-@task
+import stardag as sdag
+
+@sdag.task
 def bad(a: int) -> int:
     yield a   # raises TypeError at decoration time
 ```
@@ -105,7 +107,9 @@ mismatch loudly instead of silently producing a task that misbehaves.
 Migrate to a `Task` subclass:
 
 ```python
-class Good(Task[int]):
+import stardag as sdag
+
+class Good(sdag.Task[int]):
     a: int
     def run(self):
         yield some_dep(self.a)
@@ -120,10 +124,11 @@ class Good(Task[int]):
   dynamically-yielded task that's already on disk). Those tasks now appear
   in the build's task list in the Registry as `task_register` +
   `task_complete` events, instead of being silently excluded.
-- **Modal integration tests.** New `tests/test_integration/test_modal/test_runner.py`
+- **Modal integration tests.** New `lib/stardag/tests/test_integration/test_modal/test_runner.py`
   unit tests for `Runner.run()` dispatch behavior (no Modal account needed),
-  and `TestEndToEndDynamicDepsBuild` in `test__app.py` covers the full remote
-  round-trip for async-only tasks and sync/async dynamic deps.
+  and `TestEndToEndDynamicDepsBuild` in
+  `lib/stardag/tests/test_integration/test_modal/test__app.py` covers the
+  full remote round-trip for async-only tasks and sync/async dynamic deps.
 
 ### Known limitations
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,136 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.5.8 — Dynamic deps fixes: sequential build & async generators & Modal
+
+This release is primarily a correctness fix for dynamically-yielded tasks plus expanded support for the pattern across all executors.
+
+### Fix: `build_sequential` resolves the `requires()` chain of yielded tasks
+
+`build_sequential` (and `build_sequential_aio`) previously executed a
+dynamically yielded task directly, skipping any static `requires()` that task
+declared. The concurrent `build()` already resolved them first.
+
+```python
+import stardag as sdag
+
+class Leaf(sdag.Task[int]):
+    value: int
+    def run(self):
+        self._save(self.value * 10)
+
+class Middle(sdag.Task[int]):
+    dep: sdag.TaskLoads[int]
+    def requires(self):
+        return self.dep
+    def run(self):
+        self._save(self.dep.load() + 1)
+
+class Orchestrator(sdag.BaseTask):
+    def complete(self):
+        return False
+    def run(self):
+        middle = Middle(dep=Leaf(value=5))
+        yield middle
+        # At this point Middle — and Leaf, its static require — must be complete.
+```
+
+Before v0.5.8: `sdag.build_sequential(Orchestrator())` would run `Middle.run()`
+before `Leaf.run()`, and `Middle` would fail with `FileNotFoundError` on
+`self.dep.load()`.
+
+After v0.5.8: both sequential and concurrent executors build `Leaf` first,
+then `Middle`, then resume `Orchestrator`. ([#118](https://github.com/stardag-dev/stardag/issues/118))
+
+No code changes needed — existing tasks that relied on the concurrent
+`build()` will now work with `build_sequential()` as well.
+
+### New: async generator dynamic dependencies
+
+You can now declare dynamic dependencies from an `async def run_aio` as an
+**async generator**:
+
+```python
+import stardag as sdag
+
+class AsyncOrchestrator(sdag.Task[int]):
+    limit: int
+
+    async def run_aio(self):  # type: ignore[override]
+        range_task = make_range(limit=self.limit)
+        yield range_task
+        # Build system ensures range_task is complete here
+        values = await range_task.load_aio()
+        await self._save_aio(sum(values))
+```
+
+Both the sequential and concurrent build executors detect async generators
+via `inspect.isasyncgenfunction` and drive them with `async for`. The yield
+semantics are identical to sync generators: after `yield task`, the build
+system has ensured `task` is complete before execution resumes.
+
+### New: Modal integration handles dynamic deps
+
+Generators cannot be pickled, so `ModalTaskExecutor` couldn't previously
+handle tasks that yielded dynamic deps. `Runner.run()` now drives generators
+(sync and async) in the worker container and returns a `TaskStruct` of
+yielded deps. The build system builds those deps and re-invokes the task —
+on re-execution the generator advances past the previously-yielded batch.
+This mirrors the existing behaviour of `_run_task_in_process` for the
+subprocess executor.
+
+Async-only tasks (`run_aio` without `run`) are now also supported in Modal:
+they're executed via `asyncio.run(task.run_aio())` in the worker.
+
+### Minor breaking change: `@task` rejects generator functions
+
+Generator and async-generator functions are no longer accepted by the
+`@task` decorator:
+
+```python
+@task
+def bad(a: int) -> int:
+    yield a   # raises TypeError at decoration time
+```
+
+Dynamic dependencies were never properly supported by the decorator API —
+the class-based Task API is where the full machinery lives (type
+annotations for yielded tasks, `requires()`, etc.). The change surfaces the
+mismatch loudly instead of silently producing a task that misbehaves.
+Migrate to a `Task` subclass:
+
+```python
+class Good(Task[int]):
+    a: int
+    def run(self):
+        yield some_dep(self.a)
+        self._save(...)
+```
+
+### Also in this release
+
+- **Sequential build consistency.** `_run_task_sequential[_aio]` now routes
+  all dep discovery through a `runtime_discover()` wrapper that registers
+  previously-complete tasks surfaced at runtime (e.g. a static dep of a
+  dynamically-yielded task that's already on disk). Those tasks now appear
+  in the build's task list in the Registry as `task_register` +
+  `task_complete` events, instead of being silently excluded.
+- **Modal integration tests.** New `tests/test_integration/test_modal/test_runner.py`
+  unit tests for `Runner.run()` dispatch behavior (no Modal account needed),
+  and `TestEndToEndDynamicDepsBuild` in `test__app.py` covers the full remote
+  round-trip for async-only tasks and sync/async dynamic deps.
+
+### Known limitations
+
+- **Runtime config override for Modal.** `StardagApp.build_remote` does not
+  yet forward runtime configuration (e.g. target root overrides) to remote
+  build/worker containers. Test isolation on Modal therefore relies on
+  distinct task parameters plus pre/post volume wipes, rather than the
+  cleaner `test_harness`-style per-test subpath override used locally.
+  Tracked as [#121](https://github.com/stardag-dev/stardag/issues/121).
+
+---
+
 ## v0.5.7 — Support for user-defined generic task classes
 
 User-defined generic tasks can now be declared and instantiated directly —


### PR DESCRIPTION
## Summary

Release notes & changelog for the **v0.5.8** patch release, covering two SDK changes:

- **Bug fix**: [#118](https://github.com/stardag-dev/stardag/issues/118) / [#119](https://github.com/stardag-dev/stardag/pull/119) — ``build_sequential`` now resolves the ``requires()`` chain of dynamically-yielded tasks, matching the concurrent ``build()``.
- **Feature**: [#120](https://github.com/stardag-dev/stardag/pull/120) — async generator support for dynamic deps (``async def run_aio(self): yield ...``), Modal worker re-exec so dynamic-deps tasks can run remotely, and ``@task`` now rejects generator functions with a clear error.

## Merge order

This PR depends on [#120](https://github.com/stardag-dev/stardag/pull/120). **Do not merge until #120 lands**, otherwise the release notes would describe features that aren't in the release. After #120 merges:

1. Rebase this branch onto the new ``main`` (trivial — only CHANGELOG/RELEASE_NOTES touched).
2. Merge this PR.
3. Tag ``v0.5.8`` on the post-merge ``main`` HEAD and push the tag (triggers the ``Publish Python Package`` workflow).
4. Edit the auto-created GitHub Release with title + body from ``RELEASE_NOTES.md``, reducing heading levels by one (per the project release process).

## Test plan

- [x] ``pre-commit run --files CHANGELOG.md RELEASE_NOTES.md`` — clean.
- [x] Checked formatting matches existing entries (``## [0.5.x] — YYYY-MM-DD`` in CHANGELOG; ``## vX.Y.Z — title`` in RELEASE_NOTES).
- [x] Called out the ``@task`` generator-rejection as a minor breaking change with a migration snippet.
- [x] Known limitation ([#121](https://github.com/stardag-dev/stardag/issues/121)) documented so users hitting test-isolation issues on Modal have a reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)