### PR TITLE
Discover-time task registration + bulk register + UX polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,17 @@ notes; the bullets below are the per-component summary.
   before the edge insert.
 - **Bulk register**: build engines now collapse the discovered tasks
   into a single `task_register_bulk(_aio)` call per discover walk
-  (initial + each dynamic-deps yield), chunked at 1000 tasks per HTTP
-  request. For large fan-out DAGs this is a dramatic reduction in HTTP
-  round-trips. Per-task fallback on 404 (older API deployments).
+  (initial + each dynamic-deps yield), chunked at 50 tasks per HTTP
+  request (well under the API's 1000 hard cap so DB transactions stay
+  short and request bodies stay friendly even with fat task specs).
+  For large fan-out DAGs this is a dramatic reduction in HTTP
+  round-trips — a 5000-task DAG goes from 5000 individual POSTs to
+  100 bulk POSTs. Per-task fallback on 404 (older API deployments).
+- **Gzipped request bodies on the wire**: JSON request bodies above 1KB
+  are gzipped client-side before sending; bulk-register payloads with
+  repeated structure compress 5–10× typically. The server's new
+  `GZipRequestMiddleware` decompresses transparently — old SDKs and
+  non-gzipped requests pass through unchanged.
 - **`build_fail(_aio)` now emitted on discovery error**: if a task's
   `requires()` / `complete()` raises during discovery, the registry
   receives `build_fail` rather than the build being left RUNNING
@@ -76,6 +84,12 @@ notes; the bullets below are the per-component summary.
   phantom-creation in `_reconcile_dependency_edges`). Deduplicates by
   `task_id`, keeping the first occurrence. Same TASK_PENDING /
   TASK_REFERENCED event semantics as the single-task endpoint.
+- **`GZipRequestMiddleware`**: ASGI middleware that decompresses
+  incoming `Content-Encoding: gzip` request bodies before route
+  handlers parse them. Pass-through for non-gzipped requests so old
+  SDK versions, direct `curl` callers, and non-bulk endpoints keep
+  working unchanged. Returns 400 on malformed gzip so clients see a
+  clear error rather than a downstream parse failure.
 - **`is_phantom` on `TaskResponse` / `TaskWithStatusResponse`**: the
   flag has existed on the `Task` model for a while; it's now exposed
   in the response so the UI (and other consumers) can distinguish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ notes; the bullets below are the per-component summary.
   phantom-creation in `_reconcile_dependency_edges`). Deduplicates by
   `task_id`, keeping the first occurrence. Same TASK_PENDING /
   TASK_REFERENCED event semantics as the single-task endpoint.
+  Optional `?id_only=true` query param returns only `{id, task_id}`
+  per task instead of the full `TaskResponse` (~10× smaller
+  response — the SDK passes this since it doesn't read the response).
 - **`GZipRequestMiddleware`**: ASGI middleware that decompresses
   incoming `Content-Encoding: gzip` request bodies before route
   handlers parse them. Pass-through for non-gzipped requests so old

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,104 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.6.0] — Discover-time task registration + bulk register endpoint
+
+End-to-end overhaul of how tasks reach the registry during a build,
+motivated by "tasks don't appear in the UI in the order they're
+discovered, sometimes only after they finish executing." See
+[RELEASE_NOTES.md](RELEASE_NOTES.md#v060) for the full story and migration
+notes; the bullets below are the per-component summary.
+([#133](https://github.com/stardag-dev/stardag/pull/133))
+
+### SDK
+
+#### New behaviour
+
+- **Discover-time registration**: every task discovered during the build
+  walk is now registered with the registry _before_ any task starts
+  executing. The full DAG appears in the UI immediately rather than
+  leaves-first as tasks become runnable. Applies to both `build` /
+  `build_aio` and `build_sequential` / `build_sequential_aio`.
+- **Post-order discovery walk**: `discover()` recurses into static deps
+  first and only registers the parent once every child has registered.
+  Eliminates the brief phantom-row window where the UI used to flash up
+  `tid[:12]`-style placeholder names between parent and child
+  registration. Same trick on the dynamic-dep path: `discover(dep)`
+  runs before `task_add_dependencies(_aio)` so the dep row exists
+  before the edge insert.
+- **Bulk register**: build engines now collapse the discovered tasks
+  into a single `task_register_bulk(_aio)` call per discover walk
+  (initial + each dynamic-deps yield), chunked at 1000 tasks per HTTP
+  request. For large fan-out DAGs this is a dramatic reduction in HTTP
+  round-trips. Per-task fallback on 404 (older API deployments).
+- **`build_fail(_aio)` now emitted on discovery error**: if a task's
+  `requires()` / `complete()` raises during discovery, the registry
+  receives `build_fail` rather than the build being left RUNNING
+  forever.
+
+#### Breaking changes
+
+- **`APIRegistry.task_start[_aio]` no longer auto-calls
+  `task_register[_aio]`.** The contract is now "register first"
+  everywhere — `/start` is a pure event endpoint. Internal callers
+  (build engines, Prefect integration) are updated. External callers
+  that used `task_start_aio` directly without first calling
+  `task_register_aio` will now hit a 404 from `/start`. Migration:
+  add the explicit `await registry.task_register_aio(build_id, task)`
+  call before `task_start_aio`.
+- **Sequential build registers tasks in post-order DFS** (deps before
+  parents) where it previously used pre-order. Concurrent build is
+  approximately post-order — siblings still interleave but every
+  task's deps are guaranteed to register before it. Visible via the
+  UI / registry only; no API breakage.
+
+#### Compatibility
+
+- **Backwards compatible with the old Registry API**: the SDK's
+  `task_register_bulk(_aio)` catches the FastAPI "missing route" 404
+  and falls back to per-task `task_register(_aio)`, mirroring the
+  pattern from `task_add_dependencies`. Existing
+  `task_register(_aio)`, `task_start(_aio)`, etc. endpoints are
+  unchanged.
+
+### API
+
+#### New features
+
+- **New endpoint `POST /builds/{build_id}/tasks/bulk`**: registers up
+  to 1000 tasks in a single transaction, processing the array in order
+  so within-batch dep references resolve to existing rows (no
+  phantom-creation in `_reconcile_dependency_edges`). Deduplicates by
+  `task_id`, keeping the first occurrence. Same TASK_PENDING /
+  TASK_REFERENCED event semantics as the single-task endpoint.
+- **`is_phantom` on `TaskResponse` / `TaskWithStatusResponse`**: the
+  flag has existed on the `Task` model for a while; it's now exposed
+  in the response so the UI (and other consumers) can distinguish
+  placeholder rows from real registered tasks.
+- **`GET /builds/{id}/tasks` orders by per-build first event**:
+  joins against `events` filtered to this build and orders by
+  `min(events.created_at), Task.id`. Re-referenced tasks now appear
+  at the position where they were _first seen in this build_, not
+  where they were first ever inserted in the environment. Previously
+  unordered (DB insertion order, effectively arbitrary).
+
+#### Behaviour change
+
+- **Phantom-creation in `_reconcile_dependency_edges` is now a safety
+  hatch**: with the SDK's post-order discover walk + the bulk
+  endpoint's in-array ordering, every dep `task_id` resolves to an
+  existing row in normal operation. Phantom-creation only triggers
+  when a build crashes mid-discover, when an out-of-band caller
+  registers an edge before its upstream task, or when an older SDK is
+  used. Documented inline.
+
+### UI
+
+- **Phantom rows hidden from the build's task table** and the "X tasks"
+  counter. They still render in the DAG view (dropping nodes there
+  would leave dangling edges). Reads `is_phantom` from the API's
+  `TaskResponse`.
+
 ## `app/stardag-api|ui` only — 2026-04-28
 
 > App (API + UI) changes only — no SDK release. Deployed continuously

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,114 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.6.0 — Discover-time task registration & bulk register
+
+The build engine now registers every task with the registry as it's
+discovered (in post-order DFS), in a single bulk HTTP call per discover
+walk. The full DAG appears in the UI immediately rather than appearing
+leaves-first as tasks become runnable, and the table view stays in a
+stable order across refreshes.
+
+### What changed in your build runs
+
+Before v0.6.0:
+
+```
+[Discovery walks the DAG locally]
+[Build runs]
+   leaf-1 starts → registry sees leaf-1 for the first time
+   leaf-2 starts → registry sees leaf-2 for the first time
+   ...
+   parent starts → registry sees parent
+[UI shows tasks appearing in execution order, often leaves-first]
+```
+
+In v0.6.0:
+
+```
+[Discovery walks the DAG locally — collecting tasks in post-order]
+[ONE HTTP call: POST /builds/{id}/tasks/bulk with [leaf-1, leaf-2, ..., parent]]
+[UI immediately shows the full DAG, in stable post-order]
+[Build runs — each task already exists in the registry]
+```
+
+For large fan-out DAGs (think: a `for chunk in chunks: yield Process(chunk)`
+yielding 500 chunks), this is the difference between 500 sequential
+HTTP round-trips and one bulk POST.
+
+### Compatibility — the short version
+
+- **Old SDK ↔ new server**: works unchanged. The per-task
+  `POST /builds/{id}/tasks` endpoint hasn't changed semantics, and the
+  new `is_phantom` field on responses is silently ignored by old
+  Pydantic models.
+- **New SDK ↔ old server**: works. The SDK calls the new bulk endpoint
+  first; on a 404 ("missing route") it falls back to per-task
+  registration with a warning. You lose the per-discover single-call
+  perf win until the API is upgraded, but builds keep working.
+- **You can deploy in either order.** Server-first is recommended so
+  early SDK upgraders immediately get the bulk-call optimisation.
+
+### Migration: direct callers of `APIRegistry.task_start[_aio]`
+
+> **Skip this section** if you only build via `build()`, `build_aio()`,
+> `build_sequential()`, or `build_sequential_aio()`. The build engines
+> are updated and shield you from the contract change.
+
+`APIRegistry.task_start[_aio]` no longer auto-calls `task_register[_aio]`
+before emitting the start event. The `/start` endpoint is now pure — it
+returns 404 if the task hasn't been registered.
+
+```python
+# v0.5.9 and earlier — task_start_aio auto-registered.
+await registry.task_start_aio(build_id, task)
+
+# v0.6.0 — you must register first.
+await registry.task_register_aio(build_id, task)
+await registry.task_start_aio(build_id, task)
+```
+
+If you subclass `RegistryABC` directly: no migration needed — your
+subclass continues to work as before. The default
+`RegistryABC.task_register_bulk[_aio]` falls back to looping
+`task_register[_aio]` per task, so you don't need to override it
+unless your backend has an efficient batch path.
+
+### Behaviour notes (most users won't notice)
+
+- **Sequential build registers in post-order DFS** (leaves before
+  parents) where it previously used pre-order. Visible only in the
+  registry / UI ordering, not in any API.
+- **`build_fail(_aio)` now emitted when discovery raises.** If a
+  task's `requires()` or `complete()` throws during discovery (rare),
+  the build is now properly marked failed in the registry instead of
+  being left in RUNNING state forever.
+- **Phantom rows are filtered out of the build task table in the UI.**
+  These auto-created placeholder rows used to flash up briefly between
+  parent and child registration; they no longer occur in normal
+  operation (post-order ensures deps register first), but if one
+  legitimately exists — e.g. a build crashed mid-discover and left
+  orphan rows — the UI hides it from the table. The DAG view still
+  renders it.
+
+### Also in this release
+
+- **New `RegistryABC.task_register_bulk[_aio]` method** with a default
+  loop-`task_register` implementation. `APIRegistry` overrides it to
+  POST `/tasks/bulk`. Custom registries get the loop default for free
+  but can override for batched backends.
+- **`is_phantom` exposed on `TaskResponse`** so other API consumers
+  can distinguish placeholder rows from real registered tasks.
+- **Discover-walk race fix in concurrent build**: when two siblings
+  shared a dep (diamond DAG), the fast-path
+  `if task.id in task_states: return` could let one sibling's parent
+  append to the registration order ahead of the still-in-flight dep,
+  re-introducing the phantom window. The fast-path now awaits a
+  per-task `discover_done` event, ensuring deps always register
+  before parents even under sibling concurrency.
+
+---
+
 ## v0.5.9 — Dynamic deps visible in the DAG view
 
 Dynamically-yielded dependencies now register as graph edges in the Registry,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -32,14 +32,22 @@ In v0.6.0:
 
 ```
 [Discovery walks the DAG locally — collecting tasks in post-order]
-[ONE HTTP call: POST /builds/{id}/tasks/bulk with [leaf-1, leaf-2, ..., parent]]
+[Bulk-register: chunks of 50 tasks per POST, gzipped on the wire]
 [UI immediately shows the full DAG, in stable post-order]
 [Build runs — each task already exists in the registry]
 ```
 
 For large fan-out DAGs (think: a `for chunk in chunks: yield Process(chunk)`
 yielding 500 chunks), this is the difference between 500 sequential
-HTTP round-trips and one bulk POST.
+HTTP round-trips and 10 bulk POSTs. The chunk size of 50 is deliberately
+well under the API's 1000 hard cap — keeps DB transactions short, keeps
+request bodies friendly even with fat task specs, and limits the blast
+radius of a chunk-level failure in `warn` mode.
+
+Request bodies above 1KB are gzipped before sending — bulk payloads
+with repeated JSON structure compress 5–10× typically — and the server
+transparently decompresses via a new `GZipRequestMiddleware`. Old SDKs
+keep sending plain JSON; the middleware passes them through unchanged.
 
 ### Compatibility — the short version
 

--- a/app/stardag-api/src/stardag_api/main.py
+++ b/app/stardag-api/src/stardag_api/main.py
@@ -3,6 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from stardag_api.auth.tokens import get_token_manager
 from stardag_api.config import settings
+from stardag_api.middleware import GZipRequestMiddleware
 from stardag_api.routes import (
     auth_router,
     builds_router,
@@ -37,6 +38,12 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Decompress incoming gzipped request bodies (the SDK's bulk-register path
+# gzips bodies above ~1KB to keep large batches manageable on the wire).
+# Pass-through for non-gzipped requests so existing SDK versions and
+# direct callers keep working unchanged.
+app.add_middleware(GZipRequestMiddleware)
 
 # Auth routes - included twice with different prefixes:
 # - No prefix: JWKS at /.well-known/jwks.json (standard location)

--- a/app/stardag-api/src/stardag_api/middleware/__init__.py
+++ b/app/stardag-api/src/stardag_api/middleware/__init__.py
@@ -1,0 +1,5 @@
+"""ASGI middleware for the stardag API."""
+
+from stardag_api.middleware.gzip_request import GZipRequestMiddleware
+
+__all__ = ["GZipRequestMiddleware"]

--- a/app/stardag-api/src/stardag_api/middleware/gzip_request.py
+++ b/app/stardag-api/src/stardag_api/middleware/gzip_request.py
@@ -1,0 +1,149 @@
+"""ASGI middleware that decompresses gzipped request bodies.
+
+Starlette's built-in ``GZipMiddleware`` only handles *response*
+compression. The SDK's bulk-register path gzips request bodies above a
+small threshold to keep payload sizes manageable for large batches
+(repeated JSON keys / structure compress 5–10×). This middleware
+recognises ``Content-Encoding: gzip`` on the way in, decompresses the
+body once, and replays the decoded bytes to the downstream app —
+transparently, so route handlers (and Pydantic body parsers) see the
+same JSON they would have without compression.
+
+Pass-through for non-gzipped requests: a request without the encoding
+header (or with an unknown encoding) goes through untouched, so older
+SDK versions and direct ``curl`` callers keep working.
+"""
+
+from __future__ import annotations
+
+import gzip
+
+# Refuse to decompress oversized bodies. Bounds memory; the SDK is
+# expected to chunk well under this. 50 MB compressed is generous —
+# typical bulk-register batches at our chunk size compress to <1 MB.
+_MAX_DECOMPRESSED_BYTES = 50 * 1024 * 1024
+
+
+class GZipRequestMiddleware:
+    """Decompress gzipped request bodies before they reach route handlers.
+
+    Implemented as a pure ASGI middleware (rather than
+    ``BaseHTTPMiddleware``) so we can replay the receive callable with
+    the decompressed body cleanly, without buffering through Starlette's
+    HTTP-message abstraction twice.
+    """
+
+    def __init__(self, app) -> None:
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Headers are a list of (name_bytes, value_bytes); search for
+        # content-encoding case-insensitively.
+        content_encoding = b""
+        for name, value in scope["headers"]:
+            if name.lower() == b"content-encoding":
+                content_encoding = value
+                break
+        if content_encoding.strip().lower() != b"gzip":
+            await self.app(scope, receive, send)
+            return
+
+        # Drain the entire request body into memory. Bulk-register
+        # requests are bounded by the SDK's chunk size (50 tasks ×
+        # task_data limit), so this is safe.
+        body_chunks: list[bytes] = []
+        while True:
+            message = await receive()
+            if message["type"] == "http.request":
+                chunk = message.get("body", b"")
+                if chunk:
+                    body_chunks.append(chunk)
+                if not message.get("more_body", False):
+                    break
+            elif message["type"] == "http.disconnect":
+                # Client went away mid-upload; bail out.
+                await self.app(scope, receive, send)
+                return
+            else:
+                # Unknown message type — pass it through and stop reading.
+                break
+
+        compressed = b"".join(body_chunks)
+        try:
+            decompressed = gzip.decompress(compressed)
+        except (OSError, EOFError):
+            # Malformed gzip — return 400 directly. We can't pass the
+            # body through to the app in any sensible form.
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 400,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                    ],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b'{"detail":"Malformed gzip request body"}',
+                }
+            )
+            return
+
+        if len(decompressed) > _MAX_DECOMPRESSED_BYTES:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 413,
+                    "headers": [
+                        (b"content-type", b"application/json"),
+                    ],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": b'{"detail":"Decompressed request body exceeds size limit"}',
+                }
+            )
+            return
+
+        # Build a new headers list: drop content-encoding (otherwise
+        # downstream might double-decompress) and replace content-length
+        # with the decompressed size so any downstream body() reader
+        # behaves as expected.
+        new_headers = [
+            (name, value)
+            for name, value in scope["headers"]
+            if name.lower() not in (b"content-encoding", b"content-length")
+        ]
+        new_headers.append((b"content-length", str(len(decompressed)).encode()))
+        new_scope = {**scope, "headers": new_headers}
+
+        # Replay the decompressed body as a single ``http.request``
+        # message. After that, downstream callers reading further get
+        # ``http.disconnect`` (matching what they'd see at end-of-stream).
+        sent_body = False
+        sent_disconnect = False
+
+        async def replay_receive():
+            nonlocal sent_body, sent_disconnect
+            if not sent_body:
+                sent_body = True
+                return {
+                    "type": "http.request",
+                    "body": decompressed,
+                    "more_body": False,
+                }
+            if not sent_disconnect:
+                sent_disconnect = True
+                return {"type": "http.disconnect"}
+            # Defensive — avoid hot-looping if called again.
+            return {"type": "http.disconnect"}
+
+        await self.app(new_scope, replay_receive, send)

--- a/app/stardag-api/src/stardag_api/middleware/gzip_request.py
+++ b/app/stardag-api/src/stardag_api/middleware/gzip_request.py
@@ -12,16 +12,27 @@ same JSON they would have without compression.
 Pass-through for non-gzipped requests: a request without the encoding
 header (or with an unknown encoding) goes through untouched, so older
 SDK versions and direct ``curl`` callers keep working.
+
+Decompression is **streaming** with running size caps on both the
+compressed input and the decompressed output, so a gzip-bomb (small
+compressed, huge decompressed) can't allocate unbounded memory before
+we notice — we abort the moment either limit is breached.
 """
 
 from __future__ import annotations
 
-import gzip
+import zlib
 
-# Refuse to decompress oversized bodies. Bounds memory; the SDK is
-# expected to chunk well under this. 50 MB compressed is generous —
-# typical bulk-register batches at our chunk size compress to <1 MB.
+# Reject oversized inbound bodies. Compressed-size limit is the first
+# line of defence: even a perfectly-compressed gzip bomb can't slip past
+# this cap. Decompressed-size limit catches the case where a moderately
+# sized compressed body inflates beyond what we want to handle.
+# Typical bulk-register batches at our chunk size compress to <100 KB,
+# so the limits are generous (>100× expected payloads).
+_MAX_COMPRESSED_BYTES = 10 * 1024 * 1024
 _MAX_DECOMPRESSED_BYTES = 50 * 1024 * 1024
+# zlib gzip mode: ``MAX_WBITS | 16`` enables gzip header parsing.
+_GZIP_WBITS = zlib.MAX_WBITS | 16
 
 
 class GZipRequestMiddleware:
@@ -52,66 +63,93 @@ class GZipRequestMiddleware:
             await self.app(scope, receive, send)
             return
 
-        # Drain the entire request body into memory. Bulk-register
-        # requests are bounded by the SDK's chunk size (50 tasks ×
-        # task_data limit), so this is safe.
-        body_chunks: list[bytes] = []
+        # Stream-decompress: read body chunk by chunk, feed into the
+        # decompressor, and bail the moment either the compressed input
+        # *or* the running decompressed output crosses its cap. This
+        # bounds memory at ``_MAX_DECOMPRESSED_BYTES`` even for
+        # adversarial inputs (gzip bombs) — we never materialise the
+        # whole decompressed body if it's going to exceed the limit.
+        decompressor = zlib.decompressobj(_GZIP_WBITS)
+        decompressed_chunks: list[bytes] = []
+        compressed_total = 0
+        decompressed_total = 0
+
+        async def _send_error(status: int, detail: str) -> None:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": status,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send(
+                {
+                    "type": "http.response.body",
+                    "body": (b'{"detail":"' + detail.encode() + b'"}'),
+                }
+            )
+
         while True:
             message = await receive()
-            if message["type"] == "http.request":
-                chunk = message.get("body", b"")
-                if chunk:
-                    body_chunks.append(chunk)
-                if not message.get("more_body", False):
-                    break
-            elif message["type"] == "http.disconnect":
-                # Client went away mid-upload; bail out.
+            msg_type = message["type"]
+            if msg_type == "http.disconnect":
+                # Client went away mid-upload; nothing useful to do.
+                # Hand back to the app with the original receive so it
+                # sees the disconnect itself.
                 await self.app(scope, receive, send)
                 return
-            else:
-                # Unknown message type — pass it through and stop reading.
+            if msg_type != "http.request":
+                # Unexpected message type; bail to the app with the
+                # original receive (it'll handle whatever this is).
+                await self.app(scope, receive, send)
+                return
+
+            chunk = message.get("body", b"")
+            more_body = message.get("more_body", False)
+
+            if chunk:
+                compressed_total += len(chunk)
+                if compressed_total > _MAX_COMPRESSED_BYTES:
+                    await _send_error(413, "Compressed request body exceeds size limit")
+                    return
+                try:
+                    decoded = decompressor.decompress(
+                        chunk,
+                        max_length=_MAX_DECOMPRESSED_BYTES - decompressed_total + 1,
+                    )
+                except zlib.error:
+                    await _send_error(400, "Malformed gzip request body")
+                    return
+                if decoded:
+                    decompressed_total += len(decoded)
+                    if decompressed_total > _MAX_DECOMPRESSED_BYTES:
+                        await _send_error(
+                            413,
+                            "Decompressed request body exceeds size limit",
+                        )
+                        return
+                    # ``unconsumed_tail`` would indicate the decoder hit
+                    # ``max_length`` mid-chunk; with our +1 budget that
+                    # only happens when the decompressed output already
+                    # exceeds the cap, which we just rejected above.
+                    decompressed_chunks.append(decoded)
+
+            if not more_body:
                 break
 
-        compressed = b"".join(body_chunks)
         try:
-            decompressed = gzip.decompress(compressed)
-        except (OSError, EOFError):
-            # Malformed gzip — return 400 directly. We can't pass the
-            # body through to the app in any sensible form.
-            await send(
-                {
-                    "type": "http.response.start",
-                    "status": 400,
-                    "headers": [
-                        (b"content-type", b"application/json"),
-                    ],
-                }
-            )
-            await send(
-                {
-                    "type": "http.response.body",
-                    "body": b'{"detail":"Malformed gzip request body"}',
-                }
-            )
+            tail = decompressor.flush()
+        except zlib.error:
+            await _send_error(400, "Malformed gzip request body")
             return
+        if tail:
+            decompressed_total += len(tail)
+            if decompressed_total > _MAX_DECOMPRESSED_BYTES:
+                await _send_error(413, "Decompressed request body exceeds size limit")
+                return
+            decompressed_chunks.append(tail)
 
-        if len(decompressed) > _MAX_DECOMPRESSED_BYTES:
-            await send(
-                {
-                    "type": "http.response.start",
-                    "status": 413,
-                    "headers": [
-                        (b"content-type", b"application/json"),
-                    ],
-                }
-            )
-            await send(
-                {
-                    "type": "http.response.body",
-                    "body": b'{"detail":"Decompressed request body exceeds size limit"}',
-                }
-            )
-            return
+        decompressed = b"".join(decompressed_chunks)
 
         # Build a new headers list: drop content-encoding (otherwise
         # downstream might double-decompress) and replace content-length
@@ -126,13 +164,16 @@ class GZipRequestMiddleware:
         new_scope = {**scope, "headers": new_headers}
 
         # Replay the decompressed body as a single ``http.request``
-        # message. After that, downstream callers reading further get
-        # ``http.disconnect`` (matching what they'd see at end-of-stream).
+        # message. Subsequent reads return another empty
+        # ``http.request`` with ``more_body=False`` (a benign
+        # end-of-stream signal) rather than ``http.disconnect`` — some
+        # downstream readers treat disconnect as "client gave up", which
+        # isn't accurate here: the body was fully delivered, just
+        # already consumed.
         sent_body = False
-        sent_disconnect = False
 
         async def replay_receive():
-            nonlocal sent_body, sent_disconnect
+            nonlocal sent_body
             if not sent_body:
                 sent_body = True
                 return {
@@ -140,10 +181,10 @@ class GZipRequestMiddleware:
                     "body": decompressed,
                     "more_body": False,
                 }
-            if not sent_disconnect:
-                sent_disconnect = True
-                return {"type": "http.disconnect"}
-            # Defensive — avoid hot-looping if called again.
-            return {"type": "http.disconnect"}
+            return {
+                "type": "http.request",
+                "body": b"",
+                "more_body": False,
+            }
 
         await self.app(new_scope, replay_receive, send)

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -43,7 +43,9 @@ from stardag_api.schemas import (
     BuildResponse,
     EventResponse,
     StatusTriggeredByUser,
+    BulkTaskIdRef,
     TaskBulkCreate,
+    TaskBulkIdOnlyResponse,
     TaskBulkResponse,
     TaskCreate,
     TaskEventResponse,
@@ -943,7 +945,7 @@ _MAX_BULK_REGISTER_TASKS = 1000
 
 @router.post(
     "/{build_id}/tasks/bulk",
-    response_model=TaskBulkResponse,
+    response_model=TaskBulkResponse | TaskBulkIdOnlyResponse,
     status_code=201,
 )
 async def register_tasks_bulk(
@@ -951,6 +953,17 @@ async def register_tasks_bulk(
     payload: TaskBulkCreate,
     db: Annotated[AsyncSession, Depends(get_db)],
     auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
+    id_only: Annotated[
+        bool,
+        Query(
+            description=(
+                "If true, return only ``{id, task_id}`` pairs in the response "
+                "instead of the full TaskResponse list. Cuts response size by "
+                "~10× for batches with rich task_data; the SDK's build engine "
+                "passes this since it doesn't read the response."
+            ),
+        ),
+    ] = False,
 ):
     """Register multiple tasks to a build in a single transaction.
 
