### PR TITLE
Fix /tasks/search 500 on build_id filter (UUID cast)

### DIFF
--- a/app/stardag-api/src/stardag_api/routes/search.py
+++ b/app/stardag-api/src/stardag_api/routes/search.py
@@ -131,12 +131,26 @@ def build_jsonb_condition(
             return f"{task_alias}.{key} ILIKE '%' || :{param_name} || '%'", False, None
         return f"{task_alias}.{key} {sql_op} :{param_name}", False, None
 
-    # Build fields - require join to events and builds tables
+    # Build fields - require join to events and builds tables.
+    # builds.id is a Postgres UUID column. Bound parameters arrive from the
+    # query string as text and asyncpg sends them as character varying; an
+    # implicit `uuid = varchar` comparison is rejected by Postgres
+    # ("operator does not exist: uuid = character varying"). Use explicit
+    # casts: column-to-text for substring match, parameter-to-uuid for
+    # equality so the PK index is still usable.
     if key == "build_id":
         param_name = f"filter_build_id{param_suffix}"
         if sql_op == "ILIKE":
-            return f"builds.id ILIKE '%' || :{param_name} || '%'", True, None
-        return f"builds.id {sql_op} :{param_name}", True, None
+            return (
+                f"builds.id::text ILIKE '%' || :{param_name} || '%'",
+                True,
+                None,
+            )
+        return (
+            f"builds.id {sql_op} CAST(:{param_name} AS uuid)",
+            True,
+            None,
+        )
 
     if key == "build_name":
         param_name = f"filter_build_name{param_suffix}"

--- a/app/stardag-api/src/stardag_api/routes/search.py
+++ b/app/stardag-api/src/stardag_api/routes/search.py
@@ -6,7 +6,7 @@ from collections import Counter
 from typing import Annotated, Any
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -60,6 +60,31 @@ OPERATORS = {
 }
 
 
+def _validate_filter_value(key: str, op: str, value: str) -> None:
+    """Reject filter values that would otherwise crash at SQL execution time.
+
+    Currently only enforces UUID-shape on ``build_id`` for non-substring
+    operators. Without this, the SQL ``CAST(:p AS uuid)`` raises an
+    asyncpg ``InvalidTextRepresentation`` at execution time and the
+    request bubbles up as a 500. Validating in Python lets us return a
+    clear 400 with an actionable message instead.
+
+    ``~`` (ILIKE) is exempt — substring match is text-only and any string
+    is acceptable input.
+    """
+    if key == "build_id" and op != "~":
+        try:
+            UUID(value)
+        except (ValueError, AttributeError):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid build_id filter value {value!r}: "
+                    "must be a valid UUID for non-substring comparisons"
+                ),
+            )
+
+
 def parse_filter_string(filter_str: str) -> list[tuple[str, str, str]]:
     """Parse filter string into list of (key, operator, value) tuples.
 
@@ -68,6 +93,9 @@ def parse_filter_string(filter_str: str) -> list[tuple[str, str, str]]:
         - task_name:=:training
         - param.lr:>:0.01
         - task_namespace:~:ml
+
+    Raises HTTPException(400) if any filter value is rejected by
+    ``_validate_filter_value`` (e.g. a malformed UUID for ``build_id``).
     """
     if not filter_str:
         return []
@@ -87,7 +115,10 @@ def parse_filter_string(filter_str: str) -> list[tuple[str, str, str]]:
             key, op, value = match.groups()
             op = op or "="
             if op in OPERATORS:
-                filters.append((key.strip(), op, value.strip()))
+                key = key.strip()
+                value = value.strip()
+                _validate_filter_value(key, op, value)
+                filters.append((key, op, value))
 
     return filters
 
