### PR TITLE
Make CachedRemoteFileSystem.upload(_aio) crash-atomic

### DIFF
--- a/lib/stardag/src/stardag/target/_base.py
+++ b/lib/stardag/src/stardag/target/_base.py
@@ -977,22 +977,24 @@ def _publish_to_cache_atomically(
     cache_path: Path,
     populate: typing.Callable[[Path], None],
 ) -> None:
-    """Write to ``cache_path`` via a tmp-then-rename pattern so concurrent
+    """Write to ``cache_path`` via a tmp-then-replace pattern so concurrent
     readers (and crash recovery) never observe a partial file at the final
     path.
 
     ``populate(tmp_path)`` is called with a sibling temp path and must
     write the final contents there. On success the temp is atomically
-    renamed onto ``cache_path``. On any failure (``populate`` raising,
-    rename failing, etc.) the temp is unlinked and ``cache_path`` is
-    untouched — so a subsequent reader sees either the previous cache
-    state or no cache file at all, never a partial one.
+    moved onto ``cache_path`` via ``Path.replace``, which overwrites any
+    existing entry — supports cache refresh on POSIX *and* Windows (plain
+    ``rename`` won't overwrite on Windows). On any failure (``populate``
+    raising, replace failing, etc.) the temp is unlinked and
+    ``cache_path`` is untouched — so a subsequent reader sees either the
+    previous cache state or no cache file at all, never a partial one.
     """
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_cache_path = cache_path.with_suffix(f".tmp-{uuid6.uuid7()}")
     try:
         populate(tmp_cache_path)
-        tmp_cache_path.rename(cache_path)
+        tmp_cache_path.replace(cache_path)
     finally:
         if tmp_cache_path.exists():
             tmp_cache_path.unlink()
@@ -1007,7 +1009,7 @@ async def _publish_to_cache_atomically_aio(
     tmp_cache_path = cache_path.with_suffix(f".tmp-{uuid6.uuid7()}")
     try:
         await populate(tmp_cache_path)
-        await aiofiles.os.rename(tmp_cache_path, cache_path)
+        await aiofiles.os.replace(tmp_cache_path, cache_path)
     finally:
         if await aiofiles.os.path.exists(tmp_cache_path):
             await aiofiles.os.remove(tmp_cache_path)
@@ -1079,13 +1081,16 @@ class CachedRemoteFileSystem(RemoteFileSystemABC):
         cache_path = self.get_cache_path(uri)
         cache_path.parent.mkdir(parents=True, exist_ok=True)
         if ok_remove:
-            # POSIX rename(2) is atomic on the same filesystem — cache_path
-            # is never observed in a partial state. No temp-file hop needed.
-            # (Cross-FS rename raises EXDEV; cache_path stays untouched.)
-            source.rename(cache_path)
+            # ``replace`` is atomic on the same filesystem (rename(2) on
+            # POSIX, MoveFileEx with REPLACE_EXISTING on Windows) — and
+            # unlike plain ``rename`` it overwrites an existing
+            # cache_path so cache refreshes work cross-platform.
+            # (Cross-FS rename still raises EXDEV; cache_path stays
+            # untouched in that case.)
+            source.replace(cache_path)
         else:
-            # shutil.copy is not crash-atomic — route through tmp+rename so
-            # an interrupted copy never publishes a partial cache entry.
+            # shutil.copy is not crash-atomic — route through tmp+replace
+            # so an interrupted copy never publishes a partial cache entry.
             def _populate(tmp: Path) -> None:
                 shutil.copy(source, tmp)
 
@@ -1130,8 +1135,9 @@ class CachedRemoteFileSystem(RemoteFileSystemABC):
         cache_path = self.get_cache_path(uri)
         await aiofiles.os.makedirs(cache_path.parent, exist_ok=True)
         if ok_remove:
-            # rename(2) is atomic — see upload() for rationale.
-            await aiofiles.os.rename(source, cache_path)
+            # See upload() — replace is atomic on POSIX and overwrite-safe
+            # on Windows.
+            await aiofiles.os.replace(source, cache_path)
         else:
 
             async def _populate(tmp: Path) -> None:

--- a/lib/stardag/src/stardag/target/_base.py
+++ b/lib/stardag/src/stardag/target/_base.py
@@ -973,6 +973,46 @@ class InMemoryRemoteFileSystem(RemoteFileSystemABC):
             self.uri_to_bytes[uri] = await f.read()
 
 
+def _publish_to_cache_atomically(
+    cache_path: Path,
+    populate: typing.Callable[[Path], None],
+) -> None:
+    """Write to ``cache_path`` via a tmp-then-rename pattern so concurrent
+    readers (and crash recovery) never observe a partial file at the final
+    path.
+
+    ``populate(tmp_path)`` is called with a sibling temp path and must
+    write the final contents there. On success the temp is atomically
+    renamed onto ``cache_path``. On any failure (``populate`` raising,
+    rename failing, etc.) the temp is unlinked and ``cache_path`` is
+    untouched — so a subsequent reader sees either the previous cache
+    state or no cache file at all, never a partial one.
+    """
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_cache_path = cache_path.with_suffix(f".tmp-{uuid6.uuid7()}")
+    try:
+        populate(tmp_cache_path)
+        tmp_cache_path.rename(cache_path)
+    finally:
+        if tmp_cache_path.exists():
+            tmp_cache_path.unlink()
+
+
+async def _publish_to_cache_atomically_aio(
+    cache_path: Path,
+    populate: typing.Callable[[Path], typing.Awaitable[None]],
+) -> None:
+    """Async variant of :func:`_publish_to_cache_atomically`."""
+    await aiofiles.os.makedirs(cache_path.parent, exist_ok=True)
+    tmp_cache_path = cache_path.with_suffix(f".tmp-{uuid6.uuid7()}")
+    try:
+        await populate(tmp_cache_path)
+        await aiofiles.os.rename(tmp_cache_path, cache_path)
+    finally:
+        if await aiofiles.os.path.exists(tmp_cache_path):
+            await aiofiles.os.remove(tmp_cache_path)
+
+
 class CachedRemoteFileSystemConfig(BaseSettings):
     root: str
     root_by_prefix: typing.Dict[str, str] = {}
@@ -1036,13 +1076,15 @@ class CachedRemoteFileSystem(RemoteFileSystemABC):
     def upload(self, source: Path, uri: str, ok_remove: bool = False):
         self.wrapped.upload(source, uri, ok_remove=False)
         # NOTE only cache the file if the upload was successful!
-        cache_path = self.get_cache_path(uri)
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        if ok_remove:
-            # NOTE faster to rename than to copy!
-            source.rename(cache_path)
-        else:
-            shutil.copy(source, cache_path)
+
+        def _populate_from_source(tmp: Path) -> None:
+            if ok_remove:
+                # NOTE faster to rename than to copy!
+                source.rename(tmp)
+            else:
+                shutil.copy(source, tmp)
+
+        _publish_to_cache_atomically(self.get_cache_path(uri), _populate_from_source)
 
     def enter_readable_proxy_path(self, uri: str) -> Path:
         cache_path = self.get_cache_path(uri)
@@ -1055,14 +1097,9 @@ class CachedRemoteFileSystem(RemoteFileSystemABC):
         pass
 
     def _load_to_cache_atomically(self, uri: str, cache_path: Path):
-        tmp_cache_path = cache_path.with_suffix(f".tmp-{uuid6.uuid7()}")
-        tmp_cache_path.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            self.wrapped.download(uri, tmp_cache_path)
-            tmp_cache_path.rename(cache_path)  # type: ignore
-        finally:
-            if tmp_cache_path.exists():
-                tmp_cache_path.unlink()
+        _publish_to_cache_atomically(
+            cache_path, lambda tmp: self.wrapped.download(uri, tmp)
+        )
 
     # Async implementations
 
@@ -1085,12 +1122,16 @@ class CachedRemoteFileSystem(RemoteFileSystemABC):
     async def upload_aio(self, source: Path, uri: str, ok_remove: bool = False) -> None:
         """Async upload with cache update."""
         await self.wrapped.upload_aio(source, uri, ok_remove=False)
-        cache_path = self.get_cache_path(uri)
-        await aiofiles.os.makedirs(cache_path.parent, exist_ok=True)
-        if ok_remove:
-            await aiofiles.os.rename(source, cache_path)
-        else:
-            shutil.copy(source, cache_path)
+
+        async def _populate_from_source(tmp: Path) -> None:
+            if ok_remove:
+                await aiofiles.os.rename(source, tmp)
+            else:
+                shutil.copy(source, tmp)  # Local copy is fast, keep sync
+
+        await _publish_to_cache_atomically_aio(
+            self.get_cache_path(uri), _populate_from_source
+        )
 
     async def enter_readable_proxy_path_aio(self, uri: str) -> Path:
         """Async version returns cached path."""
@@ -1105,14 +1146,9 @@ class CachedRemoteFileSystem(RemoteFileSystemABC):
 
     async def _load_to_cache_atomically_aio(self, uri: str, cache_path: Path) -> None:
         """Async atomic download to cache."""
-        tmp_cache_path = cache_path.with_suffix(f".tmp-{uuid6.uuid7()}")
-        await aiofiles.os.makedirs(tmp_cache_path.parent, exist_ok=True)
-        try:
-            await self.wrapped.download_aio(uri, tmp_cache_path)
-            await aiofiles.os.rename(tmp_cache_path, cache_path)
-        finally:
-            if await aiofiles.os.path.exists(tmp_cache_path):
-                await aiofiles.os.remove(tmp_cache_path)
+        await _publish_to_cache_atomically_aio(
+            cache_path, lambda tmp: self.wrapped.download_aio(uri, tmp)
+        )
 
 
 class DirectoryTarget(FileSystemTarget):

--- a/lib/stardag/src/stardag/target/_base.py
+++ b/lib/stardag/src/stardag/target/_base.py
@@ -1076,15 +1076,20 @@ class CachedRemoteFileSystem(RemoteFileSystemABC):
     def upload(self, source: Path, uri: str, ok_remove: bool = False):
         self.wrapped.upload(source, uri, ok_remove=False)
         # NOTE only cache the file if the upload was successful!
-
-        def _populate_from_source(tmp: Path) -> None:
-            if ok_remove:
-                # NOTE faster to rename than to copy!
-                source.rename(tmp)
-            else:
+        cache_path = self.get_cache_path(uri)
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        if ok_remove:
+            # POSIX rename(2) is atomic on the same filesystem — cache_path
+            # is never observed in a partial state. No temp-file hop needed.
+            # (Cross-FS rename raises EXDEV; cache_path stays untouched.)
+            source.rename(cache_path)
+        else:
+            # shutil.copy is not crash-atomic — route through tmp+rename so
+            # an interrupted copy never publishes a partial cache entry.
+            def _populate(tmp: Path) -> None:
                 shutil.copy(source, tmp)
 
-        _publish_to_cache_atomically(self.get_cache_path(uri), _populate_from_source)
+            _publish_to_cache_atomically(cache_path, _populate)
 
     def enter_readable_proxy_path(self, uri: str) -> Path:
         cache_path = self.get_cache_path(uri)
@@ -1122,16 +1127,17 @@ class CachedRemoteFileSystem(RemoteFileSystemABC):
     async def upload_aio(self, source: Path, uri: str, ok_remove: bool = False) -> None:
         """Async upload with cache update."""
         await self.wrapped.upload_aio(source, uri, ok_remove=False)
+        cache_path = self.get_cache_path(uri)
+        await aiofiles.os.makedirs(cache_path.parent, exist_ok=True)
+        if ok_remove:
+            # rename(2) is atomic — see upload() for rationale.
+            await aiofiles.os.rename(source, cache_path)
+        else:
 
-        async def _populate_from_source(tmp: Path) -> None:
-            if ok_remove:
-                await aiofiles.os.rename(source, tmp)
-            else:
+            async def _populate(tmp: Path) -> None:
                 shutil.copy(source, tmp)  # Local copy is fast, keep sync
 
-        await _publish_to_cache_atomically_aio(
-            self.get_cache_path(uri), _populate_from_source
-        )
+            await _publish_to_cache_atomically_aio(cache_path, _populate)
 
     async def enter_readable_proxy_path_aio(self, uri: str) -> Path:
         """Async version returns cached path."""

--- a/lib/stardag/tests/test_target/test__base.py
+++ b/lib/stardag/tests/test_target/test__base.py
@@ -192,6 +192,127 @@ def test_cached_remote_filesystem_target(tmp_path: Path):
     assert cache_path.read_text() == "test"
 
 
+def test_cached_remote_filesystem_upload_is_crash_atomic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """A crash mid-cache-copy must not leave a partial file at the final
+    cache path. Subsequent reads short-circuit on ``cache_path.exists()``
+    without verifying length, so a partial entry would silently return
+    truncated bytes — the upload path must publish atomically (write to
+    a temp file, then rename) just like the download path does."""
+    from stardag.target import _base as base_module
+
+    rfs_base = InMemoryRemoteFileSystem()
+    cache_root = tmp_path / "cache"
+    rfs = CachedRemoteFileSystem(wrapped=rfs_base, root=str(cache_root))
+    uri = "in-memory://bucket/key"
+
+    source = tmp_path / "source.txt"
+    source.write_text("the full payload")
+
+    real_copy = base_module.shutil.copy
+
+    def partial_then_fail(src, dst):
+        # Simulate a crash partway through the copy: write some bytes,
+        # then raise. Without atomicity, ``dst == cache_path`` would now
+        # contain truncated content.
+        with open(src, "rb") as fin, open(dst, "wb") as fout:
+            fout.write(fin.read(4))  # partial
+        raise OSError("simulated mid-copy crash")
+
+    monkeypatch.setattr(base_module.shutil, "copy", partial_then_fail)
+
+    with pytest.raises(OSError, match="simulated mid-copy crash"):
+        rfs.upload(source, uri)
+
+    # The wrapped upload still succeeded (it ran before the cache copy).
+    assert rfs_base.uri_to_bytes[uri] == b"the full payload"
+
+    # No partial entry at the final cache path → next read will be served
+    # from the wrapped RFS (atomic download), repopulating the cache cleanly.
+    cache_path = rfs.get_cache_path(uri)
+    assert not cache_path.exists()
+
+    # And no leftover tmp files cluttering the cache directory.
+    leftovers = list(cache_path.parent.glob("*.tmp-*"))
+    assert leftovers == [], f"unexpected tmp files left behind: {leftovers}"
+
+    # Sanity: clearing the failure injection and reading via the cached RFS
+    # works — the wrapped RFS still has the file, atomic download repopulates.
+    monkeypatch.setattr(base_module.shutil, "copy", real_copy)
+    with RemoteFileTarget(uri=uri, rfs=rfs).open("r") as f:
+        assert f.read() == "the full payload"
+    assert cache_path.read_text() == "the full payload"
+
+
+def test_cached_remote_filesystem_upload_ok_remove_is_crash_atomic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """The ``ok_remove=True`` branch must also publish atomically. We
+    inject a failure on the *final* rename (tmp → cache_path) — without
+    the temp-file pattern there'd be no tmp at all and the source rename
+    would have already gone straight to ``cache_path``."""
+    from stardag.target import _base as base_module
+
+    rfs_base = InMemoryRemoteFileSystem()
+    cache_root = tmp_path / "cache"
+    rfs = CachedRemoteFileSystem(wrapped=rfs_base, root=str(cache_root))
+    uri = "in-memory://bucket/key"
+
+    source = tmp_path / "source.txt"
+    source.write_text("payload")
+
+    cache_path = rfs.get_cache_path(uri)
+    real_rename = base_module.Path.rename
+
+    def fail_only_final_publish(self, target):
+        if Path(target) == cache_path:
+            raise OSError("simulated final-rename crash")
+        return real_rename(self, target)
+
+    monkeypatch.setattr(base_module.Path, "rename", fail_only_final_publish)
+
+    with pytest.raises(OSError, match="simulated final-rename crash"):
+        rfs.upload(source, uri, ok_remove=True)
+
+    # No partial entry at the final cache path; tmp was cleaned up.
+    assert not cache_path.exists()
+    leftovers = list(cache_path.parent.glob("*.tmp-*"))
+    assert leftovers == [], f"unexpected tmp files left behind: {leftovers}"
+
+
+async def test_cached_remote_filesystem_upload_aio_is_crash_atomic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Async equivalent of the sync atomicity test."""
+    from stardag.target import _base as base_module
+
+    rfs_base = InMemoryRemoteFileSystem()
+    cache_root = tmp_path / "cache"
+    rfs = CachedRemoteFileSystem(wrapped=rfs_base, root=str(cache_root))
+    uri = "in-memory://bucket/key"
+
+    source = tmp_path / "source.txt"
+    source.write_text("the full payload")
+
+    def partial_then_fail(src, dst):
+        with open(src, "rb") as fin, open(dst, "wb") as fout:
+            fout.write(fin.read(4))
+        raise OSError("simulated mid-copy crash")
+
+    monkeypatch.setattr(base_module.shutil, "copy", partial_then_fail)
+
+    with pytest.raises(OSError, match="simulated mid-copy crash"):
+        await rfs.upload_aio(source, uri)
+
+    # Wrapped upload succeeded; cache is clean (no partial entry, no tmp).
+    assert rfs_base.uri_to_bytes[uri] == b"the full payload"
+    cache_path = rfs.get_cache_path(uri)
+    assert not cache_path.exists()
+    leftovers = list(cache_path.parent.glob("*.tmp-*"))
+    assert leftovers == [], f"unexpected tmp files left behind: {leftovers}"
+
+
 def test_directory_target(tmp_path: Path):
     dir_target = DirectoryTarget(uri=str(tmp_path / "test"), prototype=LocalFileTarget)
     assert not dir_target.exists()

