### PR TITLE
Post-v0.6.0 cleanup: docs fixes + stardag-examples lockfile bump + 0.5.x API drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
-## [0.6.0] — Discover-time task registration + bulk register endpoint
+## [0.6.0] — 2026-04-30
 
 End-to-end overhaul of how tasks reach the registry during a build,
 motivated by "tasks don't appear in the UI in the order they're

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -37,12 +37,29 @@ In v0.6.0:
 [Build runs — each task already exists in the registry]
 ```
 
-For large fan-out DAGs (think: a `for chunk in chunks: yield Process(chunk)`
-yielding 500 chunks), this is the difference between 500 sequential
-HTTP round-trips and 10 bulk POSTs. The chunk size of 50 is deliberately
-well under the API's 1000 hard cap — keeps DB transactions short, keeps
+For large fan-out DAGs — think a parent whose
+
+```python
+def requires(self):
+    return [Process(chunk=c) for c in self.chunks]
+```
+
+declares 500 deps — this is the difference between 500 sequential
+HTTP round-trips at task-start time (the v0.5.x behaviour) and 10
+bulk POSTs during discover (the v0.6.0 behaviour, registering all 500
+deps + the parent up front). The chunk size of 50 is deliberately well
+under the API's 1000 hard cap — keeps DB transactions short, keeps
 request bodies friendly even with fat task specs, and limits the blast
 radius of a chunk-level failure in `warn` mode.
+
+> **Note**: dynamic deps yielded _one at a time_ from `run()` /
+> `run_aio()` (`for chunk in chunks: yield Process(chunk)`) are still
+> sequential — each yield blocks until the yielded dep completes
+> before the generator advances. Bulk register only batches what's
+> already in `requires()` (or what's yielded as a single list /
+> tuple in one go: `yield [Process(c) for c in chunks]`). The DAG
+> shape determines the batch shape; v0.6.0 just stops paying N
+> round-trips to register the deps it can already see.
 
 Request bodies above 1KB are gzipped before sending — bulk payloads
 with repeated JSON structure compress 5–10× typically — and the server

--- a/lib/stardag-examples/src/stardag_examples/general/artifacts_demo.py
+++ b/lib/stardag-examples/src/stardag_examples/general/artifacts_demo.py
@@ -164,7 +164,16 @@ def main() -> None:
     """Run the artifacts demo."""
     # Load configuration
     config = load_config()
-    print("Configuration loaded. Running against Registry at:", config.api.url)
+    # ``config.registry`` is None in offline mode; the artifacts demo
+    # requires a registry, so fail fast with a helpful message.
+    if config.registry is None:
+        raise RuntimeError(
+            "This demo requires a Stardag Registry. "
+            "Configure one via `stardag config set registry <url>` or "
+            "set STARDAG_API_URL."
+        )
+    registry_url = config.registry.url
+    print("Configuration loaded. Running against Registry at:", registry_url)
 
     # Create a simple DAG:
     # DataCollector -> AnalysisReport
@@ -183,9 +192,9 @@ def main() -> None:
     print(f"\nResult: {result}")
 
     ui_url = None
-    if config.api.url == "http://localhost:8000":
+    if registry_url == "http://localhost:8000":
         ui_url = "http://localhost:3000"
-    elif config.api.url == "https://api.stardag.com":
+    elif registry_url == "https://api.stardag.com":
         ui_url = "https://app.stardag.com"
 
     if ui_url:

--- a/lib/stardag-examples/src/stardag_examples/modal/prefect/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/prefect/app.py
@@ -13,9 +13,13 @@ image = (
     .add_local_python_source("stardag_examples")
 )
 
+# v0.5.5+: ``builder_type="prefect"`` is gone. Use the
+# ``PrefectBuilder`` class re-exported from
+# ``stardag.integration.modal`` (or subclass ``Builder`` for custom
+# logic).
 app = sd_modal.StardagApp(
     "stardag_examples-prefect",
-    builder_type="prefect",  # NOTE: prefect builder
+    build_function=sd_modal.PrefectBuilder(),
     builder_settings=sd_modal.FunctionSettings(
         image=image,
         secrets=[

--- a/lib/stardag-examples/uv.lock
+++ b/lib/stardag-examples/uv.lock
@@ -1235,6 +1235,7 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -1247,6 +1248,7 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -1255,6 +1257,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -3883,7 +3886,7 @@ wheels = [
 
 [[package]]
 name = "stardag"
-version = "0.4.0"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3896,9 +3899,9 @@ dependencies = [
     { name = "typer" },
     { name = "uuid6" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/a1/23a0dc05b2f18a4e6a8e3e2067f7950c46efde7651c16ae36fafd3dd7f0e/stardag-0.4.0.tar.gz", hash = "sha256:da93c11d8a16185f40ed44d615d7a6f34f640907bf85548a387855c571bbb172", size = 421744, upload-time = "2026-03-06T09:27:53.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/68/cc4f9f1186326fb6c4d37258a0ef73b3bb5452183958a3c63d045b6a2012/stardag-0.6.0.tar.gz", hash = "sha256:1dc2885b8447f59aea9f20fdd65a324d6d63a2c8be04030da881f5ec15e85336", size = 480086, upload-time = "2026-04-30T11:37:50.526Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/d1/c5362080dfe5b61d84ee54eb25560ee566c856f23271a285bec30ac20154/stardag-0.4.0-py3-none-any.whl", hash = "sha256:2e0cc62761568654ce02cb8dd40193b8d4f303e770c0a4182acb489686a5f5dd", size = 147983, upload-time = "2026-03-06T09:27:52.213Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/17dd604b6aec545a0437cc070c26ce04063286ea533c4d0c85c07d726cbf/stardag-0.6.0-py3-none-any.whl", hash = "sha256:4bdf110eeba49c55282104f2f1b0c4e5d45763b4c322cb0e7dc78b256aea8ac0", size = 178167, upload-time = "2026-04-30T11:37:48.873Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three threads of post-release cleanup:

### 1. Docs fixes (initial commit `3a37844`)

- **`RELEASE_NOTES.md` v0.6.0**: the fan-out DAG example was wrong — it described `for chunk in chunks: yield Process(chunk)` as a 500-task batch, but yielding deps one at a time is sequential (each yield blocks until the dep completes before the generator advances). Bulk register only batches deps the engine can already see at discover time. Replaced the snippet with a static `def requires(self): return [...]` example and added a `> Note` calling out the dynamic-yield-one-at-a-time path so the next reader doesn't form the same wrong intuition.
- **`CHANGELOG.md`**: dated the v0.6.0 entry as `## [0.6.0] — 2026-04-30` to match project convention.
- The live [v0.6.0 GitHub Release](https://github.com/stardag-dev/stardag/releases/tag/v0.6.0) was edited at release time so the corrected example is already on the release page.

### 2. `stardag-examples` lockfile bump (commit `25eb767`)

Per the post-publish procedure in `cloud/.claude/CLAUDE.md`:

```bash
cd lib/stardag-examples && uv lock --upgrade-package stardag
```

The bump jumps `0.4.0 → 0.6.0` (looks like the 0.5.x bumps were never done either — separately worth tracking, but caught up here).

### 3. Latent 0.5.x API drift surfaced by the bump

The lockfile bump exposed two type errors that have been latent since 0.5.x:

- **`general/artifacts_demo.py`**: `config.api` was renamed to `config.registry` somewhere in 0.5.x. Updated `config.api.url` → `config.registry.url` and added a fail-fast check for the offline (`config.registry is None`) case.
- **`modal/prefect/app.py`**: `StardagApp(builder_type="prefect", …)` was removed in v0.5.5 in favour of `build_function=<callable>`. Switched to the upstream `sd_modal.PrefectBuilder()` (re-exported from `stardag.integration.modal` for exactly this use case). Comment in the file points at v0.5.5 so readers know which release dropped the kwarg.

## Test plan

- [x] `pre-commit run pyright-stardag-examples --all-files` — passes.
- [x] `pytest lib/stardag-examples/tests` — 9 passed, 9 skipped (skipped tests need Modal cloud creds, unrelated to this PR).
- [x] `pre-commit` clean across all changed files (ruff, ruff-format, pyright × 2, prettier).
- [ ] CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)