@@ -136,8 +167,11 @@ def build_jsonb_condition(
     # query string as text and asyncpg sends them as character varying; an
     # implicit `uuid = varchar` comparison is rejected by Postgres
     # ("operator does not exist: uuid = character varying"). Use explicit
-    # casts: column-to-text for substring match, parameter-to-uuid for
-    # equality so the PK index is still usable.
+    # casts: column-to-text for substring match, parameter-to-uuid for any
+    # non-substring comparison (=, !=, <, <=, >, >=) so the PK index is
+    # still usable. ``_validate_filter_value`` upstream enforces that
+    # non-substring values are valid UUIDs, so the cast can't fail at
+    # execution time.
     if key == "build_id":
         param_name = f"filter_build_id{param_suffix}"
         if sql_op == "ILIKE":

--- a/app/stardag-api/tests/conftest.py
+++ b/app/stardag-api/tests/conftest.py
@@ -286,3 +286,75 @@ async def pg_session(pg_engine) -> AsyncGenerator[AsyncSession, None]:
     async_session_maker = async_sessionmaker(pg_engine, expire_on_commit=False)
     async with async_session_maker() as session:
         yield session
+
+
+@pytest.fixture
+async def pg_client(pg_engine) -> AsyncGenerator[AsyncClient, None]:
+    """HTTP client backed by Postgres (Postgres-equivalent of ``client``).
+
+    Uses the same auth overrides as ``client`` so SDK / UI routes that
+    require authentication can be exercised against a real Postgres for
+    cases that depend on dialect-specific SQL (UUID casts, JSONB operators,
+    FOR UPDATE locks).
+    """
+    from stardag_api.auth import (
+        SdkAuth,
+        get_current_user,
+        get_current_user_flexible,
+        get_workspace_id_from_token,
+        require_sdk_auth,
+    )
+    from stardag_api.models import Environment, User
+
+    async_session_maker = async_sessionmaker(pg_engine, expire_on_commit=False)
+
+    async def override_get_db() -> AsyncGenerator[AsyncSession, None]:
+        async with async_session_maker() as session:
+            yield session
+
+    mock_environment = Environment(
+        id=DEFAULT_ENVIRONMENT_ID,
+        workspace_id=DEFAULT_WORKSPACE_ID,
+        name="Default Environment",
+        slug="default",
+    )
+    mock_user = User(
+        id=DEFAULT_USER_ID,
+        external_id="default-local-user",
+        email="default@localhost",
+        display_name="Default User",
+    )
+    mock_sdk_auth = SdkAuth(
+        environment=mock_environment,
+        workspace_id=DEFAULT_WORKSPACE_ID,
+        user=mock_user,
+    )
+
+    async def override_require_sdk_auth() -> SdkAuth:
+        return mock_sdk_auth
+
+    async def override_get_current_user() -> User:
+        return mock_user
+
+    async def override_get_current_user_flexible() -> User:
+        return mock_user
+
+    async def override_get_workspace_id_from_token() -> UUID:
+        return DEFAULT_WORKSPACE_ID
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[require_sdk_auth] = override_require_sdk_auth
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_current_user_flexible] = (
+        override_get_current_user_flexible
+    )
+    app.dependency_overrides[get_workspace_id_from_token] = (
+        override_get_workspace_id_from_token
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        yield ac
+
+    app.dependency_overrides.clear()

--- a/app/stardag-api/tests/test_search.py
+++ b/app/stardag-api/tests/test_search.py
@@ -5,7 +5,7 @@ from collections import Counter
 import pytest
 from httpx import AsyncClient
 
-from stardag_api.routes.search import _extract_keys
+from stardag_api.routes.search import _extract_keys, build_jsonb_condition
 
 
 # ---------------------------------------------------------------------------
@@ -154,3 +154,115 @@ async def test_sort_by_param_numeric(client: AsyncClient):
     assert len(tasks) >= 3
     task_ids = {t["task_id"] for t in tasks}
     assert {"num-1", "num-2", "num-10"}.issubset(task_ids)
+
+
+# ---------------------------------------------------------------------------
+# build_id filter SQL emission — defends the production fix for
+# "operator does not exist: uuid = character varying" by asserting the
+# generated SQL has the right casts.
+# ---------------------------------------------------------------------------
+
+
+class TestBuildIdFilterSQL:
+    def test_build_id_equality_casts_param_to_uuid(self) -> None:
+        condition, needs_join, _ = build_jsonb_condition(
+            "build_id", "=", "doesntmatter"
+        )
+        assert needs_join is True
+        assert condition is not None
+        # The bound parameter must be cast to uuid so Postgres can compare
+        # against the uuid column without a varchar-uuid mismatch.
+        assert "CAST(:filter_build_id AS uuid)" in condition
+        # The column itself stays as uuid (no ::text cast on equality).
+        assert "builds.id =" in condition
+
+    def test_build_id_inequality_casts_param_to_uuid(self) -> None:
+        condition, _, _ = build_jsonb_condition("build_id", "!=", "x")
+        assert condition is not None
+        assert "CAST(:filter_build_id AS uuid)" in condition
+        assert "builds.id !=" in condition
+
+    def test_build_id_ilike_casts_column_to_text(self) -> None:
+        condition, needs_join, _ = build_jsonb_condition("build_id", "~", "abc")
+        assert needs_join is True
+        assert condition is not None
+        # ILIKE is a string operator; uuid columns need explicit text cast.
+        assert "builds.id::text ILIKE" in condition
+        # No CAST AS uuid on this branch — substring match is text-only.
+        assert "CAST(:filter_build_id AS uuid)" not in condition
+
+
+# ---------------------------------------------------------------------------
+# End-to-end Postgres test for the build_id filter — the regression that
+# prompted the fix surfaced as an HTTP 500 in production logs:
+#   GET /api/v1/tasks/search?filter=build_id:=:<uuid> → 500
+#   "operator does not exist: uuid = character varying"
+# This test runs the full route against a real Postgres and asserts the
+# request succeeds. SQLite skips automatically because the route uses
+# Postgres-specific cast / JSONB operators throughout.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_search_filter_by_build_id_equality_does_not_500(
+    pg_client: AsyncClient,
+) -> None:
+    """Reproduces the production bug: filter=build_id:=:<uuid> previously
+    returned 500 because the bound varchar parameter couldn't be compared
+    to the uuid column. With the cast in place, the filter resolves and
+    the response is a normal task list."""
+    # Create a build + task so there's a real build_id to filter on.
+    build_resp = await pg_client.post("/api/v1/builds", json={})
+    assert build_resp.status_code == 201
+    build_id = build_resp.json()["id"]
+
+    task_resp = await pg_client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        json={
+            "task_id": "search-build-id-task",
+            "task_namespace": "test",
+            "task_name": "BuildIdSearchTest",
+            "task_data": {},
+        },
+    )
+    assert task_resp.status_code == 201
+
+    # Filter by the real build_id — the failing path in the production
+    # log. Without the fix, this returned 500.
+    resp = await pg_client.get(
+        "/api/v1/tasks/search",
+        params={"filter": f"build_id:=:{build_id}", "page_size": 50},
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    # The created task must come back via the build_id filter.
+    task_ids = {t["task_id"] for t in payload["tasks"]}
+    assert "search-build-id-task" in task_ids
+
+
+@pytest.mark.asyncio
+async def test_search_filter_by_build_id_ilike_works_against_uuid_column(
+    pg_client: AsyncClient,
+) -> None:
+    """Substring match on build_id requires builds.id::text — without the
+    cast Postgres rejects ``uuid ILIKE varchar``."""
+    build_resp = await pg_client.post("/api/v1/builds", json={})
+    build_id = build_resp.json()["id"]
+    await pg_client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        json={
+            "task_id": "search-ilike-task",
+            "task_namespace": "test",
+            "task_name": "BuildIdILike",
+            "task_data": {},
+        },
+    )
+    # Use the first 8 chars as a substring (ILIKE prefix-style).
+    prefix = build_id[:8]
+    resp = await pg_client.get(
+        "/api/v1/tasks/search",
+        params={"filter": f"build_id:~:{prefix}", "page_size": 50},
+    )
+    assert resp.status_code == 200, resp.text
+    task_ids = {t["task_id"] for t in resp.json()["tasks"]}
+    assert "search-ilike-task" in task_ids