@@ -1259,15 +1272,33 @@ async def register_tasks_bulk(
     # task INSERT batch) populated the rows we need to FK against.
     await db.commit()
 
-    # Build responses in array order from the (now-flushed) ORM
-    # instances. Refresh ensures ``created_at`` is populated for newly
-    # inserted rows (server-default would have applied at flush time).
-    responses: list[TaskResponse] = []
-    for t in tasks_in:
-        db_task = db_task_by_task_id[t.task_id]
-        responses.append(
+    # Update entity-count cache for in-process limit tracking. Done
+    # before response construction since the slim-response path skips
+    # the ORM column reads.
+    for _ in range(len(tasks_in)):
+        record_entity_created(auth.workspace_id, "events")
+    for _ in range(new_task_count):
+        record_entity_created(auth.workspace_id, "tasks")
+
+    if id_only:
+        # Slim path — caller (typically the SDK) doesn't read the
+        # response body, so save the per-task column reads + JSON
+        # serialisation. Echo only the (id ↔ task_id) mapping.
+        return TaskBulkIdOnlyResponse(
+            tasks=[
+                BulkTaskIdRef(
+                    id=db_task_by_task_id[t.task_id].id,
+                    task_id=t.task_id,
+                )
+                for t in tasks_in
+            ]
+        )
+
+    # Default: full TaskResponse for each task in array order.
+    return TaskBulkResponse(
+        tasks=[
             TaskResponse(
-                id=db_task.id,
+                id=(db_task := db_task_by_task_id[t.task_id]).id,
                 task_id=db_task.task_id,
                 environment_id=db_task.environment_id,
                 task_namespace=db_task.task_namespace,
@@ -1278,15 +1309,9 @@ async def register_tasks_bulk(
                 created_at=db_task.created_at,
                 is_phantom=db_task.is_phantom,
             )
-        )
-
-    # Update entity-count cache for in-process limit tracking.
-    for _ in range(len(tasks_in)):
-        record_entity_created(auth.workspace_id, "events")
-    for _ in range(new_task_count):
-        record_entity_created(auth.workspace_id, "tasks")
-
-    return TaskBulkResponse(tasks=responses)
+            for t in tasks_in
+        ]
+    )
 
 
 @router.post("/{build_id}/tasks/{task_id}/start", response_model=TaskEventResponse)

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1,5 +1,6 @@
 """Build management routes - primary interface for SDK."""
 
+from datetime import timedelta
 from typing import Annotated
 from uuid import UUID
 
@@ -1013,6 +1014,17 @@ async def register_tasks_bulk(
             )
         )
 
+    # Auth/build check first — a probe with a bogus build_id mustn't
+    # consume rate-limit budget or fingerprint the workspace's 24h
+    # creation limits via timing or error type.
+    build = await db.get(Build, build_id)
+    if not build:
+        raise HTTPException(status_code=404, detail="Build not found")
+    if build.environment_id != auth.environment_id:
+        raise HTTPException(
+            status_code=403, detail="Build does not belong to this environment"
+        )
+
     # Each (post-dedup) task produces exactly one event in this build.
     _raise_if_limit_exceeded(
         await check_entity_creation_limit(
@@ -1024,27 +1036,26 @@ async def register_tasks_bulk(
         )
     )
 
-    build = await db.get(Build, build_id)
-    if not build:
-        raise HTTPException(status_code=404, detail="Build not found")
-    if build.environment_id != auth.environment_id:
-        raise HTTPException(
-            status_code=403, detail="Build does not belong to this environment"
-        )
-
     # Pre-query which task_ids already exist in this environment so the
-    # 24h tasks limit only counts brand-new task creations. The previous
-    # ``amount=len(tasks_in)`` over-counted: a build that re-references
-    # all-cached tasks would burn the limit even though it creates 0 new
-    # Task rows.
-    existing_ids_result = await db.execute(
-        select(Task.task_id)
+    # 24h tasks limit only counts brand-new task creations.
+    #
+    # Note: this estimate is computed without ``FOR UPDATE`` and may
+    # diverge from the actual new-task count if a concurrent transaction
+    # inserts the same ``task_id`` between this SELECT and the bulk
+    # INSERT below. In that race we'd skip the limit check for what
+    # turns out to be 0 new rows — strictly an under-counting of the
+    # actual writes, never an over-counting, so the guard rail stays
+    # safe.
+    existing_tasks_result = await db.execute(
+        select(Task)
         .where(Task.environment_id == build.environment_id)
         .where(Task.task_id.in_([t.task_id for t in tasks_in]))
     )
-    already_existing_ids = {row[0] for row in existing_ids_result.all()}
+    existing_tasks: dict[str, Task] = {
+        t.task_id: t for t in existing_tasks_result.scalars().all()
+    }
     new_task_count_estimate = sum(
-        1 for t in tasks_in if t.task_id not in already_existing_ids
+        1 for t in tasks_in if t.task_id not in existing_tasks
     )
     if new_task_count_estimate:
         _raise_if_limit_exceeded(
@@ -1057,24 +1068,58 @@ async def register_tasks_bulk(
             )
         )
 
-    responses: list[TaskResponse] = []
-    new_task_count = 0
-
-    for t in tasks_in:
-        # Mirror the single-task register flow: select-with-lock to avoid
-        # racing apply_event_to_task on the denormalised latest_* columns
-        # against another writer on the same task.
-        result = await db.execute(
+    # Lock existing rows in **sorted task_id order** so that two
+    # concurrent bulk calls hitting overlapping cached tasks acquire
+    # locks in the same order and can't deadlock on each other. We only
+    # need FOR UPDATE on rows we'll mutate (phantom upgrades) or on rows
+    # whose denormalised ``latest_*`` columns ``apply_event_to_task``
+    # touches — i.e., existing rows. Brand-new rows are inserted
+    # without a competing writer, no lock needed.
+    if existing_tasks:
+        sorted_existing_ids = sorted(existing_tasks.keys())
+        await db.execute(
             select(Task)
             .where(Task.environment_id == build.environment_id)
-            .where(Task.task_id == t.task_id)
+            .where(Task.task_id.in_(sorted_existing_ids))
+            .order_by(Task.task_id.asc())
             .with_for_update()
         )
-        db_task = result.scalar_one_or_none()
-        task_already_existed = db_task is not None
 
-        if not db_task:
+    # Phase 1: insert new tasks + upgrade phantoms in-memory.
+    # Maintain ``pk_by_task_id`` so we can resolve dependency_task_ids
+    # in Python without per-task SELECTs, and keep ORM instances in
+    # ``db_task_by_task_id`` so we can apply events to them after
+    # flushing.
+    now = utc_now()
+    pk_by_task_id: dict[str, UUID] = {t_id: t.id for t_id, t in existing_tasks.items()}
+    db_task_by_task_id: dict[str, Task] = dict(existing_tasks)
+
+    new_task_count = 0
+    for t in tasks_in:
+        if t.task_id in existing_tasks:
+            db_task = existing_tasks[t.task_id]
+            if db_task.is_phantom:
+                # Phantom upgrade: real task data overrides the
+                # ``tid[:12]`` placeholder. Note that we deliberately do
+                # *not* reset latest_status_at / latest_status_event_id
+                # here — the apply_event_to_task(TASK_PENDING) call
+                # below refreshes them via the
+                # ``latest_status == PENDING`` branch in
+                # services/status.py:101. If that branch ever gains a
+                # phantom-upgrade short-circuit, this needs an explicit
+                # reset.
+                db_task.task_namespace = t.task_namespace
+                db_task.task_name = t.task_name
+                db_task.task_data = t.task_data
+                db_task.version = t.version
+                db_task.output_uri = t.output_uri
+                db_task.is_phantom = False
+        else:
+            # Pre-generate the UUID7 PK so we can resolve dep edges
+            # below without an extra round-trip after flush.
+            new_pk = generate_uuid7()
             db_task = Task(
+                id=new_pk,
                 task_id=t.task_id,
                 environment_id=build.environment_id,
                 task_namespace=t.task_namespace,
@@ -1084,35 +1129,142 @@ async def register_tasks_bulk(
                 output_uri=t.output_uri,
             )
             db.add(db_task)
-            await db.flush()  # Make visible to subsequent SELECTs in this txn
+            pk_by_task_id[t.task_id] = new_pk
+            db_task_by_task_id[t.task_id] = db_task
             new_task_count += 1
-        elif db_task.is_phantom:
-            db_task.task_namespace = t.task_namespace
-            db_task.task_name = t.task_name
-            db_task.task_data = t.task_data
-            db_task.version = t.version
-            db_task.output_uri = t.output_uri
-            db_task.is_phantom = False
 
-        await _reconcile_dependency_edges(
-            db=db,
-            environment_id=build.environment_id,
-            downstream_task_pk=db_task.id,
-            upstream_task_ids=t.dependency_task_ids,
-            is_dynamic=False,
-        )
-
-        event = Event(
-            build_id=build_id,
-            task_id=db_task.id,
-            event_type=EventType.TASK_REFERENCED
-            if task_already_existed
-            else EventType.TASK_PENDING,
-        )
-        db.add(event)
+    # Single flush: SQLAlchemy with asyncpg batches INSERTs of the same
+    # entity type into one round-trip when their primary keys are
+    # client-generated (which our UUID7 PKs are). For a 1000-task batch
+    # this is the difference between 1000 sequential round-trips and
+    # one ``executemany``.
+    if new_task_count:
         await db.flush()
-        apply_event_to_task(db_task, event)
 
+    # Phase 2: bulk-reconcile dependency edges.
+    # Collect all upstream task_ids referenced anywhere in the batch.
+    all_upstream_ids: set[str] = set()
+    for t in tasks_in:
+        all_upstream_ids.update(t.dependency_task_ids)
+    # Subtract task_ids already in our map (in-batch deps + pre-existing).
+    unknown_upstream_ids = all_upstream_ids - set(pk_by_task_id.keys())
+    if unknown_upstream_ids:
+        # Look up unknown upstreams in DB — they may be tasks that
+        # exist in the env but weren't part of this batch.
+        unknown_lookup_result = await db.execute(
+            select(Task.id, Task.task_id)
+            .where(Task.environment_id == build.environment_id)
+            .where(Task.task_id.in_(unknown_upstream_ids))
+        )
+        for pk, t_id in unknown_lookup_result.all():
+            pk_by_task_id[t_id] = pk
+        still_unknown = unknown_upstream_ids - set(pk_by_task_id.keys())
+        if still_unknown:
+            # Safety hatch: edges referencing a task not in the batch
+            # *and* not in the DB. Phantom-create. With the SDK's
+            # post-order discover walk this should not happen in normal
+            # operation; documented in ``_reconcile_dependency_edges``.
+            phantom_rows = [
+                {
+                    "id": generate_uuid7(),
+                    "task_id": tid,
+                    "environment_id": build.environment_id,
+                    "task_namespace": "",
+                    "task_name": tid[:12],
+                    "task_data": {},
+                    "is_phantom": True,
+                    "created_at": now,
+                    "latest_status": TaskStatus.PENDING,
+                    "latest_waiting_for_lock": False,
+                }
+                for tid in still_unknown
+            ]
+            await db.execute(
+                pg_insert(Task)
+                .values(phantom_rows)
+                .on_conflict_do_nothing(constraint="uq_task_environment_taskid")
+            )
+            # Re-fetch (ON CONFLICT DO NOTHING + RETURNING only returns
+            # rows we inserted; a concurrent writer may have created
+            # the row first and we still need its PK).
+            refetch_result = await db.execute(
+                select(Task.id, Task.task_id)
+                .where(Task.environment_id == build.environment_id)
+                .where(Task.task_id.in_(still_unknown))
+            )
+            for pk, t_id in refetch_result.all():
+                pk_by_task_id[t_id] = pk
+
+    # Build edge rows for the whole batch and bulk-insert in one shot.
+    edge_rows: list[dict[str, object]] = []
+    for t in tasks_in:
+        if not t.dependency_task_ids:
+            continue
+        downstream_pk = pk_by_task_id[t.task_id]
+        # Deduplicate within a single task's dep list (the schema
+        # constraint allows it, but emitting duplicates is wasteful).
+        seen_in_task: set[str] = set()
+        for upstream_id in t.dependency_task_ids:
+            if upstream_id in seen_in_task:
+                continue
+            seen_in_task.add(upstream_id)
+            edge_rows.append(
+                {
+                    "id": generate_uuid7(),
+                    "upstream_task_id": pk_by_task_id[upstream_id],
+                    "downstream_task_id": downstream_pk,
+                    "is_dynamic": False,
+                    "created_at": now,
+                }
+            )
+    if edge_rows:
+        await db.execute(
+            pg_insert(TaskDependency)
+            .values(edge_rows)
+            .on_conflict_do_nothing(constraint="uq_task_dependency_edge")
+        )
+
+    # Phase 3: bulk-insert events with explicit per-event timestamps so
+    # that ``list_tasks_in_build`` can order tasks by per-build first
+    # event in array order. (The endpoint joins against
+    # ``min(events.created_at)`` — if every event in this batch shared
+    # one timestamp, ordering would fall to ``Task.id``, which is
+    # unstable for re-referenced cached tasks whose UUID7 came from an
+    # earlier build.)
+    events: list[Event] = []
+    for i, t in enumerate(tasks_in):
+        already_existed = t.task_id in existing_tasks
+        events.append(
+            Event(
+                id=generate_uuid7(),
+                build_id=build_id,
+                task_id=pk_by_task_id[t.task_id],
+                event_type=EventType.TASK_REFERENCED
+                if already_existed
+                else EventType.TASK_PENDING,
+                created_at=now + timedelta(microseconds=i),
+            )
+        )
+    if events:
+        db.add_all(events)
+        # Apply event semantics in Python on the in-memory ORM rows —
+        # ``apply_event_to_task`` reads only fields we set above
+        # (event_type, created_at, id, build_id, error_message,
+        # event_metadata) and mutates the Task ORM in-place. No DB
+        # round-trip needed.
+        for t, ev in zip(tasks_in, events):
+            apply_event_to_task(db_task_by_task_id[t.task_id], ev)
+
+    # One final flush + commit at the end. Earlier flushes (just the
+    # task INSERT batch) populated the rows we need to FK against.
+    await db.commit()
+
+    # Build responses in array order from the (now-flushed) ORM
+    # instances. Refresh ensures ``created_at`` is populated for newly
+    # inserted rows (server-default would have applied at flush time).
+    responses: list[TaskResponse] = []
+    for t in tasks_in:
+        db_task = db_task_by_task_id[t.task_id]
         responses.append(
             TaskResponse(
                 id=db_task.id,
@@ -1124,10 +1276,9 @@ async def register_tasks_bulk(
                 version=db_task.version,
                 output_uri=db_task.output_uri,
                 created_at=db_task.created_at,
+                is_phantom=db_task.is_phantom,
             )
         )
-
-    await db.commit()
 
     # Update entity-count cache for in-process limit tracking.
     for _ in range(len(tasks_in)):

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1261,8 +1261,17 @@ async def list_tasks_in_build(
         .scalar_subquery()
     )
 
-    # Get all tasks by those IDs
-    result = await db.execute(select(Task).where(Task.id.in_(task_ids_subquery)))
+    # Get all tasks by those IDs, ordered by Task.created_at ASC. With the SDK
+    # registering every discovered task during the discovery walk, this gives
+    # roughly roots-first / discovery order in the UI, rather than the
+    # arbitrary insert-order behaviour of an unordered SELECT. The task PK
+    # (UUID7, time-encoded) breaks ties deterministically when several rows
+    # were created in the same instant.
+    result = await db.execute(
+        select(Task)
+        .where(Task.id.in_(task_ids_subquery))
+        .order_by(Task.created_at.asc(), Task.id.asc())
+    )
     tasks = result.scalars().all()
     task_ids = [t.id for t in tasks]
 

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1252,25 +1252,30 @@ async def list_tasks_in_build(
             status_code=403, detail="Build does not belong to this environment"
         )
 
-    # Get distinct task IDs that have events in this build
-    task_ids_subquery = (
-        select(Event.task_id)
+    # Order tasks by their first-event-in-this-build timestamp so the list
+    # reflects per-build registration/discovery order — not Task.created_at,
+    # which is the global "first ever seen in this environment" timestamp
+    # and would surface previously-cached tasks at the top of every later
+    # build. UUID7 IDs break the timestamp tie deterministically.
+    first_event_subquery = (
+        select(
+            Event.task_id.label("task_id"),
+            func.min(Event.created_at).label("first_event_at"),
+            func.min(Event.id).label("first_event_id"),
+        )
         .where(Event.build_id == build_id)
         .where(Event.task_id.isnot(None))
-        .distinct()
-        .scalar_subquery()
+        .group_by(Event.task_id)
+        .subquery()
     )
 
-    # Get all tasks by those IDs, ordered by Task.created_at ASC. With the SDK
-    # registering every discovered task during the discovery walk, this gives
-    # roughly roots-first / discovery order in the UI, rather than the
-    # arbitrary insert-order behaviour of an unordered SELECT. The task PK
-    # (UUID7, time-encoded) breaks ties deterministically when several rows
-    # were created in the same instant.
     result = await db.execute(
         select(Task)
-        .where(Task.id.in_(task_ids_subquery))
-        .order_by(Task.created_at.asc(), Task.id.asc())
+        .join(first_event_subquery, Task.id == first_event_subquery.c.task_id)
+        .order_by(
+            first_event_subquery.c.first_event_at.asc(),
+            first_event_subquery.c.first_event_id.asc(),
+        )
     )
     tasks = result.scalars().all()
     task_ids = [t.id for t in tasks]

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -964,19 +964,31 @@ async def register_tasks_bulk(
     TASK_REFERENCED event semantics, same phantom-upgrade behaviour for
     rows left over from prior failed builds.
     """
-    tasks_in = payload.tasks
+    raw_tasks = payload.tasks
 
-    if not tasks_in:
+    if not raw_tasks:
         return TaskBulkResponse(tasks=[])
 
-    if len(tasks_in) > _MAX_BULK_REGISTER_TASKS:
+    if len(raw_tasks) > _MAX_BULK_REGISTER_TASKS:
         raise HTTPException(
             status_code=400,
             detail=(
                 f"Bulk register limited to {_MAX_BULK_REGISTER_TASKS} tasks per "
-                f"call (got {len(tasks_in)})"
+                f"call (got {len(raw_tasks)})"
             ),
         )
+
+    # Deduplicate by task_id, keeping the first occurrence. The schema
+    # contract documents this so callers can rely on "first wins" semantics
+    # for accidental duplicates in a single batch (rather than getting
+    # multiple events / repeated dep reconciliation per task).
+    seen_ids: set[str] = set()
+    tasks_in: list[TaskCreate] = []
+    for t in raw_tasks:
+        if t.task_id in seen_ids:
+            continue
+        seen_ids.add(t.task_id)
+        tasks_in.append(t)
 
     # Rate limit (1 per call). The bulk endpoint deliberately doesn't count
     # as N requests — entity-creation limits below cap actual writes.
@@ -1001,23 +1013,12 @@ async def register_tasks_bulk(
             )
         )
 
-    # 24h entity-creation limits. Each task produces exactly one event;
-    # the task-creation count is an upper bound (some tasks may already
-    # exist and be referenced rather than created).
+    # Each (post-dedup) task produces exactly one event in this build.
     _raise_if_limit_exceeded(
         await check_entity_creation_limit(
             db,
             auth.workspace_id,
             "events",
-            limits_settings,
-            amount=len(tasks_in),
-        )
-    )
-    _raise_if_limit_exceeded(
-        await check_entity_creation_limit(
-            db,
-            auth.workspace_id,
-            "tasks",
             limits_settings,
             amount=len(tasks_in),
         )
@@ -1029,6 +1030,31 @@ async def register_tasks_bulk(
     if build.environment_id != auth.environment_id:
         raise HTTPException(
             status_code=403, detail="Build does not belong to this environment"
+        )
+
+    # Pre-query which task_ids already exist in this environment so the
+    # 24h tasks limit only counts brand-new task creations. The previous
+    # ``amount=len(tasks_in)`` over-counted: a build that re-references
+    # all-cached tasks would burn the limit even though it creates 0 new
+    # Task rows.
+    existing_ids_result = await db.execute(
+        select(Task.task_id)
+        .where(Task.environment_id == build.environment_id)
+        .where(Task.task_id.in_([t.task_id for t in tasks_in]))
+    )
+    already_existing_ids = {row[0] for row in existing_ids_result.all()}
+    new_task_count_estimate = sum(
+        1 for t in tasks_in if t.task_id not in already_existing_ids
+    )
+    if new_task_count_estimate:
+        _raise_if_limit_exceeded(
+            await check_entity_creation_limit(
+                db,
+                auth.workspace_id,
+                "tasks",
+                limits_settings,
+                amount=new_task_count_estimate,
+            )
         )
 
     responses: list[TaskResponse] = []

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -42,6 +42,8 @@ from stardag_api.schemas import (
     BuildResponse,
     EventResponse,
     StatusTriggeredByUser,
+    TaskBulkCreate,
+    TaskBulkResponse,
     TaskCreate,
     TaskEventResponse,
     TaskGraphExtendedResponse,
@@ -662,6 +664,22 @@ async def _reconcile_dependency_edges(
 ) -> int:
     """Create any missing upstream tasks (as phantoms) and dependency edges.
 
+    **Phantom-creation is a safety hatch, not the happy path.** With the
+    SDK's post-order discover walk (every dep registers before its
+    parent) and within-batch ordering of the bulk-register endpoint, the
+    upstream ``task_id`` lookup at step 1 always finds existing rows in
+    normal operation, so steps 2 + 3 are skipped. Phantoms only appear
+    when:
+      - A build crashes between registering a parent and registering
+        its deps (orphan rows from the failed build).
+      - An out-of-band caller registers edges via the
+        ``/dependencies`` endpoint pointing at not-yet-registered task
+        ids.
+      - A future caller registers in pre-order again.
+    The rest of the system (UI list, DAG view) treats phantoms as
+    placeholder rows and the next register-with-real-data call upgrades
+    them in place.
+
     Issues two statements when every upstream task already exists, or four
     when missing upstream ids must be created as phantoms — independent of
     N otherwise:
@@ -915,6 +933,183 @@ async def register_task(
         output_uri=db_task.output_uri,
         created_at=db_task.created_at,
     )
+
+
+# Cap on the number of tasks per bulk-register call. Bounds memory/transaction
+# size on the API side; the SDK's build engine should chunk if it ever exceeds.
+_MAX_BULK_REGISTER_TASKS = 1000
+
+
+@router.post(
+    "/{build_id}/tasks/bulk",
+    response_model=TaskBulkResponse,
+    status_code=201,
+)
+async def register_tasks_bulk(
+    build_id: UUID,
+    payload: TaskBulkCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
+):
+    """Register multiple tasks to a build in a single transaction.
+
+    Tasks are processed in array order. With the SDK's post-order discover
+    walk, deps appear earlier in the array than their parents — so when a
+    parent's ``dependency_task_ids`` resolves the API finds existing rows
+    (no phantom-creation in ``_reconcile_dependency_edges``). Within the
+    same transaction ``db.flush()`` makes earlier tasks visible to later
+    SELECTs, so the in-batch ordering carries through correctly.
+
+    Sibling-of single-task registration: same TASK_PENDING /
+    TASK_REFERENCED event semantics, same phantom-upgrade behaviour for
+    rows left over from prior failed builds.
+    """
+    tasks_in = payload.tasks
+
+    if not tasks_in:
+        return TaskBulkResponse(tasks=[])
+
+    if len(tasks_in) > _MAX_BULK_REGISTER_TASKS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Bulk register limited to {_MAX_BULK_REGISTER_TASKS} tasks per "
+                f"call (got {len(tasks_in)})"
+            ),
+        )
+
+    # Rate limit (1 per call). The bulk endpoint deliberately doesn't count
+    # as N requests — entity-creation limits below cap actual writes.
+    _raise_if_limit_exceeded(check_rate_limit(auth.workspace_id, limits_settings))
+
+    # Per-task structural limits.
+    for t in tasks_in:
+        _raise_if_limit_exceeded(
+            check_payload_size(
+                t.task_data,
+                limits_settings.max_task_data_bytes,
+                ErrorCode.TASK_DATA_SIZE_LIMIT,
+                "task_data",
+            )
+        )
+        _raise_if_limit_exceeded(
+            check_structural_limit(
+                len(t.dependency_task_ids),
+                limits_settings.max_dependency_ids_per_task,
+                ErrorCode.DEPENDENCY_COUNT_LIMIT,
+                "dependency_task_ids",
+            )
+        )
+
+    # 24h entity-creation limits. Each task produces exactly one event;
+    # the task-creation count is an upper bound (some tasks may already
+    # exist and be referenced rather than created).
+    _raise_if_limit_exceeded(
+        await check_entity_creation_limit(
+            db,
+            auth.workspace_id,
+            "events",
+            limits_settings,
+            amount=len(tasks_in),
+        )
+    )
+    _raise_if_limit_exceeded(
+        await check_entity_creation_limit(
+            db,
+            auth.workspace_id,
+            "tasks",
+            limits_settings,
+            amount=len(tasks_in),
+        )
+    )
+
+    build = await db.get(Build, build_id)
+    if not build:
+        raise HTTPException(status_code=404, detail="Build not found")
+    if build.environment_id != auth.environment_id:
+        raise HTTPException(
+            status_code=403, detail="Build does not belong to this environment"
+        )
+
+    responses: list[TaskResponse] = []
+    new_task_count = 0
+
+    for t in tasks_in:
+        # Mirror the single-task register flow: select-with-lock to avoid
+        # racing apply_event_to_task on the denormalised latest_* columns
+        # against another writer on the same task.
+        result = await db.execute(
+            select(Task)
+            .where(Task.environment_id == build.environment_id)
+            .where(Task.task_id == t.task_id)
+            .with_for_update()
+        )
+        db_task = result.scalar_one_or_none()
+        task_already_existed = db_task is not None
+
+        if not db_task:
+            db_task = Task(
+                task_id=t.task_id,
+                environment_id=build.environment_id,
+                task_namespace=t.task_namespace,
+                task_name=t.task_name,
+                task_data=t.task_data,
+                version=t.version,
+                output_uri=t.output_uri,
+            )
+            db.add(db_task)
+            await db.flush()  # Make visible to subsequent SELECTs in this txn
+            new_task_count += 1
+        elif db_task.is_phantom:
+            db_task.task_namespace = t.task_namespace
+            db_task.task_name = t.task_name
+            db_task.task_data = t.task_data
+            db_task.version = t.version
+            db_task.output_uri = t.output_uri
+            db_task.is_phantom = False
+
+        await _reconcile_dependency_edges(
+            db=db,
+            environment_id=build.environment_id,
+            downstream_task_pk=db_task.id,
+            upstream_task_ids=t.dependency_task_ids,
+            is_dynamic=False,
+        )
+
+        event = Event(
+            build_id=build_id,
+            task_id=db_task.id,
+            event_type=EventType.TASK_REFERENCED
+            if task_already_existed
+            else EventType.TASK_PENDING,
+        )
+        db.add(event)
+        await db.flush()
+        apply_event_to_task(db_task, event)
+
+        responses.append(
+            TaskResponse(
+                id=db_task.id,
+                task_id=db_task.task_id,
+                environment_id=db_task.environment_id,
+                task_namespace=db_task.task_namespace,
+                task_name=db_task.task_name,
+                task_data=db_task.task_data,
+                version=db_task.version,
+                output_uri=db_task.output_uri,
+                created_at=db_task.created_at,
+            )
+        )
+
+    await db.commit()
+
+    # Update entity-count cache for in-process limit tracking.
+    for _ in range(len(tasks_in)):
+        record_entity_created(auth.workspace_id, "events")
+    for _ in range(new_task_count):
+        record_entity_created(auth.workspace_id, "tasks")
+
+    return TaskBulkResponse(tasks=responses)
 
 
 @router.post("/{build_id}/tasks/{task_id}/start", response_model=TaskEventResponse)
@@ -1320,6 +1515,7 @@ async def list_tasks_in_build(
                 version=task.version,
                 output_uri=task.output_uri,
                 created_at=task.created_at,
+                is_phantom=task.is_phantom,
                 status=status,
                 started_at=started_at,
                 completed_at=completed_at,

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1256,12 +1256,15 @@ async def list_tasks_in_build(
     # reflects per-build registration/discovery order — not Task.created_at,
     # which is the global "first ever seen in this environment" timestamp
     # and would surface previously-cached tasks at the top of every later
-    # build. UUID7 IDs break the timestamp tie deterministically.
+    # build. ``Task.id`` (UUID7, time-encoded) breaks the timestamp tie
+    # deterministically. ``min(events.id)`` would be a more precise
+    # tiebreaker but Postgres has no ``min(uuid)`` aggregate (unlike SQLite),
+    # and the practical risk of two tasks having identical
+    # ``min(events.created_at)`` is negligible.
     first_event_subquery = (
         select(
             Event.task_id.label("task_id"),
             func.min(Event.created_at).label("first_event_at"),
-            func.min(Event.id).label("first_event_id"),
         )
         .where(Event.build_id == build_id)
         .where(Event.task_id.isnot(None))
@@ -1274,7 +1277,7 @@ async def list_tasks_in_build(
         .join(first_event_subquery, Task.id == first_event_subquery.c.task_id)
         .order_by(
             first_event_subquery.c.first_event_at.asc(),
-            first_event_subquery.c.first_event_id.asc(),
+            Task.id.asc(),
         )
     )
     tasks = result.scalars().all()

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -144,6 +144,20 @@ class TaskCreate(BaseModel):
     dependency_task_ids: list[str] = []  # task_ids of upstream dependencies
 
 
+class TaskBulkCreate(BaseModel):
+    """Schema for bulk-registering multiple tasks to a build.
+
+    Tasks are processed in array order in a single transaction. Order
+    matters: with the SDK's post-order discover, deps appear earlier in
+    the array than parents, so when a parent's dependency_task_ids resolve
+    they find existing rows (no phantom-creation in
+    _reconcile_dependency_edges). Duplicates within the array are
+    deduplicated server-side.
+    """
+
+    tasks: list[TaskCreate]
+
+
 class TaskResponse(BaseModel):
     """Schema for task response."""
 
@@ -158,6 +172,17 @@ class TaskResponse(BaseModel):
     version: str | None
     output_uri: str | None = None
     created_at: datetime
+    # True for placeholder rows auto-created by ``_reconcile_dependency_edges``
+    # when an edge points at a not-yet-registered task. With the SDK's
+    # post-order discover walk this is rare; UI treats phantoms as
+    # incomplete/registering rows.
+    is_phantom: bool = False
+
+
+class TaskBulkResponse(BaseModel):
+    """Response from a bulk task registration."""
+
+    tasks: list[TaskResponse]
 
 
 class AddDependenciesRequest(BaseModel):

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -151,8 +151,9 @@ class TaskBulkCreate(BaseModel):
     matters: with the SDK's post-order discover, deps appear earlier in
     the array than parents, so when a parent's dependency_task_ids resolve
     they find existing rows (no phantom-creation in
-    _reconcile_dependency_edges). Duplicates within the array are
-    deduplicated server-side.
+    _reconcile_dependency_edges). The endpoint deduplicates by ``task_id``
+    keeping the first occurrence, so callers don't pay event-emission
+    cost for accidental duplicates within a single batch.
     """
 
     tasks: list[TaskCreate]

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -181,9 +181,35 @@ class TaskResponse(BaseModel):
 
 
 class TaskBulkResponse(BaseModel):
-    """Response from a bulk task registration."""
+    """Full response from a bulk task registration.
+
+    Returned when ``id_only=false`` (the default) — each task in the
+    response carries its complete state (task_data, namespace, etc.),
+    matching the single-task ``register_task`` shape.
+    """
 
     tasks: list[TaskResponse]
+
+
+class BulkTaskIdRef(BaseModel):
+    """Slim id-only reference to a registered task in a bulk response."""
+
+    id: UUID
+    task_id: str
+
+
+class TaskBulkIdOnlyResponse(BaseModel):
+    """Lightweight response from a bulk task registration.
+
+    Returned when ``?id_only=true``. Contains only the
+    (database PK ↔ task_id) mapping — no task_data, no namespace, no
+    timestamps. Saves bandwidth + serialisation cost when the caller
+    (e.g. the SDK's build engine) doesn't need the full state echoed
+    back. For a 50-task batch with rich task_data this is the
+    difference between ~50 KB and ~3 KB on the wire.
+    """
+
+    tasks: list[BulkTaskIdRef]
 
 
 class AddDependenciesRequest(BaseModel):

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -677,6 +677,78 @@ async def test_bulk_register_array_order_maps_to_list_order(
 
 
 @pytest.mark.asyncio
+async def test_bulk_register_id_only_returns_slim_response(client: AsyncClient):
+    """``?id_only=true`` returns just ``{id, task_id}`` per task,
+    skipping task_data / namespace / created_at to cut response size.
+    The DB rows are still fully written — only the response payload
+    differs."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    payload = {
+        "tasks": [
+            {
+                "task_id": f"slim-task-{i}",
+                "task_namespace": "demo",
+                "task_name": "SlimTask",
+                "task_data": {"big": "x" * 1024, "i": i},
+            }
+            for i in range(3)
+        ]
+    }
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk?id_only=true",
+        json=payload,
+    )
+    assert response.status_code == 201
+    body = response.json()
+    # Slim shape — exactly id + task_id, nothing else.
+    assert {tuple(t.keys()) for t in body["tasks"]} == {("id", "task_id")}
+    assert [t["task_id"] for t in body["tasks"]] == [
+        "slim-task-0",
+        "slim-task-1",
+        "slim-task-2",
+    ]
+
+    # Sanity: the persisted rows are still complete (the slim response
+    # is a serialisation choice, not a write-time choice).
+    listed = (await client.get(f"/api/v1/builds/{build_id}/tasks")).json()
+    persisted = next(t for t in listed if t["task_id"] == "slim-task-0")
+    assert persisted["task_namespace"] == "demo"
+    assert persisted["task_data"] == {"big": "x" * 1024, "i": 0}
+
+
+@pytest.mark.asyncio
+async def test_bulk_register_default_returns_full_response(client: AsyncClient):
+    """Default (``id_only`` omitted or ``false``) returns the full
+    ``TaskResponse`` shape — backward compatible with direct API
+    callers who rely on the rich response."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk",
+        json={
+            "tasks": [
+                {
+                    "task_id": "full-task",
+                    "task_namespace": "demo",
+                    "task_name": "FullTask",
+                    "task_data": {"k": "v"},
+                }
+            ]
+        },
+    )
+    assert response.status_code == 201
+    only_task = response.json()["tasks"][0]
+    # Full shape carries task_data, namespace, created_at, is_phantom, …
+    assert only_task["task_namespace"] == "demo"
+    assert only_task["task_data"] == {"k": "v"}
+    assert "created_at" in only_task
+    assert only_task["is_phantom"] is False
+
+
+@pytest.mark.asyncio
 async def test_concurrent_bulk_registers_overlapping_tasks(
     client: AsyncClient,
 ):

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -440,8 +440,11 @@ async def test_bulk_register_upgrades_existing_phantoms(client: AsyncClient):
     assert upgraded["task_namespace"] == "real"
     assert upgraded["task_name"] == "RealTask"
 
-    # Verify via list endpoint that the upgraded task is now visible (it
-    # has a TASK_PENDING event from the bulk register).
+    # Verify via list endpoint that the upgraded task is now visible
+    # (the bulk register associates it with this build via a
+    # TASK_REFERENCED event — the row already existed as a phantom, so
+    # `task_already_existed=True` and the endpoint emits REFERENCED,
+    # not PENDING).
     listed = (await client.get(f"/api/v1/builds/{build_id}/tasks")).json()
     listed_target = [t for t in listed if t["task_id"] == "phantom-target"]
     assert len(listed_target) == 1
@@ -450,8 +453,10 @@ async def test_bulk_register_upgrades_existing_phantoms(client: AsyncClient):
 
 
 @pytest.mark.asyncio
-async def test_bulk_register_empty_array_returns_200_empty(client: AsyncClient):
-    """Empty bulk request is a no-op — returns empty array, no error."""
+async def test_bulk_register_empty_array_returns_201_empty(client: AsyncClient):
+    """Empty bulk request is a no-op — returns 201 with an empty
+    ``tasks`` array. (201 because the endpoint advertises ``status_code=201``;
+    the server doesn't bother distinguishing "0 created" from "N created".)"""
     response = await client.post("/api/v1/builds", json={})
     build_id = response.json()["id"]
     response = await client.post(

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -302,11 +302,12 @@ async def test_get_build_graph(client: AsyncClient):
 async def test_list_tasks_in_build_returns_stable_order(client: AsyncClient):
     """Tasks are returned in per-build registration order.
 
-    The SDK now registers every discovered task during the discovery walk —
-    roots first, then their static deps. The UI relies on this endpoint
-    ordering by *first event in this build* (not by ``Task.created_at``,
-    which is the global "first ever seen in this environment" timestamp).
-    Without that, repeated calls would return rows in arbitrary order.
+    The SDK registers every discovered task during the discovery walk in
+    post-order — static deps first, then their parents. The UI relies on
+    this endpoint ordering by *first event in this build* (not by
+    ``Task.created_at``, which is the global "first ever seen in this
+    environment" timestamp). Without that, repeated calls would return
+    rows in arbitrary order.
     """
     response = await client.post("/api/v1/builds", json={})
     build_id = response.json()["id"]
@@ -458,6 +459,55 @@ async def test_bulk_register_empty_array_returns_200_empty(client: AsyncClient):
     )
     assert response.status_code == 201
     assert response.json() == {"tasks": []}
+
+
+@pytest.mark.asyncio
+async def test_bulk_register_dedupes_within_batch(client: AsyncClient):
+    """Duplicate task_ids within a single bulk request are deduplicated
+    (first occurrence wins) so the caller doesn't accidentally generate
+    multiple events / repeated dep reconciliation for the same task."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk",
+        json={
+            "tasks": [
+                {
+                    "task_id": "dupe-x",
+                    "task_namespace": "first",
+                    "task_name": "First",
+                    "task_data": {"v": 1},
+                },
+                {
+                    "task_id": "dupe-x",
+                    "task_namespace": "second",  # Should be ignored.
+                    "task_name": "Second",
+                    "task_data": {"v": 2},
+                },
+                {
+                    "task_id": "other-y",
+                    "task_namespace": "",
+                    "task_name": "Other",
+                    "task_data": {},
+                },
+            ]
+        },
+    )
+    assert response.status_code == 201
+    returned = response.json()["tasks"]
+    # Two unique tasks returned in input order, second occurrence dropped.
+    assert [t["task_id"] for t in returned] == ["dupe-x", "other-y"]
+    # First occurrence's data wins.
+    dupe = next(t for t in returned if t["task_id"] == "dupe-x")
+    assert dupe["task_namespace"] == "first"
+    assert dupe["task_name"] == "First"
+    assert dupe["task_data"] == {"v": 1}
+
+    # Exactly one TASK_PENDING event per unique task_id, not two for dupe-x.
+    events = (await client.get(f"/api/v1/builds/{build_id}/events")).json()
+    pending_count = sum(1 for e in events if e["event_type"] == "task_pending")
+    assert pending_count == 2
 
 
 @pytest.mark.asyncio

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -299,6 +299,44 @@ async def test_get_build_graph(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_list_tasks_in_build_returns_stable_order(client: AsyncClient):
+    """Tasks are returned in registration order (created_at ASC, id ASC).
+
+    The SDK now registers every discovered task during the discovery walk —
+    roots first, then their static deps — so the UI relies on this endpoint
+    sorting by Task.created_at to render the table in roughly discovery
+    order. Without an ORDER BY clause Postgres/SQLite can return rows in
+    arbitrary order, which surfaces to the user as "task list shuffles
+    between refreshes".
+    """
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    expected_order = [f"order-task-{i}" for i in range(5)]
+    for task_id in expected_order:
+        await client.post(
+            f"/api/v1/builds/{build_id}/tasks",
+            json={
+                "task_id": task_id,
+                "task_namespace": "",
+                "task_name": task_id,
+                "task_data": {},
+            },
+        )
+
+    response = await client.get(f"/api/v1/builds/{build_id}/tasks")
+    assert response.status_code == 200
+    actual_order = [t["task_id"] for t in response.json()]
+    assert actual_order == expected_order, (
+        f"Expected stable insertion order; got {actual_order}"
+    )
+
+    # Hitting the endpoint a second time must return the same order.
+    response2 = await client.get(f"/api/v1/builds/{build_id}/tasks")
+    assert [t["task_id"] for t in response2.json()] == expected_order
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_in_build_includes_output_uri(client: AsyncClient):
     """Test that list_tasks_in_build endpoint includes output_uri."""
     # Create a build

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -582,6 +582,177 @@ async def test_bulk_register_referenced_event_for_existing_task(
 
 
 @pytest.mark.asyncio
+async def test_bulk_register_creates_phantom_for_unknown_upstream(
+    client: AsyncClient,
+):
+    """Edges referencing a task that's neither in this batch nor in
+    the DB trigger phantom creation (the documented safety hatch).
+    Explicit test that the bulk path emits exactly one phantom for the
+    unknown upstream, not multiple/none."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    # Two real tasks both depending on an unknown ``orphan-up`` —
+    # deliberately not present in the batch and not pre-registered.
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk",
+        json={
+            "tasks": [
+                {
+                    "task_id": "child-a",
+                    "task_namespace": "",
+                    "task_name": "ChildA",
+                    "task_data": {},
+                    "dependency_task_ids": ["orphan-up"],
+                },
+                {
+                    "task_id": "child-b",
+                    "task_namespace": "",
+                    "task_name": "ChildB",
+                    "task_data": {},
+                    "dependency_task_ids": ["orphan-up"],
+                },
+            ]
+        },
+    )
+    assert response.status_code == 201
+
+    # Inspect the build's graph: both children should point at one
+    # phantom upstream node (not two — the reconcile must dedupe across
+    # the batch).
+    graph = (
+        await client.get(f"/api/v1/builds/{build_id}/graph?upstream_depth=1")
+    ).json()
+    upstream_nodes = [n for n in graph["nodes"] if n["task_id"] == "orphan-up"]
+    assert len(upstream_nodes) == 1, (
+        f"Expected exactly one phantom row for orphan-up; saw "
+        f"{[n['task_id'] for n in upstream_nodes]}"
+    )
+    edges_to_orphan = [
+        e for e in graph["edges"] if e["source"] == upstream_nodes[0]["id"]
+    ]
+    assert len(edges_to_orphan) == 2
+
+
+@pytest.mark.asyncio
+async def test_bulk_register_array_order_maps_to_list_order(
+    client: AsyncClient,
+):
+    """The whole point of the post-order array contract: array order in
+    POST /tasks/bulk maps directly to the order the UI sees on
+    GET /tasks. Single-task path's stable-order test isn't enough — the
+    bulk path needs its own assertion."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    # Deliberately non-alphabetical input order: parent registered last
+    # (post-order DFS) — the SDK does this for every batch.
+    expected_order = ["leaf-z", "leaf-a", "leaf-m", "parent"]
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk",
+        json={
+            "tasks": [
+                {
+                    "task_id": tid,
+                    "task_namespace": "",
+                    "task_name": tid,
+                    "task_data": {},
+                    # parent depends on all three leaves; we ordered
+                    # them deliberately to make sure the API doesn't
+                    # quietly reorder by dep relationship.
+                    "dependency_task_ids": (
+                        ["leaf-z", "leaf-a", "leaf-m"] if tid == "parent" else []
+                    ),
+                }
+                for tid in expected_order
+            ]
+        },
+    )
+    assert response.status_code == 201
+    assert [t["task_id"] for t in response.json()["tasks"]] == expected_order
+
+    # And the user-visible list endpoint preserves it.
+    listed = (await client.get(f"/api/v1/builds/{build_id}/tasks")).json()
+    assert [t["task_id"] for t in listed] == expected_order
+
+
+@pytest.mark.asyncio
+async def test_concurrent_bulk_registers_overlapping_tasks(
+    client: AsyncClient,
+):
+    """Two concurrent bulk POSTs into the same environment with
+    overlapping task IDs must succeed without deadlocking. We sort the
+    SELECT FOR UPDATE by task_id to enforce a deterministic lock-
+    acquisition order; this test exercises that path with two clients
+    that would otherwise be primed for AABB / BBAA lock interleavings.
+    """
+    import asyncio
+
+    # Two builds in the same environment.
+    b1 = (await client.post("/api/v1/builds", json={})).json()["id"]
+    b2 = (await client.post("/api/v1/builds", json={})).json()["id"]
+
+    # Pre-register a couple of cached tasks both batches will
+    # re-reference (this triggers the FOR UPDATE lock path on both
+    # sides).
+    for tid in ("shared-x", "shared-y"):
+        await client.post(
+            f"/api/v1/builds/{b1}/tasks",
+            json={
+                "task_id": tid,
+                "task_namespace": "",
+                "task_name": tid,
+                "task_data": {},
+            },
+        )
+
+    # Build A bulk-registers in shared-x, shared-y order; build B in
+    # the reverse order. Without sorted FOR UPDATE acquisition, this
+    # is the classic AABB / BBAA deadlock setup.
+    payload_a = {
+        "tasks": [
+            {
+                "task_id": "shared-x",
+                "task_namespace": "",
+                "task_name": "shared-x",
+                "task_data": {},
+            },
+            {
+                "task_id": "shared-y",
+                "task_namespace": "",
+                "task_name": "shared-y",
+                "task_data": {},
+            },
+        ]
+    }
+    payload_b = {
+        "tasks": [
+            {
+                "task_id": "shared-y",
+                "task_namespace": "",
+                "task_name": "shared-y",
+                "task_data": {},
+            },
+            {
+                "task_id": "shared-x",
+                "task_namespace": "",
+                "task_name": "shared-x",
+                "task_data": {},
+            },
+        ]
+    }
+    a_resp, b_resp = await asyncio.gather(
+        client.post(f"/api/v1/builds/{b1}/tasks/bulk", json=payload_a),
+        client.post(f"/api/v1/builds/{b2}/tasks/bulk", json=payload_b),
+    )
+    assert a_resp.status_code == 201
+    assert b_resp.status_code == 201
+    # Both succeeded → no deadlock. (On SQLite, FOR UPDATE is a no-op,
+    # so this test is mainly meaningful when CI runs against Postgres,
+    # where ``Test Python (stardag-api on Postgres)`` exercises it.)
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_in_build_orders_by_per_build_first_event(
     client: AsyncClient,
 ):

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -336,6 +336,197 @@ async def test_list_tasks_in_build_returns_stable_order(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_bulk_register_creates_tasks_and_resolves_in_batch_deps(
+    client: AsyncClient,
+):
+    """Bulk register processes the array in order so that a task whose deps
+    appear earlier in the same batch resolves to existing rows — no
+    phantom-creation in _reconcile_dependency_edges. This is the key
+    invariant the SDK's post-order discover relies on.
+    """
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    # Leaf, then mid, then root. Root depends on mid, mid depends on leaf.
+    payload = {
+        "tasks": [
+            {
+                "task_id": "bulk-leaf",
+                "task_namespace": "",
+                "task_name": "Leaf",
+                "task_data": {},
+            },
+            {
+                "task_id": "bulk-mid",
+                "task_namespace": "",
+                "task_name": "Mid",
+                "task_data": {},
+                "dependency_task_ids": ["bulk-leaf"],
+            },
+            {
+                "task_id": "bulk-root",
+                "task_namespace": "",
+                "task_name": "Root",
+                "task_data": {},
+                "dependency_task_ids": ["bulk-mid"],
+            },
+        ]
+    }
+    response = await client.post(f"/api/v1/builds/{build_id}/tasks/bulk", json=payload)
+    assert response.status_code == 201
+    data = response.json()
+    assert [t["task_id"] for t in data["tasks"]] == [
+        "bulk-leaf",
+        "bulk-mid",
+        "bulk-root",
+    ]
+    # No phantom rows in the response — every task got registered with full
+    # data, never as a placeholder.
+    assert all(t["is_phantom"] is False for t in data["tasks"])
+
+    # Sanity: list endpoint returns all three with proper namespaces and
+    # names (proves no phantoms persist after the bulk call).
+    response = await client.get(f"/api/v1/builds/{build_id}/tasks")
+    assert response.status_code == 200
+    listed = response.json()
+    assert len(listed) == 3
+    assert all(t["task_name"] in {"Leaf", "Mid", "Root"} for t in listed)
+    assert all(t["is_phantom"] is False for t in listed)
+
+
+@pytest.mark.asyncio
+async def test_bulk_register_upgrades_existing_phantoms(client: AsyncClient):
+    """A phantom row created by an earlier dep-edge call gets upgraded in
+    place by a later bulk register that sends real task_data.
+
+    Phantoms don't appear in ``list_tasks_in_build`` (the endpoint filters
+    by tasks with events in the build, and phantoms are event-less), so
+    we use the graph endpoint — which traverses the dependency edges and
+    includes the phantom node — to verify upgrade behaviour.
+    """
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    # Trigger phantom creation: register a task whose dep doesn't exist yet.
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        json={
+            "task_id": "trigger",
+            "task_namespace": "",
+            "task_name": "Trigger",
+            "task_data": {},
+            "dependency_task_ids": ["phantom-target"],
+        },
+    )
+
+    # Now bulk-register the real task — it should upgrade the phantom row.
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk",
+        json={
+            "tasks": [
+                {
+                    "task_id": "phantom-target",
+                    "task_namespace": "real",
+                    "task_name": "RealTask",
+                    "task_data": {"foo": "bar"},
+                }
+            ]
+        },
+    )
+    assert response.status_code == 201
+    upgraded = response.json()["tasks"][0]
+    assert upgraded["is_phantom"] is False
+    assert upgraded["task_namespace"] == "real"
+    assert upgraded["task_name"] == "RealTask"
+
+    # Verify via list endpoint that the upgraded task is now visible (it
+    # has a TASK_PENDING event from the bulk register).
+    listed = (await client.get(f"/api/v1/builds/{build_id}/tasks")).json()
+    listed_target = [t for t in listed if t["task_id"] == "phantom-target"]
+    assert len(listed_target) == 1
+    assert listed_target[0]["is_phantom"] is False
+    assert listed_target[0]["task_namespace"] == "real"
+
+
+@pytest.mark.asyncio
+async def test_bulk_register_empty_array_returns_200_empty(client: AsyncClient):
+    """Empty bulk request is a no-op — returns empty array, no error."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk", json={"tasks": []}
+    )
+    assert response.status_code == 201
+    assert response.json() == {"tasks": []}
+
+
+@pytest.mark.asyncio
+async def test_bulk_register_caps_batch_size(client: AsyncClient):
+    """Bulk request over the cap returns 400 rather than processing
+    silently — the SDK chunks if it ever has that many tasks."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+    too_many = [
+        {
+            "task_id": f"too-many-{i}",
+            "task_namespace": "",
+            "task_name": "T",
+            "task_data": {},
+        }
+        for i in range(1001)
+    ]
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk",
+        json={"tasks": too_many},
+    )
+    assert response.status_code == 400
+    assert "limited to" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_bulk_register_referenced_event_for_existing_task(
+    client: AsyncClient,
+):
+    """A task that already exists in the env from a prior build gets a
+    TASK_REFERENCED event when bulk-registered, not a TASK_PENDING."""
+    # Build 1 creates the task.
+    r1 = await client.post("/api/v1/builds", json={})
+    b1 = r1.json()["id"]
+    await client.post(
+        f"/api/v1/builds/{b1}/tasks",
+        json={
+            "task_id": "shared-x",
+            "task_namespace": "",
+            "task_name": "X",
+            "task_data": {},
+        },
+    )
+
+    # Build 2 bulk-registers the same task.
+    r2 = await client.post("/api/v1/builds", json={})
+    b2 = r2.json()["id"]
+    response = await client.post(
+        f"/api/v1/builds/{b2}/tasks/bulk",
+        json={
+            "tasks": [
+                {
+                    "task_id": "shared-x",
+                    "task_namespace": "",
+                    "task_name": "X",
+                    "task_data": {},
+                }
+            ]
+        },
+    )
+    assert response.status_code == 201
+
+    events_response = await client.get(f"/api/v1/builds/{b2}/events")
+    event_types = [e["event_type"] for e in events_response.json()]
+    assert "task_referenced" in event_types
+    assert "task_pending" not in event_types
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_in_build_orders_by_per_build_first_event(
     client: AsyncClient,
 ):

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -300,14 +300,13 @@ async def test_get_build_graph(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_list_tasks_in_build_returns_stable_order(client: AsyncClient):
-    """Tasks are returned in registration order (created_at ASC, id ASC).
+    """Tasks are returned in per-build registration order.
 
     The SDK now registers every discovered task during the discovery walk —
-    roots first, then their static deps — so the UI relies on this endpoint
-    sorting by Task.created_at to render the table in roughly discovery
-    order. Without an ORDER BY clause Postgres/SQLite can return rows in
-    arbitrary order, which surfaces to the user as "task list shuffles
-    between refreshes".
+    roots first, then their static deps. The UI relies on this endpoint
+    ordering by *first event in this build* (not by ``Task.created_at``,
+    which is the global "first ever seen in this environment" timestamp).
+    Without that, repeated calls would return rows in arbitrary order.
     """
     response = await client.post("/api/v1/builds", json={})
     build_id = response.json()["id"]
@@ -334,6 +333,60 @@ async def test_list_tasks_in_build_returns_stable_order(client: AsyncClient):
     # Hitting the endpoint a second time must return the same order.
     response2 = await client.get(f"/api/v1/builds/{build_id}/tasks")
     assert [t["task_id"] for t in response2.json()] == expected_order
+
+
+@pytest.mark.asyncio
+async def test_list_tasks_in_build_orders_by_per_build_first_event(
+    client: AsyncClient,
+):
+    """A task that exists from an earlier build should appear at the
+    position it was *re-encountered* in the current build, not at the top
+    by virtue of having an older Task.created_at.
+    """
+    # Build 1 creates task A at the global level.
+    r1 = await client.post("/api/v1/builds", json={})
+    build1_id = r1.json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build1_id}/tasks",
+        json={
+            "task_id": "shared-A",
+            "task_namespace": "",
+            "task_name": "Shared",
+            "task_data": {},
+        },
+    )
+
+    # Build 2 registers a fresh task B *first*, then re-references the
+    # existing task A. If we ordered by Task.created_at the order would
+    # be [shared-A, fresh-B] (because shared-A was inserted earlier in
+    # build 1). With per-build ordering it must be [fresh-B, shared-A].
+    r2 = await client.post("/api/v1/builds", json={})
+    build2_id = r2.json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build2_id}/tasks",
+        json={
+            "task_id": "fresh-B",
+            "task_namespace": "",
+            "task_name": "Fresh",
+            "task_data": {},
+        },
+    )
+    await client.post(
+        f"/api/v1/builds/{build2_id}/tasks",
+        json={
+            "task_id": "shared-A",
+            "task_namespace": "",
+            "task_name": "Shared",
+            "task_data": {},
+        },
+    )
+
+    response = await client.get(f"/api/v1/builds/{build2_id}/tasks")
+    assert response.status_code == 200
+    order = [t["task_id"] for t in response.json()]
+    assert order == ["fresh-B", "shared-A"], (
+        f"Expected per-build first-event order, got {order}"
+    )
 
 
 @pytest.mark.asyncio

