### PR TITLE
Draft v0.5.9 release notes and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.5.9] — 2026-04-20
+
+### SDK
+
+#### New features
+
+- **Dynamic dependency edges now reach the Registry** so they render as upstream deps in the DAG view. Previously, a task yielded from a `run()` / `run_aio()` generator only had its own static `requires()` chain recorded — the parent → yielded-dep relationship was invisible in the UI. Build executors (`build`, `build_sequential`, and their `_aio` variants) now call a new `RegistryABC.task_add_dependencies(_aio)` method at each dynamic-deps yield, passing the upstream tasks and an `is_dynamic=True` flag. ([#123](https://github.com/stardag-dev/stardag/pull/123))
+- **`RegistryABC.task_add_dependencies(_aio)`**: new registry protocol method for recording dependency edges after `task_register`. Default no-op for in-memory registries (`NoOpRegistry` etc.). `APIRegistry` POSTs to the new `POST /builds/{build_id}/tasks/{task_id}/dependencies` endpoint.
+
+#### Compatibility
+
+- **Graceful fallback for older Registry APIs**: the SDK's `APIRegistry.task_add_dependencies(_aio)` catches the specific FastAPI "missing route" 404 (`{"detail": "Not Found"}`) and logs a warning — builds against an older API deployment continue to work, they just don't record dynamic edges. App-level 404s (e.g. `"Build not found"`, `"Task … not registered …"`) re-raise normally so genuine errors aren't hidden.
+
+### API
+
+#### New features
+
+- **`is_dynamic` column on `task_dependencies`** (nullable, `server_default='false'`) — distinguishes edges discovered at runtime from those declared via `task.requires()`. Included in `TaskEdge` / `TaskEdgeExtended` response schemas. Alembic migration `94003640952d` is additive and safely reversible.
+- **New endpoint `POST /builds/{build_id}/tasks/{task_id}/dependencies`**: accepts `{upstream_task_ids, is_dynamic=True}`, creates phantom upstream tasks for unknown ids, inserts edges idempotently via `ON CONFLICT DO NOTHING`, and returns `{added, total}`.
+- **Grouping applies at depth=0**: `GET /builds/{id}/graph` now always routes through the grouping traversal path, so `max_per_type_per_level` is honored uniformly regardless of `upstream_depth` / `downstream_depth`. Structurally-identical tasks within a build (e.g. many chunks) collapse into batch nodes in the default in-build view.
+- **`is_dynamic` propagates through group collapse**: when the extended graph collapses same-type tasks into a batch node, the resulting aggregate edge is marked `is_dynamic=True` if _any_ underlying contributor is dynamic.
+
+#### Schema change
+
+- The `GET /builds/{id}/graph` response is now always the extended shape (`TaskGraphExtendedResponse` — with `groups`, `truncated`, `total_upstream_count`, `total_downstream_count`). Previously it returned the basic `TaskGraphResponse` shape when both depths were 0. The UI already handled both shapes via `isExtendedResponse`; other consumers reading the basic shape should switch to the extended one (all the same fields are present, plus the extended fields default sensibly when depths are 0).
+
+### UI
+
+- **Dynamic dep edges render dashed** (`strokeDasharray: "6 4"`) with the same grey stroke as static deps — subtle visual distinction that stays readable in dense DAGs.
+- **Hover tooltip on dynamic edges** ("Dynamic dependency — yielded at runtime from the upstream task's run() generator.") via a new `DynamicEdge` React Flow edge type with an SVG `<title>` child and a wider transparent hit-path for easy hovering.
+
+### Examples
+
+- New `stardag_examples.general.dynamic_deps_demo` — an `Orchestrator` that first runs `GetChunksToProcess(source_uri)` to decide how many chunks to process, then dynamically yields one `TransformChunk` per chunk; each `TransformChunk` statically requires its own `LoadChunk`. Deterministic `sha256(source_uri)`-based heuristic yields 1–6 chunks of size 1–8 per URI. Good demo of both static + dynamic deps in one pipeline.
+
 ## [0.5.8] — 2026-04-20
 
 ### SDK

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,85 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.5.9 — Dynamic deps visible in the DAG view
+
+Dynamically-yielded dependencies now register as graph edges in the Registry,
+so the DAG view can finally render the parent → yielded-dep relationship.
+Before v0.5.9, a task yielded from a `run()` / `run_aio()` generator only
+had its own static `requires()` chain recorded — the yielded dep appeared as
+a disconnected node in the DAG view.
+
+```python
+import stardag as sdag
+
+class Orchestrator(sdag.Task[int]):
+    source_uri: str
+
+    def requires(self):
+        return GetChunksToProcess(source_uri=self.source_uri)
+
+    def run(self):
+        specs = self.requires().load()
+        chunks = [TransformChunk(chunk=LoadChunk(spec=s)) for s in specs]
+        yield chunks  # ← these edges now reach the registry
+        self._save(sum(c.load() for c in chunks))
+```
+
+In the UI:
+
+- **Static edges** (declared via `task.requires()`) render as solid grey
+  lines — unchanged.
+- **Dynamic edges** (yielded from `run()` / `run_aio()`) render as
+  _dashed_ grey lines. Hover an edge to see a tooltip explaining it was
+  yielded at runtime.
+
+### Registry protocol addition
+
+A new method `RegistryABC.task_add_dependencies(_aio)` has been added. It
+accepts a task plus a list of upstream tasks and an `is_dynamic` flag.
+Default implementations on in-memory registries (`NoOpRegistry` etc.) are
+no-ops. `APIRegistry` POSTs to the new
+`POST /builds/{build_id}/tasks/{task_id}/dependencies` endpoint. Users who
+subclass `RegistryABC` get the no-op default for free.
+
+### Backward compatibility with older Registry API
+
+If your SDK is newer than the deployed Registry API (no
+`/dependencies` endpoint yet), the SDK call swallows the specific
+FastAPI "missing route" 404 (`{"detail": "Not Found"}`) and logs a
+warning — your builds keep working, you just won't see dynamic edges in
+the DAG view until the API is upgraded. App-level 404s (`"Build not
+found"`, `"Task … not registered …"`) still propagate normally.
+
+### Requires a Registry API update
+
+The companion API change (`is_dynamic` column on `task_dependencies` +
+the new `/dependencies` endpoint) ships as part of the same release of
+the platform. To see dynamic edges in the UI, deploy the updated Registry
+API **before** upgrading the SDK (the SDK tolerates the old API with a
+warning; reverse ordering loses the new-edge persistence until the SDK is
+bumped).
+
+### Also in this release
+
+- **`max_per_type_per_level` grouping now applies at depth=0**. The
+  `GET /builds/{id}/graph` endpoint previously only grouped when
+  `upstream_depth` or `downstream_depth` was > 0 — the default in-build
+  view ignored the setting. Builds with many structurally-identical tasks
+  (e.g. a 50-chunk parallel fan-out) now collapse those into batch nodes
+  in the default view.
+- **Group edges inherit `is_dynamic`**: when same-type tasks collapse
+  into a batch node, the resulting aggregate edge is marked dynamic if
+  _any_ underlying contributor is dynamic.
+- **New example**:
+  `stardag_examples.general.dynamic_deps_demo` — a small pipeline with
+  one static dep feeding dynamic yields (`Orchestrator` reads a
+  `GetChunksToProcess` result to decide what to yield), each yielded
+  task having its own static require. Exercises both edge types in a
+  single DAG.
+
+---
+
 ## v0.5.8 — Dynamic deps fixes: sequential build & async generators & Modal
 
 This release is primarily a correctness fix for dynamically-yielded tasks plus expanded support for the pattern across all executors.


### PR DESCRIPTION
## Summary

Release notes & changelog for the **v0.5.9** SDK release, covering the DAG-view dynamic deps work in [#123](https://github.com/stardag-dev/stardag/pull/123):

- **SDK**: ``RegistryABC.task_add_dependencies(_aio)`` + ``APIRegistry`` impl. Dynamic dep edges now reach the Registry so they render as upstream deps in the DAG view.
- **API**: ``is_dynamic`` column + new ``/dependencies`` endpoint + grouping at depth=0 + ``is_dynamic`` propagation through group collapse.
- **UI**: dashed grey dynamic edges + hover tooltip.
- **Example**: ``stardag_examples.general.dynamic_deps_demo``.

## Merge order

This PR depends on [#123](https://github.com/stardag-dev/stardag/pull/123) being merged first so the release describes features actually on ``main``. Suggested sequence:

1. **Merge #123 to main.**
2. **Deploy to stardag-cloud**: bump the ``stardag`` submodule pointer in ``stardag-cloud`` → cut ``release`` branch → deploy API (applies the ``is_dynamic`` Alembic migration) + UI. Once the platform is running the new code, existing builds in the UI pick up the new rendering, and new builds start seeing dynamic edges.
3. **Rebase this branch onto the new main** (trivial — only ``CHANGELOG.md`` / ``RELEASE_NOTES.md`` touched) and merge.
4. **Tag ``v0.5.9`` on the post-merge ``main`` HEAD** and push — triggers the ``Publish Python Package`` workflow (TestPyPI → PyPI → signed GitHub Release). Then edit the release with the title + body from ``RELEASE_NOTES.md``, reducing heading levels by one per the project release process.

## Test plan

- [x] ``pre-commit run --files CHANGELOG.md RELEASE_NOTES.md`` — clean.
- [x] Formatting matches existing entries (``## [0.5.x] — YYYY-MM-DD`` in CHANGELOG; ``## vX.Y.Z — title`` in RELEASE_NOTES).
- [x] Release notes call out the deployment order (API before SDK) and the minor API response shape tightening on ``GET /builds/{id}/graph``.
- [x] Reference to the matching platform changes (``is_dynamic`` column, new endpoint, grouping-at-depth-0) in the "Also in this release" section so it's discoverable from the SDK notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)