--- a/app/stardag-api/tests/test_search.py
+++ b/app/stardag-api/tests/test_search.py
@@ -5,7 +5,14 @@ from collections import Counter
 import pytest
 from httpx import AsyncClient
 
-from stardag_api.routes.search import _extract_keys, build_jsonb_condition
+from fastapi import HTTPException
+
+from stardag_api.routes.search import (
+    _extract_keys,
+    _validate_filter_value,
+    build_jsonb_condition,
+    parse_filter_string,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -177,7 +184,8 @@ class TestBuildIdFilterSQL:
         assert "builds.id =" in condition
 
     def test_build_id_inequality_casts_param_to_uuid(self) -> None:
-        condition, _, _ = build_jsonb_condition("build_id", "!=", "x")
+        condition, needs_join, _ = build_jsonb_condition("build_id", "!=", "x")
+        assert needs_join is True
         assert condition is not None
         assert "CAST(:filter_build_id AS uuid)" in condition
         assert "builds.id !=" in condition
@@ -190,6 +198,47 @@ class TestBuildIdFilterSQL:
         assert "builds.id::text ILIKE" in condition
         # No CAST AS uuid on this branch — substring match is text-only.
         assert "CAST(:filter_build_id AS uuid)" not in condition
+
+
+class TestBuildIdFilterValidation:
+    """Pin the validation rules around build_id filter values without
+    needing a Postgres connection. The route's CAST AS uuid would
+    otherwise fail at execution time with a 500 — these tests prove the
+    route fails fast at the API layer with a 400 instead."""
+
+    def test_valid_uuid_for_equality_passes(self) -> None:
+        # No exception expected.
+        _validate_filter_value("build_id", "=", "019dd0c6-2b40-7de3-af35-2e7d1d1e8b37")
+
+    def test_invalid_uuid_for_equality_raises_400(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            _validate_filter_value("build_id", "=", "not-a-uuid")
+        assert exc_info.value.status_code == 400
+        assert "build_id" in exc_info.value.detail
+        assert "uuid" in exc_info.value.detail.lower()
+
+    def test_invalid_uuid_for_inequality_raises_400(self) -> None:
+        with pytest.raises(HTTPException):
+            _validate_filter_value("build_id", "!=", "garbage")
+
+    def test_invalid_uuid_for_ilike_passes(self) -> None:
+        # ILIKE is text substring match; any string is OK.
+        _validate_filter_value("build_id", "~", "not-a-uuid")
+        _validate_filter_value("build_id", "~", "abc123")
+
+    def test_other_keys_are_not_validated_as_uuid(self) -> None:
+        # task_name, params, etc. are free-form text and never UUID-checked.
+        _validate_filter_value("task_name", "=", "anything")
+        _validate_filter_value("param.lr", ">", "0.01")
+        _validate_filter_value("task_namespace", "~", "ml")
+
+    def test_parse_filter_string_propagates_validation_400(self) -> None:
+        # parse_filter_string is the single entry point for both filter
+        # call sites; ensure the validation propagates through it so every
+        # caller gets the 400 for free.
+        with pytest.raises(HTTPException) as exc_info:
+            parse_filter_string("build_id:=:not-a-uuid")
+        assert exc_info.value.status_code == 400
 
 
 # ---------------------------------------------------------------------------
@@ -257,7 +306,9 @@ async def test_search_filter_by_build_id_ilike_works_against_uuid_column(
             "task_data": {},
         },
     )
-    # Use the first 8 chars as a substring (ILIKE prefix-style).
+    # Use the first 8 chars as a substring (ILIKE prefix-style). Single
+    # build in this test, so the timestamp-prefix collision in UUID7 (every
+    # uuid7 created in the same millisecond shares its leading hex) is fine.
     prefix = build_id[:8]
     resp = await pg_client.get(
         "/api/v1/tasks/search",
@@ -266,3 +317,80 @@ async def test_search_filter_by_build_id_ilike_works_against_uuid_column(
     assert resp.status_code == 200, resp.text
     task_ids = {t["task_id"] for t in resp.json()["tasks"]}
     assert "search-ilike-task" in task_ids
+
+
+@pytest.mark.asyncio
+async def test_search_filter_by_build_id_inequality_excludes_match(
+    pg_client: AsyncClient,
+) -> None:
+    """``filter=build_id:!=:<uuid>`` must return tasks from every other
+    build but exclude tasks from the named build. Closes the e2e gap for
+    the inequality branch (the unit test pins the SQL string but doesn't
+    execute it)."""
+    # Build A: a task that should be EXCLUDED by the != filter.
+    a_resp = await pg_client.post("/api/v1/builds", json={})
+    a_build_id = a_resp.json()["id"]
+    await pg_client.post(
+        f"/api/v1/builds/{a_build_id}/tasks",
+        json={
+            "task_id": "ne-task-in-a",
+            "task_namespace": "test",
+            "task_name": "NeTaskA",
+            "task_data": {},
+        },
+    )
+
+    # Build B: a task that should be INCLUDED by the != filter.
+    b_resp = await pg_client.post("/api/v1/builds", json={})
+    b_build_id = b_resp.json()["id"]
+    await pg_client.post(
+        f"/api/v1/builds/{b_build_id}/tasks",
+        json={
+            "task_id": "ne-task-in-b",
+            "task_namespace": "test",
+            "task_name": "NeTaskB",
+            "task_data": {},
+        },
+    )
+
+    resp = await pg_client.get(
+        "/api/v1/tasks/search",
+        params={"filter": f"build_id:!=:{a_build_id}", "page_size": 100},
+    )
+    assert resp.status_code == 200, resp.text
+    task_ids = {t["task_id"] for t in resp.json()["tasks"]}
+    assert "ne-task-in-b" in task_ids
+    assert "ne-task-in-a" not in task_ids
+
+
+@pytest.mark.asyncio
+async def test_search_filter_build_id_with_malformed_uuid_returns_400(
+    pg_client: AsyncClient,
+) -> None:
+    """A non-UUID build_id value is rejected with a clear 400 instead of
+    propagating to a Postgres ``invalid input syntax for type uuid`` 500
+    at SQL execution time."""
+    resp = await pg_client.get(
+        "/api/v1/tasks/search",
+        params={"filter": "build_id:=:not-a-uuid", "page_size": 50},
+    )
+    assert resp.status_code == 400, resp.text
+    detail = resp.json()["detail"]
+    assert "build_id" in detail.lower()
+    assert "uuid" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_search_filter_build_id_ilike_accepts_non_uuid_substring(
+    pg_client: AsyncClient,
+) -> None:
+    """ILIKE (~) is a text substring match, so any string is allowed —
+    even ones that aren't valid UUIDs. Validates that the
+    ``_validate_filter_value`` carve-out for ``~`` works correctly."""
+    resp = await pg_client.get(
+        "/api/v1/tasks/search",
+        params={"filter": "build_id:~:not-a-uuid", "page_size": 50},
+    )
+    # Returns 200 with empty results (no UUID happens to contain that text).
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["tasks"] == []


### PR DESCRIPTION
## Summary

Surfaced from production logs at 2026-04-28T07:23 UTC during post-Tier-1 sanity-checking:

```
GET /api/v1/tasks/search?...&filter=build_id:=:<uuid>  →  500
asyncpg.exceptions.UndefinedFunctionError: operator does not exist:
uuid = character varying
```

`builds.id` is a Postgres UUID column. The search filter binds the value from the URL query string as text; asyncpg sends it as `varchar`; Postgres rejects the implicit `uuid = varchar` comparison without an explicit cast. Independent of the API perf tiers — same bug pre- and post-deploy.

The same code path was also broken for `ILIKE` (substring match): `uuid ILIKE varchar` is also rejected. The user just hadn't hit it because the production UI uses `=`.

## Fix

`routes/search.py:build_jsonb_condition` for `key == "build_id"`:
- **Equality / inequality** (`=`, `!=`): emit `builds.id <op> CAST(:p AS uuid)` — the bound parameter is coerced to uuid so Postgres can compare against the uuid column. PK index still usable.
- **Substring** (`ILIKE`): emit `builds.id::text ILIKE :p` — the column is rendered as text first.

## Tests

- **`TestBuildIdFilterSQL`** (3 unit tests): pin the emitted SQL strings. Run on every backend (no DB needed). Tripwires for silent regressions.
- **`test_search_filter_by_build_id_equality_does_not_500`** — end-to-end via a new `pg_client` fixture (added to `conftest.py` — the Postgres-equivalent of the existing `client` fixture). Creates a build + task and asserts `filter=build_id:=:<uuid>` returns 200.
- **`test_search_filter_by_build_id_ilike_works_against_uuid_column`** — same shape but with `~` (ILIKE), confirming the column-to-text cast.

Verified the tests would catch the regression by temporarily reverting the `search.py` change and re-running: **all 5 tests fail without the cast, all 5 pass with it**.

The search route is otherwise Postgres-specific (raw JSONB operators, etc.) so the e2e tests skip on SQLite via the `pg_client` fixture's underlying `pg_engine` skip-when-unset behaviour. The new unit tests run on every backend.

## Verification

- pytest SQLite: 210 passed, 9 skipped (all PG-only).
- pytest with `STARDAG_API_TEST_DATABASE_URL`: 218 passed, 1 skipped.
- pre-commit clean (ruff, pyright, prettier).
- The new `Test Python (stardag-api on Postgres)` CI job (added in #126) will exercise the e2e tests on every PR.

## Test plan

- [ ] CI: stardag-api SQLite pytest passes
- [ ] CI: stardag-api Postgres pytest passes (new job exercises this)
- [ ] Reviewer skim of the cast emission (CAST AS uuid for equality, `::text` for ILIKE)
- [ ] After merge: deploy via stardag-cloud submodule bump → re-test the production UI Task Explorer build_id filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)