### PR TITLE
Fix UI loading-state flicker and env-switch nav on detail pages

### DIFF
--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -142,13 +142,15 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
     loadBuild();
   }, [loadBuild]);
 
-  // Reset task-list filters and pagination when the user navigates between
-  // builds — otherwise a filter set on Build A silently applies to Build B
-  // and may produce a confusing empty list.
+  // Reset build-scoped UI state when the user navigates between builds.
+  // Otherwise, filters/pagination from Build A can silently apply to
+  // Build B, and a previously selected task can leave the detail panel
+  // and breadcrumb pointing at stale data from the prior build.
   useEffect(() => {
     setNameFilter("");
     setStatusFilter("");
     setPage(1);
+    setSelectedTask(null);
   }, [buildId]);
 
   // Refresh handler

--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -142,6 +142,15 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
     loadBuild();
   }, [loadBuild]);
 
+  // Reset task-list filters and pagination when the user navigates between
+  // builds — otherwise a filter set on Build A silently applies to Build B
+  // and may produce a confusing empty list.
+  useEffect(() => {
+    setNameFilter("");
+    setStatusFilter("");
+    setPage(1);
+  }, [buildId]);
+
   // Refresh handler
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);

--- a/app/stardag-ui/src/components/BuildsList.tsx
+++ b/app/stardag-ui/src/components/BuildsList.tsx
@@ -75,8 +75,10 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
 
   const loadBuilds = useCallback(async () => {
     if (!activeEnvironment?.id) {
+      // Don't flip loading=false here — the parent gate handles the
+      // no-environment case, and clearing loading would briefly leak
+      // the empty-state UI on env transitions.
       setBuilds([]);
-      setLoading(false);
       return;
     }
 
@@ -97,6 +99,12 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
     }
   }, [activeEnvironment?.id, page]);
 
+  // Reset to first page when the active environment changes so we don't
+  // request page N of a smaller env and flash an empty result.
+  useEffect(() => {
+    setPage(1);
+  }, [activeEnvironment?.id]);
+
   useEffect(() => {
     loadBuilds();
   }, [loadBuilds]);
@@ -111,7 +119,7 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
     );
   }
 
-  if (loading && builds.length === 0) {
+  if (loading) {
     return (
       <div className="flex h-full items-center justify-center">
         <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />

--- a/app/stardag-ui/src/components/BuildsList.tsx
+++ b/app/stardag-ui/src/components/BuildsList.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchBuilds } from "../api/tasks";
 import { useBreadcrumb } from "../context/BreadcrumbContext";
 import { useEnvironment } from "../context/EnvironmentContext";
@@ -73,6 +73,10 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
     return () => setBreadcrumb([]);
   }, [setBreadcrumb]);
 
+  // Track the env id of the most recent fetch we initiated. Used below
+  // to detect "env just changed" inside loadBuilds — see comment there.
+  const lastFetchedEnvIdRef = useRef<string | null>(null);
+
   const loadBuilds = useCallback(async () => {
     if (!activeEnvironment?.id) {
       // Don't flip loading=false here — the parent gate handles the
@@ -81,6 +85,22 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
       setBuilds([]);
       return;
     }
+
+    // If the env just changed and we're not already on page 1, reset
+    // the page and bail. The page-state update re-creates this callback
+    // on the next render, which will run with page=1 against the new
+    // env. Doing this here (instead of in a separate ``useEffect`` that
+    // runs *alongside* the fetch effect) prevents a wasted fetch with
+    // the previous page that would briefly flash an empty result.
+    if (
+      lastFetchedEnvIdRef.current !== null &&
+      lastFetchedEnvIdRef.current !== activeEnvironment.id &&
+      page !== 1
+    ) {
+      setPage(1);
+      return;
+    }
+    lastFetchedEnvIdRef.current = activeEnvironment.id;
 
     setLoading(true);
     setError(null);
@@ -98,12 +118,6 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
       setLoading(false);
     }
   }, [activeEnvironment?.id, page]);
-
-  // Reset to first page when the active environment changes so we don't
-  // request page N of a smaller env and flash an empty result.
-  useEffect(() => {
-    setPage(1);
-  }, [activeEnvironment?.id]);
 
   useEffect(() => {
     loadBuilds();

--- a/app/stardag-ui/src/components/TaskExplorer.tsx
+++ b/app/stardag-ui/src/components/TaskExplorer.tsx
@@ -425,6 +425,14 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
     searchTasks();
   }, [searchTasks]);
 
+  // Reset paginated/selected state when active environment changes so we
+  // don't request page N of a smaller env (briefly flashing an empty
+  // result) or keep a selected task that doesn't exist in the new env.
+  useEffect(() => {
+    setPage(1);
+    setSelectedTask(null);
+  }, [activeEnvironment?.id]);
+
   // DAG availability
   const canShowDag = tasks.length > 0 && tasks.length <= 500;
 

--- a/app/stardag-ui/src/components/TaskExplorer.tsx
+++ b/app/stardag-ui/src/components/TaskExplorer.tsx
@@ -365,12 +365,32 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
     return Array.from(artifactNames).sort().join(",");
   }, [columns]);
 
