### PR TITLE
Fix UI logout-on-deploy: optional stable JWT_PRIVATE_KEY from Secrets Manager

### DIFF
--- a/infra/aws-cdk/lib/api-stack.ts
+++ b/infra/aws-cdk/lib/api-stack.ts
@@ -61,7 +61,12 @@ export class ApiStack extends cdk.Stack {
     // every existing UI session on every redeploy.
     // The secret is expected to be a JSON document with a "private_key"
     // field containing a PEM-encoded RSA private key.
-    const jwtPrivateKeySecretName = process.env.STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME;
+    // Trim whitespace so a typo like ``FOO=" "`` in an env file is
+    // treated as unset instead of silently turning into a broken
+    // ``fromSecretNameV2`` lookup at synth time.
+    const rawJwtSecretName =
+      process.env.STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME?.trim();
+    const jwtPrivateKeySecretName = rawJwtSecretName || undefined;
     if (apiAutoscaleMax < apiAutoscaleMin) {
       throw new Error(
         `STARDAG_API_AUTOSCALE_MAX (${apiAutoscaleMax}) must be >= ` +
@@ -141,7 +146,13 @@ export class ApiStack extends cdk.Stack {
 
     // Look up the optional JWT private key secret so its ARN is in the
     // task definition. The secret value must already exist in Secrets
-    // Manager when the task starts; ECS fetches it at container launch.
+    // Manager when the task starts; ECS fetches it at container launch
+    // using the *execution role* (not the task role). When the secret is
+    // referenced via ``ecs.Secret.fromSecretsManager`` in the container's
+    // ``secrets`` block below, CDK auto-grants ``GetSecretValue`` to the
+    // execution role; we add an explicit grant here for clarity and to
+    // ensure the policy is in place even if a future refactor changes
+    // how the secret is referenced.
     const jwtPrivateKeySecret = jwtPrivateKeySecretName
       ? secretsmanager.Secret.fromSecretNameV2(
           this,
@@ -150,7 +161,7 @@ export class ApiStack extends cdk.Stack {
         )
       : undefined;
     if (jwtPrivateKeySecret) {
-      jwtPrivateKeySecret.grantRead(taskDefinition.taskRole);
+      jwtPrivateKeySecret.grantRead(taskDefinition.obtainExecutionRole());
     }
 
     // Grant task role permission to send emails via SES

--- a/infra/aws-cdk/lib/api-stack.ts
+++ b/infra/aws-cdk/lib/api-stack.ts
@@ -53,6 +53,15 @@ export class ApiStack extends cdk.Stack {
     // initial desired count.
     const apiAutoscaleMin = intEnv("STARDAG_API_AUTOSCALE_MIN", apiDesiredCount);
     const apiAutoscaleMax = intEnv("STARDAG_API_AUTOSCALE_MAX", 4);
+    // Optional JWT signing key, fetched from Secrets Manager. When set, the
+    // API uses a stable RSA keypair across deploys so cached internal
+    // tokens (UI sessions) survive container rollover. When unset (default
+    // for OSS / fresh deploys), the API generates an ephemeral keypair on
+    // every container start — fine for single-deploy use but invalidates
+    // every existing UI session on every redeploy.
+    // The secret is expected to be a JSON document with a "private_key"
+    // field containing a PEM-encoded RSA private key.
+    const jwtPrivateKeySecretName = process.env.STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME;
     if (apiAutoscaleMax < apiAutoscaleMin) {
       throw new Error(
         `STARDAG_API_AUTOSCALE_MAX (${apiAutoscaleMax}) must be >= ` +
@@ -130,6 +139,20 @@ export class ApiStack extends cdk.Stack {
     foundation.dbServiceSecret.grantRead(taskDefinition.taskRole);
     foundation.dbAdminSecret.grantRead(taskDefinition.taskRole);
 
+    // Look up the optional JWT private key secret so its ARN is in the
+    // task definition. The secret value must already exist in Secrets
+    // Manager when the task starts; ECS fetches it at container launch.
+    const jwtPrivateKeySecret = jwtPrivateKeySecretName
+      ? secretsmanager.Secret.fromSecretNameV2(
+          this,
+          "JwtPrivateKeySecret",
+          jwtPrivateKeySecretName,
+        )
+      : undefined;
+    if (jwtPrivateKeySecret) {
+      jwtPrivateKeySecret.grantRead(taskDefinition.taskRole);
+    }
+
     // Grant task role permission to send emails via SES
     if (foundation.ses) {
       foundation.ses.grantSendEmail(taskDefinition.taskRole);
@@ -191,6 +214,18 @@ export class ApiStack extends cdk.Stack {
           foundation.dbAdminSecret,
           "password",
         ),
+        // JWT_PRIVATE_KEY mounted from Secrets Manager when configured.
+        // Picked up by config.JWTSettings.private_key (env_prefix=JWT_).
+        // The whole RSA-2048 PEM lives under the "private_key" JSON key in
+        // the secret value. See cloud/docs for one-time provisioning.
+        ...(jwtPrivateKeySecret
+          ? {
+              JWT_PRIVATE_KEY: ecs.Secret.fromSecretsManager(
+                jwtPrivateKeySecret,
+                "private_key",
+              ),
+            }
+          : {}),
       },
       portMappings: [
         {

--- a/infra/aws-cdk/test/stardag.test.ts
+++ b/infra/aws-cdk/test/stardag.test.ts
@@ -1,5 +1,7 @@
 import * as cdk from "aws-cdk-lib";
-import { Template } from "aws-cdk-lib/assertions";
+import { Match, Template } from "aws-cdk-lib/assertions";
+import { ApiStack } from "../lib/api-stack";
+import { FoundationStack } from "../lib/foundation-stack";
 import { StardagStack } from "../lib/stardag-stack";
 
 // Mock config for testing
@@ -186,6 +188,162 @@ describe("StardagStack", () => {
       template.hasOutput("UiUrl", {
         Value: "https://app.example.com",
       });
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ApiStack — split-stack production path. Covers the optional JWT private
+// key secret wiring (STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME).
+// ---------------------------------------------------------------------------
+
+function synthApiStack(jwtSecretName: string | undefined): Template {
+  const original = process.env.STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME;
+  if (jwtSecretName === undefined) {
+    delete process.env.STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME;
+  } else {
+    process.env.STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME = jwtSecretName;
+  }
+  try {
+    const app = new cdk.App();
+    const env = {
+      account: mockConfig.awsAccountId,
+      region: mockConfig.awsRegion,
+    };
+    const foundation = new FoundationStack(app, "Foundation", {
+      env,
+      config: mockConfig,
+    });
+    const apiStack = new ApiStack(app, "Api", {
+      env,
+      config: mockConfig,
+      foundation,
+    });
+    return Template.fromStack(apiStack);
+  } finally {
+    if (original === undefined) {
+      delete process.env.STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME;
+    } else {
+      process.env.STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME = original;
+    }
+  }
+}
+
+describe("ApiStack JWT_PRIVATE_KEY secret wiring", () => {
+  describe("when STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME is unset", () => {
+    let template: Template;
+
+    beforeAll(() => {
+      template = synthApiStack(undefined);
+    });
+
+    test("does not mount JWT_PRIVATE_KEY in the container secrets block", () => {
+      // No container in the API task def references JWT_PRIVATE_KEY.
+      const taskDefs = template.findResources("AWS::ECS::TaskDefinition");
+      const apiTaskDef = Object.values(taskDefs).find(
+        (td) =>
+          td.Properties.ContainerDefinitions?.some(
+            (c: { Name?: string }) => c.Name === "Api",
+          ),
+      );
+      expect(apiTaskDef).toBeDefined();
+      const secrets = apiTaskDef!.Properties.ContainerDefinitions[0].Secrets ?? [];
+      const names = secrets.map((s: { Name: string }) => s.Name);
+      expect(names).not.toContain("JWT_PRIVATE_KEY");
+    });
+  });
+
+  describe("when STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME is set", () => {
+    let template: Template;
+    const secretName = "stardag/api/jwt-private-key";
+
+    beforeAll(() => {
+      template = synthApiStack(secretName);
+    });
+
+    test("mounts JWT_PRIVATE_KEY from Secrets Manager :private_key field", () => {
+      // ``ValueFrom`` is a CFN ``Fn::Join`` that builds the secret ARN at
+      // deploy time (``arn:aws:secretsmanager:<region>:<account>:secret:<name>:private_key::``).
+      // Match by serialising the template and asserting the assembled
+      // string substring is present — robust against the nested join form.
+      const taskDefs = template.findResources("AWS::ECS::TaskDefinition");
+      const apiTaskDef = Object.values(taskDefs).find(
+        (td) =>
+          td.Properties.ContainerDefinitions?.some(
+            (c: { Name?: string }) => c.Name === "Api",
+          ),
+      );
+      expect(apiTaskDef).toBeDefined();
+      const containers = apiTaskDef!.Properties.ContainerDefinitions as Array<{
+        Name: string;
+        Secrets?: Array<{ Name: string; ValueFrom: unknown }>;
+      }>;
+      const apiContainer = containers.find((c) => c.Name === "Api")!;
+      const jwtSecret = apiContainer.Secrets?.find((s) => s.Name === "JWT_PRIVATE_KEY");
+      expect(jwtSecret).toBeDefined();
+      // ValueFrom is { "Fn::Join": ["", [...parts...]] }; flatten to a
+      // string of all string parts and assert the secret name + private_key
+      // suffix appear.
+      const valueFromStr = JSON.stringify(jwtSecret!.ValueFrom);
+      expect(valueFromStr).toContain(secretName);
+      expect(valueFromStr).toContain(":private_key::");
+    });
+
+    test("execution role IAM policy allows GetSecretValue on the JWT secret", () => {
+      // The execution role's policy must include GetSecretValue (the
+      // ECS agent uses the execution role at task launch to fetch
+      // secrets — granting only the task role would fail to launch).
+      // Each ``AWS::IAM::Policy`` resource is attached to one or more
+      // roles; find any policy whose statements grant GetSecretValue on
+      // a resource ARN containing our secret name.
+      const policies = template.findResources("AWS::IAM::Policy");
+      let found = false;
+      for (const p of Object.values(policies)) {
+        const stmts = p.Properties.PolicyDocument.Statement as Array<{
+          Action: string | string[];
+          Effect: string;
+          Resource: unknown;
+        }>;
+        for (const stmt of stmts) {
+          const actions = Array.isArray(stmt.Action) ? stmt.Action : [stmt.Action];
+          if (
+            stmt.Effect === "Allow" &&
+            actions.includes("secretsmanager:GetSecretValue") &&
+            JSON.stringify(stmt.Resource).includes(secretName)
+          ) {
+            // Confirm at least one attached role has "ExecutionRole" in
+            // its logical ID — that's the role ECS uses at task start.
+            const roles = (p.Properties.Roles ?? []) as Array<{
+              Ref?: string;
+            }>;
+            const execRoleAttached = roles.some(
+              (r) => r.Ref?.includes("ExecutionRole"),
+            );
+            if (execRoleAttached) {
+              found = true;
+              break;
+            }
+          }
+        }
+        if (found) break;
+      }
+      expect(found).toBe(true);
+    });
+  });
+
+  describe("when STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME is whitespace", () => {
+    test("treats whitespace as unset (no JWT_PRIVATE_KEY in template)", () => {
+      const template = synthApiStack("   ");
+      const taskDefs = template.findResources("AWS::ECS::TaskDefinition");
+      const apiTaskDef = Object.values(taskDefs).find(
+        (td) =>
+          td.Properties.ContainerDefinitions?.some(
+            (c: { Name?: string }) => c.Name === "Api",
+          ),
+      );
+      const secrets = apiTaskDef?.Properties.ContainerDefinitions[0].Secrets ?? [];
+      const names = secrets.map((s: { Name: string }) => s.Name);
+      expect(names).not.toContain("JWT_PRIVATE_KEY");
     });
   });
 });


### PR DESCRIPTION
## Summary

Fixes the UI session loss across every API deploy. Diagnosis from prod investigation:

When ``JWT_PRIVATE_KEY`` is unset, ``InternalTokenManager`` generates a fresh ephemeral RSA keypair on every container start (``auth/tokens.py:107``). The UI exchanges its OIDC token for an internal JWT signed by this keypair and caches it in ``localStorage`` keyed by its 10-min ``expiresAt``. After every deploy:

- New container has a new keypair.
- UI's cached internal token (signed by the OLD key) fails signature verification on the new pod → 401.
- Cache thinks the token is still fresh (``expiresAt > now+30s``), so the UI never refreshes.
- Result: workspace dropdown populated (Cognito ID token still valid) but environments / builds / search all silently 401 → empty state with no error message until the user manually clears site data and re-logs in.

## Fix

Wire ``JWT_PRIVATE_KEY`` as an optional ECS task secret in ``api-stack.ts``, sourced from AWS Secrets Manager when ``STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME`` is set at synth time. The secret is expected to be a JSON document with a ``private_key`` field containing the PEM-encoded RSA private key (idiomatic AWS Secrets Manager pattern).

Default OSS path (env var unset) preserves the ephemeral keypair behaviour, which is fine for fresh deploys and single-task local setups.

## Production rollout

After this PR merges, the matching ``stardag-cloud`` PR will:

1. Generate an RSA-2048 keypair (one-time):
   ```bash
   openssl genrsa -out jwt-private.pem 2048
   ```
2. Provision in Secrets Manager:
   ```bash
   aws secretsmanager create-secret \
     --name stardag/api/jwt-private-key \
     --secret-string "{\"private_key\": $(jq -Rs . < jwt-private.pem)}"
   ```
3. Set ``STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME=stardag/api/jwt-private-key`` in ``cloud/config/.env.deploy``.
4. Bump submodule pointer.
5. Merge → deploy.

The first task to come up signs new tokens with the stable key; subsequent deploys reuse the same key so existing UI sessions continue to validate. **No more deploy-induced re-logins.**

## Not in scope (followup)

Defense-in-depth UI 401 refresh + session-expired UX is tracked in a separate ``stardag-ui`` PR. Even with this fix, normal 10-min internal-token TTL expiry can still leave the UI in a silent empty-state if the user is idle past 10 min — the UI fix handles 401 → re-exchange OIDC for a fresh internal token → retry, or surface "session expired" with a clear re-login button if Cognito itself has timed out.

## Verification

- ``npx cdk synth StardagApi`` with env var set → renders:
  ```
  - Name: JWT_PRIVATE_KEY
    ValueFrom: arn:aws:secretsmanager:us-east-1:763997220528:secret:stardag/api/jwt-private-key:private_key::
  ```
  IAM grant added (`secretsmanager:GetSecretValue`).
- Synth without env var → no ``JWT_PRIVATE_KEY`` in template (OSS-friendly).
- ``npm run build`` + ``npm test`` (19 jest tests): clean.
- pre-commit clean.

## Test plan

- [ ] CI: CDK build + jest passes.
- [ ] Reviewer skim of the optional secret-mount pattern.
- [ ] After merge: provision the prod secret + matching stardag-cloud submodule bump PR.
- [ ] Post-deploy: redeploy a second time within an hour, confirm any UI session opened pre-redeploy still works without re-login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)