--- a/lib/stardag/tests/test_target/test__base.py
+++ b/lib/stardag/tests/test_target/test__base.py
@@ -245,13 +245,16 @@ def test_cached_remote_filesystem_upload_is_crash_atomic(
     assert cache_path.read_text() == "the full payload"
 
 
-def test_cached_remote_filesystem_upload_ok_remove_is_crash_atomic(
+def test_cached_remote_filesystem_upload_ok_remove_rename_failure_is_safe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """The ``ok_remove=True`` branch must also publish atomically. We
-    inject a failure on the *final* rename (tmp → cache_path) — without
-    the temp-file pattern there'd be no tmp at all and the source rename
-    would have already gone straight to ``cache_path``."""
+    """The ``ok_remove=True`` branch publishes via a single direct rename
+    (POSIX-atomic on same FS), bypassing the tmp-file helper. If that
+    rename fails (e.g., EXDEV across filesystems, or any other reason —
+    simulated here), ``cache_path`` must not exist. Atomicity here is a
+    POSIX guarantee on ``rename(2)``, not something we orchestrate; this
+    test guards against a future regression to a non-atomic write path
+    (e.g., switching to ``shutil.move``) for the rename branch."""
     from stardag.target import _base as base_module
 
     rfs_base = InMemoryRemoteFileSystem()
@@ -265,17 +268,18 @@ def test_cached_remote_filesystem_upload_ok_remove_is_crash_atomic(
     cache_path = rfs.get_cache_path(uri)
     real_rename = base_module.Path.rename
 
-    def fail_only_final_publish(self, target):
+    def fail_only_cache_publish(self, target):
         if Path(target) == cache_path:
-            raise OSError("simulated final-rename crash")
+            raise OSError("simulated rename failure")
         return real_rename(self, target)
 
-    monkeypatch.setattr(base_module.Path, "rename", fail_only_final_publish)
+    monkeypatch.setattr(base_module.Path, "rename", fail_only_cache_publish)
 
-    with pytest.raises(OSError, match="simulated final-rename crash"):
+    with pytest.raises(OSError, match="simulated rename failure"):
         rfs.upload(source, uri, ok_remove=True)
 
-    # No partial entry at the final cache path; tmp was cleaned up.
+    # No entry at the final cache path; no tmp files (none should have
+    # been created by the rename branch).
     assert not cache_path.exists()
     leftovers = list(cache_path.parent.glob("*.tmp-*"))
     assert leftovers == [], f"unexpected tmp files left behind: {leftovers}"

--- a/lib/stardag/tests/test_target/test__base.py
+++ b/lib/stardag/tests/test_target/test__base.py
@@ -245,16 +245,16 @@ def test_cached_remote_filesystem_upload_is_crash_atomic(
     assert cache_path.read_text() == "the full payload"
 
 
-def test_cached_remote_filesystem_upload_ok_remove_rename_failure_is_safe(
+def test_cached_remote_filesystem_upload_ok_remove_publish_failure_is_safe(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ):
-    """The ``ok_remove=True`` branch publishes via a single direct rename
-    (POSIX-atomic on same FS), bypassing the tmp-file helper. If that
-    rename fails (e.g., EXDEV across filesystems, or any other reason —
-    simulated here), ``cache_path`` must not exist. Atomicity here is a
-    POSIX guarantee on ``rename(2)``, not something we orchestrate; this
-    test guards against a future regression to a non-atomic write path
-    (e.g., switching to ``shutil.move``) for the rename branch."""
+    """The ``ok_remove=True`` branch publishes via a single direct
+    ``Path.replace`` call (atomic on POSIX via rename(2), atomic on
+    Windows via MoveFileEx with REPLACE_EXISTING). If that replace fails
+    (e.g., EXDEV across filesystems, or any other reason — simulated
+    here), ``cache_path`` must not exist and the wrapped remote upload
+    must still have succeeded (it runs before the cache publish step).
+    Guards against a future regression to a non-atomic write path."""
     from stardag.target import _base as base_module
 
     rfs_base = InMemoryRemoteFileSystem()
@@ -266,23 +266,50 @@ def test_cached_remote_filesystem_upload_ok_remove_rename_failure_is_safe(
     source.write_text("payload")
 
     cache_path = rfs.get_cache_path(uri)
-    real_rename = base_module.Path.rename
+    real_replace = base_module.Path.replace
 
     def fail_only_cache_publish(self, target):
         if Path(target) == cache_path:
-            raise OSError("simulated rename failure")
-        return real_rename(self, target)
+            raise OSError("simulated replace failure")
+        return real_replace(self, target)
 
-    monkeypatch.setattr(base_module.Path, "rename", fail_only_cache_publish)
+    monkeypatch.setattr(base_module.Path, "replace", fail_only_cache_publish)
 
-    with pytest.raises(OSError, match="simulated rename failure"):
+    with pytest.raises(OSError, match="simulated replace failure"):
         rfs.upload(source, uri, ok_remove=True)
 
+    # Wrapped upload still ran before the cache publish step.
+    assert rfs_base.uri_to_bytes[uri] == b"payload"
+
     # No entry at the final cache path; no tmp files (none should have
-    # been created by the rename branch).
+    # been created — ok_remove=True bypasses the tmp helper).
     assert not cache_path.exists()
     leftovers = list(cache_path.parent.glob("*.tmp-*"))
     assert leftovers == [], f"unexpected tmp files left behind: {leftovers}"
+
+
+def test_cached_remote_filesystem_upload_refreshes_existing_cache_entry(
+    tmp_path: Path,
+):
+    """Re-uploading the same URI must replace the cache entry — exercises
+    the overwrite semantics of ``Path.replace`` (cross-platform: rename(2)
+    on POSIX, ``MoveFileEx REPLACE_EXISTING`` on Windows). Plain
+    ``Path.rename`` would error here on Windows, breaking cache refresh."""
+    rfs_base = InMemoryRemoteFileSystem()
+    rfs = CachedRemoteFileSystem(wrapped=rfs_base, root=str(tmp_path / "cache"))
+    uri = "in-memory://bucket/key"
+    target = RemoteFileTarget(uri=uri, rfs=rfs)
+
+    with target.open("w") as f:
+        f.write("first")
+    cache_path = rfs.get_cache_path(uri)
+    assert cache_path.read_text() == "first"
+
+    with target.open("w") as f:
+        f.write("second")
+
+    assert cache_path.read_text() == "second"
+    assert rfs_base.uri_to_bytes[uri] == b"second"
 
 
 async def test_cached_remote_filesystem_upload_aio_is_crash_atomic(


### PR DESCRIPTION
## Summary

`CachedRemoteFileSystem.download()` short-circuits on `cache_path.exists()` without verifying file length, so any partial file at the final cache path silently poisons subsequent reads — they'd return the truncated bytes, no error, no way for the cache to detect it.

Until now, `upload()` / `upload_aio()` wrote to that final path **directly** via `shutil.copy(source, cache_path)` (copy branch) or `source.rename(cache_path)` (rename branch when `ok_remove=True`). A process killed mid-copy (OOM, SIGKILL, power loss) would leave a truncated file at `cache_path`. Every future read on that machine would return the partial bytes until the file was manually removed.

The download path already used a tmp-then-rename pattern via `_load_to_cache_atomically(_aio)`. This PR:

1. Factors that pattern into reusable helpers `_publish_to_cache_atomically(_aio)`. The helper takes a `populate(tmp_path)` callback — agnostic of how the temp gets populated. Used by both download paths and the upload `ok_remove=False` (`shutil.copy`) branch.
2. Uses `Path.replace` / `aiofiles.os.replace` (rather than `rename`) for the final publish step. POSIX-atomic via rename(2), atomic-with-overwrite on Windows via `MoveFileEx REPLACE_EXISTING`. Plain `rename` would fail to overwrite on Windows, breaking cache refresh on re-uploads.
3. Leaves `ok_remove=True` as a single direct `source.replace(cache_path)`. POSIX `rename(2)` (and Windows `MoveFileEx`) are inherently atomic — no temp-file hop needed when the populate operation is already atomic. This also avoids any path where a failed publish could lose `source` (the helper's `finally` would unlink a tmp that `source` had been moved into).

After the fix, a crash during cache population leaves either the previous cache state or no cache file at all — never a partial one. Re-uploading the same URI works on both POSIX and Windows.

## Behavioural notes

- `wrapped.upload(...)` runs first and is unchanged. If it fails, the cache is never touched.
- `ok_remove=True` is now a **direct** `source.replace(cache_path)`. If that fails (EXDEV cross-filesystem, permissions, etc.), POSIX/Windows guarantee both `source` and `cache_path` are unchanged — caller can retry safely.
- `ok_remove=False` is `shutil.copy(source, tmp)` + `tmp.replace(cache_path)`. Crash mid-copy leaves a partial tmp (cleaned up in `finally`); `cache_path` is untouched.
- `download` / `enter_readable_proxy_path` (and their async variants) are refactored to share the same helper. Same external behavior, less duplication.

## Test plan

Four new tests in `lib/stardag/tests/test_target/test__base.py`:

- [x] `test_cached_remote_filesystem_upload_is_crash_atomic` — copy branch (sync): monkeypatch `shutil.copy` to write partial bytes then raise. Assert: final `cache_path` does not exist; no `.tmp-*` files left; wrapped RFS still has the file; a subsequent read repopulates the cache cleanly via the atomic download.
- [x] `test_cached_remote_filesystem_upload_ok_remove_publish_failure_is_safe` — rename branch (sync): monkeypatch `Path.replace` to fail. Assert: cache_path doesn't exist, no tmp leaks, wrapped RFS contains the payload.
- [x] `test_cached_remote_filesystem_upload_aio_is_crash_atomic` — async equivalent of the copy-branch test.
- [x] `test_cached_remote_filesystem_upload_refreshes_existing_cache_entry` — re-upload smoke test: upload twice, assert the cache entry updates. Exercises overwrite semantics; would fail on Windows with plain `rename`.

All 19 tests in `test__base.py` pass. The 5 modal cache integration tests (real Modal volume, real round-trips) also pass — confirms the refactor doesn't regress the existing happy path.

## Follow-up

PR [#137](https://github.com/stardag-dev/stardag/pull/137) (v0.6.1 release notes) currently describes cache writes with a caveat about partial entries on crash. Once this fix lands, that wording should be tightened to remove the caveat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)