--- a/app/stardag-api/tests/test_gzip_request.py
+++ b/app/stardag-api/tests/test_gzip_request.py
@@ -128,6 +128,62 @@ async def test_malformed_gzip_returns_400(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_gzip_bomb_aborts_with_413(client: AsyncClient, monkeypatch):
+    """Streaming decompression must abort the moment the decompressed
+    output crosses the cap — without first allocating the full output.
+    A small compressed body that inflates to >cap returns 413."""
+    from stardag_api.middleware import gzip_request as gzip_mw
+
+    # Lower the cap so the test stays fast and obvious.
+    monkeypatch.setattr(gzip_mw, "_MAX_DECOMPRESSED_BYTES", 1024)
+
+    # 100 KB of zeros compresses to ~100 bytes — small compressed,
+    # 100× the configured decompressed cap.
+    bomb = gzip.compress(b"\x00" * (100 * 1024))
+    assert len(bomb) < 1024, "bomb should be small compressed"
+
+    response = await client.post(
+        "/api/v1/builds",
+        content=bomb,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert response.status_code == 413
+    assert "decompressed" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_oversized_compressed_body_rejected(client: AsyncClient, monkeypatch):
+    """If the compressed input itself exceeds the cap we reject before
+    spending CPU on decompression. First line of defence."""
+    from stardag_api.middleware import gzip_request as gzip_mw
+
+    monkeypatch.setattr(gzip_mw, "_MAX_COMPRESSED_BYTES", 256)
+
+    # gzip.compress on random-ish bytes won't compress well; we just
+    # need the *compressed* output to exceed 256 B. Use repeated random
+    # garbage that gzip can't deflate efficiently.
+    import os
+
+    body = os.urandom(2048)  # ~2 KB; gzip overhead keeps it >256 B.
+    payload = gzip.compress(body)
+    assert len(payload) > 256
+
+    response = await client.post(
+        "/api/v1/builds",
+        content=payload,
+        headers={
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert response.status_code == 413
+    assert "compressed" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
 async def test_gzipped_single_task_register(client: AsyncClient):
     """Even single-task POST works under gzip — the middleware doesn't
     care which route the request is for, just whether the body is

--- a/app/stardag-api/tests/test_gzip_request.py
+++ b/app/stardag-api/tests/test_gzip_request.py
@@ -1,0 +1,153 @@
+"""End-to-end tests for the gzip request-body middleware.
+
+The SDK gzips request bodies above ~1KB on bulk-register paths;
+``GZipRequestMiddleware`` decompresses them transparently before route
+handlers see the body. These tests verify the round-trip via the test
+client, plus the pass-through and error paths.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+
+import pytest
+from httpx import AsyncClient
+
+
+def _gzip_json(body: dict) -> bytes:
+    return gzip.compress(json.dumps(body, separators=(",", ":")).encode())
+
+
+@pytest.mark.asyncio
+async def test_gzipped_bulk_register_round_trips(client: AsyncClient):
+    """A gzipped bulk-register POST is decompressed server-side and
+    handled identically to a non-gzipped POST: same response body, same
+    Task rows persisted."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    payload = {
+        "tasks": [
+            {
+                "task_id": f"gzip-task-{i}",
+                "task_namespace": "",
+                "task_name": "GzipTask",
+                "task_data": {"i": i},
+            }
+            for i in range(5)
+        ]
+    }
+
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk",
+        content=_gzip_json(payload),
+        headers={
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert response.status_code == 201
+    returned_ids = [t["task_id"] for t in response.json()["tasks"]]
+    assert returned_ids == [f"gzip-task-{i}" for i in range(5)]
+
+    # The list endpoint sees the rows that the gzip request created.
+    listed = (await client.get(f"/api/v1/builds/{build_id}/tasks")).json()
+    assert {t["task_id"] for t in listed} == set(returned_ids)
+
+
+@pytest.mark.asyncio
+async def test_non_gzipped_request_is_pass_through(client: AsyncClient):
+    """Requests without ``Content-Encoding: gzip`` go through the
+    middleware untouched. This is the path old SDKs take, and also the
+    path direct ``curl`` users take."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        json={
+            "task_id": "no-encoding-task",
+            "task_namespace": "",
+            "task_name": "Plain",
+            "task_data": {},
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["task_id"] == "no-encoding-task"
+
+
+@pytest.mark.asyncio
+async def test_unknown_content_encoding_passes_through(client: AsyncClient):
+    """Only ``Content-Encoding: gzip`` triggers decompression. An
+    unknown encoding header is treated as no encoding (the route handler
+    receives the body as-is, which would normally be a JSON parse — same
+    pre-existing behaviour as before the middleware was added)."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    body = {
+        "task_id": "br-task",
+        "task_namespace": "",
+        "task_name": "BrTask",
+        "task_data": {},
+    }
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        content=json.dumps(body).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "Content-Encoding": "br",  # Brotli, not supported.
+        },
+    )
+    # Body was plain JSON, so the handler should still parse it
+    # successfully — the middleware's only job is to reject *gzipped*
+    # bodies it can't handle, not to second-guess unknown encodings.
+    assert response.status_code == 201
+    assert response.json()["task_id"] == "br-task"
+
+
+@pytest.mark.asyncio
+async def test_malformed_gzip_returns_400(client: AsyncClient):
+    """Body claims gzip but isn't valid gzip data → 400 with a clear
+    detail. Important so a buggy client doesn't get a confusing
+    downstream "JSON parse failed" or 500."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/bulk",
+        content=b"this is not gzip data",
+        headers={
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert response.status_code == 400
+    assert "gzip" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_gzipped_single_task_register(client: AsyncClient):
+    """Even single-task POST works under gzip — the middleware doesn't
+    care which route the request is for, just whether the body is
+    gzipped. Demonstrates the middleware isn't bulk-endpoint-specific."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    body = {
+        "task_id": "gzipped-single",
+        "task_namespace": "",
+        "task_name": "Single",
+        "task_data": {"some": "data"},
+    }
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        content=_gzip_json(body),
+        headers={
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+        },
+    )
+    assert response.status_code == 201
+    assert response.json()["task_id"] == "gzipped-single"

--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -288,8 +288,16 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
     return () => setBreadcrumb([]);
   }, [build, buildId, selectedTask, onBack, setBreadcrumb]);
 
+  // Hide phantom rows (placeholders auto-created by the API when an edge
+  // pointed at a not-yet-registered task). With the SDK's post-order
+  // discover walk this is rare; phantoms still render in the DAG (where
+  // dropping them would break edges) but we keep them out of the table
+  // and the "X tasks" counter to avoid showing "tid[:12]"-style
+  // placeholder names alongside real tasks.
+  const realTasks = useMemo(() => allTasks.filter((t) => !t.is_phantom), [allTasks]);
+
   // Client-side filtering
-  const filteredTasks = allTasks.filter((task) => {
+  const filteredTasks = realTasks.filter((task) => {
     if (
       nameFilter &&
       !task.task_name.toLowerCase().includes(nameFilter.toLowerCase())
@@ -419,7 +427,7 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
                 </div>
                 <div className="flex items-center gap-1.5">
                   <span className="text-xs text-gray-500 dark:text-gray-400">
-                    {allTasks.length} tasks
+                    {realTasks.length} tasks
                   </span>
                   <button
                     onClick={handleRefreshClick}
@@ -540,7 +548,7 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
                     <DagControls
                       value={dagControls}
                       onChange={setDagControls}
-                      primaryCount={allTasks.length}
+                      primaryCount={realTasks.length}
                       upstreamCount={extendedGraph?.total_upstream_count ?? 0}
                       downstreamCount={extendedGraph?.total_downstream_count ?? 0}
                       groupCount={extendedGraph?.groups.length ?? 0}
@@ -651,7 +659,7 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
               <DagControls
                 value={dagControls}
                 onChange={setDagControls}
-                primaryCount={allTasks.length}
+                primaryCount={realTasks.length}
                 upstreamCount={extendedGraph?.total_upstream_count ?? 0}
                 downstreamCount={extendedGraph?.total_downstream_count ?? 0}
                 groupCount={extendedGraph?.groups.length ?? 0}

--- a/app/stardag-ui/src/types/task.ts
+++ b/app/stardag-ui/src/types/task.ts
@@ -70,6 +70,10 @@ export interface Task {
   status_build_id?: string;
   // Git commit hash from the event that determined the current status
   commit_hash?: string | null;
+  // True for placeholder rows the API auto-creates when an edge points at
+  // a not-yet-registered task (legacy/safety-hatch path; with the SDK's
+  // post-order discover this is rare). UI hides phantoms from list views.
+  is_phantom?: boolean;
 }
 
 export interface TaskListResponse {

--- a/lib/stardag/src/stardag/build/_base.py
+++ b/lib/stardag/src/stardag/build/_base.py
@@ -145,6 +145,8 @@ class TaskExecutionState:
     dynamic_deps: list[BaseTask] = field(default_factory=list)
     # Generator if task has dynamic deps and is suspended
     generator: Generator[TaskStruct, None, None] | None = None
+    # True when registry.task_register has been called for this task in this build
+    registered: bool = False
     # True when registry.task_start has been called
     started: bool = False
     # True when task execution has fully completed

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -474,12 +474,14 @@ async def build_aio(
     """Build tasks concurrently using hybrid async/thread/process execution.
 
     This is the main build function for production use. It:
-    - Discovers all tasks in the DAG(s)
+    - Discovers all tasks in the DAG(s) and registers each one with the
+      registry as soon as it's discovered (so the full DAG is visible in the
+      UI immediately, not progressively as tasks become runnable)
     - Schedules tasks for execution when dependencies are met
     - Handles dynamic dependencies via generator suspension
     - Supports multiple root tasks (built concurrently)
     - Routes tasks to async/thread/process based on ExecutionModeSelector
-    - Manages all registry interactions (start/complete/fail task)
+    - Manages all registry interactions (register/start/complete/fail task)
     - Optionally uses global concurrency locks for distributed execution
 
     Args:
@@ -544,12 +546,42 @@ async def build_aio(
     # Currently executing tasks
     executing: set[UUID] = set()
 
-    # Tasks found to be already complete during discovery (to register after build starts)
+    # Tasks found to be already complete during discovery (mark complete in registry
+    # after discovery finishes — registration itself happens inline in discover()).
     previously_completed_tasks: list[BaseTask] = []
 
     # Synchronization for concurrent discovery
     discover_lock = asyncio.Lock()
     discover_semaphore = asyncio.Semaphore(max_concurrent_discover)
+
+    # Start or resume build *before* discovery so we can register tasks as
+    # they're found. Registering on discover (instead of at start-of-execution)
+    # makes the full DAG visible in the UI immediately rather than appearing
+    # leaves-first as tasks become runnable.
+    if resume_build_id is not None:
+        build_id = resume_build_id
+        logger.info(f"Resuming build: {build_id}")
+    else:
+        build_id = await registry.build_start_aio(root_tasks=tasks)
+        logger.info(f"Started build: {build_id}")
+
+    async def register_discovered(task: BaseTask) -> None:
+        """Register a freshly-discovered task with the registry.
+
+        Records on ``state.registered`` whether the call succeeded so that
+        ``submit_with_lock`` can retry the registration later if the discover
+        attempt was lost in ``warn`` mode.
+        """
+        try:
+            await registry.task_register_aio(build_id, task)
+        except Exception as reg_err:
+            handle_registry_error(
+                reg_err,
+                f"Failed to register task {task.id} during discovery",
+                on_registry_failure,
+            )
+            return
+        task_states[task.id].registered = True
 
     async def discover(task: BaseTask) -> None:
         """Recursively discover tasks, stopping at already-complete tasks.
@@ -560,7 +592,9 @@ async def build_aio(
 
         Uses concurrent recursion with TaskGroup for parallel discovery,
         with a lock protecting shared data structures and a semaphore
-        limiting concurrent completion checks.
+        limiting concurrent completion checks. Each newly-discovered task is
+        registered with the registry (concurrently, fire-and-forget within
+        the TaskGroup) so the full DAG appears in the UI immediately.
         """
         # Check if already discovered and reserve our spot (with lock)
         async with discover_lock:
@@ -572,6 +606,9 @@ async def build_aio(
             )
             completion_events[task.id] = asyncio.Event()
             task_count.discovered += 1
+
+        # Register with the registry (HTTP I/O — outside the lock).
+        await register_discovered(task)
 
         # Check completion outside lock (I/O bound, use semaphore to limit concurrency)
         async with discover_semaphore:
@@ -598,29 +635,17 @@ async def build_aio(
         for root in tasks:
             tg.create_task(discover(root))
 
-    # Start or resume build
-    if resume_build_id is not None:
-        build_id = resume_build_id
-        logger.info(f"Resuming build: {build_id}")
-    else:
-        build_id = await registry.build_start_aio(root_tasks=tasks)
-        logger.info(f"Started build: {build_id}")
-
-    # Register previously completed tasks so they appear in the build's task list.
-    # These get TASK_REFERENCED events since they already exist. We also call
-    # task_complete_aio to self-heal tasks that were left in "Started" state from
-    # a previous build that crashed or timed out — their target exists, so they
-    # are complete, but the registry still shows them as running.
-    for task in previously_completed_tasks:
-        try:
-            await registry.task_register_aio(build_id, task)
-        except Exception as reg_err:
-            handle_registry_error(
-                reg_err,
-                f"Failed to register previously completed task {task.id}",
-                on_registry_failure,
-            )
-            continue
+    # Mark previously completed tasks as complete in the registry. Registration
+    # already happened inline in discover() above; we still need to fire
+    # task_complete_aio so they appear COMPLETED rather than PENDING — and to
+    # self-heal tasks left in "Started" state from a previous build that
+    # crashed (their target exists, so they are complete, but the registry
+    # still shows them as running).
+    async def mark_previously_completed(task: BaseTask) -> None:
+        if not task_states[task.id].registered:
+            # Registration failed in `warn` mode; skip task_complete since
+            # the API row doesn't exist.
+            return
         try:
             await registry.task_complete_aio(build_id, task)
         except Exception as reg_err:
@@ -629,6 +654,11 @@ async def build_aio(
                 f"Failed to mark previously completed task {task.id} as complete",
                 on_registry_failure,
             )
+
+    if previously_completed_tasks:
+        async with asyncio.TaskGroup() as tg:
+            for task in previously_completed_tasks:
+                tg.create_task(mark_previously_completed(task))
 
     await task_executor.setup()
 
@@ -949,8 +979,20 @@ async def build_aio(
             held_locks.add(task_id_str)
 
         # Now we have the lock (or locking wasn't needed)
-        # Start the task in registry
+        # Start the task in registry. The task was already registered during
+        # discover; if registration failed in `warn` mode we retry once here so
+        # the /start endpoint doesn't 404.
         if not state.started:
+            if not state.registered:
+                try:
+                    await registry.task_register_aio(build_id, task)
+                    state.registered = True
+                except Exception as reg_err:
+                    handle_registry_error(
+                        reg_err,
+                        f"Failed to register task {task.id} before start",
+                        on_registry_failure,
+                    )
             await registry.task_start_aio(build_id, task)
             state.started = True
         elif state.dynamic_deps:

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -48,6 +48,12 @@ from stardag.registry import RegistryABC, registry_provider
 logger = logging.getLogger(__name__)
 
 
+# Maximum number of tasks per ``task_register_bulk_aio`` call. Matches the
+# Stardag API server's per-call cap and keeps each transaction bounded.
+# The build engine chunks ``pending_registrations`` accordingly.
+_BULK_REGISTER_CHUNK_SIZE = 1000
+
+
 # =============================================================================
 # Execution Mode Selection
 # =============================================================================
@@ -552,10 +558,17 @@ async def build_aio(
     # Tasks accumulated during the current discover() walk, in post-order,
     # awaiting the bulk-registration call. Within each subtree this is
     # strict post-order; sibling subtrees may interleave (TaskGroup runs
-    # them concurrently), but each task's static deps are always emitted
+    # them concurrently), but each task's static deps are always appended
     # before it — which is all the API needs to avoid phantom-creation.
     # Cleared by ``flush_pending_registrations`` after each bulk call.
     pending_registrations: list[BaseTask] = []
+    # Per-task event signalling that this task's discover() has finished
+    # appending it to pending_registrations. The fast-path
+    # ``if task.id in task_states: return`` would otherwise let a sibling
+    # discoverer race past — appending its own parent ahead of the still-
+    # in-flight dep — re-introducing exactly the phantom window the
+    # post-order walk is designed to eliminate (diamond DAGs, shared deps).
+    discover_done: dict[UUID, asyncio.Event] = {}
 
     # Synchronization for concurrent discovery
     discover_lock = asyncio.Lock()
@@ -586,53 +599,90 @@ async def build_aio(
         Uses concurrent recursion with TaskGroup for parallel discovery,
         with a lock protecting shared data structures and a semaphore
         limiting concurrent completion checks.
+
+        Concurrency invariant: when a sibling coroutine encounters this
+        task already-discovered (fast-path), it ``await``s the
+        ``discover_done`` event before returning. Without that, a
+        diamond-DAG sibling could append its own parent to
+        ``pending_registrations`` before this coroutine appends the
+        shared dep — re-introducing the phantom window we're trying to
+        eliminate.
         """
         # Check if already discovered and reserve our spot (with lock)
         async with discover_lock:
             if task.id in task_states:
-                return
-            static_deps = flatten_task_struct(task.requires())
-            task_states[task.id] = TaskExecutionState(
-                task=task, static_deps=static_deps
-            )
-            completion_events[task.id] = asyncio.Event()
-            task_count.discovered += 1
+                done_event = discover_done[task.id]
+                already_seen = True
+            else:
+                static_deps = flatten_task_struct(task.requires())
+                task_states[task.id] = TaskExecutionState(
+                    task=task, static_deps=static_deps
+                )
+                completion_events[task.id] = asyncio.Event()
+                discover_done[task.id] = asyncio.Event()
+                done_event = discover_done[task.id]
+                task_count.discovered += 1
+                already_seen = False
 
-        # Check completion outside lock (I/O bound, use semaphore to limit concurrency)
-        async with discover_semaphore:
-            is_complete = await task.complete_aio()
+        if already_seen:
+            # Wait for the original discoverer to finish appending this
+            # task to pending_registrations before returning. Otherwise a
+            # parent further up our chain would append ahead of the dep.
+            await done_event.wait()
+            return
 
-        if is_complete:
-            async with discover_lock:
-                completion_cache.add(task.id)
-                task_states[task.id].completed = True
-                completion_events[task.id].set()
-                task_count.previously_completed += 1
-                previously_completed_tasks.append(task)
-            if not register_all:
-                # Don't recurse into deps — they're already built. Append
-                # to pending_registrations (leaf in post-order).
-                pending_registrations.append(task)
-                return
+        # ``static_deps`` is only assigned in the else-branch above, but
+        # pyright can't infer the control flow; pull it back from the
+        # state we just stored.
+        static_deps = task_states[task.id].static_deps
 
-        # Task not complete (or register_all) — recurse into deps first
-        # (post-order). TaskGroup waits for all children to finish before
-        # this body continues, so all child appends to pending_registrations
-        # land before our own append below.
-        async with asyncio.TaskGroup() as tg:
-            for dep in static_deps:
-                tg.create_task(discover(dep))
+        try:
+            # Check completion outside lock (I/O bound, use semaphore to limit concurrency)
+            async with discover_semaphore:
+                is_complete = await task.complete_aio()
 
-        # Append self after children — preserves post-order within subtree.
-        pending_registrations.append(task)
+            if is_complete:
+                async with discover_lock:
+                    completion_cache.add(task.id)
+                    task_states[task.id].completed = True
+                    completion_events[task.id].set()
+                    task_count.previously_completed += 1
+                    previously_completed_tasks.append(task)
+                if not register_all:
+                    # Don't recurse into deps — they're already built.
+                    # Append to pending_registrations (leaf in post-order).
+                    pending_registrations.append(task)
+                    return
+
+            # Task not complete (or register_all) — recurse into deps
+            # first (post-order). TaskGroup waits for all children to
+            # finish before this body continues, so all child appends to
+            # pending_registrations land before our own append below.
+            async with asyncio.TaskGroup() as tg:
+                for dep in static_deps:
+                    tg.create_task(discover(dep))
+
+            # Append self after children — preserves post-order within
+            # subtree.
+            pending_registrations.append(task)
+        finally:
+            # Always set so any sibling fast-path waiters can proceed,
+            # even when this discover() raised. (TaskGroup will propagate
+            # the failure to siblings via cancellation, but we don't want
+            # waiters to deadlock on a never-set event before that
+            # cancellation reaches them.)
+            done_event.set()
 
     async def flush_pending_registrations() -> None:
         """Bulk-register every task accumulated since the last flush.
 
         Called after each discover-walk (initial walk and each dynamic-deps
-        walk). On bulk-call failure: ``warn`` mode logs and continues —
-        the per-task retry inside ``submit_with_lock`` will pick up the
-        slack as tasks become runnable. ``raise`` mode propagates.
+        walk). Chunks ``batch`` into ``_BULK_REGISTER_CHUNK_SIZE``-sized
+        slices to stay within the API's per-call cap and to keep each
+        transaction bounded. On chunk failure: ``warn`` mode logs and
+        stops processing further chunks — the per-task retry inside
+        ``submit_with_lock`` picks up the slack as tasks become runnable.
+        ``raise`` mode propagates.
         """
         if not pending_registrations:
             return
@@ -640,23 +690,30 @@ async def build_aio(
         # event loop tick can't accidentally re-register these tasks.
         batch = list(pending_registrations)
         pending_registrations.clear()
-        try:
-            await registry.task_register_bulk_aio(build_id, batch)
-        except Exception as reg_err:
-            # Include up to 5 task IDs in the warning so debugging is
-            # possible without dumping a 1000-id list into logs.
-            ids_preview = ", ".join(str(t.id) for t in batch[:5])
-            if len(batch) > 5:
-                ids_preview += f", +{len(batch) - 5} more"
-            handle_registry_error(
-                reg_err,
-                f"Failed to bulk-register {len(batch)} tasks during discovery "
-                f"(ids: {ids_preview})",
-                on_registry_failure,
-            )
-            return
-        for t in batch:
-            task_states[t.id].registered = True
+
+        for chunk_start in range(0, len(batch), _BULK_REGISTER_CHUNK_SIZE):
+            chunk = batch[chunk_start : chunk_start + _BULK_REGISTER_CHUNK_SIZE]
+            try:
+                await registry.task_register_bulk_aio(build_id, chunk)
+            except Exception as reg_err:
+                # Include up to 5 task IDs in the warning so debugging is
+                # possible without dumping a 1000-id list into logs.
+                ids_preview = ", ".join(str(t.id) for t in chunk[:5])
+                if len(chunk) > 5:
+                    ids_preview += f", +{len(chunk) - 5} more"
+                total_chunks = (
+                    len(batch) + _BULK_REGISTER_CHUNK_SIZE - 1
+                ) // _BULK_REGISTER_CHUNK_SIZE
+                this_chunk = (chunk_start // _BULK_REGISTER_CHUNK_SIZE) + 1
+                handle_registry_error(
+                    reg_err,
+                    f"Failed to bulk-register chunk {this_chunk}/{total_chunks} "
+                    f"({len(chunk)} tasks; ids: {ids_preview})",
+                    on_registry_failure,
+                )
+                return
+            for t in chunk:
+                task_states[t.id].registered = True
 
     # Mark previously completed tasks as complete in the registry. Registration
     # already happened inline in discover() above; we still need to fire

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -48,10 +48,15 @@ from stardag.registry import RegistryABC, registry_provider
 logger = logging.getLogger(__name__)
 
 
-# Maximum number of tasks per ``task_register_bulk_aio`` call. Matches the
-# Stardag API server's per-call cap and keeps each transaction bounded.
-# The build engine chunks ``pending_registrations`` accordingly.
-_BULK_REGISTER_CHUNK_SIZE = 1000
+# Number of tasks the build engine sends per ``task_register_bulk_aio``
+# HTTP call. Deliberately well under the API's hard cap (1000) so that
+# (a) DB transactions on the server stay short and don't contend with
+# concurrent builds, (b) compressed request bodies stay easily within
+# any reverse-proxy limit even with fat task specs, and (c) a chunk
+# failure in ``warn`` mode loses few tasks before the per-task fallback
+# kicks in. For a 5000-task DAG it's still 100 requests instead of 5000
+# — most of the bulk-register win remains.
+_BULK_REGISTER_CHUNK_SIZE = 50
 
 
 # =============================================================================

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -630,11 +630,6 @@ async def build_aio(
             for dep in static_deps:
                 tg.create_task(discover(dep))
 
-    # Discover all tasks from roots concurrently
-    async with asyncio.TaskGroup() as tg:
-        for root in tasks:
-            tg.create_task(discover(root))
-
     # Mark previously completed tasks as complete in the registry. Registration
     # already happened inline in discover() above; we still need to fire
     # task_complete_aio so they appear COMPLETED rather than PENDING — and to
@@ -654,13 +649,6 @@ async def build_aio(
                 f"Failed to mark previously completed task {task.id} as complete",
                 on_registry_failure,
             )
-
-    if previously_completed_tasks:
-        async with asyncio.TaskGroup() as tg:
-            for task in previously_completed_tasks:
-                tg.create_task(mark_previously_completed(task))
-
-    await task_executor.setup()
 
     # Map task_id -> asyncio.Task for in-flight executions
     pending_futures: dict[UUID, asyncio.Task] = {}
@@ -993,16 +981,55 @@ async def build_aio(
                         f"Failed to register task {task.id} before start",
                         on_registry_failure,
                     )
-            await registry.task_start_aio(build_id, task)
-            state.started = True
+            # Skip /start if registration never succeeded — the endpoint
+            # would 404 and that hard-fails the build even in `warn` mode.
+            if state.registered:
+                try:
+                    await registry.task_start_aio(build_id, task)
+                    state.started = True
+                except Exception as reg_err:
+                    handle_registry_error(
+                        reg_err,
+                        f"Failed to start task {task.id}",
+                        on_registry_failure,
+                    )
         elif state.dynamic_deps:
-            # Task was suspended waiting for dynamic deps, now resuming
-            await registry.task_resume_aio(build_id, task)
+            # Task was suspended waiting for dynamic deps, now resuming. Same
+            # warn-mode protection: no point firing /resume if registration
+            # never landed.
+            if state.registered:
+                try:
+                    await registry.task_resume_aio(build_id, task)
+                except Exception as reg_err:
+                    handle_registry_error(
+                        reg_err,
+                        f"Failed to resume task {task.id}",
+                        on_registry_failure,
+                    )
 
         # Execute the task via the executor
         return await task_executor.submit(task)
 
     try:
+        # Discover all tasks from roots concurrently. Inline-registration
+        # makes the full DAG appear in the registry/UI immediately. If any
+        # discover() raises (e.g. a task's requires() throws), the outer
+        # except below emits build_fail_aio so the build doesn't get stuck
+        # in RUNNING state.
+        async with asyncio.TaskGroup() as tg:
+            for root in tasks:
+                tg.create_task(discover(root))
+
+        # Mark previously-completed tasks as complete (concurrently). Has to
+        # happen after discover finishes so previously_completed_tasks is
+        # fully populated.
+        if previously_completed_tasks:
+            async with asyncio.TaskGroup() as tg:
+                for task in previously_completed_tasks:
+                    tg.create_task(mark_previously_completed(task))
+
+        await task_executor.setup()
+
         # Main build loop using as_completed pattern
         while True:
             # Check if all roots complete

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -547,17 +547,23 @@ async def build_aio(
     executing: set[UUID] = set()
 
     # Tasks found to be already complete during discovery (mark complete in registry
-    # after discovery finishes — registration itself happens inline in discover()).
+    # after discovery finishes — registration itself happens via the bulk call).
     previously_completed_tasks: list[BaseTask] = []
+    # Tasks accumulated during the current discover() walk, in post-order,
+    # awaiting the bulk-registration call. Within each subtree this is
+    # strict post-order; sibling subtrees may interleave (TaskGroup runs
+    # them concurrently), but each task's static deps are always emitted
+    # before it — which is all the API needs to avoid phantom-creation.
+    # Cleared by ``flush_pending_registrations`` after each bulk call.
+    pending_registrations: list[BaseTask] = []
 
     # Synchronization for concurrent discovery
     discover_lock = asyncio.Lock()
     discover_semaphore = asyncio.Semaphore(max_concurrent_discover)
 
-    # Start or resume build *before* discovery so we can register tasks as
-    # they're found. Registering on discover (instead of at start-of-execution)
-    # makes the full DAG visible in the UI immediately rather than appearing
-    # leaves-first as tasks become runnable.
+    # Start or resume build *before* discovery so we have a build_id to
+    # register tasks against. Registering during discovery makes the full
+    # DAG visible in the UI immediately, not leaves-first as tasks run.
     if resume_build_id is not None:
         build_id = resume_build_id
         logger.info(f"Resuming build: {build_id}")
@@ -565,36 +571,21 @@ async def build_aio(
         build_id = await registry.build_start_aio(root_tasks=tasks)
         logger.info(f"Started build: {build_id}")
 
-    async def register_discovered(task: BaseTask) -> None:
-        """Register a freshly-discovered task with the registry.
-
-        Records on ``state.registered`` whether the call succeeded so that
-        ``submit_with_lock`` can retry the registration later if the discover
-        attempt was lost in ``warn`` mode.
-        """
-        try:
-            await registry.task_register_aio(build_id, task)
-        except Exception as reg_err:
-            handle_registry_error(
-                reg_err,
-                f"Failed to register task {task.id} during discovery",
-                on_registry_failure,
-            )
-            return
-        task_states[task.id].registered = True
-
     async def discover(task: BaseTask) -> None:
         """Recursively discover tasks, stopping at already-complete tasks.
 
-        This optimization avoids traversing into dependency subgraphs that
-        are already complete, which can significantly reduce discovery time
-        for large DAGs with cached results.
+        Discovery only populates local state and ``pending_registrations``;
+        the actual ``task_register_bulk_aio`` call fires once via
+        ``flush_pending_registrations()`` after the whole walk completes.
+        Walks in **post-order** so deps appear in ``pending_registrations``
+        before their parents — the bulk endpoint processes the array in
+        order, so by the time a parent's ``dependency_task_ids`` are
+        reconciled the dep rows already exist (no phantom creation in
+        ``_reconcile_dependency_edges``).
 
         Uses concurrent recursion with TaskGroup for parallel discovery,
         with a lock protecting shared data structures and a semaphore
-        limiting concurrent completion checks. Each newly-discovered task is
-        registered with the registry (concurrently, fire-and-forget within
-        the TaskGroup) so the full DAG appears in the UI immediately.
+        limiting concurrent completion checks.
         """
         # Check if already discovered and reserve our spot (with lock)
         async with discover_lock:
@@ -606,9 +597,6 @@ async def build_aio(
             )
             completion_events[task.id] = asyncio.Event()
             task_count.discovered += 1
-
-        # Register with the registry (HTTP I/O — outside the lock).
-        await register_discovered(task)
 
         # Check completion outside lock (I/O bound, use semaphore to limit concurrency)
         async with discover_semaphore:
@@ -622,13 +610,53 @@ async def build_aio(
                 task_count.previously_completed += 1
                 previously_completed_tasks.append(task)
             if not register_all:
-                # Don't recurse into deps - they're already built
+                # Don't recurse into deps — they're already built. Append
+                # to pending_registrations (leaf in post-order).
+                pending_registrations.append(task)
                 return
 
-        # Task not complete (or register_all) - recurse into dependencies
+        # Task not complete (or register_all) — recurse into deps first
+        # (post-order). TaskGroup waits for all children to finish before
+        # this body continues, so all child appends to pending_registrations
+        # land before our own append below.
         async with asyncio.TaskGroup() as tg:
             for dep in static_deps:
                 tg.create_task(discover(dep))
+
+        # Append self after children — preserves post-order within subtree.
+        pending_registrations.append(task)
+
+    async def flush_pending_registrations() -> None:
+        """Bulk-register every task accumulated since the last flush.
+
+        Called after each discover-walk (initial walk and each dynamic-deps
+        walk). On bulk-call failure: ``warn`` mode logs and continues —
+        the per-task retry inside ``submit_with_lock`` will pick up the
+        slack as tasks become runnable. ``raise`` mode propagates.
+        """
+        if not pending_registrations:
+            return
+        # Snapshot then clear so a recursive discover call inside the same
+        # event loop tick can't accidentally re-register these tasks.
+        batch = list(pending_registrations)
+        pending_registrations.clear()
+        try:
+            await registry.task_register_bulk_aio(build_id, batch)
+        except Exception as reg_err:
+            # Include up to 5 task IDs in the warning so debugging is
+            # possible without dumping a 1000-id list into logs.
+            ids_preview = ", ".join(str(t.id) for t in batch[:5])
+            if len(batch) > 5:
+                ids_preview += f", +{len(batch) - 5} more"
+            handle_registry_error(
+                reg_err,
+                f"Failed to bulk-register {len(batch)} tasks during discovery "
+                f"(ids: {ids_preview})",
+                on_registry_failure,
+            )
+            return
+        for t in batch:
+            task_states[t.id].registered = True
 
     # Mark previously completed tasks as complete in the registry. Registration
     # already happened inline in discover() above; we still need to fire
@@ -763,9 +791,20 @@ async def build_aio(
                     on_registry_failure,
                 )
 
-            # Record yielded deps as edges so the DAG view shows them. This is
-            # the ONLY place dynamic edges enter the registry — static deps are
-            # recorded by task_register via task.requires().
+            # Discover any new dynamic deps FIRST (which post-order-collects
+            # them and their requires() subtree into pending_registrations).
+            # Then bulk-register the new batch BEFORE recording the edge —
+            # this way the upstream row exists when the edge insert runs,
+            # and _reconcile_dependency_edges doesn't have to phantom-
+            # create it.
+            for dep in dynamic_deps:
+                if dep.id not in task_states:
+                    await discover(dep)
+            await flush_pending_registrations()
+
+            # Now record yielded deps as edges so the DAG view shows them.
+            # This is the ONLY place dynamic edges enter the registry —
+            # static deps are recorded by task_register via task.requires().
             if dynamic_deps:
                 try:
                     await registry.task_add_dependencies_aio(
@@ -777,11 +816,6 @@ async def build_aio(
                         f"Failed to record dynamic deps for task {task.id}",
                         on_registry_failure,
                     )
-
-            # Discover any new dynamic deps (discover handles counting)
-            for dep in dynamic_deps:
-                if dep.id not in task_states:
-                    await discover(dep)
 
             # Accumulate dynamic deps (don't overwrite)
             existing_dyn_ids = {d.id for d in state.dynamic_deps}
@@ -1020,9 +1054,14 @@ async def build_aio(
             for root in tasks:
                 tg.create_task(discover(root))
 
+        # Bulk-register every discovered task in one HTTP call. Order is
+        # post-order so the API resolves all dependency_task_ids to existing
+        # rows without phantom-creating any.
+        await flush_pending_registrations()
+
         # Mark previously-completed tasks as complete (concurrently). Has to
-        # happen after discover finishes so previously_completed_tasks is
-        # fully populated.
+        # happen after registration so the API rows exist; previously_completed
+        # is populated during discover() above.
         if previously_completed_tasks:
             async with asyncio.TaskGroup() as tg:
                 for task in previously_completed_tasks:

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -240,9 +240,6 @@ def build_sequential(
         for dep in flatten_task_struct(task.requires()):
             discover(dep)
 
-    for root in tasks_list:
-        discover(root)
-
     # Mark previously-completed tasks as complete in the registry. Registration
     # already happened inline in discover(); we still need to fire
     # task_complete so they appear COMPLETED rather than PENDING — and to
@@ -275,8 +272,6 @@ def build_sequential(
                     f"Failed to mark previously completed task {pc_task.id} as complete",
                     on_registry_failure,
                 )
-
-    mark_pending_previously_completed()
 
     def runtime_discover(task: BaseTask) -> None:
         """``discover()`` wrapper used after the initial registration pass.
@@ -353,6 +348,16 @@ def build_sequential(
             held_locks.discard(task_id)
 
     try:
+        # Discover all tasks (with inline registration). If discover() raises
+        # (e.g. requires() / complete() throws), the outer except below emits
+        # build_fail so the build doesn't get stuck in RUNNING state.
+        for root in tasks_list:
+            discover(root)
+
+        # Mark previously-completed tasks as complete now that discovery has
+        # populated previously_completed_tasks fully.
+        mark_pending_previously_completed()
+
         # Build in topological order
         while True:
             ready_task = _find_ready_task(all_tasks, completion_cache, failed_cache)
@@ -499,9 +504,18 @@ def _run_task_sequential(
                 task_count.succeeded += 1
 
     # The task should already be registered (during discover), but retry once
-    # if discover-time registration failed in `warn` mode so /start doesn't 404.
+    # if discover-time registration failed in `warn` mode. We still wrap
+    # /start in handle_registry_error so a 404 (registration didn't land) or
+    # a transient blip doesn't hard-fail the build in `warn` mode.
     register_task_once(task)
-    registry.task_start(build_id, task)
+    try:
+        registry.task_start(build_id, task)
+    except Exception as reg_err:
+        handle_registry_error(
+            reg_err,
+            f"Failed to start task {task.id}",
+            on_registry_failure,
+        )
 
     has_run = _has_custom_run(task)
     has_run_aio = _has_custom_run_aio(task)
@@ -574,7 +588,14 @@ def _run_task_sequential(
                 break
 
     completion_cache.add(task.id)
-    registry.task_complete(build_id, task)
+    try:
+        registry.task_complete(build_id, task)
+    except Exception as reg_err:
+        handle_registry_error(
+            reg_err,
+            f"Failed to complete task {task.id}",
+            on_registry_failure,
+        )
 
     # Upload artifacts if any
     try:
@@ -707,9 +728,6 @@ async def build_sequential_aio(
         for dep in flatten_task_struct(task.requires()):
             await discover(dep)
 
-    for root in tasks_list:
-        await discover(root)
-
     # Mark previously-completed tasks as complete in the registry. Registration
     # already happened inline in discover(); we still need to fire
     # task_complete_aio so they appear COMPLETED rather than PENDING.
@@ -739,8 +757,6 @@ async def build_sequential_aio(
                     f"Failed to mark previously completed task {pc_task.id} as complete",
                     on_registry_failure,
                 )
-
-    await mark_pending_previously_completed_aio()
 
     async def runtime_discover_aio(task: BaseTask) -> None:
         """``discover()`` wrapper used after the initial registration pass.
@@ -819,6 +835,16 @@ async def build_sequential_aio(
             held_locks.discard(task_id)
 
     try:
+        # Discover all tasks (with inline registration). If discover() raises
+        # (e.g. requires() / complete_aio() throws), the outer except below
+        # emits build_fail_aio so the build doesn't get stuck in RUNNING state.
+        for root in tasks_list:
+            await discover(root)
+
+        # Mark previously-completed tasks as complete now that discovery has
+        # populated previously_completed_tasks fully.
+        await mark_pending_previously_completed_aio()
+
         # Build in topological order
         while True:
             ready_task = _find_ready_task(all_tasks, completion_cache, failed_cache)
@@ -978,9 +1004,18 @@ async def _run_task_sequential_aio(
                 task_count.succeeded += 1
 
     # The task should already be registered (during discover), but retry once
-    # if discover-time registration failed in `warn` mode so /start doesn't 404.
+    # if discover-time registration failed in `warn` mode. We still wrap
+    # /start in handle_registry_error so a 404 (registration didn't land) or
+    # a transient blip doesn't hard-fail the build in `warn` mode.
     await register_task_once_aio(task)
-    await registry.task_start_aio(build_id, task)
+    try:
+        await registry.task_start_aio(build_id, task)
+    except Exception as reg_err:
+        handle_registry_error(
+            reg_err,
+            f"Failed to start task {task.id}",
+            on_registry_failure,
+        )
 
     has_run = _has_custom_run(task)
     has_run_aio = _has_custom_run_aio(task)
@@ -1045,7 +1080,14 @@ async def _run_task_sequential_aio(
                     task_count.succeeded += 1
 
     completion_cache.add(task.id)
-    await registry.task_complete_aio(build_id, task)
+    try:
+        await registry.task_complete_aio(build_id, task)
+    except Exception as reg_err:
+        handle_registry_error(
+            reg_err,
+            f"Failed to complete task {task.id}",
+            on_registry_failure,
+        )
 
     # Upload artifacts if any
     try:

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -51,10 +51,12 @@ from stardag.registry import RegistryABC, registry_provider
 logger = logging.getLogger(__name__)
 
 
-# Maximum number of tasks per ``task_register_bulk[_aio]`` call. Matches
-# the Stardag API server's per-call cap; we chunk ``pending_registrations``
-# accordingly to stay within it for large fan-out DAGs.
-_BULK_REGISTER_CHUNK_SIZE = 1000
+# Number of tasks the build engine sends per ``task_register_bulk[_aio]``
+# HTTP call. Deliberately well under the API's hard cap (1000) — see
+# the matching constant in ``_concurrent.py`` for rationale (smaller DB
+# transactions, fewer warn-mode losses, friendlier compressed body
+# sizes for fat task specs).
+_BULK_REGISTER_CHUNK_SIZE = 50
 
 
 # ---------------------------------------------------------------------------

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -51,6 +51,12 @@ from stardag.registry import RegistryABC, registry_provider
 logger = logging.getLogger(__name__)
 
 
+# Maximum number of tasks per ``task_register_bulk[_aio]`` call. Matches
+# the Stardag API server's per-call cap; we chunk ``pending_registrations``
+# accordingly to stay within it for large fan-out DAGs.
+_BULK_REGISTER_CHUNK_SIZE = 1000
+
+
 # ---------------------------------------------------------------------------
 # Pure helper functions shared by both sync and async build variants.
 # These contain no I/O and are safe to call from any context.
@@ -225,30 +231,39 @@ def build_sequential(
         """Bulk-register every task accumulated since the last flush.
 
         Called after each discover walk (initial walk and any runtime
-        walk triggered by dynamic deps). On bulk-call failure: ``warn``
-        mode logs and continues; the per-task retry inside
-        ``_run_task_sequential`` will fall back to per-task register as
+        walk triggered by dynamic deps). Chunks the batch into
+        ``_BULK_REGISTER_CHUNK_SIZE``-sized slices to stay within the
+        API's per-call cap. On chunk failure: ``warn`` mode logs and
+        stops processing further chunks; the per-task retry inside
+        ``_run_task_sequential`` falls back to per-task register as
         tasks become runnable. ``raise`` mode propagates.
         """
         if not pending_registrations:
             return
         batch = list(pending_registrations)
         pending_registrations.clear()
-        try:
-            registry.task_register_bulk(build_id, batch)
-        except Exception as reg_err:
-            ids_preview = ", ".join(str(t.id) for t in batch[:5])
-            if len(batch) > 5:
-                ids_preview += f", +{len(batch) - 5} more"
-            handle_registry_error(
-                reg_err,
-                f"Failed to bulk-register {len(batch)} tasks during discovery "
-                f"(ids: {ids_preview})",
-                on_registry_failure,
-            )
-            return
-        for t in batch:
-            registered_tasks.add(t.id)
+
+        for chunk_start in range(0, len(batch), _BULK_REGISTER_CHUNK_SIZE):
+            chunk = batch[chunk_start : chunk_start + _BULK_REGISTER_CHUNK_SIZE]
+            try:
+                registry.task_register_bulk(build_id, chunk)
+            except Exception as reg_err:
+                ids_preview = ", ".join(str(t.id) for t in chunk[:5])
+                if len(chunk) > 5:
+                    ids_preview += f", +{len(chunk) - 5} more"
+                total_chunks = (
+                    len(batch) + _BULK_REGISTER_CHUNK_SIZE - 1
+                ) // _BULK_REGISTER_CHUNK_SIZE
+                this_chunk = (chunk_start // _BULK_REGISTER_CHUNK_SIZE) + 1
+                handle_registry_error(
+                    reg_err,
+                    f"Failed to bulk-register chunk {this_chunk}/{total_chunks} "
+                    f"({len(chunk)} tasks; ids: {ids_preview})",
+                    on_registry_failure,
+                )
+                return
+            for t in chunk:
+                registered_tasks.add(t.id)
 
     def discover(task: BaseTask) -> None:
         """Recursively discover tasks, stopping at already-complete tasks.
@@ -756,26 +771,39 @@ async def build_sequential_aio(
             )
 
     async def flush_pending_registrations_aio() -> None:
-        """Bulk-register every task collected since the last flush."""
+        """Bulk-register every task collected since the last flush.
+
+        Chunks the batch into ``_BULK_REGISTER_CHUNK_SIZE``-sized slices
+        to stay within the API's per-call cap. Stops on first chunk
+        failure (per-task retry inside ``_run_task_sequential_aio``
+        handles the rest in ``warn`` mode).
+        """
         if not pending_registrations:
             return
         batch = list(pending_registrations)
         pending_registrations.clear()
-        try:
-            await registry.task_register_bulk_aio(build_id, batch)
-        except Exception as reg_err:
-            ids_preview = ", ".join(str(t.id) for t in batch[:5])
-            if len(batch) > 5:
-                ids_preview += f", +{len(batch) - 5} more"
-            handle_registry_error(
-                reg_err,
-                f"Failed to bulk-register {len(batch)} tasks during discovery "
-                f"(ids: {ids_preview})",
-                on_registry_failure,
-            )
-            return
-        for t in batch:
-            registered_tasks.add(t.id)
+
+        for chunk_start in range(0, len(batch), _BULK_REGISTER_CHUNK_SIZE):
+            chunk = batch[chunk_start : chunk_start + _BULK_REGISTER_CHUNK_SIZE]
+            try:
+                await registry.task_register_bulk_aio(build_id, chunk)
+            except Exception as reg_err:
+                ids_preview = ", ".join(str(t.id) for t in chunk[:5])
+                if len(chunk) > 5:
+                    ids_preview += f", +{len(chunk) - 5} more"
+                total_chunks = (
+                    len(batch) + _BULK_REGISTER_CHUNK_SIZE - 1
+                ) // _BULK_REGISTER_CHUNK_SIZE
+                this_chunk = (chunk_start // _BULK_REGISTER_CHUNK_SIZE) + 1
+                handle_registry_error(
+                    reg_err,
+                    f"Failed to bulk-register chunk {this_chunk}/{total_chunks} "
+                    f"({len(chunk)} tasks; ids: {ids_preview})",
+                    on_registry_failure,
+                )
+                return
+            for t in chunk:
+                registered_tasks.add(t.id)
 
     async def discover(task: BaseTask) -> None:
         """Recursively discover tasks, stopping at already-complete tasks.

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -134,6 +134,10 @@ def build_sequential(
 
     This is intended primarily for debugging and testing.
 
+    Tasks are registered with the registry as they are discovered (in
+    deterministic DFS order from the roots), so the full DAG appears in the
+    UI immediately rather than progressively as tasks become runnable.
+
     Task execution policy:
     - Sync-only tasks: run via `run()`
     - Async-only tasks: run via `asyncio.run(run_aio())`. (Does not work if called
@@ -180,13 +184,48 @@ def build_sequential(
     # Discover all tasks, stopping at already-complete tasks
     all_tasks: dict[UUID, BaseTask] = {}
     previously_completed_tasks: list[BaseTask] = []
+    # Tasks already registered with the registry. Tracked so subsequent
+    # registration attempts (e.g. from `_run_task_sequential` for tasks first
+    # surfaced at runtime via dynamic deps) don't fire duplicate API calls.
+    registered_tasks: set[UUID] = set()
+
+    # Start or resume build *before* discovery so we can register tasks as
+    # they're found. Registering on discover (instead of at start-of-execution)
+    # makes the full DAG visible in the UI immediately, and gives a stable
+    # roots-first registration order in the sequential build.
+    if resume_build_id is not None:
+        build_id = resume_build_id
+    else:
+        build_id = registry.build_start(root_tasks=tasks_list)
+
+    def register_task_once(task: BaseTask) -> None:
+        """Register a task with the registry exactly once per build."""
+        if task.id in registered_tasks:
+            return
+        try:
+            registry.task_register(build_id, task)
+            registered_tasks.add(task.id)
+        except Exception as reg_err:
+            handle_registry_error(
+                reg_err,
+                f"Failed to register task {task.id}",
+                on_registry_failure,
+            )
 
     def discover(task: BaseTask) -> None:
-        """Recursively discover tasks, stopping at already-complete tasks."""
+        """Recursively discover tasks, stopping at already-complete tasks.
+
+        Each newly-discovered task is registered with the registry inline so
+        the full DAG becomes visible in the UI as soon as discovery finishes,
+        rather than appearing leaves-first as tasks become runnable.
+        """
         if task.id in all_tasks:
             return
         all_tasks[task.id] = task
         task_count.discovered += 1
+
+        # Register the task immediately so it's visible in the UI/DAG view.
+        register_task_once(task)
 
         # Check if this task is already complete
         if task.complete():
@@ -204,38 +243,29 @@ def build_sequential(
     for root in tasks_list:
         discover(root)
 
-    # Start or resume build
-    if resume_build_id is not None:
-        build_id = resume_build_id
-    else:
-        build_id = registry.build_start(root_tasks=tasks_list)
+    # Mark previously-completed tasks as complete in the registry. Registration
+    # already happened inline in discover(); we still need to fire
+    # task_complete so they appear COMPLETED rather than PENDING — and to
+    # self-heal tasks left in "Started" state from a previous build that
+    # crashed (their target exists, so they are complete, but the registry
+    # still shows them as running).
+    completed_previously_completed_count = 0
 
-    # Register previously completed tasks so they appear in the build's task list.
-    # We also call task_complete to mark them as done — otherwise they remain in
-    # PENDING state in the registry (e.g. WrapperTasks that are complete because
-    # their deps are complete, but were never explicitly run).
-    registered_previously_completed_count = 0
+    def mark_pending_previously_completed() -> None:
+        """Send task_complete for any previously-completed tasks not yet marked.
 
-    def register_pending_previously_completed() -> None:
-        """Register and complete any previously-completed tasks not yet sent to the registry.
-
-        Drains ``previously_completed_tasks`` starting from the last registered
-        index. Called both for the initial bulk registration and after any
-        runtime ``discover()`` call that might newly surface a complete task
-        (e.g. the static dep of a dynamically yielded task).
+        Drains ``previously_completed_tasks`` starting from the last marked
+        index. Called both for the initial bulk pass and after any runtime
+        ``discover()`` call that might newly surface a complete task (e.g. the
+        static dep of a dynamically yielded task).
         """
-        nonlocal registered_previously_completed_count
-        while registered_previously_completed_count < len(previously_completed_tasks):
-            pc_task = previously_completed_tasks[registered_previously_completed_count]
-            registered_previously_completed_count += 1
-            try:
-                registry.task_register(build_id, pc_task)
-            except Exception as reg_err:
-                handle_registry_error(
-                    reg_err,
-                    f"Failed to register previously completed task {pc_task.id}",
-                    on_registry_failure,
-                )
+        nonlocal completed_previously_completed_count
+        while completed_previously_completed_count < len(previously_completed_tasks):
+            pc_task = previously_completed_tasks[completed_previously_completed_count]
+            completed_previously_completed_count += 1
+            if pc_task.id not in registered_tasks:
+                # Registration failed in `warn` mode; can't mark complete
+                # against a row that was never written.
                 continue
             try:
                 registry.task_complete(build_id, pc_task)
@@ -246,17 +276,18 @@ def build_sequential(
                     on_registry_failure,
                 )
 
-    register_pending_previously_completed()
+    mark_pending_previously_completed()
 
     def runtime_discover(task: BaseTask) -> None:
         """``discover()`` wrapper used after the initial registration pass.
 
-        Registers any previously-completed tasks that ``discover()`` surfaces
-        at runtime (e.g. when processing a dynamically yielded task's
-        ``requires()`` chain).
+        Marks as complete any previously-completed tasks that ``discover()``
+        surfaces at runtime (e.g. when processing a dynamically yielded
+        task's ``requires()`` chain). Registration itself happens inside
+        ``discover()`` via ``register_task_once``.
         """
         discover(task)
-        register_pending_previously_completed()
+        mark_pending_previously_completed()
 
     def acquire_lock_sync(task: BaseTask) -> LockAcquisitionResult:
         """Acquire lock synchronously with retry/backoff."""
@@ -349,9 +380,11 @@ def build_sequential(
                     error = RuntimeError(
                         f"Failed to acquire lock: {lock_result.error_message}"
                     )
+                    # Ensure the task row exists before failing it (no-op if
+                    # registration succeeded during discovery; retry if it
+                    # failed in `warn` mode).
+                    register_task_once(ready_task)
                     try:
-                        # Register first so the registry has a task row to fail
-                        registry.task_register(build_id, ready_task)
                         registry.task_fail(build_id, ready_task, str(error))
                     except Exception as reg_err:
                         handle_registry_error(
@@ -377,6 +410,7 @@ def build_sequential(
                     registry,
                     dual_run_default,
                     runtime_discover,
+                    register_task_once,
                     task_count,
                     on_registry_failure,
                 )
@@ -430,6 +464,7 @@ def _run_task_sequential(
     registry: RegistryABC,
     dual_run_default: Literal["sync", "async"],
     discover: Callable[[BaseTask], None],
+    register_task_once: Callable[[BaseTask], None],
     task_count: TaskCount | None = None,
     on_registry_failure: OnRegistryFailure = "raise",
 ) -> None:
@@ -456,12 +491,16 @@ def _run_task_sequential(
                 registry,
                 dual_run_default,
                 discover,
+                register_task_once,
                 task_count,
                 on_registry_failure,
             )
             if task_count is not None:
                 task_count.succeeded += 1
 
+    # The task should already be registered (during discover), but retry once
+    # if discover-time registration failed in `warn` mode so /start doesn't 404.
+    register_task_once(task)
     registry.task_start(build_id, task)
 
     has_run = _has_custom_run(task)
@@ -524,6 +563,7 @@ def _run_task_sequential(
                             registry,
                             dual_run_default,
                             discover,
+                            register_task_once,
                             task_count,
                             on_registry_failure,
                         )
@@ -563,6 +603,10 @@ async def build_sequential_aio(
     """Async API for building tasks sequentially.
 
     This is intended primarily for debugging and testing.
+
+    Tasks are registered with the registry as they are discovered (in
+    deterministic DFS order from the roots), so the full DAG appears in the
+    UI immediately rather than progressively as tasks become runnable.
 
     Task execution policy:
     - Sync-only tasks: runs *blocking* via `run()` in main event loop if
@@ -610,13 +654,45 @@ async def build_sequential_aio(
     # Discover all tasks, stopping at already-complete tasks
     all_tasks: dict[UUID, BaseTask] = {}
     previously_completed_tasks: list[BaseTask] = []
+    # Tasks already registered with the registry. Tracked so subsequent
+    # registration attempts don't fire duplicate API calls.
+    registered_tasks: set[UUID] = set()
+
+    # Start or resume build *before* discovery so we can register tasks as
+    # they're found.
+    if resume_build_id is not None:
+        build_id = resume_build_id
+    else:
+        build_id = await registry.build_start_aio(root_tasks=tasks_list)
+
+    async def register_task_once_aio(task: BaseTask) -> None:
+        """Register a task with the registry exactly once per build."""
+        if task.id in registered_tasks:
+            return
+        try:
+            await registry.task_register_aio(build_id, task)
+            registered_tasks.add(task.id)
+        except Exception as reg_err:
+            handle_registry_error(
+                reg_err,
+                f"Failed to register task {task.id}",
+                on_registry_failure,
+            )
 
     async def discover(task: BaseTask) -> None:
-        """Recursively discover tasks, stopping at already-complete tasks."""
+        """Recursively discover tasks, stopping at already-complete tasks.
+
+        Each newly-discovered task is registered with the registry inline so
+        the full DAG becomes visible in the UI as soon as discovery finishes,
+        rather than appearing leaves-first as tasks become runnable.
+        """
         if task.id in all_tasks:
             return
         all_tasks[task.id] = task
         task_count.discovered += 1
+
+        # Register the task immediately so it's visible in the UI/DAG view.
+        await register_task_once_aio(task)
 
         # Check if this task is already complete
         if await task.complete_aio():
@@ -634,38 +710,26 @@ async def build_sequential_aio(
     for root in tasks_list:
         await discover(root)
 
-    # Start or resume build
-    if resume_build_id is not None:
-        build_id = resume_build_id
-    else:
-        build_id = await registry.build_start_aio(root_tasks=tasks_list)
+    # Mark previously-completed tasks as complete in the registry. Registration
+    # already happened inline in discover(); we still need to fire
+    # task_complete_aio so they appear COMPLETED rather than PENDING.
+    completed_previously_completed_count = 0
 
-    # Register previously completed tasks so they appear in the build's task list.
-    # We also call task_complete_aio to mark them as done — otherwise they remain in
-    # PENDING state in the registry (e.g. WrapperTasks that are complete because
-    # their deps are complete, but were never explicitly run).
-    registered_previously_completed_count = 0
+    async def mark_pending_previously_completed_aio() -> None:
+        """Send task_complete for any previously-completed tasks not yet marked.
 
-    async def register_pending_previously_completed_aio() -> None:
-        """Register and complete previously-completed tasks not yet sent to the registry.
-
-        Drains ``previously_completed_tasks`` starting from the last registered
-        index. Called for the initial bulk registration and after any runtime
+        Drains ``previously_completed_tasks`` starting from the last marked
+        index. Called for the initial bulk pass and after any runtime
         ``discover()`` call that might surface a new complete task (e.g. the
         static dep of a dynamically yielded task).
         """
-        nonlocal registered_previously_completed_count
-        while registered_previously_completed_count < len(previously_completed_tasks):
-            pc_task = previously_completed_tasks[registered_previously_completed_count]
-            registered_previously_completed_count += 1
-            try:
-                await registry.task_register_aio(build_id, pc_task)
-            except Exception as reg_err:
-                handle_registry_error(
-                    reg_err,
-                    f"Failed to register previously completed task {pc_task.id}",
-                    on_registry_failure,
-                )
+        nonlocal completed_previously_completed_count
+        while completed_previously_completed_count < len(previously_completed_tasks):
+            pc_task = previously_completed_tasks[completed_previously_completed_count]
+            completed_previously_completed_count += 1
+            if pc_task.id not in registered_tasks:
+                # Registration failed in `warn` mode; skip task_complete since
+                # the API row doesn't exist.
                 continue
             try:
                 await registry.task_complete_aio(build_id, pc_task)
@@ -676,17 +740,18 @@ async def build_sequential_aio(
                     on_registry_failure,
                 )
 
-    await register_pending_previously_completed_aio()
+    await mark_pending_previously_completed_aio()
 
     async def runtime_discover_aio(task: BaseTask) -> None:
         """``discover()`` wrapper used after the initial registration pass.
 
-        Registers any previously-completed tasks that ``discover()`` surfaces
-        at runtime (e.g. when processing a dynamically yielded task's
-        ``requires()`` chain).
+        Marks as complete any previously-completed tasks that ``discover()``
+        surfaces at runtime (e.g. when processing a dynamically yielded
+        task's ``requires()`` chain). Registration itself happens inside
+        ``discover()`` via ``register_task_once_aio``.
         """
         await discover(task)
-        await register_pending_previously_completed_aio()
+        await mark_pending_previously_completed_aio()
 
     async def acquire_lock_aio(task: BaseTask) -> LockAcquisitionResult:
         """Acquire lock asynchronously with retry/backoff."""
@@ -781,9 +846,11 @@ async def build_sequential_aio(
                     error = RuntimeError(
                         f"Failed to acquire lock: {lock_result.error_message}"
                     )
+                    # Ensure the task row exists before failing it (no-op if
+                    # registration succeeded during discovery; retry if it
+                    # failed in `warn` mode).
+                    await register_task_once_aio(ready_task)
                     try:
-                        # Register first so the registry has a task row to fail
-                        await registry.task_register_aio(build_id, ready_task)
                         await registry.task_fail_aio(build_id, ready_task, str(error))
                     except Exception as reg_err:
                         handle_registry_error(
@@ -809,6 +876,7 @@ async def build_sequential_aio(
                     registry,
                     sync_run_default,
                     runtime_discover_aio,
+                    register_task_once_aio,
                     task_count,
                     on_registry_failure,
                 )
@@ -884,6 +952,7 @@ async def _run_task_sequential_aio(
     registry: RegistryABC,
     sync_run_default: Literal["thread", "blocking"],
     discover: Callable[[BaseTask], Awaitable[None]],
+    register_task_once_aio: Callable[[BaseTask], Awaitable[None]],
     task_count: TaskCount | None = None,
     on_registry_failure: OnRegistryFailure = "raise",
 ) -> None:
@@ -901,12 +970,16 @@ async def _run_task_sequential_aio(
                 registry,
                 sync_run_default,
                 discover,
+                register_task_once_aio,
                 task_count,
                 on_registry_failure,
             )
             if task_count is not None:
                 task_count.succeeded += 1
 
+    # The task should already be registered (during discover), but retry once
+    # if discover-time registration failed in `warn` mode so /start doesn't 404.
+    await register_task_once_aio(task)
     await registry.task_start_aio(build_id, task)
 
     has_run = _has_custom_run(task)
@@ -964,6 +1037,7 @@ async def _run_task_sequential_aio(
                     registry,
                     sync_run_default,
                     discover,
+                    register_task_once_aio,
                     task_count,
                     on_registry_failure,
                 )

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -184,22 +184,31 @@ def build_sequential(
     # Discover all tasks, stopping at already-complete tasks
     all_tasks: dict[UUID, BaseTask] = {}
     previously_completed_tasks: list[BaseTask] = []
-    # Tasks already registered with the registry. Tracked so subsequent
-    # registration attempts (e.g. from `_run_task_sequential` for tasks first
-    # surfaced at runtime via dynamic deps) don't fire duplicate API calls.
+    # Tasks already registered with the registry. Tracked so the per-task
+    # retry path inside _run_task_sequential / lock-failure handling
+    # doesn't double-register.
     registered_tasks: set[UUID] = set()
+    # Tasks accumulated during the current discover() walk (post-order)
+    # awaiting the bulk-register call. Cleared by
+    # ``flush_pending_registrations()``.
+    pending_registrations: list[BaseTask] = []
 
-    # Start or resume build *before* discovery so we can register tasks as
-    # they're found. Registering on discover (instead of at start-of-execution)
-    # makes the full DAG visible in the UI immediately, and gives a stable
-    # roots-first registration order in the sequential build.
+    # Start or resume build *before* discovery so we have a build_id to
+    # register tasks against.
     if resume_build_id is not None:
         build_id = resume_build_id
     else:
         build_id = registry.build_start(root_tasks=tasks_list)
 
     def register_task_once(task: BaseTask) -> None:
-        """Register a task with the registry exactly once per build."""
+        """Register a single task (used as a fallback retry path).
+
+        The happy path uses ``flush_pending_registrations`` to bulk-
+        register every task collected during a discover walk. This per-
+        task fallback exists for the lock-failure branch and for
+        ``_run_task_sequential`` when discover-time registration was
+        skipped or failed in ``warn`` mode.
+        """
         if task.id in registered_tasks:
             return
         try:
@@ -212,20 +221,46 @@ def build_sequential(
                 on_registry_failure,
             )
 
+    def flush_pending_registrations() -> None:
+        """Bulk-register every task accumulated since the last flush.
+
+        Called after each discover walk (initial walk and any runtime
+        walk triggered by dynamic deps). On bulk-call failure: ``warn``
+        mode logs and continues; the per-task retry inside
+        ``_run_task_sequential`` will fall back to per-task register as
+        tasks become runnable. ``raise`` mode propagates.
+        """
+        if not pending_registrations:
+            return
+        batch = list(pending_registrations)
+        pending_registrations.clear()
+        try:
+            registry.task_register_bulk(build_id, batch)
+        except Exception as reg_err:
+            ids_preview = ", ".join(str(t.id) for t in batch[:5])
+            if len(batch) > 5:
+                ids_preview += f", +{len(batch) - 5} more"
+            handle_registry_error(
+                reg_err,
+                f"Failed to bulk-register {len(batch)} tasks during discovery "
+                f"(ids: {ids_preview})",
+                on_registry_failure,
+            )
+            return
+        for t in batch:
+            registered_tasks.add(t.id)
+
     def discover(task: BaseTask) -> None:
         """Recursively discover tasks, stopping at already-complete tasks.
 
-        Each newly-discovered task is registered with the registry inline so
-        the full DAG becomes visible in the UI as soon as discovery finishes,
-        rather than appearing leaves-first as tasks become runnable.
+        Discovery only collects into ``pending_registrations`` (post-order
+        — deps first, parents last). The actual bulk-register call fires
+        via ``flush_pending_registrations()`` after the walk.
         """
         if task.id in all_tasks:
             return
         all_tasks[task.id] = task
         task_count.discovered += 1
-
-        # Register the task immediately so it's visible in the UI/DAG view.
-        register_task_once(task)
 
         # Check if this task is already complete
         if task.complete():
@@ -233,12 +268,20 @@ def build_sequential(
             task_count.previously_completed += 1
             previously_completed_tasks.append(task)
             if not register_all:
-                # Don't recurse into deps - they're already built
+                # Don't recurse into deps - they're already built. Append
+                # to pending_registrations (leaf in post-order).
+                pending_registrations.append(task)
                 return
 
-        # Task not complete (or register_all) - recurse into dependencies
+        # Task not complete (or register_all) — recurse into deps first
+        # (post-order), so when we register this task its deps already
+        # exist in the API.
         for dep in flatten_task_struct(task.requires()):
             discover(dep)
+
+        # All deps are registered. Append self after children — preserves
+        # post-order within the subtree.
+        pending_registrations.append(task)
 
     # Mark previously-completed tasks as complete in the registry. Registration
     # already happened inline in discover(); we still need to fire
@@ -276,12 +319,13 @@ def build_sequential(
     def runtime_discover(task: BaseTask) -> None:
         """``discover()`` wrapper used after the initial registration pass.
 
-        Marks as complete any previously-completed tasks that ``discover()``
-        surfaces at runtime (e.g. when processing a dynamically yielded
-        task's ``requires()`` chain). Registration itself happens inside
-        ``discover()`` via ``register_task_once``.
+        Walks ``discover()`` (collecting newly-found tasks into
+        ``pending_registrations``), bulk-registers them, then sends
+        task_complete for any previously-completed tasks the walk
+        surfaced.
         """
         discover(task)
+        flush_pending_registrations()
         mark_pending_previously_completed()
 
     def acquire_lock_sync(task: BaseTask) -> LockAcquisitionResult:
@@ -348,14 +392,19 @@ def build_sequential(
             held_locks.discard(task_id)
 
     try:
-        # Discover all tasks (with inline registration). If discover() raises
-        # (e.g. requires() / complete() throws), the outer except below emits
-        # build_fail so the build doesn't get stuck in RUNNING state.
+        # Discover all tasks. If discover() raises (e.g. requires() /
+        # complete() throws), the outer except below emits build_fail so
+        # the build doesn't get stuck in RUNNING state.
         for root in tasks_list:
             discover(root)
 
-        # Mark previously-completed tasks as complete now that discovery has
-        # populated previously_completed_tasks fully.
+        # Bulk-register every discovered task in one HTTP call. Order is
+        # post-order so the API resolves dependency_task_ids without
+        # phantom-creating any rows.
+        flush_pending_registrations()
+
+        # Mark previously-completed tasks as complete now that registration
+        # has landed.
         mark_pending_previously_completed()
 
         # Build in topological order
@@ -544,28 +593,13 @@ def _run_task_sequential(
                 yielded = next(gen)
                 dynamic_deps = flatten_task_struct(yielded)
 
-                # Record yielded deps as edges so the DAG view shows them
-                # (static deps are recorded via task_register).
-                if dynamic_deps:
-                    try:
-                        registry.task_add_dependencies(
-                            build_id, task, dynamic_deps, is_dynamic=True
-                        )
-                    except Exception as reg_err:
-                        handle_registry_error(
-                            reg_err,
-                            f"Failed to record dynamic deps for task {task.id}",
-                            on_registry_failure,
-                        )
-
-                # Discover and build dynamic deps using the same discover()
-                # function used for static deps, so task_count.discovered
-                # is properly incremented and sub-deps are fully recursed.
+                # Discover and build dynamic deps FIRST. discover() runtime
+                # wrapper recurses into requires() and post-order-registers
+                # everything in the subtree, so by the time we record the
+                # edge below, every upstream row already exists in the API
+                # and _reconcile_dependency_edges doesn't have to
+                # phantom-create anything.
                 for dep in dynamic_deps:
-                    # discover() is the runtime wrapper from build_sequential: it
-                    # recurses into requires(), and registers any previously-complete
-                    # tasks it surfaces (so they appear in the build's task list even
-                    # though they were first seen after the initial registration pass).
                     discover(dep)
 
                     if dep.id not in completion_cache:
@@ -583,6 +617,20 @@ def _run_task_sequential(
                         )
                         if task_count is not None:
                             task_count.succeeded += 1
+
+                # Now record yielded deps as edges so the DAG view shows
+                # them (static deps are recorded via task_register).
+                if dynamic_deps:
+                    try:
+                        registry.task_add_dependencies(
+                            build_id, task, dynamic_deps, is_dynamic=True
+                        )
+                    except Exception as reg_err:
+                        handle_registry_error(
+                            reg_err,
+                            f"Failed to record dynamic deps for task {task.id}",
+                            on_registry_failure,
+                        )
 
             except StopIteration:
                 break
@@ -675,19 +723,26 @@ async def build_sequential_aio(
     # Discover all tasks, stopping at already-complete tasks
     all_tasks: dict[UUID, BaseTask] = {}
     previously_completed_tasks: list[BaseTask] = []
-    # Tasks already registered with the registry. Tracked so subsequent
-    # registration attempts don't fire duplicate API calls.
+    # Tasks already registered with the registry. Tracked so per-task
+    # fallback retry paths don't double-register.
     registered_tasks: set[UUID] = set()
+    # Tasks accumulated during the current discover() walk (post-order),
+    # awaiting bulk registration. Cleared by flush_pending_registrations_aio.
+    pending_registrations: list[BaseTask] = []
 
-    # Start or resume build *before* discovery so we can register tasks as
-    # they're found.
+    # Start or resume build *before* discovery so we have a build_id to
+    # register tasks against.
     if resume_build_id is not None:
         build_id = resume_build_id
     else:
         build_id = await registry.build_start_aio(root_tasks=tasks_list)
 
     async def register_task_once_aio(task: BaseTask) -> None:
-        """Register a task with the registry exactly once per build."""
+        """Register a single task (per-task fallback retry path).
+
+        Used by ``_run_task_sequential_aio`` when discover-time bulk
+        registration was skipped or failed in ``warn`` mode.
+        """
         if task.id in registered_tasks:
             return
         try:
@@ -700,20 +755,39 @@ async def build_sequential_aio(
                 on_registry_failure,
             )
 
+    async def flush_pending_registrations_aio() -> None:
+        """Bulk-register every task collected since the last flush."""
+        if not pending_registrations:
+            return
+        batch = list(pending_registrations)
+        pending_registrations.clear()
+        try:
+            await registry.task_register_bulk_aio(build_id, batch)
+        except Exception as reg_err:
+            ids_preview = ", ".join(str(t.id) for t in batch[:5])
+            if len(batch) > 5:
+                ids_preview += f", +{len(batch) - 5} more"
+            handle_registry_error(
+                reg_err,
+                f"Failed to bulk-register {len(batch)} tasks during discovery "
+                f"(ids: {ids_preview})",
+                on_registry_failure,
+            )
+            return
+        for t in batch:
+            registered_tasks.add(t.id)
+
     async def discover(task: BaseTask) -> None:
         """Recursively discover tasks, stopping at already-complete tasks.
 
-        Each newly-discovered task is registered with the registry inline so
-        the full DAG becomes visible in the UI as soon as discovery finishes,
-        rather than appearing leaves-first as tasks become runnable.
+        Discovery only collects into ``pending_registrations`` in
+        post-order (deps first, parents last). The bulk-register call
+        fires via ``flush_pending_registrations_aio()`` after the walk.
         """
         if task.id in all_tasks:
             return
         all_tasks[task.id] = task
         task_count.discovered += 1
-
-        # Register the task immediately so it's visible in the UI/DAG view.
-        await register_task_once_aio(task)
 
         # Check if this task is already complete
         if await task.complete_aio():
@@ -721,12 +795,19 @@ async def build_sequential_aio(
             task_count.previously_completed += 1
             previously_completed_tasks.append(task)
             if not register_all:
-                # Don't recurse into deps - they're already built
+                # Don't recurse into deps - they're already built. Append
+                # to pending_registrations (leaf in post-order).
+                pending_registrations.append(task)
                 return
 
-        # Task not complete (or register_all) - recurse into dependencies
+        # Task not complete (or register_all) — recurse into deps first
+        # (post-order), so by the time the bulk register call processes
+        # this task its deps are already in the array (and thus in the DB).
         for dep in flatten_task_struct(task.requires()):
             await discover(dep)
+
+        # Append self after children — preserves post-order within subtree.
+        pending_registrations.append(task)
 
     # Mark previously-completed tasks as complete in the registry. Registration
     # already happened inline in discover(); we still need to fire
@@ -761,12 +842,13 @@ async def build_sequential_aio(
     async def runtime_discover_aio(task: BaseTask) -> None:
         """``discover()`` wrapper used after the initial registration pass.
 
-        Marks as complete any previously-completed tasks that ``discover()``
-        surfaces at runtime (e.g. when processing a dynamically yielded
-        task's ``requires()`` chain). Registration itself happens inside
-        ``discover()`` via ``register_task_once_aio``.
+        Walks ``discover()`` (collecting newly-found tasks into
+        ``pending_registrations``), bulk-registers them, then sends
+        task_complete for any previously-completed tasks the walk
+        surfaced.
         """
         await discover(task)
+        await flush_pending_registrations_aio()
         await mark_pending_previously_completed_aio()
 
     async def acquire_lock_aio(task: BaseTask) -> LockAcquisitionResult:
@@ -835,14 +917,17 @@ async def build_sequential_aio(
             held_locks.discard(task_id)
 
     try:
-        # Discover all tasks (with inline registration). If discover() raises
-        # (e.g. requires() / complete_aio() throws), the outer except below
-        # emits build_fail_aio so the build doesn't get stuck in RUNNING state.
+        # Discover all tasks. If discover() raises (e.g. requires() /
+        # complete_aio() throws), the outer except below emits
+        # build_fail_aio so the build doesn't get stuck in RUNNING state.
         for root in tasks_list:
             await discover(root)
 
-        # Mark previously-completed tasks as complete now that discovery has
-        # populated previously_completed_tasks fully.
+        # Bulk-register every discovered task in one HTTP call.
+        await flush_pending_registrations_aio()
+
+        # Mark previously-completed tasks as complete now that registration
+        # has landed.
         await mark_pending_previously_completed_aio()
 
         # Build in topological order
@@ -1042,24 +1127,11 @@ async def _run_task_sequential_aio(
     async for yielded in _iter_dynamic_deps(result):
         dynamic_deps = flatten_task_struct(yielded)
 
-        # Record yielded deps as edges so the DAG view shows them
-        # (static deps are recorded via task_register).
-        if dynamic_deps:
-            try:
-                await registry.task_add_dependencies_aio(
-                    build_id, task, dynamic_deps, is_dynamic=True
-                )
-            except Exception as reg_err:
-                handle_registry_error(
-                    reg_err,
-                    f"Failed to record dynamic deps for task {task.id}",
-                    on_registry_failure,
-                )
-
-        # discover() is the runtime wrapper from build_sequential_aio: it
-        # recurses into requires(), and registers any previously-complete
-        # tasks it surfaces (so they appear in the build's task list even
-        # though they were first seen after the initial registration pass).
+        # Discover and build dynamic deps FIRST. discover() is the runtime
+        # wrapper that recurses into requires() and post-order-registers
+        # everything in the subtree, so the upstream rows already exist in
+        # the API by the time we record the edge below — no phantom
+        # creation in _reconcile_dependency_edges.
         for dep in dynamic_deps:
             await discover(dep)
 
@@ -1078,6 +1150,20 @@ async def _run_task_sequential_aio(
                 )
                 if task_count is not None:
                     task_count.succeeded += 1
+
+        # Now record yielded deps as edges so the DAG view shows them
+        # (static deps are recorded via task_register).
+        if dynamic_deps:
+            try:
+                await registry.task_add_dependencies_aio(
+                    build_id, task, dynamic_deps, is_dynamic=True
+                )
+            except Exception as reg_err:
+                handle_registry_error(
+                    reg_err,
+                    f"Failed to record dynamic deps for task {task.id}",
+                    on_registry_failure,
+                )
 
     completion_cache.add(task.id)
     try:

--- a/lib/stardag/src/stardag/integration/prefect/_build.py
+++ b/lib/stardag/src/stardag/integration/prefect/_build.py
@@ -117,6 +117,10 @@ class _PrefectTaskRunWrapper:
             - Generator: Task has dynamic deps and is suspended (in-process).
             - TaskStruct: Task has dynamic deps but completed (cross-process).
         """
+        # Register before starting — the /start endpoint requires the task
+        # to exist in the build, and as of the discover-time-registration
+        # change `task_start_aio` no longer auto-registers.
+        await self.registry.task_register_aio(self.build_id, task)
         await self.registry.task_start_aio(self.build_id, task)
 
         if self.before_run_callback is not None:

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -45,6 +45,12 @@ _RETRY_CONFIG = Retry(
 _MAX_RATE_LIMIT_RETRIES = 5
 _MAX_RETRY_WAIT = 60  # Cap wait time at 60 seconds
 
+# Maximum number of tasks per ``task_register_bulk[_aio]`` HTTP call.
+# Mirrors the server's per-call cap; the build engine chunks above this so
+# this is mostly a defensive check for direct external callers of
+# ``APIRegistry``.
+_MAX_BULK_REGISTER_TASKS = 1000
+
 
 def _is_route_not_found(err: NotFoundError) -> bool:
     """Distinguish FastAPI's default "missing route" 404 from app-level 404s.
@@ -424,9 +430,21 @@ class APIRegistry(RegistryABC):
         Falls back to per-task ``task_register`` if the API doesn't
         support the endpoint (older deployments) — same backwards-compat
         pattern as ``task_add_dependencies``.
+
+        Raises ``ValueError`` if the batch exceeds
+        ``_MAX_BULK_REGISTER_TASKS`` (mirrors the server cap). The build
+        engine chunks above this method; external callers of
+        ``APIRegistry`` get an explicit client-side error rather than a
+        400 from the server.
         """
         if not tasks:
             return
+        if len(tasks) > _MAX_BULK_REGISTER_TASKS:
+            raise ValueError(
+                f"task_register_bulk supports at most {_MAX_BULK_REGISTER_TASKS} "
+                f"tasks per call (got {len(tasks)}). Chunk the input on the "
+                f"caller side."
+            )
         try:
             self._request(
                 "POST",
@@ -790,9 +808,20 @@ class APIRegistry(RegistryABC):
 
         Falls back to per-task ``task_register_aio`` if the API doesn't
         support the endpoint (older deployments).
+
+        Raises ``ValueError`` if the batch exceeds
+        ``_MAX_BULK_REGISTER_TASKS`` (mirrors the server cap). The build
+        engine chunks above this method; external callers get an
+        explicit client-side error rather than a 400 from the server.
         """
         if not tasks:
             return
+        if len(tasks) > _MAX_BULK_REGISTER_TASKS:
+            raise ValueError(
+                f"task_register_bulk_aio supports at most {_MAX_BULK_REGISTER_TASKS} "
+                f"tasks per call (got {len(tasks)}). Chunk the input on the "
+                f"caller side."
+            )
         try:
             await self._arequest(
                 "POST",

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -428,10 +428,12 @@ class APIRegistry(RegistryABC):
         return params
 
     def task_start(self, build_id: UUID, task: "BaseTask") -> None:
-        """Mark a task as started."""
-        # Ensure task is registered first
-        self.task_register(build_id, task)
+        """Mark a task as started.
 
+        Caller must have already registered the task (via ``task_register`` or
+        as a side effect of a parent's static-deps reconciliation). The /start
+        endpoint will 404 otherwise.
+        """
         self._request(
             "POST",
             f"{self.api_url}/api/v1/builds/{build_id}/tasks/{task.id}/start",
@@ -754,9 +756,12 @@ class APIRegistry(RegistryABC):
         )
 
     async def task_start_aio(self, build_id: UUID, task: "BaseTask") -> None:
-        """Async version - mark a task as started."""
-        await self.task_register_aio(build_id, task)
+        """Async version - mark a task as started.
 
+        Caller must have already registered the task (via ``task_register_aio``
+        or as a side effect of a parent's static-deps reconciliation). The
+        /start endpoint will 404 otherwise.
+        """
         await self._arequest(
             "POST",
             f"{self.api_url}/api/v1/builds/{build_id}/tasks/{task.id}/start",

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -418,6 +418,34 @@ class APIRegistry(RegistryABC):
             operation=f"Register task {task.id}",
         )
 
+    def task_register_bulk(self, build_id: UUID, tasks: Sequence["BaseTask"]) -> None:
+        """Bulk-register tasks via the ``/tasks/bulk`` endpoint.
+
+        Falls back to per-task ``task_register`` if the API doesn't
+        support the endpoint (older deployments) — same backwards-compat
+        pattern as ``task_add_dependencies``.
+        """
+        if not tasks:
+            return
+        try:
+            self._request(
+                "POST",
+                f"{self.api_url}/api/v1/builds/{build_id}/tasks/bulk",
+                json={"tasks": [_get_task_data_for_registration(t) for t in tasks]},
+                params=self._get_params(),
+                operation=f"Bulk-register {len(tasks)} tasks",
+            )
+        except NotFoundError as e:
+            if not _is_route_not_found(e):
+                raise
+            logger.warning(
+                "Registry API does not support POST /tasks/bulk; "
+                "falling back to per-task registration. "
+                "Upgrade the Registry API for batched registration."
+            )
+            for t in tasks:
+                self.task_register(build_id, t)
+
     def _get_event_params(self) -> dict[str, str]:
         """Get query params for event endpoints, including commit_hash."""
         params = self._get_params()
@@ -754,6 +782,35 @@ class APIRegistry(RegistryABC):
             params=self._get_params(),
             operation=f"Register task {task.id}",
         )
+
+    async def task_register_bulk_aio(
+        self, build_id: UUID, tasks: Sequence["BaseTask"]
+    ) -> None:
+        """Async bulk-register via ``/tasks/bulk`` (one HTTP call instead of N).
+
+        Falls back to per-task ``task_register_aio`` if the API doesn't
+        support the endpoint (older deployments).
+        """
+        if not tasks:
+            return
+        try:
+            await self._arequest(
+                "POST",
+                f"{self.api_url}/api/v1/builds/{build_id}/tasks/bulk",
+                json={"tasks": [_get_task_data_for_registration(t) for t in tasks]},
+                params=self._get_params(),
+                operation=f"Bulk-register {len(tasks)} tasks",
+            )
+        except NotFoundError as e:
+            if not _is_route_not_found(e):
+                raise
+            logger.warning(
+                "Registry API does not support POST /tasks/bulk; "
+                "falling back to per-task registration. "
+                "Upgrade the Registry API for batched registration."
+            )
+            for t in tasks:
+                await self.task_register_aio(build_id, t)
 
     async def task_start_aio(self, build_id: UUID, task: "BaseTask") -> None:
         """Async version - mark a task as started.

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -1,10 +1,12 @@
 """API-based registry that communicates with the stardag-api service."""
 
 import asyncio
+import gzip
+import json as _json
 import logging
 import time
 from collections.abc import Sequence
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from uuid import UUID
 
 import httpx
@@ -50,6 +52,41 @@ _MAX_RETRY_WAIT = 60  # Cap wait time at 60 seconds
 # this is mostly a defensive check for direct external callers of
 # ``APIRegistry``.
 _MAX_BULK_REGISTER_TASKS = 1000
+
+# Threshold above which JSON request bodies are gzipped before sending.
+# Below this, gzip's headers + per-call CPU make compression a net loss;
+# above it, repeated keys / structure in our payloads (especially
+# ``task_register_bulk``) compress 5–10×, so the wire savings dominate.
+# The server transparently decompresses via ``GZipRequestMiddleware``.
+_GZIP_REQUEST_THRESHOLD_BYTES = 1024
+
+
+def _maybe_gzip_json_body(
+    body: object,
+) -> tuple[bytes | None, dict[str, str]]:
+    """Serialize a JSON body and gzip it when worthwhile.
+
+    Returns a ``(content_bytes, extra_headers)`` pair suitable for httpx's
+    ``content=`` + ``headers=`` kwargs:
+
+    - ``body is None`` -> ``(None, {})`` (caller skips the JSON body
+      entirely).
+    - body small (< ``_GZIP_REQUEST_THRESHOLD_BYTES``) -> raw JSON bytes
+      + ``Content-Type: application/json``.
+    - body big -> gzipped JSON bytes + ``Content-Type`` and
+      ``Content-Encoding: gzip``.
+
+    Always serialises with ``separators=(",", ":")`` so the size
+    threshold doesn't depend on whitespace.
+    """
+    if body is None:
+        return None, {}
+    encoded = _json.dumps(body, separators=(",", ":")).encode("utf-8")
+    headers: dict[str, str] = {"Content-Type": "application/json"}
+    if len(encoded) < _GZIP_REQUEST_THRESHOLD_BYTES:
+        return encoded, headers
+    headers["Content-Encoding"] = "gzip"
+    return gzip.compress(encoded), headers
 
 
 def _is_route_not_found(err: NotFoundError) -> bool:
@@ -265,12 +302,22 @@ class APIRegistry(RegistryABC):
     ) -> httpx.Response:
         """Make a sync HTTP request with automatic rate-limit retry.
 
+        JSON bodies above ``_GZIP_REQUEST_THRESHOLD_BYTES`` are gzipped
+        before sending; the server's ``GZipRequestMiddleware`` handles
+        the decode transparently.
+
         Rate limit 429s (RATE_LIMIT error_code) are retried with backoff
         respecting the Retry-After header. Quota 429s (24h limits) are
         raised immediately as QuotaExceededError.
         """
+        content, body_headers = _maybe_gzip_json_body(json)
+        request_kwargs: dict[str, Any] = {"params": params}
+        if content is not None:
+            request_kwargs["content"] = content
+            request_kwargs["headers"] = body_headers
+
         for attempt in range(_MAX_RATE_LIMIT_RETRIES + 1):
-            response = self.client.request(method, url, json=json, params=params)
+            response = self.client.request(method, url, **request_kwargs)
             try:
                 self._handle_response_error(response, operation)
                 return response
@@ -305,14 +352,22 @@ class APIRegistry(RegistryABC):
     ) -> httpx.Response:
         """Make an async HTTP request with automatic rate-limit retry.
 
+        JSON bodies above ``_GZIP_REQUEST_THRESHOLD_BYTES`` are gzipped
+        before sending; the server's ``GZipRequestMiddleware`` handles
+        the decode transparently.
+
         Rate limit 429s (RATE_LIMIT error_code) are retried with backoff
         respecting the Retry-After header. Quota 429s (24h limits) are
         raised immediately as QuotaExceededError.
         """
+        content, body_headers = _maybe_gzip_json_body(json)
+        request_kwargs: dict[str, Any] = {"params": params}
+        if content is not None:
+            request_kwargs["content"] = content
+            request_kwargs["headers"] = body_headers
+
         for attempt in range(_MAX_RATE_LIMIT_RETRIES + 1):
-            response = await self.async_client.request(
-                method, url, json=json, params=params
-            )
+            response = await self.async_client.request(method, url, **request_kwargs)
             try:
                 self._handle_response_error(response, operation)
                 return response

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -47,10 +47,15 @@ _RETRY_CONFIG = Retry(
 _MAX_RATE_LIMIT_RETRIES = 5
 _MAX_RETRY_WAIT = 60  # Cap wait time at 60 seconds
 
-# Maximum number of tasks per ``task_register_bulk[_aio]`` HTTP call.
-# Mirrors the server's per-call cap; the build engine chunks above this so
-# this is mostly a defensive check for direct external callers of
-# ``APIRegistry``.
+# Hard cap on tasks per ``task_register_bulk[_aio]`` HTTP call. Mirrors
+# the server's per-call cap.
+#
+# **Asymmetry intentional**: the build engine's
+# ``_BULK_REGISTER_CHUNK_SIZE`` (50) is the *working* size — small
+# enough to keep DB transactions short and request bodies friendly.
+# The 1000 here is the *defensive* ceiling for direct external callers
+# of ``APIRegistry`` who haven't been told about the lower working
+# size. Don't reduce this thinking 50 is the real limit — it isn't.
 _MAX_BULK_REGISTER_TASKS = 1000
 
 # Threshold above which JSON request bodies are gzipped before sending.

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -496,6 +496,11 @@ class APIRegistry(RegistryABC):
         engine chunks above this method; external callers of
         ``APIRegistry`` get an explicit client-side error rather than a
         400 from the server.
+
+        Passes ``?id_only=true`` so the server returns only the
+        ``{id, task_id}`` mapping rather than echoing back full
+        ``TaskResponse`` rows we'd discard anyway. Cuts response size
+        by ~10× for batches with rich task_data.
         """
         if not tasks:
             return
@@ -510,7 +515,7 @@ class APIRegistry(RegistryABC):
                 "POST",
                 f"{self.api_url}/api/v1/builds/{build_id}/tasks/bulk",
                 json={"tasks": [_get_task_data_for_registration(t) for t in tasks]},
-                params=self._get_params(),
+                params={**self._get_params(), "id_only": "true"},
                 operation=f"Bulk-register {len(tasks)} tasks",
             )
         except NotFoundError as e:
@@ -873,6 +878,11 @@ class APIRegistry(RegistryABC):
         ``_MAX_BULK_REGISTER_TASKS`` (mirrors the server cap). The build
         engine chunks above this method; external callers get an
         explicit client-side error rather than a 400 from the server.
+
+        Passes ``?id_only=true`` so the server returns only the
+        ``{id, task_id}`` mapping rather than echoing full ``TaskResponse``
+        rows that we discard. Cuts response size by ~10× for batches
+        with rich task_data.
         """
         if not tasks:
             return
@@ -887,7 +897,7 @@ class APIRegistry(RegistryABC):
                 "POST",
                 f"{self.api_url}/api/v1/builds/{build_id}/tasks/bulk",
                 json={"tasks": [_get_task_data_for_registration(t) for t in tasks]},
-                params=self._get_params(),
+                params={**self._get_params(), "id_only": "true"},
                 operation=f"Bulk-register {len(tasks)} tasks",
             )
         except NotFoundError as e:

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -129,6 +129,26 @@ class RegistryABC(metaclass=abc.ABCMeta):
         """
         pass
 
+    def task_register_bulk(self, build_id: UUID, tasks: Sequence["BaseTask"]) -> None:
+        """Register many tasks to a build in a single call.
+
+        Default implementation falls back to ``task_register`` per task —
+        backends that can batch (e.g. the API registry's bulk endpoint)
+        should override this to make one HTTP call instead of N.
+
+        Order of ``tasks`` is significant: the SDK's post-order discover
+        walk emits deps before parents so that ``dependency_task_ids``
+        lookups inside the registry resolve to existing rows (no phantom
+        creation). Backends that process the batch as one transaction
+        should preserve array order.
+
+        Args:
+            build_id: The build UUID returned by build_start.
+            tasks: Tasks to register, in registration order.
+        """
+        for task in tasks:
+            self.task_register(build_id, task)
+
     def task_start(self, build_id: UUID, task: "BaseTask") -> None:
         """Mark a task as started/running.
 
@@ -305,6 +325,18 @@ class RegistryABC(metaclass=abc.ABCMeta):
     async def task_register_aio(self, build_id: UUID, task: "BaseTask") -> None:
         """Async version of task_register."""
         self.task_register(build_id, task)
+
+    async def task_register_bulk_aio(
+        self, build_id: UUID, tasks: Sequence["BaseTask"]
+    ) -> None:
+        """Async version of task_register_bulk.
+
+        Default implementation falls back to ``task_register_aio`` per
+        task. Override for backends that can batch (the API registry
+        does so with the ``/tasks/bulk`` endpoint).
+        """
+        for task in tasks:
+            await self.task_register_aio(build_id, task)
 
     async def task_start_aio(self, build_id: UUID, task: "BaseTask") -> None:
         """Async version of task_start."""

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -132,7 +132,9 @@ class RegistryABC(metaclass=abc.ABCMeta):
     def task_start(self, build_id: UUID, task: "BaseTask") -> None:
         """Mark a task as started/running.
 
-        Called immediately before a task begins execution.
+        Called immediately before a task begins execution. The caller is
+        responsible for having already registered the task in the build —
+        ``task_start`` only emits the started event.
 
         Args:
             build_id: The build UUID returned by build_start.

--- a/lib/stardag/tests/test_build/test_sequential.py
+++ b/lib/stardag/tests/test_build/test_sequential.py
@@ -1595,6 +1595,105 @@ class TestBulkRegister:
         )
 
 
+class TestConcurrentDiscoverRaceFreedom:
+    """The concurrent discover walk used a fast-path
+    ``if task.id in task_states: return`` that could let a sibling
+    discoverer for a shared dep return *before* the original discoverer
+    appended that dep to ``pending_registrations`` — letting a parent
+    append ahead of its dep and re-introducing phantom-creation. Fixed
+    by waiting on a per-task ``discover_done`` event in the fast-path.
+
+    A diamond DAG (parent → mid_a, mid_b; mid_a, mid_b → leaf) exercises
+    this: both mid_a and mid_b race on ``discover(leaf)``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_diamond_dag_orders_shared_dep_before_all_parents(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = BulkTrackingRegistry()
+
+        leaf = SyncOnlyTask(name="diamond_leaf")
+        mid_a = SyncOnlyTask(name="diamond_mid_a", deps=(leaf,))
+        mid_b = SyncOnlyTask(name="diamond_mid_b", deps=(leaf,))
+        parent = SyncOnlyTask(name="diamond_parent", deps=(mid_a, mid_b))
+
+        await build_aio([parent], registry=registry)
+
+        assert len(registry.bulk_batches) == 1
+        order = registry.bulk_batches[0]
+        positions = {tid: i for i, tid in enumerate(order)}
+
+        # Shared dep must appear before *both* its parents, even when
+        # they're discovered concurrently and one of them hits the
+        # fast-path on the second discover(leaf) call.
+        assert positions[leaf.id] < positions[mid_a.id]
+        assert positions[leaf.id] < positions[mid_b.id]
+        # Parent comes last.
+        assert positions[parent.id] == len(order) - 1
+
+
+class TestBulkRegisterChunking:
+    """Discovery batches over the API cap must be chunked into
+    <=cap-sized bulk calls — otherwise the server 400s and we silently
+    fall back to per-task registration in warn mode (defeating the
+    bulk-register optimisation).
+    """
+
+    def test_sequential_chunks_large_batch(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        monkeypatch,
+    ):
+        """Force chunking by lowering the chunk constant to 3, build a
+        DAG of 7 tasks, assert 3 chunked bulk calls of sizes 3, 3, 1."""
+        from stardag.build import _sequential
+
+        monkeypatch.setattr(_sequential, "_BULK_REGISTER_CHUNK_SIZE", 3)
+
+        registry = BulkTrackingRegistry()
+        leaves = [SyncOnlyTask(name=f"chunk_leaf_{i}") for i in range(6)]
+        root = SyncOnlyTask(name="chunk_root", deps=tuple(leaves))
+
+        build_sequential([root], registry=registry)
+
+        # 7 tasks total → 3 chunks at chunk_size=3 (3+3+1).
+        chunk_sizes = [len(b) for b in registry.bulk_batches]
+        assert chunk_sizes == [3, 3, 1], (
+            f"Expected chunks of [3, 3, 1]; got {chunk_sizes}"
+        )
+        # All tasks accounted for, in post-order — root last.
+        flat = [tid for chunk in registry.bulk_batches for tid in chunk]
+        assert set(flat) == {root.id, *(leaf.id for leaf in leaves)}
+        assert flat[-1] == root.id
+
+    @pytest.mark.asyncio
+    async def test_concurrent_chunks_large_batch(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        monkeypatch,
+    ):
+        from stardag.build import _concurrent
+
+        monkeypatch.setattr(_concurrent, "_BULK_REGISTER_CHUNK_SIZE", 3)
+
+        registry = BulkTrackingRegistry()
+        leaves = [SyncOnlyTask(name=f"async_chunk_leaf_{i}") for i in range(6)]
+        root = SyncOnlyTask(name="async_chunk_root", deps=tuple(leaves))
+
+        await build_aio([root], registry=registry)
+
+        chunk_sizes = [len(b) for b in registry.bulk_batches]
+        assert chunk_sizes == [3, 3, 1], chunk_sizes
+        flat = [tid for chunk in registry.bulk_batches for tid in chunk]
+        assert set(flat) == {root.id, *(leaf.id for leaf in leaves)}
+        # Root must come after every leaf even with concurrent sibling
+        # interleaving.
+        leaf_positions = [flat.index(leaf.id) for leaf in leaves]
+        assert flat.index(root.id) > max(leaf_positions)
+
+
 class TestNoPhantomsHappyPath:
     """In normal operation (post-order discover + bulk register) every
     task is registered with its real data before any edge referencing it

--- a/lib/stardag/tests/test_build/test_sequential.py
+++ b/lib/stardag/tests/test_build/test_sequential.py
@@ -1208,3 +1208,243 @@ class TestDynamicDepEdgesRegistryAio:
         assert (dyn.id, parent.id) in tracking.dynamic_dep_edges, (
             f"Dynamic edge not reported; saw: {tracking.dynamic_dep_edges}"
         )
+
+
+# ============================================================================
+# Test: Discover-time task registration
+#
+# All discovered tasks must be registered with the registry before any task
+# starts executing (so the full DAG is visible in the UI immediately, not
+# leaves-first as tasks become runnable). Sequential build must register in
+# deterministic DFS order from the roots.
+# ============================================================================
+
+
+class OrderedTrackingRegistry(NoOpRegistry):
+    """A NoOpRegistry that records the order of every lifecycle call."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, UUID]] = []
+
+    def task_register(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_register", task.id))
+
+    def task_start(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_start", task.id))
+
+    def task_complete(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_complete", task.id))
+
+    def task_fail(self, build_id: UUID, task, error_message=None) -> None:
+        self.calls.append(("task_fail", task.id))
+
+    async def task_register_aio(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_register", task.id))
+
+    async def task_start_aio(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_start", task.id))
+
+    async def task_complete_aio(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_complete", task.id))
+
+    async def task_fail_aio(self, build_id: UUID, task, error_message=None) -> None:
+        self.calls.append(("task_fail", task.id))
+
+
+class TestDiscoverTimeRegistrationSequential:
+    """Sequential build registers all discovered tasks before any task starts."""
+
+    def test_all_tasks_registered_before_any_start(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Every discovered task should be registered before the first task_start."""
+        tracking = OrderedTrackingRegistry()
+
+        leaf_a = SyncOnlyTask(name="reg_leaf_a")
+        leaf_b = SyncOnlyTask(name="reg_leaf_b")
+        root = SyncOnlyTask(name="reg_root", deps=(leaf_a, leaf_b))
+
+        summary = build_sequential([root], registry=tracking)
+        assert summary.status == BuildExitStatus.SUCCESS
+
+        first_start_idx = next(
+            i for i, (m, _) in enumerate(tracking.calls) if m == "task_start"
+        )
+        prefix = tracking.calls[:first_start_idx]
+        registered_before_start = {tid for m, tid in prefix if m == "task_register"}
+
+        assert {leaf_a.id, leaf_b.id, root.id}.issubset(registered_before_start), (
+            f"Expected all 3 tasks registered before first task_start; "
+            f"prefix calls: {prefix}"
+        )
+
+    def test_each_task_registered_exactly_once(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """task_register must be called exactly once per task per build (no
+        duplicate-from-task_start_aio noise)."""
+        tracking = OrderedTrackingRegistry()
+
+        leaf = SyncOnlyTask(name="once_leaf")
+        root = SyncOnlyTask(name="once_root", deps=(leaf,))
+
+        build_sequential([root], registry=tracking)
+
+        for task in (leaf, root):
+            register_calls = [
+                c for c in tracking.calls if c == ("task_register", task.id)
+            ]
+            assert len(register_calls) == 1, (
+                f"Expected exactly 1 task_register for {task.id}, got {register_calls}"
+            )
+
+    def test_registration_order_is_dfs_from_roots(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Sequential build registers in DFS order: root first, then deps."""
+        tracking = OrderedTrackingRegistry()
+
+        leaf_a = SyncOnlyTask(name="dfs_leaf_a")
+        leaf_b = SyncOnlyTask(name="dfs_leaf_b")
+        root = SyncOnlyTask(name="dfs_root", deps=(leaf_a, leaf_b))
+
+        build_sequential([root], registry=tracking)
+
+        register_order = [tid for m, tid in tracking.calls if m == "task_register"]
+        # Each task registered exactly once and the order is root, leaf_a, leaf_b
+        assert register_order == [root.id, leaf_a.id, leaf_b.id], (
+            f"Expected DFS-from-root order; got {register_order}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_all_tasks_registered_before_start_aio(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        tracking = OrderedTrackingRegistry()
+
+        leaf = SyncOnlyTask(name="aio_leaf")
+        root = SyncOnlyTask(name="aio_root", deps=(leaf,))
+
+        await build_sequential_aio([root], registry=tracking)
+
+        first_start_idx = next(
+            i for i, (m, _) in enumerate(tracking.calls) if m == "task_start"
+        )
+        prefix = tracking.calls[:first_start_idx]
+        registered_before_start = {tid for m, tid in prefix if m == "task_register"}
+        assert {leaf.id, root.id}.issubset(registered_before_start)
+
+    @pytest.mark.asyncio
+    async def test_each_task_registered_exactly_once_aio(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        tracking = OrderedTrackingRegistry()
+        leaf = SyncOnlyTask(name="once_leaf_aio")
+        root = SyncOnlyTask(name="once_root_aio", deps=(leaf,))
+        await build_sequential_aio([root], registry=tracking)
+        for task in (leaf, root):
+            register_calls = [
+                c for c in tracking.calls if c == ("task_register", task.id)
+            ]
+            assert len(register_calls) == 1
+
+    def test_dynamic_deps_registered_when_discovered(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Tasks first discovered through a dynamic-deps yield must also be
+        registered (and only once)."""
+        tracking = OrderedTrackingRegistry()
+
+        dyn = DynamicDepsTask(value="dyn_reg")
+        orchestrator = DynamicDepsTask(value="orch_reg", dynamic_deps=(dyn,))
+
+        summary = build_sequential([orchestrator], registry=tracking)
+        assert summary.status == BuildExitStatus.SUCCESS
+
+        for task in (orchestrator, dyn):
+            register_calls = [
+                c for c in tracking.calls if c == ("task_register", task.id)
+            ]
+            assert len(register_calls) == 1, (
+                f"Expected exactly 1 task_register for {task.id}, got {register_calls}"
+            )
+
+
+@pytest.mark.parametrize(
+    "build_aio_fn",
+    [build_aio, build_sequential_aio],
+    ids=["concurrent", "sequential"],
+)
+class TestDiscoverTimeRegistrationAio:
+    """Both async builds register every discovered task once, before any
+    task starts. Concurrent build doesn't guarantee a deterministic order
+    between siblings, but parents-before-deps holds and start-after-register
+    holds for every task."""
+
+    @pytest.mark.asyncio
+    async def test_all_registered_before_any_start(
+        self,
+        build_aio_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        tracking = OrderedTrackingRegistry()
+        leaf_a = SyncOnlyTask(name=f"common_a_{build_aio_fn.__name__}")
+        leaf_b = SyncOnlyTask(name=f"common_b_{build_aio_fn.__name__}")
+        root = SyncOnlyTask(
+            name=f"common_root_{build_aio_fn.__name__}", deps=(leaf_a, leaf_b)
+        )
+        await build_aio_fn([root], registry=tracking)
+
+        first_start_idx = next(
+            i for i, (m, _) in enumerate(tracking.calls) if m == "task_start"
+        )
+        prefix = tracking.calls[:first_start_idx]
+        registered_before_start = {tid for m, tid in prefix if m == "task_register"}
+        assert {leaf_a.id, leaf_b.id, root.id}.issubset(registered_before_start)
+
+    @pytest.mark.asyncio
+    async def test_each_task_registered_exactly_once(
+        self,
+        build_aio_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        tracking = OrderedTrackingRegistry()
+        leaf = SyncOnlyTask(name=f"once_leaf_{build_aio_fn.__name__}")
+        root = SyncOnlyTask(name=f"once_root_{build_aio_fn.__name__}", deps=(leaf,))
+        await build_aio_fn([root], registry=tracking)
+        for task in (leaf, root):
+            register_calls = [
+                c for c in tracking.calls if c == ("task_register", task.id)
+            ]
+            assert len(register_calls) == 1, (
+                f"Expected exactly 1 task_register for {task.id}, got {register_calls}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_previously_completed_registered_in_discover(
+        self,
+        build_aio_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Previously-completed tasks should also be registered exactly once
+        and never get task_start."""
+        # Pre-build to make the task previously-complete.
+        pre = SyncOnlyTask(name=f"pre_{build_aio_fn.__name__}")
+        await build_aio_fn([pre], registry=NoOpRegistry())
+        assert pre.complete()
+
+        tracking = OrderedTrackingRegistry()
+        await build_aio_fn([pre], registry=tracking)
+
+        register_calls = [c for c in tracking.calls if c == ("task_register", pre.id)]
+        complete_calls = [c for c in tracking.calls if c == ("task_complete", pre.id)]
+        start_calls = [c for c in tracking.calls if c == ("task_start", pre.id)]
+        assert len(register_calls) == 1
+        assert len(complete_calls) == 1
+        assert start_calls == []

--- a/lib/stardag/tests/test_build/test_sequential.py
+++ b/lib/stardag/tests/test_build/test_sequential.py
@@ -1300,11 +1300,15 @@ class TestDiscoverTimeRegistrationSequential:
                 f"Expected exactly 1 task_register for {task.id}, got {register_calls}"
             )
 
-    def test_registration_order_is_dfs_from_roots(
+    def test_registration_order_is_post_order_dfs(
         self,
         default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
     ):
-        """Sequential build registers in DFS order: root first, then deps."""
+        """Sequential build registers in post-order DFS: leaves first, then
+        their parents. This ensures every dep already exists in the registry
+        by the time its parent is registered, so the API never has to
+        phantom-create a dep row.
+        """
         tracking = OrderedTrackingRegistry()
 
         leaf_a = SyncOnlyTask(name="dfs_leaf_a")
@@ -1314,9 +1318,9 @@ class TestDiscoverTimeRegistrationSequential:
         build_sequential([root], registry=tracking)
 
         register_order = [tid for m, tid in tracking.calls if m == "task_register"]
-        # Each task registered exactly once and the order is root, leaf_a, leaf_b
-        assert register_order == [root.id, leaf_a.id, leaf_b.id], (
-            f"Expected DFS-from-root order; got {register_order}"
+        # Post-order DFS: leaf_a, leaf_b, root.
+        assert register_order == [leaf_a.id, leaf_b.id, root.id], (
+            f"Expected post-order DFS (leaves before parents); got {register_order}"
         )
 
     @pytest.mark.asyncio
@@ -1448,6 +1452,181 @@ class TestDiscoverTimeRegistrationAio:
         assert len(register_calls) == 1
         assert len(complete_calls) == 1
         assert start_calls == []
+
+
+# ============================================================================
+# Test: Bulk register
+#
+# Build engine should emit one bulk-register call per discover walk
+# instead of N per-task calls. Verifies the registration order within the
+# batch is post-order (deps before parents), so the API never has to
+# phantom-create a row.
+# ============================================================================
+
+
+class BulkTrackingRegistry(NoOpRegistry):
+    """A registry that records bulk_register batches *and* per-task calls."""
+
+    def __init__(self) -> None:
+        self.bulk_batches: list[list[UUID]] = []
+        self.per_task_register_calls: list[UUID] = []
+        self.task_complete_calls: list[UUID] = []
+        self.task_start_calls: list[UUID] = []
+
+    def task_register(self, build_id: UUID, task) -> None:
+        self.per_task_register_calls.append(task.id)
+
+    async def task_register_aio(self, build_id: UUID, task) -> None:
+        self.per_task_register_calls.append(task.id)
+
+    def task_register_bulk(self, build_id: UUID, tasks) -> None:
+        self.bulk_batches.append([t.id for t in tasks])
+
+    async def task_register_bulk_aio(self, build_id: UUID, tasks) -> None:
+        self.bulk_batches.append([t.id for t in tasks])
+
+    def task_start(self, build_id: UUID, task) -> None:
+        self.task_start_calls.append(task.id)
+
+    async def task_start_aio(self, build_id: UUID, task) -> None:
+        self.task_start_calls.append(task.id)
+
+    def task_complete(self, build_id: UUID, task) -> None:
+        self.task_complete_calls.append(task.id)
+
+    async def task_complete_aio(self, build_id: UUID, task) -> None:
+        self.task_complete_calls.append(task.id)
+
+
+class TestBulkRegister:
+    """Verify the build engine batches discover-time registrations."""
+
+    def test_sequential_emits_one_bulk_call_for_static_dag(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = BulkTrackingRegistry()
+
+        leaf_a = SyncOnlyTask(name="bulk_seq_leaf_a")
+        leaf_b = SyncOnlyTask(name="bulk_seq_leaf_b")
+        root = SyncOnlyTask(name="bulk_seq_root", deps=(leaf_a, leaf_b))
+
+        build_sequential([root], registry=registry)
+
+        # Exactly one bulk batch with all three tasks. No per-task
+        # task_register calls (would mean the bulk path fell through).
+        assert len(registry.bulk_batches) == 1, registry.bulk_batches
+        assert set(registry.bulk_batches[0]) == {leaf_a.id, leaf_b.id, root.id}
+        assert registry.per_task_register_calls == []
+
+    def test_sequential_bulk_order_is_post_order(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = BulkTrackingRegistry()
+
+        leaf_a = SyncOnlyTask(name="po_leaf_a")
+        leaf_b = SyncOnlyTask(name="po_leaf_b")
+        root = SyncOnlyTask(name="po_root", deps=(leaf_a, leaf_b))
+
+        build_sequential([root], registry=registry)
+
+        order = registry.bulk_batches[0]
+        # Leaves come before the root. Within siblings the SDK preserves
+        # the order returned by ``flatten_task_struct(requires())``.
+        assert order == [leaf_a.id, leaf_b.id, root.id], (
+            f"Expected post-order DFS, got {order}"
+        )
+
+    @pytest.mark.parametrize(
+        "build_aio_fn",
+        [build_aio, build_sequential_aio],
+        ids=["concurrent", "sequential"],
+    )
+    @pytest.mark.asyncio
+    async def test_aio_emits_one_bulk_call_for_static_dag(
+        self,
+        build_aio_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = BulkTrackingRegistry()
+        leaf_a = SyncOnlyTask(name=f"bulk_aio_la_{build_aio_fn.__name__}")
+        leaf_b = SyncOnlyTask(name=f"bulk_aio_lb_{build_aio_fn.__name__}")
+        root = SyncOnlyTask(
+            name=f"bulk_aio_root_{build_aio_fn.__name__}", deps=(leaf_a, leaf_b)
+        )
+
+        await build_aio_fn([root], registry=registry)
+
+        # One bulk call covering the whole DAG. The concurrent build may
+        # interleave sibling subtrees but each subtree is post-order, so
+        # parents always come after their deps within the batch.
+        assert len(registry.bulk_batches) == 1
+        batch = registry.bulk_batches[0]
+        assert set(batch) == {leaf_a.id, leaf_b.id, root.id}
+        # Root comes after both leaves regardless of sibling interleaving.
+        leaf_indices = [batch.index(leaf_a.id), batch.index(leaf_b.id)]
+        assert batch.index(root.id) > max(leaf_indices)
+        assert registry.per_task_register_calls == []
+
+    def test_dynamic_deps_trigger_separate_bulk_call(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Each dynamic-deps yield triggers its own bulk-register call so
+        the new tasks are registered before the edge is recorded."""
+        registry = BulkTrackingRegistry()
+
+        dyn = DynamicDepsTask(value="dyn_bulk")
+        orchestrator = DynamicDepsTask(value="orch_bulk", dynamic_deps=(dyn,))
+
+        build_sequential([orchestrator], registry=registry)
+
+        # First batch: orchestrator (root has no static deps so it's the
+        # only thing in the initial walk). Second batch: dyn (yielded at
+        # runtime). At least 2 separate bulk calls.
+        assert len(registry.bulk_batches) >= 2, registry.bulk_batches
+        first_batch_ids = set(registry.bulk_batches[0])
+        assert orchestrator.id in first_batch_ids
+        # dyn must show up in some later batch.
+        dyn_in_later_batch = any(dyn.id in batch for batch in registry.bulk_batches[1:])
+        assert dyn_in_later_batch, (
+            f"dyn task not found in any post-initial batch: {registry.bulk_batches}"
+        )
+
+
+class TestNoPhantomsHappyPath:
+    """In normal operation (post-order discover + bulk register) every
+    task is registered with its real data before any edge referencing it
+    is emitted. The simplest way to verify this is to see that
+    ``dependency_task_ids`` only ever contains ids for tasks that
+    appeared *earlier* in the same bulk batch — so the API resolves them
+    without phantom creation.
+    """
+
+    def test_bulk_array_orders_deps_before_parents(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = BulkTrackingRegistry()
+
+        leaf_a = SyncOnlyTask(name="np_leaf_a")
+        leaf_b = SyncOnlyTask(name="np_leaf_b")
+        mid = SyncOnlyTask(name="np_mid", deps=(leaf_a,))
+        root = SyncOnlyTask(name="np_root", deps=(mid, leaf_b))
+
+        build_sequential([root], registry=registry)
+
+        order = registry.bulk_batches[0]
+        # For every task in the batch, all of its *registration-time*
+        # deps must appear earlier in the array.
+        positions = {tid: i for i, tid in enumerate(order)}
+        for task in (leaf_a, leaf_b, mid, root):
+            for dep in task.deps:
+                assert positions[dep.id] < positions[task.id], (
+                    f"Dep {dep.id} should appear before {task.id} in bulk order; "
+                    f"got positions {positions}"
+                )
 
 
 # ============================================================================

--- a/lib/stardag/tests/test_build/test_sequential.py
+++ b/lib/stardag/tests/test_build/test_sequential.py
@@ -1448,3 +1448,215 @@ class TestDiscoverTimeRegistrationAio:
         assert len(register_calls) == 1
         assert len(complete_calls) == 1
         assert start_calls == []
+
+
+# ============================================================================
+# Test: Discover-time registration error handling
+# ============================================================================
+
+
+class FailOnStartRegistry(NoOpRegistry):
+    """Always 404s task_start (e.g. registration didn't land in warn mode)."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, UUID]] = []
+
+    def task_register(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_register", task.id))
+
+    def task_start(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_start", task.id))
+        raise ConnectionError("would-be 404 on /start")
+
+    def task_complete(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_complete", task.id))
+
+    async def task_register_aio(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_register", task.id))
+
+    async def task_start_aio(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_start", task.id))
+        raise ConnectionError("would-be 404 on /start")
+
+    async def task_complete_aio(self, build_id: UUID, task) -> None:
+        self.calls.append(("task_complete", task.id))
+
+
+class TestDiscoverTimeRegistrationErrorHandling:
+    """In `warn` mode, registry hiccups during discover-time registration —
+    or the resulting 404 from /start when registration didn't land — must
+    not abort the build. The task still executes locally."""
+
+    def test_warn_mode_tolerates_start_failure_sequential(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = FailOnStartRegistry()
+        task = SyncOnlyTask(name="warn_start_seq")
+        summary = build_sequential(
+            [task], registry=registry, on_registry_failure="warn"
+        )
+        assert summary.status == BuildExitStatus.SUCCESS
+        # Task ran (so its target exists) and the build didn't blow up.
+        assert task.complete()
+
+    def test_raise_mode_propagates_start_failure_sequential(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = FailOnStartRegistry()
+        task = SyncOnlyTask(name="raise_start_seq")
+        with pytest.raises(ConnectionError, match="would-be 404"):
+            build_sequential([task], registry=registry, on_registry_failure="raise")
+
+    @pytest.mark.parametrize(
+        "build_aio_fn",
+        [build_aio, build_sequential_aio],
+        ids=["concurrent", "sequential"],
+    )
+    @pytest.mark.asyncio
+    async def test_warn_mode_tolerates_start_failure_aio(
+        self,
+        build_aio_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = FailOnStartRegistry()
+        task = SyncOnlyTask(name=f"warn_start_aio_{build_aio_fn.__name__}")
+        summary = await build_aio_fn(
+            [task], registry=registry, on_registry_failure="warn"
+        )
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert task.complete()
+
+    def test_warn_mode_skips_start_when_registration_failed_concurrent(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Concurrent build: when discover-time register fails (and the
+        retry inside submit_with_lock also fails), task_start_aio should
+        be skipped rather than 404-ing the build."""
+
+        class AlwaysFailRegisterRegistry(NoOpRegistry):
+            def __init__(self) -> None:
+                self.calls: list[tuple[str, UUID]] = []
+
+            def task_register(self, build_id, task) -> None:
+                self.calls.append(("task_register", task.id))
+                raise ConnectionError("register down")
+
+            def task_start(self, build_id, task) -> None:
+                self.calls.append(("task_start", task.id))
+
+            def task_complete(self, build_id, task) -> None:
+                self.calls.append(("task_complete", task.id))
+
+            async def task_register_aio(self, build_id, task) -> None:
+                self.calls.append(("task_register", task.id))
+                raise ConnectionError("register down")
+
+            async def task_start_aio(self, build_id, task) -> None:
+                self.calls.append(("task_start", task.id))
+
+            async def task_complete_aio(self, build_id, task) -> None:
+                self.calls.append(("task_complete", task.id))
+
+        registry = AlwaysFailRegisterRegistry()
+        task = SyncOnlyTask(name="skip_start_concurrent")
+        summary = build([task], registry=registry, on_registry_failure="warn")
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert task.complete()
+        # No start event should have been attempted — registration never
+        # landed, so /start would have 404'd.
+        start_calls = [c for c in registry.calls if c[0] == "task_start"]
+        assert start_calls == [], (
+            f"Expected /start to be skipped when registration didn't land; "
+            f"got {registry.calls}"
+        )
+
+
+# ============================================================================
+# Test: build_fail emitted when discover() raises
+# ============================================================================
+
+
+class _FailingRequiresTask(SyncOnlyTask):
+    """A task whose requires() raises, simulating a discovery-time crash."""
+
+    def requires(self):
+        raise RuntimeError("requires() exploded during discovery")
+
+
+class BuildFailTrackingRegistry(NoOpRegistry):
+    def __init__(self) -> None:
+        self.build_started_with: UUID | None = None
+        self.build_failed_with: UUID | None = None
+        self.build_completed_with: UUID | None = None
+
+    def build_start(self, root_tasks=None, description=None):
+        from uuid import uuid4
+
+        self.build_started_with = uuid4()
+        return self.build_started_with
+
+    async def build_start_aio(self, root_tasks=None, description=None):
+        return self.build_start(root_tasks, description)
+
+    def build_fail(self, build_id, error_message=None):
+        self.build_failed_with = build_id
+
+    async def build_fail_aio(self, build_id, error_message=None):
+        self.build_fail(build_id, error_message)
+
+    def build_complete(self, build_id):
+        self.build_completed_with = build_id
+
+    async def build_complete_aio(self, build_id):
+        self.build_complete(build_id)
+
+    def task_register(self, build_id, task):
+        pass
+
+    async def task_register_aio(self, build_id, task):
+        pass
+
+
+class TestDiscoveryFailureBuildFail:
+    """If discovery raises, build_fail must reach the registry — otherwise
+    the build is left RUNNING forever."""
+
+    def test_sequential_emits_build_fail_when_discover_raises(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = BuildFailTrackingRegistry()
+        with pytest.raises(RuntimeError, match="requires.*exploded"):
+            build_sequential([_FailingRequiresTask(name="boom")], registry=registry)
+        assert registry.build_started_with is not None
+        assert registry.build_failed_with == registry.build_started_with
+        assert registry.build_completed_with is None
+
+    @pytest.mark.parametrize(
+        "build_aio_fn",
+        [build_aio, build_sequential_aio],
+        ids=["concurrent", "sequential"],
+    )
+    @pytest.mark.asyncio
+    async def test_aio_emits_build_fail_when_discover_raises(
+        self,
+        build_aio_fn,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        registry = BuildFailTrackingRegistry()
+        # build_aio's TaskGroup wraps the RuntimeError in an ExceptionGroup;
+        # build_sequential_aio re-raises directly. Both subclass `Exception`,
+        # so a single Exception catch works on Python 3.10+ without
+        # name-resolving BaseExceptionGroup at parse time.
+        with pytest.raises(Exception):
+            await build_aio_fn(
+                [_FailingRequiresTask(name=f"boom_{build_aio_fn.__name__}")],
+                registry=registry,
+            )
+        assert registry.build_started_with is not None
+        assert registry.build_failed_with == registry.build_started_with
+        assert registry.build_completed_with is None

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -145,14 +145,18 @@ class TestAPIRegistryGzipsWireFormat:
     def _make_fake_task(self, task_id: str, task_data: dict):
         """Produce an object that ``_get_task_data_for_registration``
         accepts. Avoids spinning up a real Task subclass — we only need
-        the fields the helper reads."""
+        the fields the helper reads. ``id`` is set per-instance so a
+        batch of fake tasks has 50 distinct UUIDs (otherwise a class-
+        attribute UUID would make the bulk gzip test silently exercise
+        50 *identical* tasks, which is not the realistic payload we
+        want to compress)."""
         from uuid import uuid4
 
         class _Fake:
-            id = uuid4()
             version = ""
 
             def __init__(self, tid, td):
+                self.id = uuid4()
                 self._tid = tid
                 self._td = td
 
@@ -168,13 +172,7 @@ class TestAPIRegistryGzipsWireFormat:
             def requires(self):
                 return ()
 
-        f = _Fake(task_id, task_data)
-        # ``_get_task_data_for_registration`` reads ``task.id`` for the
-        # outgoing ``task_id`` field, so override it to a deterministic
-        # value rather than the random UUID.
-        # (We pass the random UUID through; the test only checks gzip
-        # behaviour, not the resulting string.)
-        return f
+        return _Fake(task_id, task_data)
 
     def test_large_bulk_register_uses_gzip_on_wire(self):
         registry, captured = self._make_registry_and_capture()
@@ -198,9 +196,14 @@ class TestAPIRegistryGzipsWireFormat:
             f"Expected Content-Encoding: gzip on big bulk request; "
             f"headers were {dict(request.headers)}"
         )
-        # Decompressed body round-trips back to JSON with all 50 tasks.
+        # Decompressed body round-trips back to JSON with all 50 tasks,
+        # each carrying a distinct task_id (UUID per-instance — proves
+        # we're really compressing a batch of unique tasks, not 50
+        # copies of one).
         decoded = json.loads(gzip.decompress(request.content))
         assert len(decoded["tasks"]) == 50
+        sent_ids = {t["task_id"] for t in decoded["tasks"]}
+        assert len(sent_ids) == 50
 
     def test_small_single_register_does_not_gzip(self):
         registry, captured = self._make_registry_and_capture()

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -196,6 +196,13 @@ class TestAPIRegistryGzipsWireFormat:
             f"Expected Content-Encoding: gzip on big bulk request; "
             f"headers were {dict(request.headers)}"
         )
+        # SDK opts into the slim ``id_only=true`` response shape since
+        # it doesn't read the response body — this saves ~10× on
+        # response size at the server.
+        assert request.url.params.get("id_only") == "true", (
+            f"Expected id_only=true on bulk register request; "
+            f"params were {dict(request.url.params)}"
+        )
         # Decompressed body round-trips back to JSON with all 50 tasks,
         # each carrying a distinct task_id (UUID per-instance — proves
         # we're really compressing a batch of unique tasks, not 50

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -2,9 +2,227 @@
 
 from __future__ import annotations
 
+import gzip
+import json
 
 from stardag.exceptions import APIError, NotFoundError
-from stardag.registry._api_registry import _is_route_not_found
+from stardag.registry._api_registry import (
+    _GZIP_REQUEST_THRESHOLD_BYTES,
+    _is_route_not_found,
+    _maybe_gzip_json_body,
+)
+
+
+class TestMaybeGzipJsonBody:
+    """Decision boundary for the gzip-on-request behaviour."""
+
+    def test_none_body_returns_no_content(self):
+        content, headers = _maybe_gzip_json_body(None)
+        assert content is None
+        assert headers == {}
+
+    def test_small_body_is_not_gzipped(self):
+        body = {"task_id": "x", "task_name": "y"}
+        content, headers = _maybe_gzip_json_body(body)
+        assert content is not None
+        assert len(content) < _GZIP_REQUEST_THRESHOLD_BYTES
+        assert headers == {"Content-Type": "application/json"}
+        # Round-trips as JSON without decompression.
+        assert json.loads(content) == body
+
+    def test_large_body_is_gzipped(self):
+        # Build a body well above the threshold with repeated structure
+        # (representative of bulk-register payloads).
+        body = {
+            "tasks": [
+                {
+                    "task_id": f"task-{i:08d}",
+                    "task_namespace": "demo.namespace",
+                    "task_name": "RepeatedTask",
+                    "task_data": {"index": i, "label": "x" * 32},
+                    "dependency_task_ids": [],
+                }
+                for i in range(50)
+            ]
+        }
+        content, headers = _maybe_gzip_json_body(body)
+        assert content is not None
+        assert headers["Content-Type"] == "application/json"
+        assert headers["Content-Encoding"] == "gzip"
+        # Decompresses back to the original JSON.
+        assert json.loads(gzip.decompress(content)) == body
+        # And actually saved bytes — repeated keys/structure should
+        # compress well below the original.
+        original_bytes = json.dumps(body, separators=(",", ":")).encode()
+        assert len(content) < len(original_bytes) // 2, (
+            f"Expected at least 2x compression on a structured bulk "
+            f"payload; got {len(original_bytes)} -> {len(content)}"
+        )
+
+    def test_threshold_exact_boundary(self):
+        # Construct a payload whose serialised size is exactly at the
+        # threshold to verify the strict-less-than boundary
+        # (``< threshold`` => raw, ``>= threshold`` => gzipped).
+        # The ``key`` value is sized so the final dump hits the boundary.
+        target = _GZIP_REQUEST_THRESHOLD_BYTES
+        # ``{"k":"<padding>"}``: braces+quotes+colon+commas = 8 bytes
+        # of overhead (no commas here, just `{"k":""}` = 8 bytes).
+        padding_len = target - len('{"k":""}')
+        body = {"k": "x" * padding_len}
+        encoded = json.dumps(body, separators=(",", ":")).encode()
+        assert len(encoded) == target, "size-control assumption broke"
+        content, headers = _maybe_gzip_json_body(body)
+        # At the threshold we DO compress.
+        assert headers.get("Content-Encoding") == "gzip"
+        assert content is not None and gzip.decompress(content) == encoded
+
+
+class TestAPIRegistryGzipsWireFormat:
+    """End-to-end check that ``APIRegistry`` *actually* emits gzipped
+    bytes on the wire for bulk-register payloads — not just that the
+    helper function would, if invoked. Uses ``httpx.MockTransport`` to
+    capture the outgoing request before it hits the network.
+    """
+
+    def _make_registry_and_capture(self):
+        """Build an APIRegistry whose sync httpx client points at a
+        MockTransport that records every outgoing request. Returns
+        (registry, captured_requests_list)."""
+        import httpx
+
+        from stardag.registry._api_registry import APIRegistry
+
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            # Realistic bulk-register response shape (one TaskResponse per
+            # task in payload), enough for APIRegistry to consider the
+            # call successful.
+            decompressed_body = (
+                gzip.decompress(request.content)
+                if request.headers.get("content-encoding") == "gzip"
+                else request.content
+            )
+            payload = json.loads(decompressed_body)
+            tasks = payload.get("tasks", [])
+            from uuid import uuid4
+
+            return httpx.Response(
+                201,
+                json={
+                    "tasks": [
+                        {
+                            "id": str(uuid4()),
+                            "task_id": t["task_id"],
+                            "environment_id": "00000000-0000-0000-0000-000000000003",
+                            "task_namespace": t.get("task_namespace", ""),
+                            "task_name": t["task_name"],
+                            "task_data": t["task_data"],
+                            "version": None,
+                            "output_uri": None,
+                            "created_at": "2026-04-30T00:00:00+00:00",
+                            "is_phantom": False,
+                        }
+                        for t in tasks
+                    ]
+                },
+            )
+
+        # Instantiate APIRegistry with explicit creds so it doesn't
+        # depend on environment variables. Override the inner httpx
+        # client with our MockTransport-backed one.
+        registry = APIRegistry(
+            api_url="http://test.invalid",
+            api_key="test-key",
+        )
+        registry._client = httpx.Client(
+            transport=httpx.MockTransport(handler),
+            auth=registry._auth,
+        )
+        return registry, captured
+
+    def _make_fake_task(self, task_id: str, task_data: dict):
+        """Produce an object that ``_get_task_data_for_registration``
+        accepts. Avoids spinning up a real Task subclass — we only need
+        the fields the helper reads."""
+        from uuid import uuid4
+
+        class _Fake:
+            id = uuid4()
+            version = ""
+
+            def __init__(self, tid, td):
+                self._tid = tid
+                self._td = td
+
+            def get_namespace(self):
+                return "test"
+
+            def get_name(self):
+                return "FakeTask"
+
+            def model_dump(self, mode="json"):
+                return self._td
+
+            def requires(self):
+                return ()
+
+        f = _Fake(task_id, task_data)
+        # ``_get_task_data_for_registration`` reads ``task.id`` for the
+        # outgoing ``task_id`` field, so override it to a deterministic
+        # value rather than the random UUID.
+        # (We pass the random UUID through; the test only checks gzip
+        # behaviour, not the resulting string.)
+        return f
+
+    def test_large_bulk_register_uses_gzip_on_wire(self):
+        registry, captured = self._make_registry_and_capture()
+
+        # 50 tasks × ~150 bytes serialised each ≈ 7.5KB > 1KB threshold.
+        tasks = [
+            self._make_fake_task(
+                f"big-task-{i:04d}",
+                {"index": i, "label": "x" * 64, "extra": "padding-" * 8},
+            )
+            for i in range(50)
+        ]
+        registry.task_register_bulk(
+            build_id=__import__("uuid").UUID("00000000-0000-0000-0000-000000000001"),
+            tasks=tasks,  # type: ignore[arg-type]
+        )
+
+        assert len(captured) == 1
+        request = captured[0]
+        assert request.headers.get("content-encoding") == "gzip", (
+            f"Expected Content-Encoding: gzip on big bulk request; "
+            f"headers were {dict(request.headers)}"
+        )
+        # Decompressed body round-trips back to JSON with all 50 tasks.
+        decoded = json.loads(gzip.decompress(request.content))
+        assert len(decoded["tasks"]) == 50
+
+    def test_small_single_register_does_not_gzip(self):
+        registry, captured = self._make_registry_and_capture()
+
+        task = self._make_fake_task("small-task", {"x": 1})
+        registry.task_register(
+            build_id=__import__("uuid").UUID("00000000-0000-0000-0000-000000000001"),
+            task=task,  # type: ignore[arg-type]
+        )
+
+        assert len(captured) == 1
+        request = captured[0]
+        # Tiny payload — gzip overhead would be a net loss, so no
+        # Content-Encoding header.
+        assert "content-encoding" not in {k.lower() for k in request.headers.keys()}, (
+            f"Did not expect gzip on a single small task; headers were "
+            f"{dict(request.headers)}"
+        )
+        # Body is plain JSON (not gzip-prefixed bytes).
+        decoded = json.loads(request.content)
+        assert "task_id" in decoded
+        assert decoded["task_name"] == "FakeTask"
 
 
 class TestIsRouteNotFound:


### PR DESCRIPTION
## Summary

End-to-end overhaul of how tasks reach the registry during a build, motivated by "tasks don't appear in the UI in the order they're discovered, sometimes only after they finish executing." Multiple logical changes kept in one PR because they share scaffolding and the tests cross-reference each other.

### 1. Tasks are registered at discover-time, not at start-time
The build engine (sync + async, sequential + concurrent) used to send `task_register` only when each task became runnable, so leaves arrived in the registry first and roots last. Now every task discovered during the walk is registered before any task starts running, so the full DAG appears in the UI immediately.

### 2. Post-order discovery walk
The walk recurses into deps first and registers the parent only after every child has registered. This means a parent's `dependency_task_ids` always resolve to existing rows in `_reconcile_dependency_edges` — eliminating the brief phantom-row window where the UI used to flash up `tid[:12]`-style placeholder names between parent and child registration. Same trick on the dynamic-dep path: `discover(dep)` runs before `task_add_dependencies_aio` so the dep row exists before the edge insert.

The concurrent build's discover walk was also vulnerable to a diamond-DAG race: two siblings' `discover()` calls for a shared dep could see the fast-path `if task.id in task_states` and append their own parents to `pending_registrations` before the original discoverer appended the dep. Fixed via per-task `discover_done` events that the fast-path now `await`s.

### 3. Bulk-register endpoint
New `POST /api/v1/builds/{id}/tasks/bulk` registers up to 1000 tasks in one transaction, processing the array in order so within-batch dep references resolve to existing rows (no phantom-creation in the happy path). Deduplicates by `task_id`, keeping the first occurrence. Same `TASK_PENDING` / `TASK_REFERENCED` event semantics as the single-task endpoint.

**Inside the transaction it's now ~6 SQL round-trips constant in batch size**, not the ~5N the original implementation had: pre-query existing tasks → sorted `SELECT FOR UPDATE` on existing rows only (deadlock mitigation) → bulk INSERT new tasks (UUID7 client-side PKs, single `executemany`) → bulk INSERT edges (computed in-Python from `pk_by_task_id`) → bulk INSERT events with microsecond-spaced `created_at` for stable ordering → in-Python `apply_event_to_task` on ORM rows → commit.

Optional `?id_only=true` query param returns only `{id, task_id}` per task instead of the full `TaskResponse` (~10× smaller response). The SDK passes this since it discards the response.

### 4. SDK adopts bulk register, with chunking + gzip + fallback
Build engine accumulates discovered tasks into `pending_registrations` (post-order) and flushes via one `task_register_bulk_aio` call after each discover walk (initial + each dynamic-deps yield). Chunked at **50 tasks per HTTP call** — well under the API's 1000 hard cap so DB transactions stay short, request bodies stay friendly even with fat task specs, and a chunk failure in `warn` mode loses few tasks before per-task fallback. For a 5000-task DAG this is 100 bulk POSTs instead of 5000 individual ones.

JSON request bodies above 1 KB are **gzipped on the wire** (typical bulk payloads compress 5–10× from repeated structure). The server's new `GZipRequestMiddleware` decompresses transparently — pure ASGI, **streaming** with running caps on both compressed (10 MB) and decompressed (50 MB) size so gzip-bombs can't allocate unbounded memory. Old SDKs and non-gzipped requests pass through unchanged.

Bulk-register falls back to per-task `task_register_aio` on a "missing route" 404 (older API deployments). The fallback is gated on the FastAPI default `{"detail": "Not Found"}` body so it doesn't trigger on app-level 404s like `"Build not found"`.

### 5. Stable per-build ordering in the API
`GET /builds/{id}/tasks` now joins against `events` filtered to this build and orders by `min(events.created_at), Task.id` — so a re-referenced task appears at the position where it was *seen in this build*, not where it was first ever inserted in the environment. Postgres-safe (no `min(uuid)` aggregate).

### 6. UX polish: phantom rows hidden from list views
`is_phantom` is now exposed on `TaskResponse` / `TaskWithStatusResponse`. The UI's `BuildView` filters phantoms out of the table list and the "X tasks" counter, so even if a phantom slips through (build crash mid-discover, out-of-band register, etc.) the user doesn't see ugly placeholder names alongside real tasks. The DAG view still renders them — dropping nodes there would break edges.

### 7. Robustness: `build_fail` on discovery error, warn-mode resilience
- If a task's `requires()` / `complete()` raises during discovery, `build_fail[_aio]` is now emitted rather than the build being left RUNNING forever.
- `task_start[_aio]` / `task_complete[_aio]` / `task_resume_aio` all wrapped in `handle_registry_error` so `warn` mode genuinely tolerates registry hiccups (without hard-failing on a 404 from `/start` after a discover-time register failure).

## Behaviour changes to be aware of

- **`APIRegistry.task_start[_aio]` no longer auto-calls `task_register[_aio]`.** Contract is now "register first" everywhere — `/start` is a pure event endpoint. Internal callers (build engines, Prefect integration) updated. External callers that used `task_start_aio` directly without a prior `task_register_aio` will now hit a 404 from `/start`. Migration: add an explicit `await registry.task_register_aio(build_id, task)` before `task_start_aio`.
- **Sequential build registers in post-order DFS** (deps before parents) where it previously used pre-order. Concurrent build is approximately post-order — siblings still interleave but every task's deps are guaranteed to register before it. Visible only in registry / UI ordering; no API breakage.
- **`_reconcile_dependency_edges` phantom-creation is now a safety hatch**, not the happy path. Documented inline. Triggers only on edge cases like build crash mid-discover or out-of-band edge registrations.

## Backwards compatibility

- **Old SDK ↔ new server**: works unchanged. Per-task `POST /tasks` endpoint hasn't changed semantics; new `is_phantom` field is silently ignored by old Pydantic models.
- **New SDK ↔ old server**: works. `/tasks/bulk` 404s → SDK falls back to per-task register (no perf win until API is upgraded, but builds keep working).
- **Server-first deploy recommended** so early SDK upgraders immediately benefit from bulk register, but either order works.

## Test plan

- [x] `pytest lib/stardag/tests/test_build/` — 118 passed
- [x] `pytest lib/stardag/tests/test_registry/` — 56 passed
- [x] Full SDK suite — 503 passed (excluding modal which needs cloud creds)
- [x] `pytest app/stardag-api/tests/` — 250 passed, 17 skipped
- [x] All 9 CI checks green: Integration Tests, Integration Tests (Browser), Lint, Test Frontend, Test Python 3.11/3.12/3.13/3.14, Test Python (stardag-api on Postgres) — the Postgres job exercises real `FOR UPDATE` lock acquisition and the deadlock-mitigation test
- [x] `pre-commit` clean (ruff, ruff-format, pyright × 2, eslint, tsc)
- [ ] Post-deploy: canary deploy first, watch p99 of `/tasks/bulk` for one hour, verify in a real build that the full DAG renders before any task starts and that the table view stays stable across refreshes.

## New tests (29)

**SDK (`lib/stardag/tests/`)**:
- `test_build/test_sequential.py`:
  - `TestDiscoverTimeRegistrationSequential`, `TestDiscoverTimeRegistrationAio` — registration-before-start invariant, exactly-once-per-build, dynamic deps registered when discovered.
  - `TestDiscoverTimeRegistrationErrorHandling` — `warn` mode tolerates `/start` 404; `raise` propagates; concurrent build skips `/start` when registration never landed.
  - `TestDiscoveryFailureBuildFail` — `build_fail[_aio]` emitted when a task's `requires()` raises.
  - `TestBulkRegister` — exactly-1 batch for static DAG, post-order, dynamic deps trigger separate batch.
  - `TestNoPhantomsHappyPath` — bulk array always orders deps before parents (diamond DAG).
  - `TestConcurrentDiscoverRaceFreedom` — diamond-DAG race fix: shared dep before *both* parents.
  - `TestBulkRegisterChunking` — `monkeypatch`ed chunk size of 3 → 7-task DAG produces three batches of [3, 3, 1] preserving post-order.
- `test_registry/test_api_registry.py`:
  - `TestMaybeGzipJsonBody` — None / small / threshold-exact / large body gzip decision.
  - `TestAPIRegistryGzipsWireFormat` — `httpx.MockTransport`-based: 50 distinct fake tasks → outgoing request has `Content-Encoding: gzip` *and* `id_only=true` query param; small single-task → no gzip.

**API (`app/stardag-api/tests/`)**:
- `test_builds.py`:
  - `test_list_tasks_in_build_returns_stable_order` — stable insertion order across repeated calls.
  - `test_list_tasks_in_build_orders_by_per_build_first_event` — re-referenced task lands at its current-build position.
  - `test_bulk_register_creates_tasks_and_resolves_in_batch_deps` — in-batch dep resolution, no phantoms in happy path.
  - `test_bulk_register_upgrades_existing_phantoms` — phantom upgrade in place.
  - `test_bulk_register_empty_array_returns_201_empty`, `test_bulk_register_caps_batch_size`.
  - `test_bulk_register_dedupes_within_batch` — first-occurrence wins.
  - `test_bulk_register_referenced_event_for_existing_task`.
  - `test_bulk_register_creates_phantom_for_unknown_upstream` — explicit safety-hatch phantom test.
  - `test_bulk_register_array_order_maps_to_list_order` — bulk path's user-visible ordering contract.
  - `test_concurrent_bulk_registers_overlapping_tasks` — two parallel POSTs with reversed orders, both succeed (Postgres-meaningful).
  - `test_bulk_register_id_only_returns_slim_response` / `test_bulk_register_default_returns_full_response` — slim vs full response shapes.
- `test_gzip_request.py`:
  - Round-trip via test client, pass-through for non-gzipped, unknown-encoding pass-through, malformed gzip → 400, single-task gzip works.
  - `test_gzip_bomb_aborts_with_413` — streaming decompression aborts mid-stream when decompressed cap breached (`monkeypatch`ed to 1 KB).
  - `test_oversized_compressed_body_rejected` — compressed-size cap is the first line of defence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)