+  // Track the env id of the most recent search we initiated. Used below
+  // to detect "env just changed" inside searchTasks — see comment there.
+  const lastFetchedEnvIdRef = useRef<string | null>(null);
+
   // Search tasks
   const searchTasks = useCallback(async () => {
     if (!activeEnvironment?.id) {
       setTasks([]);
       return;
     }
+
+    // If the env just changed and we're not already on page 1, reset
+    // the page and bail. The page-state update re-creates this callback
+    // on the next render, which will run with page=1 against the new
+    // env. Doing this here (instead of in a separate ``useEffect`` that
+    // runs *alongside* the fetch effect) prevents a wasted search with
+    // the previous page that would briefly flash an empty result.
+    if (
+      lastFetchedEnvIdRef.current !== null &&
+      lastFetchedEnvIdRef.current !== activeEnvironment.id &&
+      page !== 1
+    ) {
+      setPage(1);
+      return;
+    }
+    lastFetchedEnvIdRef.current = activeEnvironment.id;
 
     setLoading(true);
     setError(null);
@@ -425,11 +445,11 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
     searchTasks();
   }, [searchTasks]);
 
-  // Reset paginated/selected state when active environment changes so we
-  // don't request page N of a smaller env (briefly flashing an empty
-  // result) or keep a selected task that doesn't exist in the new env.
+  // Clear the selected task when the env changes — the previously
+  // selected task ID belongs to the prior env and won't resolve here.
+  // (Page reset is handled inline in searchTasks above to avoid a race
+  // with the fetch effect.)
   useEffect(() => {
-    setPage(1);
     setSelectedTask(null);
   }, [activeEnvironment?.id]);
 

--- a/app/stardag-ui/src/context/EnvironmentContext.tsx
+++ b/app/stardag-ui/src/context/EnvironmentContext.tsx
@@ -205,6 +205,17 @@ export function EnvironmentProvider({ children }: EnvironmentProviderProps) {
     } else {
       localStorage.removeItem(STORAGE_KEY_ENVIRONMENT);
     }
+
+    // If the user is currently on an env-scoped detail route (e.g.
+    // /builds/<id>), the resource ID belongs to the *previous*
+    // environment and won't resolve in the new one. Redirect to the
+    // builds overview instead of leaving the user on a broken page.
+    // Collection routes (/tasks, /settings, /invites, ...) refetch
+    // against the new env on their own and don't need a redirect.
+    if (/\/builds\/[^/]+/.test(window.location.pathname)) {
+      window.history.pushState({}, "", "/");
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }
   }, []);
 
   // Get URL path for current workspace/environment


### PR DESCRIPTION
## Summary

Four small fixes around state hygiene when the active environment or current build changes mid-view.

### 1. `BuildsList`: empty-state flashing during loading

The spinner was gated on `loading && builds.length === 0`, which meant any *refetch* (env transition, returning to the route with stale state) would skip the spinner and either flash "No builds yet" or render stale data while the new request was in flight. Specifically the user-reported case:

1. Component mounts with `activeEnvironment` still resolving from context → `loadBuilds` early-returns and sets `loading=false`.
2. Env arrives → re-render with `loading=false, builds=[]` → "No builds yet" flashes.
3. Effect re-fires → `setLoading(true)` → spinner finally appears.

Fixes:
- Spinner now shows whenever `loading` is true.
- Stop calling `setLoading(false)` in the no-env early-return — the parent gate (`!activeEnvironment` → "Select an environment") handles that case, and clearing `loading` was the source of the leaked empty state.

### 2. `BuildsList` + `TaskExplorer`: page reset on env change

The `loadX` callbacks depend on `[activeEnvironment?.id, page]`. Switching from env-A while on page 2 issued *page 2 of env-B*, often briefly flashing an empty result. Now both reset `page → 1` when `activeEnvironment?.id` changes. `TaskExplorer` also clears `selectedTask` for the same reason — the previously-selected task ID won't exist in the new env.

### 3. `BuildView`: filter reset on `buildId` change

`nameFilter`, `statusFilter`, `page` previously persisted across builds. Filtering Build A's tasks by "failed" then opening Build B applied the same filter silently, producing a confusing empty list.

### 4. `EnvironmentContext.setActiveEnvironment`: redirect on env-scoped detail pages

User-reported: viewing `/builds/<id>` for build X (env A), switching to env B made the page keep fetching X against env B, surfacing "Failed to fetch graph". Now the env setter checks `window.location.pathname` and, if it matches `/builds/:id`, redirects to `/` (mirroring the existing `setActiveWorkspace` redirect pattern).

The redirect is intentionally conditional — collection routes (`/tasks`, `/settings`, `/invites`) refetch correctly on their own and don't need to bounce back to home.

`/builds/:id` is currently the only env-scoped detail route in the app (TaskDetail is a modal inside BuildView, not a URL); if more are added the regex should be widened.

## Test plan

- [x] Existing vitest suite passes (4/4)
- [x] eslint + tsc + prettier clean
- [x] `npm run build` clean
- [ ] Manual: navigate to /builds → only spinner shown until list resolves (no "No builds" flash)
- [ ] Manual: open Build X (env A), switch to env B → redirected to `/`, no "Failed to fetch graph"
- [ ] Manual: paginate Builds to page 2, switch env → lands on page 1 of new env, no empty flash
- [ ] Manual: filter tasks in Build A by status, click Build B in list → Build B tasks appear unfiltered

🤖 Generated with [Claude Code](https://claude.com/claude-code)