### PR TITLE
Changelog: `app/stardag-api|ui` only — 2026-04-28 (server-side fixes #125–#131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,14 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## `app/stardag-api|ui` only — 2026-04-28
 
-> Server-side changes only — no SDK release. Deployed continuously via
-> `stardag-cloud`.
+> App (API + UI) changes only — no SDK release. Deployed continuously
+> via `stardag-cloud`.
 
 ### API
 
 - **Performance**: bcrypt API-key validation moved off the event loop (in-process TTL cache + `asyncio.to_thread`), explicit DB pool config, gunicorn `--preload`/`UvicornWorker` with parameterised workers and sizing. JSONB metadata columns, `(environment_id, created_at)` indices, batched dependency reconciliation. Denormalised `Task.latest_*` status columns with `SELECT … FOR UPDATE` concurrent-write protection. ([#125](https://github.com/stardag-dev/stardag/pull/125), [#126](https://github.com/stardag-dev/stardag/pull/126), [#127](https://github.com/stardag-dev/stardag/pull/127))
 - **Bug fix**: `/tasks/search` no longer 500s on `filter=build_id:=:<uuid>`; malformed UUIDs now return 400. ([#128](https://github.com/stardag-dev/stardag/pull/128))
-- **Stable internal JWT signing key (optional)**: load the RSA keypair from a configured secret (`JWT_PRIVATE_KEY_SECRET_NAME`) instead of generating an ephemeral one per container, so deploys and scaleouts don't invalidate cached internal tokens. ([#129](https://github.com/stardag-dev/stardag/pull/129))
+- **Stable internal JWT signing key (optional)**: when `STARDAG_API_JWT_PRIVATE_KEY_SECRET_NAME` is set at CDK synth time, the named Secrets Manager secret (containing a PEM RSA private key under `private_key`) is mounted into the container as `JWT_PRIVATE_KEY` and used by the internal token manager instead of generating an ephemeral keypair per container. Deploys and scaleouts no longer invalidate cached internal tokens. ([#129](https://github.com/stardag-dev/stardag/pull/129))
 
 ### UI
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## `app/stardag-api|ui` only — 2026-04-28
+
+> Server-side changes only — no SDK release. Deployed continuously via
+> `stardag-cloud`.
+
 ### API
 
 - **Performance**: bcrypt API-key validation moved off the event loop (in-process TTL cache + `asyncio.to_thread`), explicit DB pool config, gunicorn `--preload`/`UvicornWorker` with parameterised workers and sizing. JSONB metadata columns, `(environment_id, created_at)` indices, batched dependency reconciliation. Denormalised `Task.latest_*` status columns with `SELECT … FOR UPDATE` concurrent-write protection. ([#125](https://github.com/stardag-dev/stardag/pull/125), [#126](https://github.com/stardag-dev/stardag/pull/126), [#127](https://github.com/stardag-dev/stardag/pull/127))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### API
+
+- **Performance**: bcrypt API-key validation moved off the event loop (in-process TTL cache + `asyncio.to_thread`), explicit DB pool config, gunicorn `--preload`/`UvicornWorker` with parameterised workers and sizing. JSONB metadata columns, `(environment_id, created_at)` indices, batched dependency reconciliation. Denormalised `Task.latest_*` status columns with `SELECT … FOR UPDATE` concurrent-write protection. ([#125](https://github.com/stardag-dev/stardag/pull/125), [#126](https://github.com/stardag-dev/stardag/pull/126), [#127](https://github.com/stardag-dev/stardag/pull/127))
+- **Bug fix**: `/tasks/search` no longer 500s on `filter=build_id:=:<uuid>`; malformed UUIDs now return 400. ([#128](https://github.com/stardag-dev/stardag/pull/128))
+- **Stable internal JWT signing key (optional)**: load the RSA keypair from a configured secret (`JWT_PRIVATE_KEY_SECRET_NAME`) instead of generating an ephemeral one per container, so deploys and scaleouts don't invalidate cached internal tokens. ([#129](https://github.com/stardag-dev/stardag/pull/129))
+
+### UI
+
+- **401 retry + session-expired overlay**: `fetchWithAuth` retries 401 once with a force-refreshed Cognito token; on unrecoverable 401 a non-dismissible modal prompts re-login instead of leaving the user on silent empty states. ([#130](https://github.com/stardag-dev/stardag/pull/130))
+- **Loading-state and nav hygiene**: BuildsList no longer flashes "No builds yet" between env-arrival and the first fetch; BuildsList + TaskExplorer reset to page 1 on env change (no extra fetch with the old page); BuildView clears filters / pagination / selected task when navigating between builds; switching env from a `/builds/:id` page redirects to `/` instead of surfacing "Failed to fetch graph". ([#131](https://github.com/stardag-dev/stardag/pull/131))
+
 ## [0.5.9] — 2026-04-20
 
 ### SDK


### PR DESCRIPTION
## Summary

Logs everything merged since 0.5.9 under a new `` `app/stardag-api|ui` only — 2026-04-28 `` section. These changes are server-side only (no SDK release) and reach prod via `stardag-cloud`, so `[Unreleased]` (reserved for the next SDK release) doesn't fit — kept empty as a placeholder.

Two short bullets per section (API + UI):

- **API perf** (#125, #126, #127) — bcrypt off the event loop + JSONB columns + indices + denormalised status columns
- **Search** (#128) — UUID cast for `build_id` filter
- **Stable internal JWT signing key (optional)** (#129)
- **UI 401 retry + session-expired overlay** (#130)
- **UI loading-state + env-switch nav hygiene** (#131)

🤖 Generated with [Claude Code](https://claude.com/claude-code)