### PR TITLE
Add optional local-disk cache for modalvol RemoteFileSystem (mirrors S3)

### DIFF
--- a/lib/stardag/src/stardag/integration/modal/_target.py
+++ b/lib/stardag/src/stardag/integration/modal/_target.py
@@ -8,7 +8,8 @@ import aiofiles
 import modal
 from modal.exception import NotFoundError, ResourceExhaustedError
 from modal.volume import FileEntryType
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import ValidationError
+from pydantic_settings import SettingsConfigDict
 from tenacity import (
     before_sleep_log,
     retry,
@@ -31,20 +32,10 @@ logger = logging.getLogger(__name__)
 
 MODAL_VOLUME_URI_PREFIX = "modalvol://"
 VOLUME_MOUNT_PATH_PREFIX = "/mnt/stardag-volumes"
-DEFAULT_CACHE_ROOT = Path("~/.stardag/cache/modalvol/").expanduser().absolute()
 
 
 class ModalVolumeCacheConfig(CachedRemoteFileSystemConfig):
-    root: str = str(DEFAULT_CACHE_ROOT)
-
-    model_config = SettingsConfigDict(
-        env_prefix="stardag_target_modalvol_cache_",
-        env_nested_delimiter="__",
-    )
-
-
-class ModalVolumeFileSystemConfig(BaseSettings):
-    """Settings for the Modal-volume RemoteFileSystem (API-based path).
+    """Local-disk cache config for the Modal-volume RemoteFileSystem.
 
     Caching wraps the API-based ``ModalVolumeRemoteFileSystem`` only — when a
     volume is locally mounted (running on Modal, or via
@@ -52,24 +43,26 @@ class ModalVolumeFileSystemConfig(BaseSettings):
     returns a ``ModalMountedVolumeFileTarget`` that bypasses the RFS entirely
     and is therefore unaffected by these settings.
 
-    .. warning::
-        Modal volume names are unique only within a ``(workspace,
-        environment)`` pair, unlike S3 bucket names which are globally unique.
-        The same ``modalvol://<name>/...`` URI can therefore resolve to
-        different content across workspaces or environments. The cache is
-        keyed by URI alone, so if you switch between workspaces or
-        environments you **must** namespace the cache root accordingly to
-        avoid collisions — for example by including the workspace and
-        environment in ``STARDAG_TARGET_MODALVOL_CACHE_ROOT`` (e.g.
-        ``~/.stardag/cache/modalvol/<workspace>/<environment>/``) or by using
-        ``root_by_prefix`` to map specific volumes to dedicated cache
-        directories.
+    Caching is **opt-in** via ``STARDAG_TARGET_MODALVOL_CACHE_ROOT``: ``root``
+    has no default. Modal volume names are only unique within a
+    ``(workspace, environment)`` pair (unlike S3 bucket names which are
+    globally unique), so a default cache root would silently collide across
+    workspaces/environments — the cache is keyed by URI alone, and the same
+    ``modalvol://<name>/...`` URI can resolve to different content under
+    different credentials. Forcing the user to set the root makes the
+    workspace/environment scoping a deliberate choice — e.g.
+    ``STARDAG_TARGET_MODALVOL_CACHE_ROOT=~/.stardag/cache/modalvol/<workspace>/<environment>/``,
+    or use ``root_by_prefix`` to map specific volumes to dedicated cache
+    directories.
     """
 
-    use_cache: bool = False
-    cache: ModalVolumeCacheConfig = ModalVolumeCacheConfig()
+    # NOTE inherited ``root: str`` is required (no default) — set
+    # STARDAG_TARGET_MODALVOL_CACHE_ROOT to enable caching.
 
-    model_config = SettingsConfigDict(env_prefix="stardag_target_modalvol_")
+    model_config = SettingsConfigDict(
+        env_prefix="stardag_target_modalvol_cache_",
+        env_nested_delimiter="__",
+    )
 
 
 def get_default_volume_mount_path(volume_name: str) -> Path:
@@ -303,13 +296,23 @@ class ModalVolumeRemoteFileSystem(RemoteFileSystemABC):
             batch.put_file(source, in_volume_path)
 
 
+def _get_modal_volume_cache_config() -> ModalVolumeCacheConfig | None:
+    """Return cache config if STARDAG_TARGET_MODALVOL_CACHE_ROOT is set,
+    else None. Caching is opt-in via that env var; ``root`` has no default
+    (see ``ModalVolumeCacheConfig`` docstring for why)."""
+    try:
+        return ModalVolumeCacheConfig()  # type: ignore[call-arg]
+    except ValidationError:
+        return None
+
+
 def _init_modal_volume_file_system() -> RemoteFileSystemABC:
     file_system: RemoteFileSystemABC = ModalVolumeRemoteFileSystem()
-    config = ModalVolumeFileSystemConfig()
-    if config.use_cache:
+    cache_config = _get_modal_volume_cache_config()
+    if cache_config is not None:
         file_system = CachedRemoteFileSystem(
             wrapped=file_system,
-            **config.cache.model_dump(),
+            **cache_config.model_dump(),
         )
     return file_system
 

--- a/lib/stardag/src/stardag/integration/modal/_target.py
+++ b/lib/stardag/src/stardag/integration/modal/_target.py
@@ -8,6 +8,7 @@ import aiofiles
 import modal
 from modal.exception import NotFoundError, ResourceExhaustedError
 from modal.volume import FileEntryType
+from pydantic_settings import BaseSettings, SettingsConfigDict
 from tenacity import (
     before_sleep_log,
     retry,
@@ -17,13 +18,58 @@ from tenacity import (
 )
 
 from stardag.integration.modal._config import modal_config_provider
-from stardag.target import LocalFileTarget, RemoteFileSystemABC, RemoteFileTarget
+from stardag.target import (
+    CachedRemoteFileSystem,
+    CachedRemoteFileSystemConfig,
+    LocalFileTarget,
+    RemoteFileSystemABC,
+    RemoteFileTarget,
+)
 from stardag.utils.resource_provider import resource_provider
 
 logger = logging.getLogger(__name__)
 
 MODAL_VOLUME_URI_PREFIX = "modalvol://"
 VOLUME_MOUNT_PATH_PREFIX = "/mnt/stardag-volumes"
+DEFAULT_CACHE_ROOT = Path("~/.stardag/cache/modalvol/").expanduser().absolute()
+
+
+class ModalVolumeCacheConfig(CachedRemoteFileSystemConfig):
+    root: str = str(DEFAULT_CACHE_ROOT)
+
+    model_config = SettingsConfigDict(
+        env_prefix="stardag_target_modalvol_cache_",
+        env_nested_delimiter="__",
+    )
+
+
+class ModalVolumeFileSystemConfig(BaseSettings):
+    """Settings for the Modal-volume RemoteFileSystem (API-based path).
+
+    Caching wraps the API-based ``ModalVolumeRemoteFileSystem`` only — when a
+    volume is locally mounted (running on Modal, or via
+    ``STARDAG_MODAL_VOLUME_MOUNTS`` / the auto-mount path), ``get_modal_target``
+    returns a ``ModalMountedVolumeFileTarget`` that bypasses the RFS entirely
+    and is therefore unaffected by these settings.
+
+    .. warning::
+        Modal volume names are unique only within a ``(workspace,
+        environment)`` pair, unlike S3 bucket names which are globally unique.
+        The same ``modalvol://<name>/...`` URI can therefore resolve to
+        different content across workspaces or environments. The cache is
+        keyed by URI alone, so if you switch between workspaces or
+        environments you **must** namespace the cache root accordingly to
+        avoid collisions — for example by including the workspace and
+        environment in ``STARDAG_TARGET_MODALVOL_CACHE_ROOT`` (e.g.
+        ``~/.stardag/cache/modalvol/<workspace>/<environment>/``) or by using
+        ``root_by_prefix`` to map specific volumes to dedicated cache
+        directories.
+    """
+
+    use_cache: bool = False
+    cache: ModalVolumeCacheConfig = ModalVolumeCacheConfig()
+
+    model_config = SettingsConfigDict(env_prefix="stardag_target_modalvol_")
 
 
 def get_default_volume_mount_path(volume_name: str) -> Path:
@@ -257,8 +303,19 @@ class ModalVolumeRemoteFileSystem(RemoteFileSystemABC):
             batch.put_file(source, in_volume_path)
 
 
+def _init_modal_volume_file_system() -> RemoteFileSystemABC:
+    file_system: RemoteFileSystemABC = ModalVolumeRemoteFileSystem()
+    config = ModalVolumeFileSystemConfig()
+    if config.use_cache:
+        file_system = CachedRemoteFileSystem(
+            wrapped=file_system,
+            **config.cache.model_dump(),
+        )
+    return file_system
+
+
 modal_volume_rfs_provider = resource_provider(
-    RemoteFileSystemABC, ModalVolumeRemoteFileSystem
+    RemoteFileSystemABC, _init_modal_volume_file_system
 )
 
 

--- a/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
@@ -1,0 +1,208 @@
+"""Tests for the optional disk-cache wrapper around ModalVolumeRemoteFileSystem.
+
+These tests run locally (no `modal.Function`) — caching only applies to the
+API-based ``RemoteFileTarget`` path used outside Modal. Auth + a real
+``stardag-testing`` volume are required, mirroring ``test__target.py``.
+"""
+
+import asyncio
+import uuid
+from pathlib import Path
+
+import pytest
+
+from stardag.target import CachedRemoteFileSystem, RemoteFileTarget
+
+VOLUME_NAME = "stardag-testing"
+
+try:
+    import modal
+    from modal.exception import AuthError
+
+    from stardag.integration import modal as sd_modal
+    from stardag.integration.modal._target import (
+        ModalVolumeRemoteFileSystem,
+        _init_modal_volume_file_system,
+        modal_volume_rfs_provider,
+    )
+
+    try:
+        VOLUME = modal.Volume.from_name(VOLUME_NAME, create_if_missing=True)
+        VOLUME.listdir("/")
+    except AuthError:
+        pytest.skip("Skipping modal tests (not authenticated)", allow_module_level=True)
+
+except ImportError:
+    pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+
+@pytest.fixture
+def reset_rfs_provider():
+    """Drop the cached provider state before and after each test."""
+    modal_volume_rfs_provider.clear()
+    yield
+    modal_volume_rfs_provider.clear()
+
+
+# ---------------------------------------------------------------------------
+# Wiring: USE_CACHE env var toggles the wrapper.
+# ---------------------------------------------------------------------------
+
+
+def test_init_unwrapped_when_use_cache_unset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("STARDAG_TARGET_MODALVOL_USE_CACHE", raising=False)
+    fs = _init_modal_volume_file_system()
+    assert isinstance(fs, ModalVolumeRemoteFileSystem)
+    assert not isinstance(fs, CachedRemoteFileSystem)
+
+
+def test_init_wrapped_when_use_cache_set(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("STARDAG_TARGET_MODALVOL_USE_CACHE", "true")
+    fs = _init_modal_volume_file_system()
+    assert isinstance(fs, CachedRemoteFileSystem)
+    assert isinstance(fs.wrapped, ModalVolumeRemoteFileSystem)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: write/read/exists through a cached target hits the real volume
+# AND populates the local cache directory.
+# ---------------------------------------------------------------------------
+
+
+def _override_with_cached_rfs(cache_root: Path):
+    return modal_volume_rfs_provider.override(
+        CachedRemoteFileSystem(
+            wrapped=ModalVolumeRemoteFileSystem(),
+            root=str(cache_root),
+        )
+    )
+
+
+def _expected_cache_path(cache_root: Path, rel: str) -> Path:
+    return cache_root / VOLUME_NAME / rel
+
+
+def test_round_trip_populates_cache(tmp_path: Path, reset_rfs_provider):
+    cache_root = tmp_path / "cache"
+    temp_dir = f"test-cache-{uuid.uuid4()}"
+    rel = f"{temp_dir}/test.txt"
+    uri = f"modalvol://{VOLUME_NAME}/{rel}"
+    expected_cache_file = _expected_cache_path(cache_root, rel)
+
+    with _override_with_cached_rfs(cache_root):
+        target = sd_modal.get_modal_target(uri)
+        # Cache only applies on the API-based path; mounted targets bypass the RFS.
+        assert isinstance(target, RemoteFileTarget)
+
+        try:
+            with target.open("w") as f:
+                f.write("hello cache")
+
+            assert expected_cache_file.exists()
+            assert expected_cache_file.read_text() == "hello cache"
+
+            assert target.exists()
+
+            with target.open("r") as f:
+                assert f.read() == "hello cache"
+        finally:
+            try:
+                VOLUME.remove_file(temp_dir, recursive=True)
+            except Exception:
+                pass
+
+
+def test_round_trip_populates_cache_aio(tmp_path: Path, reset_rfs_provider):
+    cache_root = tmp_path / "cache"
+    temp_dir = f"test-cache-aio-{uuid.uuid4()}"
+    rel = f"{temp_dir}/test_aio.txt"
+    uri = f"modalvol://{VOLUME_NAME}/{rel}"
+    expected_cache_file = _expected_cache_path(cache_root, rel)
+
+    async def _run():
+        with _override_with_cached_rfs(cache_root):
+            target = sd_modal.get_modal_target(uri)
+            assert isinstance(target, RemoteFileTarget)
+
+            async with target.open_aio("w") as f:
+                await f.write("hello cache aio")
+
+            assert expected_cache_file.exists()
+            assert expected_cache_file.read_text() == "hello cache aio"
+
+            assert await target.exists_aio()
+
+            async with target.open_aio("r") as f:
+                assert await f.read() == "hello cache aio"
+
+    try:
+        asyncio.run(_run())
+    finally:
+        try:
+            VOLUME.remove_file(temp_dir, recursive=True)
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Cache-hit isolation: once cached, a read can be served without the wrapped
+# RFS being touched. Verified by swapping the wrapped RFS for one that errors
+# on every operation, then re-reading.
+# ---------------------------------------------------------------------------
+
+
+class _ExplodingRemoteFileSystem(ModalVolumeRemoteFileSystem):
+    """Test double: any RFS operation raises, so a successful read proves
+    the result came from the local cache."""
+
+    URI_PREFIX = ModalVolumeRemoteFileSystem.URI_PREFIX
+
+    def exists(self, uri: str) -> bool:
+        raise AssertionError(f"unexpected exists() call for {uri}")
+
+    def download(self, uri: str, destination: Path):
+        raise AssertionError(f"unexpected download() call for {uri}")
+
+    def upload(self, source: Path, uri: str, ok_remove: bool = False):
+        raise AssertionError(f"unexpected upload() call for {uri}")
+
+    async def exists_aio(self, uri: str) -> bool:
+        raise AssertionError(f"unexpected exists_aio() call for {uri}")
+
+    async def download_aio(self, uri: str, destination: Path) -> None:
+        raise AssertionError(f"unexpected download_aio() call for {uri}")
+
+    async def upload_aio(self, source: Path, uri: str, ok_remove: bool = False) -> None:
+        raise AssertionError(f"unexpected upload_aio() call for {uri}")
+
+
+def test_cached_read_does_not_hit_wrapped_rfs(tmp_path: Path, reset_rfs_provider):
+    """After a write populates the cache, reads should not touch the wrapped RFS."""
+    cache_root = tmp_path / "cache"
+    temp_dir = f"test-cache-hit-{uuid.uuid4()}"
+    rel = f"{temp_dir}/test.txt"
+    uri = f"modalvol://{VOLUME_NAME}/{rel}"
+
+    # 1) Write through a real cached RFS so both volume and cache are populated.
+    with _override_with_cached_rfs(cache_root):
+        target = sd_modal.get_modal_target(uri)
+        try:
+            with target.open("w") as f:
+                f.write("cache hit")
+
+            # 2) Swap in a cached RFS whose wrapped backend explodes on access.
+            #    A successful read proves it came from the cache layer alone.
+            exploding = CachedRemoteFileSystem(
+                wrapped=_ExplodingRemoteFileSystem(),
+                root=str(cache_root),
+            )
+            with modal_volume_rfs_provider.override(exploding):
+                target_hit = sd_modal.get_modal_target(uri)
+                assert target_hit.exists()
+                with target_hit.open("r") as f:
+                    assert f.read() == "cache hit"
+        finally:
+            try:
+                VOLUME.remove_file(temp_dir, recursive=True)
+            except Exception:
+                pass

--- a/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
@@ -1,23 +1,30 @@
-"""Tests for the optional disk-cache wrapper around ModalVolumeRemoteFileSystem.
+"""Round-trip tests for the optional disk-cache wrapper around
+``ModalVolumeRemoteFileSystem``.
 
-These tests run locally (no `modal.Function`) — caching only applies to the
-API-based ``RemoteFileTarget`` path used outside Modal. Auth + a real
-``stardag-testing`` volume are required, mirroring ``test__target.py``.
+These tests hit the **real** Modal API and create/delete files on a
+pre-existing ``stardag-testing`` volume in whichever
+``(workspace, environment)`` is currently active for your local Modal
+credentials. They run locally (no ``modal.Function``) — caching only
+applies to the API-based ``RemoteFileTarget`` path used outside Modal.
+Pure configuration wiring is covered (without Modal auth) by
+``test__target_cache_config.py``.
 
 .. warning::
-    These tests hit the **real** Modal API and create/delete files on a real
-    volume in whichever ``(workspace, environment)`` is currently active for
-    your local Modal credentials. The caller is responsible for ensuring an
-    appropriate profile/environment is selected before running — e.g. a
-    personal/dev workspace, *not* a shared or production-adjacent one. Check
-    with ``modal profile current`` and switch with
+    The caller is responsible for ensuring an appropriate
+    profile/environment is selected before running — e.g. a personal/dev
+    workspace, *not* a shared or production-adjacent one. Check with
+    ``modal profile current`` and switch with
     ``modal profile activate <profile>`` if needed. The ``stardag-testing``
-    volume is auto-created on first run if missing.
+    volume must already exist in the active workspace/environment; these
+    tests deliberately do **not** auto-create it (test discovery should
+    not mutate external state). Create it once with
+    ``modal volume create stardag-testing`` if you intend to run these
+    tests locally.
 
 TODO: harden the setup so these tests can run in CI — pin to a dedicated
 test workspace/environment via ``MODAL_PROFILE`` / ``MODAL_ENVIRONMENT``,
-provision credentials as a CI secret, and gate on those being set instead
-of skipping silently on missing auth.
+provision credentials as a CI secret, and gate on those being set
+instead of skipping silently on missing auth/volume.
 """
 
 import asyncio
@@ -32,20 +39,27 @@ VOLUME_NAME = "stardag-testing"
 
 try:
     import modal
-    from modal.exception import AuthError
+    from modal.exception import AuthError, NotFoundError
 
     from stardag.integration import modal as sd_modal
     from stardag.integration.modal._target import (
         ModalVolumeRemoteFileSystem,
-        _init_modal_volume_file_system,
         modal_volume_rfs_provider,
     )
 
     try:
-        VOLUME = modal.Volume.from_name(VOLUME_NAME, create_if_missing=True)
+        VOLUME = modal.Volume.from_name(VOLUME_NAME)
         VOLUME.listdir("/")
     except AuthError:
         pytest.skip("Skipping modal tests (not authenticated)", allow_module_level=True)
+    except NotFoundError:
+        pytest.skip(
+            f"Skipping modal cache round-trip tests: volume {VOLUME_NAME!r} "
+            "not found in the active Modal workspace/environment. Create it "
+            f"with `modal volume create {VOLUME_NAME}` (in a personal/dev "
+            "workspace — not a shared one) before running these tests.",
+            allow_module_level=True,
+        )
 
 except ImportError:
     pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
@@ -57,25 +71,6 @@ def reset_rfs_provider():
     modal_volume_rfs_provider.clear()
     yield
     modal_volume_rfs_provider.clear()
-
-
-# ---------------------------------------------------------------------------
-# Wiring: USE_CACHE env var toggles the wrapper.
-# ---------------------------------------------------------------------------
-
-
-def test_init_unwrapped_when_use_cache_unset(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("STARDAG_TARGET_MODALVOL_USE_CACHE", raising=False)
-    fs = _init_modal_volume_file_system()
-    assert isinstance(fs, ModalVolumeRemoteFileSystem)
-    assert not isinstance(fs, CachedRemoteFileSystem)
-
-
-def test_init_wrapped_when_use_cache_set(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("STARDAG_TARGET_MODALVOL_USE_CACHE", "true")
-    fs = _init_modal_volume_file_system()
-    assert isinstance(fs, CachedRemoteFileSystem)
-    assert isinstance(fs.wrapped, ModalVolumeRemoteFileSystem)
 
 
 # ---------------------------------------------------------------------------

--- a/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
@@ -3,6 +3,21 @@
 These tests run locally (no `modal.Function`) — caching only applies to the
 API-based ``RemoteFileTarget`` path used outside Modal. Auth + a real
 ``stardag-testing`` volume are required, mirroring ``test__target.py``.
+
+.. warning::
+    These tests hit the **real** Modal API and create/delete files on a real
+    volume in whichever ``(workspace, environment)`` is currently active for
+    your local Modal credentials. The caller is responsible for ensuring an
+    appropriate profile/environment is selected before running — e.g. a
+    personal/dev workspace, *not* a shared or production-adjacent one. Check
+    with ``modal profile current`` and switch with
+    ``modal profile activate <profile>`` if needed. The ``stardag-testing``
+    volume is auto-created on first run if missing.
+
+TODO: harden the setup so these tests can run in CI — pin to a dedicated
+test workspace/environment via ``MODAL_PROFILE`` / ``MODAL_ENVIRONMENT``,
+provision credentials as a CI secret, and gate on those being set instead
+of skipping silently on missing auth.
 """
 
 import asyncio

--- a/lib/stardag/tests/test_integration/test_modal/test__target_cache_config.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__target_cache_config.py
@@ -1,0 +1,38 @@
+"""Pure configuration tests for the modalvol disk-cache wiring.
+
+These tests only exercise ``_init_modal_volume_file_system()`` — they do
+**not** hit the Modal API and do **not** require Modal credentials or a
+real volume. Round-trip behaviour against a real volume is covered by
+``test__target_cache.py`` (which is gated on auth).
+"""
+
+import pytest
+
+try:
+    import modal  # noqa: F401  — gate import errors at module level
+except ImportError:
+    pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+from stardag.integration.modal._target import (
+    ModalVolumeRemoteFileSystem,
+    _init_modal_volume_file_system,
+)
+from stardag.target import CachedRemoteFileSystem
+
+
+def test_init_unwrapped_when_cache_root_unset(monkeypatch: pytest.MonkeyPatch):
+    """No env var → caching is disabled and the bare RFS is returned."""
+    monkeypatch.delenv("STARDAG_TARGET_MODALVOL_CACHE_ROOT", raising=False)
+    fs = _init_modal_volume_file_system()
+    assert isinstance(fs, ModalVolumeRemoteFileSystem)
+    assert not isinstance(fs, CachedRemoteFileSystem)
+
+
+def test_init_wrapped_when_cache_root_set(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Setting STARDAG_TARGET_MODALVOL_CACHE_ROOT enables caching with that
+    root — there is intentionally no default root."""
+    monkeypatch.setenv("STARDAG_TARGET_MODALVOL_CACHE_ROOT", str(tmp_path))
+    fs = _init_modal_volume_file_system()
+    assert isinstance(fs, CachedRemoteFileSystem)
+    assert isinstance(fs.wrapped, ModalVolumeRemoteFileSystem)
+    assert str(fs.root) == str(tmp_path)


### PR DESCRIPTION
## Summary

- Adds optional local-disk caching for `modalvol://` targets — wraps `ModalVolumeRemoteFileSystem` with `CachedRemoteFileSystem` when caching is enabled.
- **Caching is opt-in via the cache root** (`STARDAG_TARGET_MODALVOL_CACHE_ROOT`). There is no default cache root and no separate "use cache" flag.
- Cache only applies on the API-based path used outside Modal. When a volume is locally mounted (`STARDAG_MODAL_VOLUME_MOUNTS` / auto-mount path), `get_modal_target` returns a `ModalMountedVolumeFileTarget` that bypasses the RFS entirely — so caching is automatically inactive on Modal workers, as required.

## Why no default cache root?

Unlike S3 bucket names, Modal volume names are **only unique within a `(workspace, environment)` pair**. The same `modalvol://<name>/...` URI can therefore resolve to different content under different credentials. Because `CachedRemoteFileSystem` keys cache entries by URI alone, a default like `~/.stardag/cache/modalvol/` would silently collide across profiles after a workspace/environment switch — returning stale or cross-tenant data.

Forcing the user to set the root makes the workspace/environment scoping a deliberate choice. Recommended pattern: include the workspace and environment in the path, e.g. `STARDAG_TARGET_MODALVOL_CACHE_ROOT=~/.stardag/cache/modalvol/<workspace>/<environment>/`. Or use `root_by_prefix` to map specific volumes to dedicated cache directories. The `ModalVolumeCacheConfig` docstring spells this out.

## Resulting env-var surface

| S3 | Modal volume |
|---|---|
| `STARDAG_TARGET_S3_USE_CACHE` (toggle) + `STARDAG_TARGET_S3_CACHE_ROOT` (defaulted) | `STARDAG_TARGET_MODALVOL_CACHE_ROOT` (sole toggle, no default) |
| `STARDAG_TARGET_S3_CACHE_ROOT_BY_PREFIX` | `STARDAG_TARGET_MODALVOL_CACHE_ROOT_BY_PREFIX` |
| `STARDAG_TARGET_S3_CACHE_ALLOW_CACHE_CHECK_EXISTS` | `STARDAG_TARGET_MODALVOL_CACHE_ALLOW_CACHE_CHECK_EXISTS` |

The S3 setup uses two env vars (`USE_CACHE` + `CACHE_ROOT`) because S3 has a globally-unique namespace where a default root is safe. The modalvol setup deliberately diverges: presence of `CACHE_ROOT` is the sole toggle, since any default would risk collisions.

## Test plan

- `tests/test_integration/test_modal/test__target_cache_config.py` — pure config tests, **no Modal credentials required**:
  - [x] `STARDAG_TARGET_MODALVOL_CACHE_ROOT` unset → bare `ModalVolumeRemoteFileSystem`
  - [x] `STARDAG_TARGET_MODALVOL_CACHE_ROOT` set → wrapped in `CachedRemoteFileSystem` with that root
- `tests/test_integration/test_modal/test__target_cache.py` — round-trip tests against a real Modal volume (auth + pre-existing `stardag-testing` volume required; skips with explicit instructions if not present):
  - [x] sync write/read/exists round-trip populates the cache directory at the expected path
  - [x] async equivalent
  - [x] cache-hit reads do not touch the wrapped RFS (verified by swapping in a test double that asserts on every method call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)