### PR TITLE
Fix UI silent empty-state on 401: retry with fresh token, surface session-expired overlay

### DIFF
--- a/app/stardag-ui/src/App.tsx
+++ b/app/stardag-ui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { setAccessTokenGetter } from "./api/client";
+import { setAccessTokenGetter, setSessionExpiredHandler } from "./api/client";
 import { AuthCallback } from "./components/AuthCallback";
 import { BuildsList } from "./components/BuildsList";
 import { BuildView } from "./components/BuildView";
@@ -8,6 +8,7 @@ import { CodeExampleTabs } from "./components/CodeExampleTabs";
 import { LandingPageDemo } from "./components/LandingPageDemo";
 import { Logo } from "./components/Logo";
 import { OnboardingModal } from "./components/OnboardingModal";
+import { SessionExpiredOverlay } from "./components/SessionExpiredOverlay";
 import { WorkspaceSelector } from "./components/WorkspaceSelector";
 import { WorkspaceSettings } from "./components/WorkspaceSettings";
 import { PendingInvites } from "./components/PendingInvites";
@@ -214,11 +215,16 @@ function SettingsPage({
 
 // Connect API client to auth when auth context is available
 function AuthConnector({ children }: { children: React.ReactNode }) {
-  const { getAccessToken } = useAuth();
+  const { getAccessToken, notifySessionExpired } = useAuth();
 
   useEffect(() => {
     setAccessTokenGetter(getAccessToken);
   }, [getAccessToken]);
+
+  useEffect(() => {
+    setSessionExpiredHandler(notifySessionExpired);
+    return () => setSessionExpiredHandler(null);
+  }, [notifySessionExpired]);
 
   return <>{children}</>;
 }
@@ -706,6 +712,10 @@ function App() {
           <EnvironmentProvider>
             <BreadcrumbProvider>
               <Router />
+              {/* Top-level overlay so the modal renders above any page,
+                  including unauthenticated screens. The component is a
+                  no-op when ``sessionExpired`` is false. */}
+              <SessionExpiredOverlay />
             </BreadcrumbProvider>
           </EnvironmentProvider>
         </AuthConnector>

--- a/app/stardag-ui/src/api/client.test.ts
+++ b/app/stardag-ui/src/api/client.test.ts
@@ -5,7 +5,10 @@ import {
   setAccessTokenGetter,
   setCurrentWorkspaceId,
   setSessionExpiredHandler,
+  type GetAccessToken,
 } from "./client";
+
+const nullTokenGetter: GetAccessToken = async () => null;
 
 describe("fetchWithAuth — 401 retry semantics", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
@@ -18,19 +21,20 @@ describe("fetchWithAuth — 401 retry semantics", () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
-    setAccessTokenGetter((async () => null) as never);
+    setAccessTokenGetter(nullTokenGetter);
     setSessionExpiredHandler(null);
     setCurrentWorkspaceId(null);
   });
 
   it("retries once with a refreshed token after a 401", async () => {
     let call = 0;
-    const tokenGetter = vi.fn(async (_workspaceId, opts) => {
+    const impl: GetAccessToken = async (_workspaceId, opts) => {
       call += 1;
       if (opts?.forceRefresh) return "fresh-token";
       return "stale-token";
-    });
-    setAccessTokenGetter(tokenGetter as never);
+    };
+    const tokenGetter = vi.fn(impl);
+    setAccessTokenGetter(tokenGetter);
 
     fetchMock
       .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }))
@@ -52,7 +56,8 @@ describe("fetchWithAuth — 401 retry semantics", () => {
   });
 
   it("returns the original response without retry when status is not 401", async () => {
-    setAccessTokenGetter((async () => "tok") as never);
+    const tokenGetter: GetAccessToken = async () => "tok";
+    setAccessTokenGetter(tokenGetter);
     fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }));
 
     const resp = await fetchWithAuth("/api/v1/builds");
@@ -61,7 +66,7 @@ describe("fetchWithAuth — 401 retry semantics", () => {
   });
 
   it("does not retry when no token was attached on attempt 1", async () => {
-    setAccessTokenGetter((async () => null) as never);
+    setAccessTokenGetter(nullTokenGetter);
     fetchMock.mockResolvedValueOnce(new Response("unauthorized", { status: 401 }));
 
     const resp = await fetchWithAuth("/api/v1/builds");
@@ -70,10 +75,10 @@ describe("fetchWithAuth — 401 retry semantics", () => {
   });
 
   it("calls the session-expired handler when the retry also returns 401", async () => {
-    const tokenGetter = vi.fn(async (_workspaceId, opts) => {
-      return opts?.forceRefresh ? "fresh-token" : "stale-token";
-    });
-    setAccessTokenGetter(tokenGetter as never);
+    const impl: GetAccessToken = async (_workspaceId, opts) =>
+      opts?.forceRefresh ? "fresh-token" : "stale-token";
+    const tokenGetter = vi.fn(impl);
+    setAccessTokenGetter(tokenGetter);
     const handler = vi.fn();
     setSessionExpiredHandler(handler);
 
@@ -90,8 +95,9 @@ describe("fetchWithAuth — 401 retry semantics", () => {
     // Cognito silent renew can return the same token if it's not yet
     // expired client-side; in that case retrying with the same bearer
     // would just produce another 401 — short-circuit and signal expired.
-    const tokenGetter = vi.fn(async () => "same-token");
-    setAccessTokenGetter(tokenGetter as never);
+    const impl: GetAccessToken = async () => "same-token";
+    const tokenGetter = vi.fn(impl);
+    setAccessTokenGetter(tokenGetter);
     const handler = vi.fn();
     setSessionExpiredHandler(handler);
 
@@ -104,10 +110,10 @@ describe("fetchWithAuth — 401 retry semantics", () => {
   });
 
   it("calls the session-expired handler when refresh returns null", async () => {
-    const tokenGetter = vi.fn(async (_workspaceId, opts) => {
-      return opts?.forceRefresh ? null : "stale-token";
-    });
-    setAccessTokenGetter(tokenGetter as never);
+    const impl: GetAccessToken = async (_workspaceId, opts) =>
+      opts?.forceRefresh ? null : "stale-token";
+    const tokenGetter = vi.fn(impl);
+    setAccessTokenGetter(tokenGetter);
     const handler = vi.fn();
     setSessionExpiredHandler(handler);
 

--- a/app/stardag-ui/src/api/client.test.ts
+++ b/app/stardag-ui/src/api/client.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  fetchWithAuth,
+  setAccessTokenGetter,
+  setCurrentWorkspaceId,
+  setSessionExpiredHandler,
+} from "./client";
+
+describe("fetchWithAuth — 401 retry semantics", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    setCurrentWorkspaceId("ws-1");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setAccessTokenGetter((async () => null) as never);
+    setSessionExpiredHandler(null);
+    setCurrentWorkspaceId(null);
+  });
+
+  it("retries once with a refreshed token after a 401", async () => {
+    let call = 0;
+    const tokenGetter = vi.fn(async (_workspaceId, opts) => {
+      call += 1;
+      if (opts?.forceRefresh) return "fresh-token";
+      return "stale-token";
+    });
+    setAccessTokenGetter(tokenGetter as never);
+
+    fetchMock
+      .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }))
+      .mockResolvedValueOnce(new Response('{"ok":true}', { status: 200 }));
+
+    const resp = await fetchWithAuth("/api/v1/builds");
+    expect(resp.status).toBe(200);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const [, secondCall] = fetchMock.mock.calls;
+    const headers = (secondCall[1] as RequestInit).headers as Headers;
+    expect(headers.get("Authorization")).toBe("Bearer fresh-token");
+
+    // Token getter was called twice: once normally, once with forceRefresh.
+    expect(tokenGetter).toHaveBeenCalledTimes(2);
+    expect(tokenGetter.mock.calls[0][1]).toEqual({ forceRefresh: false });
+    expect(tokenGetter.mock.calls[1][1]).toEqual({ forceRefresh: true });
+    expect(call).toBe(2);
+  });
+
+  it("returns the original response without retry when status is not 401", async () => {
+    setAccessTokenGetter((async () => "tok") as never);
+    fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }));
+
+    const resp = await fetchWithAuth("/api/v1/builds");
+    expect(resp.status).toBe(403);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry when no token was attached on attempt 1", async () => {
+    setAccessTokenGetter((async () => null) as never);
+    fetchMock.mockResolvedValueOnce(new Response("unauthorized", { status: 401 }));
+
+    const resp = await fetchWithAuth("/api/v1/builds");
+    expect(resp.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the session-expired handler when the retry also returns 401", async () => {
+    const tokenGetter = vi.fn(async (_workspaceId, opts) => {
+      return opts?.forceRefresh ? "fresh-token" : "stale-token";
+    });
+    setAccessTokenGetter(tokenGetter as never);
+    const handler = vi.fn();
+    setSessionExpiredHandler(handler);
+
+    fetchMock
+      .mockResolvedValueOnce(new Response("unauthorized", { status: 401 }))
+      .mockResolvedValueOnce(new Response("still unauthorized", { status: 401 }));
+
+    const resp = await fetchWithAuth("/api/v1/builds");
+    expect(resp.status).toBe(401);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the session-expired handler when the refresh returns the same token", async () => {
+    // Cognito silent renew can return the same token if it's not yet
+    // expired client-side; in that case retrying with the same bearer
+    // would just produce another 401 — short-circuit and signal expired.
+    const tokenGetter = vi.fn(async () => "same-token");
+    setAccessTokenGetter(tokenGetter as never);
+    const handler = vi.fn();
+    setSessionExpiredHandler(handler);
+
+    fetchMock.mockResolvedValueOnce(new Response("unauthorized", { status: 401 }));
+
+    const resp = await fetchWithAuth("/api/v1/builds");
+    expect(resp.status).toBe(401);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls the session-expired handler when refresh returns null", async () => {
+    const tokenGetter = vi.fn(async (_workspaceId, opts) => {
+      return opts?.forceRefresh ? null : "stale-token";
+    });
+    setAccessTokenGetter(tokenGetter as never);
+    const handler = vi.fn();
+    setSessionExpiredHandler(handler);
+
+    fetchMock.mockResolvedValueOnce(new Response("unauthorized", { status: 401 }));
+
+    const resp = await fetchWithAuth("/api/v1/builds");
+    expect(resp.status).toBe(401);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/stardag-ui/src/api/client.ts
+++ b/app/stardag-ui/src/api/client.ts
@@ -1,6 +1,6 @@
 // API client with authentication support
 
-interface GetAccessTokenOptions {
+export interface GetAccessTokenOptions {
   /**
    * Skip the localStorage token cache and always re-exchange via Cognito.
    * Used by ``fetchWithAuth`` after an unexpected 401 to recover from a
@@ -11,7 +11,7 @@ interface GetAccessTokenOptions {
   forceRefresh?: boolean;
 }
 
-type GetAccessToken = (
+export type GetAccessToken = (
   workspaceId: string | null,
   opts?: GetAccessTokenOptions,
 ) => Promise<string | null>;

--- a/app/stardag-ui/src/api/client.ts
+++ b/app/stardag-ui/src/api/client.ts
@@ -1,13 +1,38 @@
 // API client with authentication support
 
-type GetAccessToken = (workspaceId: string | null) => Promise<string | null>;
+interface GetAccessTokenOptions {
+  /**
+   * Skip the localStorage token cache and always re-exchange via Cognito.
+   * Used by ``fetchWithAuth`` after an unexpected 401 to recover from a
+   * cached internal token that has gone stale before its client-side
+   * ``expiresAt`` (e.g. signed by a prior API container's keypair, or the
+   * server has rotated the JWT signing key).
+   */
+  forceRefresh?: boolean;
+}
+
+type GetAccessToken = (
+  workspaceId: string | null,
+  opts?: GetAccessTokenOptions,
+) => Promise<string | null>;
+
+type SessionExpiredHandler = () => void;
 
 let getAccessTokenFn: GetAccessToken | null = null;
 let currentWorkspaceId: string | null = null;
+let sessionExpiredHandler: SessionExpiredHandler | null = null;
 
 // Set the access token getter (called by AuthConnector)
 export function setAccessTokenGetter(fn: GetAccessToken): void {
   getAccessTokenFn = fn;
+}
+
+// Set the session-expired handler (called by AuthConnector). Invoked by
+// the fetch wrappers when a 401 cannot be recovered via re-exchange — at
+// that point the user's Cognito session has likely expired and they need
+// to log in again.
+export function setSessionExpiredHandler(handler: SessionExpiredHandler | null): void {
+  sessionExpiredHandler = handler;
 }
 
 // Set the current workspace ID (called by EnvironmentContext when workspace changes)
@@ -20,29 +45,75 @@ export function getCurrentWorkspaceId(): string | null {
   return currentWorkspaceId;
 }
 
+/**
+ * Internal helper that runs the actual fetch and handles 401 once.
+ *
+ * Flow:
+ *  1. Pull a token from ``getTokenFor()`` (the caller decides whether to
+ *     resolve a workspace token, the bootstrap OIDC token, etc.).
+ *  2. Send the request.
+ *  3. If status is 401 *and* we got a token on attempt 1, force a refresh
+ *     and retry exactly once. We don't retry when there was no token on
+ *     attempt 1 (an unauthenticated caller can't usefully retry).
+ *  4. If the retry also returns 401, signal the session-expired handler
+ *     (the user needs to log in again) and return the response — the
+ *     caller's ``response.ok`` check still gets to throw its own error.
+ */
+async function fetchWithRetry(
+  url: string,
+  options: RequestInit,
+  getTokenFor: (forceRefresh: boolean) => Promise<string | null>,
+): Promise<Response> {
+  const headers = new Headers(options.headers);
+
+  let token: string | null = null;
+  try {
+    token = await getTokenFor(false);
+  } catch (error) {
+    console.warn("Failed to get access token:", error);
+  }
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+
+  const response = await fetch(url, { ...options, headers });
+
+  if (response.status !== 401 || !token) {
+    return response;
+  }
+
+  // 401 with a token attached → either the token is stale (server rotated
+  // its signing key, or the cached token outlived its TTL despite the
+  // client's belief that it was still valid) or the token has been
+  // explicitly invalidated server-side. Force a refresh and retry once.
+  let refreshedToken: string | null = null;
+  try {
+    refreshedToken = await getTokenFor(true);
+  } catch (error) {
+    console.warn("Token refresh after 401 failed:", error);
+  }
+  if (!refreshedToken || refreshedToken === token) {
+    sessionExpiredHandler?.();
+    return response;
+  }
+
+  const retryHeaders = new Headers(options.headers);
+  retryHeaders.set("Authorization", `Bearer ${refreshedToken}`);
+  const retryResponse = await fetch(url, { ...options, headers: retryHeaders });
+  if (retryResponse.status === 401) {
+    sessionExpiredHandler?.();
+  }
+  return retryResponse;
+}
+
 // Fetch wrapper that includes auth headers when available
 export async function fetchWithAuth(
   url: string,
   options: RequestInit = {},
 ): Promise<Response> {
-  const headers = new Headers(options.headers);
-
-  // Add auth header if we have a token getter
-  if (getAccessTokenFn) {
-    try {
-      // Use workspace-scoped token if workspace is set, otherwise use OIDC ID token
-      const token = await getAccessTokenFn(currentWorkspaceId);
-      if (token) {
-        headers.set("Authorization", `Bearer ${token}`);
-      }
-    } catch (error) {
-      console.warn("Failed to get access token:", error);
-    }
-  }
-
-  return fetch(url, {
-    ...options,
-    headers,
+  return fetchWithRetry(url, options, async (forceRefresh) => {
+    if (!getAccessTokenFn) return null;
+    return getAccessTokenFn(currentWorkspaceId, { forceRefresh });
   });
 }
 
@@ -52,23 +123,9 @@ export async function fetchWithBootstrapAuth(
   url: string,
   options: RequestInit = {},
 ): Promise<Response> {
-  const headers = new Headers(options.headers);
-
-  // Always use OIDC ID token (pass null for workspaceId)
-  if (getAccessTokenFn) {
-    try {
-      const token = await getAccessTokenFn(null);
-      if (token) {
-        headers.set("Authorization", `Bearer ${token}`);
-      }
-    } catch (error) {
-      console.warn("Failed to get bootstrap access token:", error);
-    }
-  }
-
-  return fetch(url, {
-    ...options,
-    headers,
+  return fetchWithRetry(url, options, async (forceRefresh) => {
+    if (!getAccessTokenFn) return null;
+    return getAccessTokenFn(null, { forceRefresh });
   });
 }
 
@@ -78,21 +135,8 @@ export async function fetchWithWorkspaceAuth(
   workspaceId: string,
   options: RequestInit = {},
 ): Promise<Response> {
-  const headers = new Headers(options.headers);
-
-  if (getAccessTokenFn) {
-    try {
-      const token = await getAccessTokenFn(workspaceId);
-      if (token) {
-        headers.set("Authorization", `Bearer ${token}`);
-      }
-    } catch (error) {
-      console.warn("Failed to get access token:", error);
-    }
-  }
-
-  return fetch(url, {
-    ...options,
-    headers,
+  return fetchWithRetry(url, options, async (forceRefresh) => {
+    if (!getAccessTokenFn) return null;
+    return getAccessTokenFn(workspaceId, { forceRefresh });
   });
 }

--- a/app/stardag-ui/src/components/SessionExpiredOverlay.tsx
+++ b/app/stardag-ui/src/components/SessionExpiredOverlay.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react";
+import { useAuth } from "../context/AuthContext";
+
+/**
+ * Modal that takes over the screen when the API client has signalled an
+ * unrecoverable 401. Replaces the previous silent empty-state UX.
+ *
+ * The overlay is non-dismissible by design — the user genuinely cannot
+ * use the app until they re-authenticate, so any "close" affordance
+ * would just lead to more empty states.
+ */
+export function SessionExpiredOverlay() {
+  const { sessionExpired, login, logout } = useAuth();
+  const [isLoggingIn, setIsLoggingIn] = useState(false);
+
+  if (!sessionExpired) return null;
+
+  async function handleSignIn() {
+    setIsLoggingIn(true);
+    try {
+      // ``login()`` calls signinRedirect — the browser navigates away to
+      // Cognito and comes back to the OIDC callback URL, which finishes
+      // the sign-in flow and clears the sessionExpired flag via the
+      // AuthContext's user-loaded handler.
+      await login();
+    } catch (error) {
+      console.error("Re-login failed:", error);
+      setIsLoggingIn(false);
+    }
+  }
+
+  async function handleSignOut() {
+    // If for some reason the user wants to sign out fully (e.g. they
+    // signed in as the wrong account upstream and need to switch),
+    // ``logout`` clears local state + redirects to the IdP's logout.
+    try {
+      await logout();
+    } catch (error) {
+      console.error("Logout failed:", error);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="session-expired-title"
+    >
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-2xl dark:bg-gray-800">
+        <h2
+          id="session-expired-title"
+          className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+        >
+          Session expired
+        </h2>
+        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+          Your sign-in has expired or was invalidated. Please sign in again to continue.
+        </p>
+        <div className="mt-5 flex items-center justify-end gap-3">
+          <button
+            type="button"
+            onClick={handleSignOut}
+            className="rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            Sign out
+          </button>
+          <button
+            type="button"
+            onClick={handleSignIn}
+            disabled={isLoggingIn}
+            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isLoggingIn ? "Signing in…" : "Sign in again"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/stardag-ui/src/components/SessionExpiredOverlay.tsx
+++ b/app/stardag-ui/src/components/SessionExpiredOverlay.tsx
@@ -1,19 +1,20 @@
 import { useState } from "react";
 import { useAuth } from "../context/AuthContext";
+import { Modal } from "./Modal";
 
 /**
  * Modal that takes over the screen when the API client has signalled an
  * unrecoverable 401. Replaces the previous silent empty-state UX.
  *
- * The overlay is non-dismissible by design — the user genuinely cannot
- * use the app until they re-authenticate, so any "close" affordance
- * would just lead to more empty states.
+ * Non-dismissible by design — the user genuinely cannot use the app
+ * until they re-authenticate, so any "close" affordance would just
+ * lead to more empty states. We pass a no-op ``onClose`` to ``Modal``
+ * and disable the overlay-click + close-button affordances. Pressing
+ * Escape will fire the no-op ``onClose`` and the modal stays mounted.
  */
 export function SessionExpiredOverlay() {
   const { sessionExpired, login, logout } = useAuth();
   const [isLoggingIn, setIsLoggingIn] = useState(false);
-
-  if (!sessionExpired) return null;
 
   async function handleSignIn() {
     setIsLoggingIn(true);
@@ -25,6 +26,11 @@ export function SessionExpiredOverlay() {
       await login();
     } catch (error) {
       console.error("Re-login failed:", error);
+    } finally {
+      // Reset in ``finally`` so the button doesn't stay disabled if
+      // ``login()`` resolves without navigating (misconfigured redirect,
+      // disabled auth, etc.). In the happy path the page navigates away
+      // before this matters.
       setIsLoggingIn(false);
     }
   }
@@ -41,40 +47,35 @@ export function SessionExpiredOverlay() {
   }
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="session-expired-title"
+    <Modal
+      isOpen={sessionExpired}
+      onClose={() => {
+        /* non-dismissible */
+      }}
+      title="Session expired"
+      closeOnOverlay={false}
+      showCloseButton={false}
     >
-      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-2xl dark:bg-gray-800">
-        <h2
-          id="session-expired-title"
-          className="text-lg font-semibold text-gray-900 dark:text-gray-100"
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        Your sign-in has expired or was invalidated. Please sign in again to continue.
+      </p>
+      <div className="mt-5 flex items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={handleSignOut}
+          className="rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
         >
-          Session expired
-        </h2>
-        <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
-          Your sign-in has expired or was invalidated. Please sign in again to continue.
-        </p>
-        <div className="mt-5 flex items-center justify-end gap-3">
-          <button
-            type="button"
-            onClick={handleSignOut}
-            className="rounded-md px-3 py-2 text-sm text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
-          >
-            Sign out
-          </button>
-          <button
-            type="button"
-            onClick={handleSignIn}
-            disabled={isLoggingIn}
-            className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isLoggingIn ? "Signing in…" : "Sign in again"}
-          </button>
-        </div>
+          Sign out
+        </button>
+        <button
+          type="button"
+          onClick={handleSignIn}
+          disabled={isLoggingIn}
+          className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isLoggingIn ? "Signing in…" : "Sign in again"}
+        </button>
       </div>
-    </div>
+    </Modal>
   );
 }

--- a/app/stardag-ui/src/context/AuthContext.tsx
+++ b/app/stardag-ui/src/context/AuthContext.tsx
@@ -20,6 +20,14 @@ interface WorkspaceToken {
   expiresAt: number; // Unix timestamp in ms
 }
 
+interface GetAccessTokenOptions {
+  /**
+   * Skip the localStorage token cache and always re-exchange via Cognito.
+   * Used by the fetch wrapper after an unexpected 401.
+   */
+  forceRefresh?: boolean;
+}
+
 interface AuthContextType {
   user: User | null;
   isLoading: boolean;
@@ -28,14 +36,32 @@ interface AuthContextType {
   logout: () => Promise<void>;
   // Get the OIDC access token (for token exchange only)
   getOidcAccessToken: () => Promise<string | null>;
-  // Get workspace-scoped access token for API calls
-  getAccessToken: (workspaceId: string | null) => Promise<string | null>;
-  // Exchange OIDC token for workspace-scoped token
-  exchangeForWorkspaceToken: (workspaceId: string) => Promise<string | null>;
+  // Get workspace-scoped access token for API calls.
+  // ``forceRefresh: true`` skips the localStorage cache and re-exchanges.
+  getAccessToken: (
+    workspaceId: string | null,
+    opts?: GetAccessTokenOptions,
+  ) => Promise<string | null>;
+  // Exchange OIDC token for workspace-scoped token. ``forceRefresh: true``
+  // skips the localStorage cache and re-exchanges from a freshly-renewed
+  // Cognito session.
+  exchangeForWorkspaceToken: (
+    workspaceId: string,
+    opts?: GetAccessTokenOptions,
+  ) => Promise<string | null>;
   // Current workspace for which we have a valid token
   currentTokenWorkspaceId: string | null;
   // Token exchange in progress
   isExchangingToken: boolean;
+  // True when the API client signalled an unrecoverable 401. The UI shows
+  // a "session expired" overlay; clears on successful re-login.
+  sessionExpired: boolean;
+  // Imperatively flag the session as expired (used by the API client's
+  // 401 retry path).
+  notifySessionExpired: () => void;
+  // Clear the flag — call after a successful re-login so the overlay
+  // doesn't keep shadowing the app.
+  clearSessionExpired: () => void;
 }
 
 const AuthContext = createContext<AuthContextType | null>(null);
@@ -83,6 +109,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
     null,
   );
   const [isExchangingToken, setIsExchangingToken] = useState(false);
+  const [sessionExpired, setSessionExpired] = useState(false);
+
+  const notifySessionExpired = useCallback(() => {
+    setSessionExpired(true);
+  }, []);
+
+  const clearSessionExpired = useCallback(() => {
+    setSessionExpired(false);
+  }, []);
 
   const manager = getUserManager();
 
@@ -109,7 +144,13 @@ export function AuthProvider({ children }: AuthProviderProps) {
     loadUser();
 
     // Listen for user changes (e.g., token refresh)
-    const handleUserLoaded = (user: User) => setUser(user);
+    const handleUserLoaded = (user: User) => {
+      setUser(user);
+      // A fresh user load (silent renew completed, redirect callback
+      // returned, etc.) means the session is healthy again — clear any
+      // stale "session expired" flag so the overlay disappears.
+      setSessionExpired(false);
+    };
     const handleUserUnloaded = () => {
       setUser(null);
       setCurrentTokenWorkspaceId(null);
@@ -194,6 +235,21 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   }, [manager]);
 
+  // Force a silent renew of the Cognito session and return the renewed
+  // ID token. Distinguished from ``getIdToken`` because the API client's
+  // 401 retry path can't trust whatever's already cached locally — the
+  // cached id_token may itself be the reason we got the 401 (very rare,
+  // e.g. clock skew or Cognito-side revocation).
+  const getRefreshedIdToken = useCallback(async (): Promise<string | null> => {
+    if (!manager) return null;
+    try {
+      const renewedUser = await manager.signinSilent();
+      return renewedUser?.id_token ?? null;
+    } catch {
+      return null;
+    }
+  }, [manager]);
+
   // Get OIDC access token (for token exchange)
   const getOidcAccessToken = useCallback(async (): Promise<string | null> => {
     if (!manager) return null;
@@ -211,18 +267,47 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   }, [manager]);
 
-  // Exchange OIDC token for workspace-scoped token
+  // Force a silent renew and return the renewed access token. Sibling to
+  // ``getRefreshedIdToken``; used by ``exchangeForWorkspaceToken`` when
+  // the caller asked for ``forceRefresh: true``.
+  const getRefreshedOidcAccessToken = useCallback(async (): Promise<string | null> => {
+    if (!manager) return null;
+    try {
+      const renewedUser = await manager.signinSilent();
+      return renewedUser?.access_token ?? null;
+    } catch {
+      return null;
+    }
+  }, [manager]);
+
+  // Exchange OIDC token for workspace-scoped token. ``forceRefresh: true``
+  // skips the localStorage cache and re-exchanges with the Cognito-provided
+  // OIDC token — used after an unexpected 401 to recover from a stale
+  // cached internal token (e.g. signed by a prior API container's keypair
+  // or invalidated by a server-side rotation).
   const exchangeForWorkspaceToken = useCallback(
-    async (workspaceId: string): Promise<string | null> => {
-      // Check cache first
-      const cached = getStoredWorkspaceToken(workspaceId);
-      if (cached) {
-        setCurrentTokenWorkspaceId(workspaceId);
-        return cached.accessToken;
+    async (
+      workspaceId: string,
+      opts: GetAccessTokenOptions = {},
+    ): Promise<string | null> => {
+      if (!opts.forceRefresh) {
+        const cached = getStoredWorkspaceToken(workspaceId);
+        if (cached) {
+          setCurrentTokenWorkspaceId(workspaceId);
+          return cached.accessToken;
+        }
+      } else {
+        // Drop the stale cache entry so subsequent reads don't accidentally
+        // pick it up again.
+        clearWorkspaceToken(workspaceId);
       }
 
-      // Get OIDC access token
-      const oidcToken = await getOidcAccessToken();
+      // Get OIDC access token. If forceRefresh is set, prefer a freshly-
+      // renewed Cognito token rather than whatever is in the user manager
+      // (the cached one might also be stale relative to the API).
+      const oidcToken = opts.forceRefresh
+        ? await getRefreshedOidcAccessToken()
+        : await getOidcAccessToken();
       if (!oidcToken) {
         console.warn("No OIDC token available for exchange");
         return null;
@@ -242,30 +327,35 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setIsExchangingToken(false);
       }
     },
-    [getOidcAccessToken],
+    [getOidcAccessToken, getRefreshedOidcAccessToken],
   );
 
   // Get access token for API calls (workspace-scoped if workspaceId provided)
   const getAccessToken = useCallback(
-    async (workspaceId: string | null): Promise<string | null> => {
+    async (
+      workspaceId: string | null,
+      opts: GetAccessTokenOptions = {},
+    ): Promise<string | null> => {
       // If no workspace specified, use ID token for bootstrap endpoints
       // (ID token contains email/name claims needed by /ui/me endpoints)
       // NOTE: Access token doesn't have user claims in Cognito
       if (!workspaceId) {
-        return getIdToken();
+        return opts.forceRefresh ? getRefreshedIdToken() : getIdToken();
       }
 
-      // Check if we have a valid cached token for this workspace
-      const cached = getStoredWorkspaceToken(workspaceId);
-      if (cached) {
-        setCurrentTokenWorkspaceId(workspaceId);
-        return cached.accessToken;
+      if (!opts.forceRefresh) {
+        // Check if we have a valid cached token for this workspace
+        const cached = getStoredWorkspaceToken(workspaceId);
+        if (cached) {
+          setCurrentTokenWorkspaceId(workspaceId);
+          return cached.accessToken;
+        }
       }
 
-      // Need to exchange for a new token
-      return exchangeForWorkspaceToken(workspaceId);
+      // Need to (re-)exchange for a new token
+      return exchangeForWorkspaceToken(workspaceId, opts);
     },
-    [getIdToken, exchangeForWorkspaceToken],
+    [getIdToken, getRefreshedIdToken, exchangeForWorkspaceToken],
   );
 
   const value: AuthContextType = {
@@ -279,6 +369,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     exchangeForWorkspaceToken,
     currentTokenWorkspaceId,
     isExchangingToken,
+    sessionExpired,
+    notifySessionExpired,
+    clearSessionExpired,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;


### PR DESCRIPTION
## Summary

Defense-in-depth UX layer that complements #129 (stable `JWT_PRIVATE_KEY`).

#129 fixed the *root cause* of the post-deploy logout (each ECS task generated its own ephemeral RSA keypair, so cached internal tokens silently went stale across deploys). But tokens still expire for legitimate reasons — the 10-min API TTL, Cognito session timeout, manual revocation — and previously the UI just rendered empty states ("no builds", "no environment", etc.) with no indication that re-authentication was needed.

This PR adds:

1. **401 retry with forced token refresh** in `fetchWithAuth` (and the bootstrap/workspace variants). If the original request had a token attached and got a 401, we re-exchange via Cognito with `forceRefresh: true` and retry once.
2. **Session-expired overlay** when recovery fails. `AuthContext` exposes a `sessionExpired` flag; `SessionExpiredOverlay` is a non-dismissible modal with "Sign in again" / "Sign out" actions. On successful re-login the OIDC callback fires `handleUserLoaded`, which clears the flag.

### Recovery / signal logic in `fetchWithRetry`

| Attempt 1 | Refresh result | Attempt 2 | Outcome |
|---|---|---|---|
| 401 with token | new token differs | 200 | success (silent recovery) |
| 401 with token | new token differs | 401 | session-expired handler fires |
| 401 with token | same token | — | skip retry, session-expired fires |
| 401 with token | null / throw | — | skip retry, session-expired fires |
| 401, no token attached | — | — | return 401 (caller is unauth) |
| non-401 | — | — | return as-is |

The "same token" short-circuit covers the case where Cognito's silent renew returns a still-valid (client-side) token — retrying with the same `Bearer` would just produce another 401, so we skip straight to the expired UX.

## Test plan

- [x] 6 new vitest cases in `src/api/client.test.ts`:
  - retries once with a refreshed token after a 401
  - returns the original response without retry when status is not 401
  - does not retry when no token was attached on attempt 1
  - calls the session-expired handler when the retry also returns 401
  - calls the session-expired handler when refresh returns the same token
  - calls the session-expired handler when refresh returns null
- [x] Existing 4 vitest tests still pass
- [x] `npm run build` clean
- [x] eslint + tsc + prettier clean
- [ ] Manual verification after deploy: deliberately let session expire (or invalidate token server-side) → overlay appears, "Sign in again" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)