### PR TITLE
API perf Tier 1: bcrypt cache, engine config, gunicorn workers, parameterised infra

### DIFF
--- a/app/stardag-api/Dockerfile
+++ b/app/stardag-api/Dockerfile
@@ -18,4 +18,11 @@ COPY migrations/ migrations/
 
 EXPOSE 8000
 
-CMD ["uvicorn", "stardag_api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+# gunicorn with multiple uvicorn workers absorbs CPU-bound bursts (auth /
+# JWT verification, bcrypt cache misses) better than a single uvicorn
+# process. The default is sized for the production Fargate sizing
+# (1 vCPU); override at deploy time via GUNICORN_WORKERS for a different
+# sizing. Note: limits.py rate-limiter and entity-count cache are
+# per-process; effective per-instance limits scale with worker count.
+ENV GUNICORN_WORKERS=2
+CMD ["sh", "-c", "exec gunicorn stardag_api.main:app -k uvicorn.workers.UvicornWorker -w ${GUNICORN_WORKERS} --bind 0.0.0.0:8000 --access-logfile - --error-logfile -"]

--- a/app/stardag-api/Dockerfile
+++ b/app/stardag-api/Dockerfile
@@ -24,5 +24,12 @@ EXPOSE 8000
 # (1 vCPU); override at deploy time via GUNICORN_WORKERS for a different
 # sizing. Note: limits.py rate-limiter and entity-count cache are
 # per-process; effective per-instance limits scale with worker count.
+#
+# --preload imports the app module once in the master process before
+# fork()-ing workers. main.py eagerly instantiates the InternalTokenManager
+# at import time, so its (potentially ephemeral) RSA keypair is generated
+# in the master and inherited by every worker. Without --preload, each
+# worker would generate its own keypair — a token signed in worker A
+# would then fail validation in worker B and return 401.
 ENV GUNICORN_WORKERS=2
-CMD ["sh", "-c", "exec gunicorn stardag_api.main:app -k uvicorn.workers.UvicornWorker -w ${GUNICORN_WORKERS} --bind 0.0.0.0:8000 --access-logfile - --error-logfile -"]
+CMD ["sh", "-c", "exec gunicorn stardag_api.main:app -k uvicorn.workers.UvicornWorker -w ${GUNICORN_WORKERS} --preload --bind 0.0.0.0:8000 --access-logfile - --error-logfile -"]

--- a/app/stardag-api/pyproject.toml
+++ b/app/stardag-api/pyproject.toml
@@ -7,6 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn[standard]>=0.32.0",
+    "gunicorn>=23.0.0",
     "sqlalchemy[asyncio]>=2.0.0",
     "asyncpg>=0.30.0",
     "alembic>=1.14.0",

--- a/app/stardag-api/src/stardag_api/db/__init__.py
+++ b/app/stardag-api/src/stardag_api/db/__init__.py
@@ -4,7 +4,25 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from stardag_api.config import settings
 
-engine = create_async_engine(settings.effective_database_url)
+# Pool sizing: pool_size + max_overflow caps simultaneous connections per
+# process. With multiple uvicorn workers per ECS task this multiplies; sized
+# to stay well under Aurora's max_connections at the lowest ACU we run.
+# pool_pre_ping handles Aurora idle-timeouts and quiet failovers transparently.
+# pool_recycle forces a fresh connection at least every 30 min, defending
+# against silent NLB / Aurora-side disconnects.
+_engine_kwargs: dict[str, object] = {
+    "pool_size": 10,
+    "max_overflow": 20,
+    "pool_pre_ping": True,
+    "pool_recycle": 1800,
+}
+
+# SQLite (used by the in-memory test DB) doesn't support these pool settings;
+# pass them only for real DB backends.
+if settings.effective_database_url.startswith("sqlite"):
+    _engine_kwargs = {}
+
+engine = create_async_engine(settings.effective_database_url, **_engine_kwargs)
 async_session_maker = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/app/stardag-api/src/stardag_api/main.py
+++ b/app/stardag-api/src/stardag_api/main.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from stardag_api.auth.tokens import get_token_manager
 from stardag_api.config import settings
 from stardag_api.routes import (
     auth_router,
@@ -12,6 +13,14 @@ from stardag_api.routes import (
     tasks_router,
     ui_router,
 )
+
+
+# Eagerly construct the InternalTokenManager so its (potentially ephemeral)
+# RSA keypair is generated at module-import time. Combined with gunicorn's
+# --preload flag this happens once in the master process and is inherited
+# by every forked worker — without it, each worker would generate a fresh
+# keypair and tokens signed in one worker would fail validation in another.
+get_token_manager()
 
 
 app = FastAPI(

--- a/app/stardag-api/src/stardag_api/services/api_keys.py
+++ b/app/stardag-api/src/stardag_api/services/api_keys.py
@@ -111,12 +111,13 @@ class _ValidationCache:
         return hashlib.sha256(full_key.encode("utf-8")).digest()
 
     def get(self, full_key: str) -> UUID | None:
-        entry = self._cache.get(self._hash(full_key))
+        key = self._hash(full_key)
+        entry = self._cache.get(key)
         if entry is None:
             return None
         api_key_id, expires_at = entry
         if time.monotonic() > expires_at:
-            self._cache.pop(self._hash(full_key), None)
+            self._cache.pop(key, None)
             return None
         return api_key_id
 

--- a/app/stardag-api/src/stardag_api/services/api_keys.py
+++ b/app/stardag-api/src/stardag_api/services/api_keys.py
@@ -24,8 +24,10 @@ KEY_RANDOM_BYTES = 24  # 32 chars in base64
 # Validation cache TTL. Bcrypt verification is ~20-100ms of CPU per check at
 # default cost (12 rounds). Caching the result for a short window collapses
 # repeated SDK calls (which can be hundreds per build burst) to a single bcrypt
-# verification per key per minute per process. Revoked/expired keys are
-# detected on the next request after the entry expires.
+# verification per key per minute per process. Revocations are still detected
+# on the next request: validate_api_key re-fetches the ApiKey row by primary
+# key on cache hit and re-checks revoked_at, so the TTL only bounds how long
+# we can skip bcrypt — not how long a revoked key continues to authenticate.
 _VALIDATION_CACHE_TTL_SECONDS = 60.0
 # Soft cap on cache entries; valid keys only grow the cache, so this is mostly
 # a safety net. If exceeded the cache is cleared and re-warmed.
@@ -89,9 +91,12 @@ class _ValidationCache:
 
     Keys are sha256(full_key) so the plaintext key isn't kept as a dict key.
     Values are (api_key_id, expires_at_monotonic). Entries expire after
-    _VALIDATION_CACHE_TTL_SECONDS; revoked keys are detected on the next
-    request after the entry expires (acceptable per the in-memory guardrail
-    pattern used elsewhere in this service).
+    _VALIDATION_CACHE_TTL_SECONDS, which bounds how long a successful bcrypt
+    verification can be skipped for repeated requests in this process.
+    Revocations and deletions are detected immediately on the next cache-hit
+    request — validate_api_key re-fetches the ApiKey row by primary key and
+    re-checks revoked_at — so the TTL is purely a bcrypt-skip window, not a
+    correctness window.
 
     Concurrency: mutated only by async handlers running on a single uvicorn
     worker's event loop, so dict ops are safe without a lock.

--- a/app/stardag-api/src/stardag_api/services/api_keys.py
+++ b/app/stardag-api/src/stardag_api/services/api_keys.py
@@ -1,6 +1,10 @@
 """API Key service for generating, validating, and managing API keys."""
 
+import asyncio
+import hashlib
+import logging
 import secrets
+import time
 from datetime import datetime, timezone
 from uuid import UUID
 
@@ -10,10 +14,22 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from stardag_api.models import ApiKey
 
+logger = logging.getLogger(__name__)
+
 # Key format: sk_<environment_prefix>_<random_bytes>
 # Total length: ~40 characters
 KEY_PREFIX = "sk_"
 KEY_RANDOM_BYTES = 24  # 32 chars in base64
+
+# Validation cache TTL. Bcrypt verification is ~20-100ms of CPU per check at
+# default cost (12 rounds). Caching the result for a short window collapses
+# repeated SDK calls (which can be hundreds per build burst) to a single bcrypt
+# verification per key per minute per process. Revoked/expired keys are
+# detected on the next request after the entry expires.
+_VALIDATION_CACHE_TTL_SECONDS = 60.0
+# Soft cap on cache entries; valid keys only grow the cache, so this is mostly
+# a safety net. If exceeded the cache is cleared and re-warmed.
+_VALIDATION_CACHE_MAX_ENTRIES = 10_000
 
 
 def generate_api_key(environment_id: UUID) -> tuple[str, str, str]:
@@ -56,6 +72,74 @@ def verify_api_key(full_key: str, key_hash: str) -> bool:
         return bcrypt.checkpw(full_key.encode("utf-8"), key_hash.encode("utf-8"))
     except Exception:
         return False
+
+
+async def verify_api_key_async(full_key: str, key_hash: str) -> bool:
+    """Async wrapper around verify_api_key.
+
+    bcrypt is CPU-bound and synchronous; running it on the event loop blocks
+    every other request on this worker for the duration of the check. Offload
+    to a thread so the loop can keep serving traffic.
+    """
+    return await asyncio.to_thread(verify_api_key, full_key, key_hash)
+
+
+class _ValidationCache:
+    """In-process TTL cache for validate_api_key results.
+
+    Keys are sha256(full_key) so the plaintext key isn't kept as a dict key.
+    Values are (api_key_id, expires_at_monotonic). Entries expire after
+    _VALIDATION_CACHE_TTL_SECONDS; revoked keys are detected on the next
+    request after the entry expires (acceptable per the in-memory guardrail
+    pattern used elsewhere in this service).
+
+    Concurrency: mutated only by async handlers running on a single uvicorn
+    worker's event loop, so dict ops are safe without a lock.
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: float = _VALIDATION_CACHE_TTL_SECONDS,
+        max_entries: int = _VALIDATION_CACHE_MAX_ENTRIES,
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._max_entries = max_entries
+        self._cache: dict[bytes, tuple[UUID, float]] = {}
+
+    @staticmethod
+    def _hash(full_key: str) -> bytes:
+        return hashlib.sha256(full_key.encode("utf-8")).digest()
+
+    def get(self, full_key: str) -> UUID | None:
+        entry = self._cache.get(self._hash(full_key))
+        if entry is None:
+            return None
+        api_key_id, expires_at = entry
+        if time.monotonic() > expires_at:
+            self._cache.pop(self._hash(full_key), None)
+            return None
+        return api_key_id
+
+    def put(self, full_key: str, api_key_id: UUID) -> None:
+        if len(self._cache) >= self._max_entries:
+            logger.warning(
+                "api-key validation cache exceeded %d entries; clearing",
+                self._max_entries,
+            )
+            self._cache.clear()
+        self._cache[self._hash(full_key)] = (
+            api_key_id,
+            time.monotonic() + self._ttl,
+        )
+
+    def invalidate(self, full_key: str) -> None:
+        self._cache.pop(self._hash(full_key), None)
+
+    def clear(self) -> None:
+        self._cache.clear()
+
+
+_validation_cache = _ValidationCache()
 
 
 async def create_api_key(
@@ -187,7 +271,13 @@ async def validate_api_key(
 ) -> ApiKey | None:
     """Validate an API key and return the associated key record.
 
-    This is the main authentication function for API key auth.
+    This is the main authentication function for API key auth. Successful
+    validations are cached in-process for _VALIDATION_CACHE_TTL_SECONDS so
+    we don't run bcrypt on every authenticated request. On cache hit we
+    still re-fetch the ApiKey by primary key and re-check `revoked_at`, so
+    revocations take effect on the next request after revoke. The bcrypt
+    verification on cache miss runs in a thread so it doesn't block the
+    event loop.
 
     Args:
         db: Database session
@@ -206,15 +296,27 @@ async def validate_api_key(
     except IndexError:
         return None
 
-    # Find potential matches by prefix
+    # Cache hit: confirm the row still exists and isn't revoked, then return.
+    # We trade one PK lookup for skipping the prefix scan + bcrypt loop.
+    cached_id = _validation_cache.get(full_key)
+    if cached_id is not None:
+        api_key = await db.get(ApiKey, cached_id)
+        if api_key is not None and api_key.revoked_at is None:
+            return api_key
+        # Revoked or deleted since cache entry was created.
+        _validation_cache.invalidate(full_key)
+
+    # Cache miss: do the full validation flow.
     candidates = await find_api_key_by_prefix(db, key_prefix)
 
-    # Verify against each candidate's hash
     for candidate in candidates:
-        if verify_api_key(full_key, candidate.key_hash):
-            # Update last_used_at
+        if await verify_api_key_async(full_key, candidate.key_hash):
+            # Update last_used_at on cache miss only — once per TTL window
+            # is plenty for this informational column and avoids per-request
+            # write traffic.
             candidate.last_used_at = datetime.now(timezone.utc)
             await db.flush()
+            _validation_cache.put(full_key, candidate.id)
             return candidate
 
     return None

--- a/app/stardag-api/tests/conftest.py
+++ b/app/stardag-api/tests/conftest.py
@@ -205,12 +205,15 @@ async def unauthenticated_client(async_engine) -> AsyncGenerator[AsyncClient, No
 def clear_limits_caches():
     """Clear in-memory caches between tests to prevent cross-test pollution."""
     from stardag_api.limits import _entity_cache, _rate_limiter
+    from stardag_api.services.api_keys import _validation_cache
 
     _rate_limiter.clear()
     _entity_cache.clear()
+    _validation_cache.clear()
     yield
     _rate_limiter.clear()
     _entity_cache.clear()
+    _validation_cache.clear()
 
 
 # PostgreSQL test fixtures for integration testing with real migrations

--- a/app/stardag-api/tests/test_api_keys.py
+++ b/app/stardag-api/tests/test_api_keys.py
@@ -68,9 +68,10 @@ class TestValidationCache:
             cache.put(f"sk_k{i}", UUID(int=i))
         # Fourth put should clear the cache before inserting.
         cache.put("sk_k_overflow", UUID(int=99))
-        # The first three are gone.
+        # All three pre-overflow entries are gone.
         assert cache.get("sk_k0") is None
         assert cache.get("sk_k1") is None
+        assert cache.get("sk_k2") is None
         # The new entry is present.
         assert cache.get("sk_k_overflow") == UUID(int=99)
 

--- a/app/stardag-api/tests/test_api_keys.py
+++ b/app/stardag-api/tests/test_api_keys.py
@@ -1,0 +1,209 @@
+"""Tests for the api_keys service, focusing on validation, the in-process
+TTL cache, and revocation semantics."""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from stardag_api.services import api_keys
+from stardag_api.services.api_keys import (
+    _ValidationCache,
+    create_api_key,
+    revoke_api_key,
+    validate_api_key,
+)
+from tests.conftest import DEFAULT_ENVIRONMENT_ID
+
+
+# ---------------------------------------------------------------------------
+# _ValidationCache unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidationCache:
+    def test_get_missing_returns_none(self) -> None:
+        cache = _ValidationCache()
+        assert cache.get("sk_anything") is None
+
+    def test_put_then_get_returns_id(self) -> None:
+        cache = _ValidationCache(ttl_seconds=60)
+        api_key_id = UUID("00000000-0000-0000-0000-00000000abcd")
+        cache.put("sk_full_key", api_key_id)
+        assert cache.get("sk_full_key") == api_key_id
+
+    def test_get_after_ttl_returns_none(self) -> None:
+        cache = _ValidationCache(ttl_seconds=60)
+        api_key_id = UUID("00000000-0000-0000-0000-00000000abcd")
+
+        with patch.object(time, "monotonic", return_value=1000.0):
+            cache.put("sk_full_key", api_key_id)
+
+        # Past the TTL.
+        with patch.object(time, "monotonic", return_value=1061.0):
+            assert cache.get("sk_full_key") is None
+
+    def test_invalidate_drops_entry(self) -> None:
+        cache = _ValidationCache()
+        api_key_id = UUID("00000000-0000-0000-0000-00000000abcd")
+        cache.put("sk_full_key", api_key_id)
+        cache.invalidate("sk_full_key")
+        assert cache.get("sk_full_key") is None
+
+    def test_clear_drops_all_entries(self) -> None:
+        cache = _ValidationCache()
+        cache.put("sk_a", UUID("00000000-0000-0000-0000-000000000001"))
+        cache.put("sk_b", UUID("00000000-0000-0000-0000-000000000002"))
+        cache.clear()
+        assert cache.get("sk_a") is None
+        assert cache.get("sk_b") is None
+
+    def test_max_entries_clears_when_exceeded(self) -> None:
+        cache = _ValidationCache(max_entries=3)
+        for i in range(3):
+            cache.put(f"sk_k{i}", UUID(int=i))
+        # Fourth put should clear the cache before inserting.
+        cache.put("sk_k_overflow", UUID(int=99))
+        # The first three are gone.
+        assert cache.get("sk_k0") is None
+        assert cache.get("sk_k1") is None
+        # The new entry is present.
+        assert cache.get("sk_k_overflow") == UUID(int=99)
+
+    def test_keys_are_hashed_not_stored_plain(self) -> None:
+        # Ensure the dict is keyed by sha256 digest, not the raw secret.
+        cache = _ValidationCache()
+        cache.put("sk_secret", UUID(int=1))
+        # No raw key should appear in the cache state.
+        for stored_key in cache._cache:  # noqa: SLF001 — internal state check
+            assert b"sk_secret" not in stored_key
+
+
+# ---------------------------------------------------------------------------
+# validate_api_key integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateApiKey:
+    async def test_invalid_format_returns_none(
+        self, async_session: AsyncSession
+    ) -> None:
+        assert await validate_api_key(async_session, "not-a-key") is None
+        assert await validate_api_key(async_session, "") is None
+
+    async def test_valid_key_returns_record(self, async_session: AsyncSession) -> None:
+        api_key, full_key = await create_api_key(
+            async_session, DEFAULT_ENVIRONMENT_ID, name="t1"
+        )
+        await async_session.commit()
+        result = await validate_api_key(async_session, full_key)
+        assert result is not None
+        assert result.id == api_key.id
+
+    async def test_unknown_key_returns_none(self, async_session: AsyncSession) -> None:
+        # Well-formed but never created.
+        unknown = "sk_abcdef_" + "x" * 32
+        assert await validate_api_key(async_session, unknown) is None
+
+    async def test_revoked_key_returns_none(self, async_session: AsyncSession) -> None:
+        api_key, full_key = await create_api_key(
+            async_session, DEFAULT_ENVIRONMENT_ID, name="t-revoke"
+        )
+        await async_session.commit()
+        # Validate once to warm cache.
+        assert await validate_api_key(async_session, full_key) is not None
+
+        await revoke_api_key(async_session, api_key.id)
+        await async_session.commit()
+        # Cache hit path must still detect revocation via PK refetch.
+        assert await validate_api_key(async_session, full_key) is None
+
+
+# ---------------------------------------------------------------------------
+# Cache hit path skips bcrypt; cache miss path uses asyncio.to_thread
+# ---------------------------------------------------------------------------
+
+
+class TestValidateCachingBehavior:
+    async def test_cache_hit_skips_bcrypt(self, async_session: AsyncSession) -> None:
+        _, full_key = await create_api_key(
+            async_session, DEFAULT_ENVIRONMENT_ID, name="t-cache"
+        )
+        await async_session.commit()
+
+        # Warm the cache.
+        assert await validate_api_key(async_session, full_key) is not None
+
+        # On the second call, verify_api_key (bcrypt) must not run.
+        with patch.object(api_keys, "verify_api_key_async") as mock_verify:
+            result = await validate_api_key(async_session, full_key)
+            assert result is not None
+            mock_verify.assert_not_awaited()
+
+    async def test_cache_miss_uses_async_verify(
+        self, async_session: AsyncSession
+    ) -> None:
+        _, full_key = await create_api_key(
+            async_session, DEFAULT_ENVIRONMENT_ID, name="t-miss"
+        )
+        await async_session.commit()
+
+        # Cold cache. verify_api_key_async should be awaited at least once.
+        with patch.object(
+            api_keys, "verify_api_key_async", wraps=api_keys.verify_api_key_async
+        ) as mock_verify:
+            result = await validate_api_key(async_session, full_key)
+            assert result is not None
+            mock_verify.assert_awaited()
+
+    async def test_cache_isolated_per_full_key(
+        self, async_session: AsyncSession
+    ) -> None:
+        _, key_a = await create_api_key(
+            async_session, DEFAULT_ENVIRONMENT_ID, name="t-a"
+        )
+        _, key_b = await create_api_key(
+            async_session, DEFAULT_ENVIRONMENT_ID, name="t-b"
+        )
+        await async_session.commit()
+        # Validating key_a must not let key_b validate from cache.
+        assert await validate_api_key(async_session, key_a) is not None
+        with patch.object(api_keys, "verify_api_key_async") as mock_verify:
+            mock_verify.return_value = False
+            # key_b is unknown to the cache, so it must take the verify path.
+            await validate_api_key(async_session, key_b)
+            mock_verify.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# verify_api_key_async runs in a thread
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyAsync:
+    async def test_async_verify_returns_true_for_valid(self) -> None:
+        # Use a known-good plaintext/hash pair so we don't depend on the
+        # in-DB record. generate_api_key bakes the hash so we round-trip it.
+        from stardag_api.services.api_keys import generate_api_key
+
+        full_key, _, key_hash = generate_api_key(DEFAULT_ENVIRONMENT_ID)
+        assert await api_keys.verify_api_key_async(full_key, key_hash) is True
+
+    async def test_async_verify_returns_false_for_wrong(self) -> None:
+        from stardag_api.services.api_keys import generate_api_key
+
+        _, _, key_hash = generate_api_key(DEFAULT_ENVIRONMENT_ID)
+        assert await api_keys.verify_api_key_async("sk_wrong_value", key_hash) is False
+
+
+@pytest.fixture(autouse=True)
+def _clear_validation_cache_each_test():
+    """The autouse cache-clearing fixture in conftest also clears this one,
+    but be explicit here so test order doesn't matter."""
+    api_keys._validation_cache.clear()
+    yield
+    api_keys._validation_cache.clear()

--- a/app/stardag-api/uv.lock
+++ b/app/stardag-api/uv.lock
@@ -505,6 +505,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gunicorn"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c4/f4/e78fa054248fab913e2eab0332c6c2cb07421fca1ce56d8fe43b6aef57a4/gunicorn-25.3.0.tar.gz", hash = "sha256:f74e1b2f9f76f6cd1ca01198968bd2dd65830edc24b6e8e4d78de8320e2fe889", size = 634883, upload-time = "2026-03-27T00:00:26.092Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/c8/8aaf447698c4d59aa853fd318eed300b5c9e44459f242ab8ead6c9c09792/gunicorn-25.3.0-py3-none-any.whl", hash = "sha256:cacea387dab08cd6776501621c295a904fe8e3b7aae9a1a3cbb26f4e7ed54660", size = 208403, upload-time = "2026-03-27T00:00:27.386Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1155,6 +1167,7 @@ dependencies = [
     { name = "bcrypt" },
     { name = "boto3" },
     { name = "fastapi" },
+    { name = "gunicorn" },
     { name = "httpx" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -1180,6 +1193,7 @@ requires-dist = [
     { name = "bcrypt", specifier = ">=4.0.0" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "pydantic", specifier = ">=2.8.2" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },

--- a/infra/aws-cdk/lib/api-stack.ts
+++ b/infra/aws-cdk/lib/api-stack.ts
@@ -53,7 +53,28 @@ export class ApiStack extends cdk.Stack {
     // initial desired count.
     const apiAutoscaleMin = intEnv("STARDAG_API_AUTOSCALE_MIN", apiDesiredCount);
     const apiAutoscaleMax = intEnv("STARDAG_API_AUTOSCALE_MAX", 4);
+    if (apiAutoscaleMax < apiAutoscaleMin) {
+      throw new Error(
+        `STARDAG_API_AUTOSCALE_MAX (${apiAutoscaleMax}) must be >= ` +
+          `STARDAG_API_AUTOSCALE_MIN (${apiAutoscaleMin})`,
+      );
+    }
     const apiGunicornWorkers = process.env.STARDAG_API_GUNICORN_WORKERS;
+    if (apiGunicornWorkers !== undefined) {
+      const trimmed = apiGunicornWorkers.trim();
+      const parsed = Number.parseInt(trimmed, 10);
+      if (
+        trimmed.length === 0 ||
+        !Number.isInteger(parsed) ||
+        parsed < 1 ||
+        parsed.toString() !== trimmed
+      ) {
+        throw new Error(
+          `STARDAG_API_GUNICORN_WORKERS=${JSON.stringify(apiGunicornWorkers)} ` +
+            `must be a positive integer`,
+        );
+      }
+    }
 
     // =============================================================
     // ECS Cluster

--- a/infra/aws-cdk/lib/api-stack.ts
+++ b/infra/aws-cdk/lib/api-stack.ts
@@ -38,6 +38,15 @@ export class ApiStack extends cdk.Stack {
 
     const { config, foundation } = props;
 
+    // Sizing knobs that ops may want to tune at deploy time without
+    // editing this file. Defaults match the OSS-friendly free-tier shape;
+    // production overrides come from the environment.
+    const apiCpu = Number(process.env.STARDAG_API_CPU ?? 256);
+    const apiMemoryMiB = Number(process.env.STARDAG_API_MEMORY_MIB ?? 512);
+    const apiDesiredCount = Number(process.env.STARDAG_API_DESIRED_COUNT ?? 1);
+    const apiAutoscaleMax = Number(process.env.STARDAG_API_AUTOSCALE_MAX ?? 4);
+    const apiGunicornWorkers = process.env.STARDAG_API_GUNICORN_WORKERS;
+
     // =============================================================
     // ECS Cluster
     // =============================================================
@@ -80,8 +89,8 @@ export class ApiStack extends cdk.Stack {
     // Task Definition
     // =============================================================
     const taskDefinition = new ecs.FargateTaskDefinition(this, "TaskDef", {
-      cpu: 256,
-      memoryLimitMiB: 512,
+      cpu: apiCpu,
+      memoryLimitMiB: apiMemoryMiB,
       runtimePlatform: {
         cpuArchitecture: ecs.CpuArchitecture.X86_64,
         operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
@@ -137,6 +146,9 @@ export class ApiStack extends cdk.Stack {
         LIMITS_MAX_ASSETS_PER_WORKSPACE_24H: "1000",
         LIMITS_MAX_DEPENDENCY_IDS_PER_TASK: "500",
         LIMITS_MAX_ASSETS_PER_TASK: "10",
+        // Worker count is read by the Dockerfile CMD; keep undefined here
+        // to fall through to the image's default (sized for 1 vCPU).
+        ...(apiGunicornWorkers ? { GUNICORN_WORKERS: apiGunicornWorkers } : {}),
       },
       secrets: {
         // Inject database credentials from Secrets Manager
@@ -181,7 +193,7 @@ export class ApiStack extends cdk.Stack {
       {
         cluster: this.cluster,
         taskDefinition,
-        desiredCount: 1,
+        desiredCount: apiDesiredCount,
         serviceName: "stardag-api",
 
         // Networking
@@ -234,8 +246,8 @@ export class ApiStack extends cdk.Stack {
     // Auto Scaling
     // =============================================================
     const scaling = this.service.service.autoScaleTaskCount({
-      minCapacity: 1,
-      maxCapacity: 4,
+      minCapacity: apiDesiredCount,
+      maxCapacity: apiAutoscaleMax,
     });
 
     scaling.scaleOnCpuUtilization("CpuScaling", {

--- a/infra/aws-cdk/lib/api-stack.ts
+++ b/infra/aws-cdk/lib/api-stack.ts
@@ -11,6 +11,7 @@ import * as route53 from "aws-cdk-lib/aws-route53";
 import * as route53_targets from "aws-cdk-lib/aws-route53-targets";
 import { Construct } from "constructs";
 import { StardagConfig } from "./config";
+import { intEnv } from "./env";
 import { FoundationStack } from "./foundation-stack";
 
 export interface ApiStackProps extends cdk.StackProps {
@@ -40,11 +41,18 @@ export class ApiStack extends cdk.Stack {
 
     // Sizing knobs that ops may want to tune at deploy time without
     // editing this file. Defaults match the OSS-friendly free-tier shape;
-    // production overrides come from the environment.
-    const apiCpu = Number(process.env.STARDAG_API_CPU ?? 256);
-    const apiMemoryMiB = Number(process.env.STARDAG_API_MEMORY_MIB ?? 512);
-    const apiDesiredCount = Number(process.env.STARDAG_API_DESIRED_COUNT ?? 1);
-    const apiAutoscaleMax = Number(process.env.STARDAG_API_AUTOSCALE_MAX ?? 4);
+    // production overrides come from the environment. Each helper throws
+    // on malformed input rather than silently emitting NaN into the
+    // rendered template.
+    const apiCpu = intEnv("STARDAG_API_CPU", 256);
+    const apiMemoryMiB = intEnv("STARDAG_API_MEMORY_MIB", 512);
+    const apiDesiredCount = intEnv("STARDAG_API_DESIRED_COUNT", 1);
+    // Autoscale floor defaults to desiredCount so ops who only set
+    // DESIRED_COUNT get the historical behaviour. Override with
+    // STARDAG_API_AUTOSCALE_MIN to let the service scale below the
+    // initial desired count.
+    const apiAutoscaleMin = intEnv("STARDAG_API_AUTOSCALE_MIN", apiDesiredCount);
+    const apiAutoscaleMax = intEnv("STARDAG_API_AUTOSCALE_MAX", 4);
     const apiGunicornWorkers = process.env.STARDAG_API_GUNICORN_WORKERS;
 
     // =============================================================
@@ -246,7 +254,7 @@ export class ApiStack extends cdk.Stack {
     // Auto Scaling
     // =============================================================
     const scaling = this.service.service.autoScaleTaskCount({
-      minCapacity: apiDesiredCount,
+      minCapacity: apiAutoscaleMin,
       maxCapacity: apiAutoscaleMax,
     });
 

--- a/infra/aws-cdk/lib/env.ts
+++ b/infra/aws-cdk/lib/env.ts
@@ -1,0 +1,32 @@
+/**
+ * Helpers for parsing CDK sizing knobs from environment variables.
+ *
+ * The naive `Number(process.env.X ?? default)` pattern silently produces
+ * `NaN` on malformed input (e.g. `STARDAG_API_CPU=1o24`); that NaN then
+ * propagates into FargateTaskDefinition / Aurora capacity / desiredCount
+ * without complaint, and CDK synth emits `"NaN"` strings. These helpers
+ * fail loudly so a deploy-time typo doesn't render the rendered template
+ * useless.
+ */
+
+export function numEnv(key: string, defaultValue: number): number {
+  const raw = process.env[key];
+  if (raw === undefined || raw === "") return defaultValue;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) {
+    throw new Error(
+      `Environment variable ${key}=${JSON.stringify(raw)} is not a finite number`,
+    );
+  }
+  return n;
+}
+
+export function intEnv(key: string, defaultValue: number): number {
+  const n = numEnv(key, defaultValue);
+  if (!Number.isInteger(n)) {
+    throw new Error(
+      `Environment variable ${key}=${process.env[key]} is not an integer`,
+    );
+  }
+  return n;
+}

--- a/infra/aws-cdk/lib/foundation-stack.ts
+++ b/infra/aws-cdk/lib/foundation-stack.ts
@@ -68,11 +68,19 @@ export class FoundationStack extends cdk.Stack {
     // =============================================================
     // Database
     // =============================================================
+    const dbMinAcu = numEnv("STARDAG_DB_MIN_ACU", 0.5);
+    const dbMaxAcu = numEnv("STARDAG_DB_MAX_ACU", 4);
+    if (dbMaxAcu < dbMinAcu) {
+      throw new Error(
+        `STARDAG_DB_MAX_ACU (${dbMaxAcu}) must be >= ` +
+          `STARDAG_DB_MIN_ACU (${dbMinAcu})`,
+      );
+    }
     const database = new StardagDatabase(this, "Database", {
       vpc: this.vpc,
       databaseName: "stardag",
-      minCapacity: numEnv("STARDAG_DB_MIN_ACU", 0.5),
-      maxCapacity: numEnv("STARDAG_DB_MAX_ACU", 4),
+      minCapacity: dbMinAcu,
+      maxCapacity: dbMaxAcu,
     });
 
     this.dbClusterEndpoint = database.cluster.clusterEndpoint.hostname;

--- a/infra/aws-cdk/lib/foundation-stack.ts
+++ b/infra/aws-cdk/lib/foundation-stack.ts
@@ -4,6 +4,7 @@ import * as ecr from "aws-cdk-lib/aws-ecr";
 import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import { Construct } from "constructs";
 import { StardagConfig } from "./config";
+import { numEnv } from "./env";
 import { StardagVpc } from "./constructs/vpc";
 import { StardagDatabase } from "./constructs/database";
 import { StardagCognito } from "./constructs/cognito";
@@ -70,8 +71,8 @@ export class FoundationStack extends cdk.Stack {
     const database = new StardagDatabase(this, "Database", {
       vpc: this.vpc,
       databaseName: "stardag",
-      minCapacity: Number(process.env.STARDAG_DB_MIN_ACU ?? 0.5),
-      maxCapacity: Number(process.env.STARDAG_DB_MAX_ACU ?? 4),
+      minCapacity: numEnv("STARDAG_DB_MIN_ACU", 0.5),
+      maxCapacity: numEnv("STARDAG_DB_MAX_ACU", 4),
     });
 
     this.dbClusterEndpoint = database.cluster.clusterEndpoint.hostname;

--- a/infra/aws-cdk/lib/foundation-stack.ts
+++ b/infra/aws-cdk/lib/foundation-stack.ts
@@ -70,8 +70,8 @@ export class FoundationStack extends cdk.Stack {
     const database = new StardagDatabase(this, "Database", {
       vpc: this.vpc,
       databaseName: "stardag",
-      minCapacity: 0.5,
-      maxCapacity: 4,
+      minCapacity: Number(process.env.STARDAG_DB_MIN_ACU ?? 0.5),
+      maxCapacity: Number(process.env.STARDAG_DB_MAX_ACU ?? 4),
     });
 
     this.dbClusterEndpoint = database.cluster.clusterEndpoint.hostname;

--- a/infra/aws-cdk/lib/stardag-stack.ts
+++ b/infra/aws-cdk/lib/stardag-stack.ts
@@ -1,6 +1,7 @@
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import { StardagConfig } from "./config";
+import { intEnv, numEnv } from "./env";
 import { StardagVpc } from "./constructs/vpc";
 import { StardagDatabase } from "./constructs/database";
 import { StardagCognito } from "./constructs/cognito";
@@ -39,8 +40,8 @@ export class StardagStack extends cdk.Stack {
     this.database = new StardagDatabase(this, "Database", {
       vpc: this.vpc.vpc,
       databaseName: "stardag",
-      minCapacity: Number(process.env.STARDAG_DB_MIN_ACU ?? 0.5),
-      maxCapacity: Number(process.env.STARDAG_DB_MAX_ACU ?? 4),
+      minCapacity: numEnv("STARDAG_DB_MIN_ACU", 0.5),
+      maxCapacity: numEnv("STARDAG_DB_MAX_ACU", 4),
     });
 
     // =============================================================
@@ -83,9 +84,9 @@ export class StardagStack extends cdk.Stack {
       oidcAudience: this.cognito.userPoolClient.userPoolClientId,
       apiDomain: config.apiDomain,
       uiDomain: config.uiDomain,
-      cpu: Number(process.env.STARDAG_API_CPU ?? 256),
-      memoryLimitMiB: Number(process.env.STARDAG_API_MEMORY_MIB ?? 512),
-      desiredCount: Number(process.env.STARDAG_API_DESIRED_COUNT ?? 1),
+      cpu: intEnv("STARDAG_API_CPU", 256),
+      memoryLimitMiB: intEnv("STARDAG_API_MEMORY_MIB", 512),
+      desiredCount: intEnv("STARDAG_API_DESIRED_COUNT", 1),
       certificate: this.dns?.apiCertificate,
     });
 

--- a/infra/aws-cdk/lib/stardag-stack.ts
+++ b/infra/aws-cdk/lib/stardag-stack.ts
@@ -39,8 +39,8 @@ export class StardagStack extends cdk.Stack {
     this.database = new StardagDatabase(this, "Database", {
       vpc: this.vpc.vpc,
       databaseName: "stardag",
-      minCapacity: 0.5, // Minimum ACU
-      maxCapacity: 4, // Scale up to 4 ACU under load
+      minCapacity: Number(process.env.STARDAG_DB_MIN_ACU ?? 0.5),
+      maxCapacity: Number(process.env.STARDAG_DB_MAX_ACU ?? 4),
     });
 
     // =============================================================
@@ -83,9 +83,9 @@ export class StardagStack extends cdk.Stack {
       oidcAudience: this.cognito.userPoolClient.userPoolClientId,
       apiDomain: config.apiDomain,
       uiDomain: config.uiDomain,
-      cpu: 256, // 0.25 vCPU
-      memoryLimitMiB: 512,
-      desiredCount: 1,
+      cpu: Number(process.env.STARDAG_API_CPU ?? 256),
+      memoryLimitMiB: Number(process.env.STARDAG_API_MEMORY_MIB ?? 512),
+      desiredCount: Number(process.env.STARDAG_API_DESIRED_COUNT ?? 1),
       certificate: this.dns?.apiCertificate,
     });
 

--- a/infra/aws-cdk/lib/stardag-stack.ts
+++ b/infra/aws-cdk/lib/stardag-stack.ts
@@ -37,11 +37,19 @@ export class StardagStack extends cdk.Stack {
     });
 
     // Aurora Serverless v2 PostgreSQL
+    const dbMinAcu = numEnv("STARDAG_DB_MIN_ACU", 0.5);
+    const dbMaxAcu = numEnv("STARDAG_DB_MAX_ACU", 4);
+    if (dbMaxAcu < dbMinAcu) {
+      throw new Error(
+        `STARDAG_DB_MAX_ACU (${dbMaxAcu}) must be >= ` +
+          `STARDAG_DB_MIN_ACU (${dbMinAcu})`,
+      );
+    }
     this.database = new StardagDatabase(this, "Database", {
       vpc: this.vpc.vpc,
       databaseName: "stardag",
-      minCapacity: numEnv("STARDAG_DB_MIN_ACU", 0.5),
-      maxCapacity: numEnv("STARDAG_DB_MAX_ACU", 4),
+      minCapacity: dbMinAcu,
+      maxCapacity: dbMaxAcu,
     });
 
     // =============================================================


### PR DESCRIPTION
## Summary

Tier 1 of an internal three-step plan to fix production API saturation observed on 2026-04-27.

### Diagnosis (background for all three tiers)

During SDK build bursts the production API ran at 100% CPU on a single 0.25 vCPU Fargate task; ALB p99 latency hit 30–48s, SDK clients tripped `httpx.ReadTimeout` at 30s, and the UI was sluggish. CPU profile pointed at four issues:

1. **bcrypt API-key validation runs synchronously on the event loop on every authenticated request.** At default cost (12 rounds), 20–100ms CPU per check. A 200-task SDK burst sends ~1000 authenticated requests → 50s of bcrypt CPU work in a 5-minute window on 0.25 vCPU. Single biggest CPU sink.
2. `tasks.task_data`, `events.event_metadata`, `task_artifacts.body_json`, `builds.root_task_ids` are plain `json` (text), not `JSONB`. Postgres reparses on every `->>` access; no GIN possible. Hits the Task Explorer search hot path.
3. `services/status.py:get_all_task_global_statuses` walks every event for a set of tasks across all builds and replays in Python on every UI list/graph/search request — O(events) per request.
4. `routes/builds.py:_reconcile_dependency_edges` did 3–4 round-trips per upstream dep. A 5-dep `register_task` was ~15 RT just for deps.

The three-tier plan addresses these in order of leverage — Tier 1 is this PR (the bcrypt CPU sink + production sizing); Tier 2 covers issues 2 + 4; Tier 3 covers issue 3.

### Tier 1 changes

- **`services/api_keys.py`** — In-process TTL cache (60s) for `validate_api_key` results, sha256-keyed so plaintext keys aren't held as dict keys. Cache hit re-fetches the `ApiKey` row by primary key and re-checks `revoked_at` so revocations take effect immediately. Cache miss runs `bcrypt.checkpw` via `asyncio.to_thread()` so even cold checks don't block the event loop. `last_used_at` update moves to the cache-miss path (~once per TTL window). The cache is per-worker, not per-task — with `GUNICORN_WORKERS=2` each key is bcrypt-verified once per minute *per worker*, so the bcrypt-CPU projection above assumes per-worker amortisation; with 2 workers + 1 ECS task that becomes ~2 verifications/key/min instead of one. Still negligible vs. the pre-cache cost.
- **`db/__init__.py`** — Explicit `pool_size=10, max_overflow=20, pool_pre_ping=True, pool_recycle=1800` for production. `pool_pre_ping` defends against Aurora idle-timeouts and quiet failovers; `pool_recycle` against silent NLB/Aurora-side disconnects. SQLite test DB keeps defaults.
- **`Dockerfile`** — Switch from solo `uvicorn` to `gunicorn -k uvicorn.workers.UvicornWorker -w ${GUNICORN_WORKERS:-2}`. Adds `gunicorn` to `pyproject.toml`. With more than 0.25 vCPU, multiple workers absorb CPU-bound spikes (auth/JWT/bcrypt cache misses) without starving each other. Note: `limits.py` rate-limiter and entity-count cache are per-process; effective per-instance limits scale with worker count, as documented in `limits.py:84`.
- **`infra/aws-cdk/lib/{api-stack,foundation-stack,stardag-stack}.ts`** — Read `cpu`, `memoryLimitMiB`, `desiredCount`, ECS autoscale min/max, gunicorn worker count, and Aurora min/max ACU from env vars (`STARDAG_API_CPU`, `STARDAG_API_MEMORY_MIB`, `STARDAG_API_DESIRED_COUNT`, `STARDAG_API_AUTOSCALE_MIN`, `STARDAG_API_AUTOSCALE_MAX`, `STARDAG_API_GUNICORN_WORKERS`, `STARDAG_DB_MIN_ACU`, `STARDAG_DB_MAX_ACU`) with the existing hardcoded values as defaults. `STARDAG_API_AUTOSCALE_MIN` defaults to `STARDAG_API_DESIRED_COUNT` so existing deploys get the historical behaviour. Lets ops tune production sizing from the deploy environment without editing source; OSS users still get free-tier-friendly defaults. Parsing helpers in `infra/aws-cdk/lib/env.ts` throw on malformed input rather than emitting `NaN` into the rendered template.
- **`tests/test_api_keys.py`** — 16 new tests covering cache TTL, eviction, hashed-key storage, async verify path, revocation propagation, and per-key cache isolation.

### Expected production impact

After this change ships and `STARDAG_API_CPU=1024 STARDAG_API_MEMORY_MIB=2048` are set in the deploy environment, bursts of authenticated SDK calls should no longer saturate the API container. Aurora ACU floor stays at the existing 0.5 for now.

### Not in scope (follow-up tiers)

- Tier 2 (#126): indices + JSON→JSONB migration + batched dependency reconciliation.
- Tier 3 (#127): denormalise task latest status + slim Pydantic list responses.

### Verification

- `pytest`: 207 passed, 1 skipped (16 new in `test_api_keys.py`).
- `npm test` (CDK): 19 passed.
- `pre-commit run --files <changed>`: clean (prettier, ruff, pyright).
- `cdk synth StardagApi` with `STARDAG_API_CPU=1024 STARDAG_API_MEMORY_MIB=2048` renders `Cpu: "1024", Memory: "2048"`.

## Test plan

- [ ] CI: stardag-api pytest passes
- [ ] CI: CDK build + jest passes
- [ ] Reviewer skim of `services/api_keys.py` cache semantics (revocation, TTL, eviction)
- [ ] Reviewer skim of `Dockerfile` CMD form (sh -c with `exec` so gunicorn replaces the shell process and signals propagate)
- [ ] Confirm Aurora floor decision: leaving at 0.5 ACU per current plan
- [ ] After merge: deploy environment sets `STARDAG_API_CPU=1024`, `STARDAG_API_MEMORY_MIB=2048`, `STARDAG_API_DESIRED_COUNT=1` and a deploy is triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)
