### PR TITLE
Cancel in-flight siblings on FAIL_FAST + emit TASK_SKIPPED for blocked tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,56 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.7.0] — 2026-05-05
+
+`FailMode.FAIL_FAST` now actually fails fast: in-flight sibling tasks
+are cancelled (rather than silently abandoned) and tasks blocked by a
+failed dependency emit `TASK_SKIPPED` rather than staying `PENDING`
+forever. No client-code changes — `pip install -U stardag` is
+sufficient. See
+[RELEASE_NOTES.md](RELEASE_NOTES.md#v070--fail_fast-actually-fails-fast-explicit-skipped-status-for-blocked-tasks)
+for details.
+([#139](https://github.com/stardag-dev/stardag/pull/139))
+
+### SDK
+
+#### New behaviour
+
+- **FAIL_FAST cancels in-flight siblings.** Asyncio cancel propagates
+  into `modal.Function.remote.aio` and terminates the remote
+  container; each cancelled task fires `TASK_CANCELLED` and releases
+  any global lock it held. Previously the build re-raised in place,
+  abandoning Modal calls (containers kept running and billing; registry
+  left them stuck in `RUNNING`).
+- **Tasks blocked by failed deps emit `TASK_SKIPPED`** (both
+  `FAIL_FAST` and `CONTINUE`). A fixed-point walk after the loop emits
+  per-task skip events for transitively blocked downstream work.
+- **Sibling completions in the same `asyncio.wait` `done` batch as a
+  failure are no longer lost** — `process_result` defers FAIL_FAST
+  escalation until the batch finishes, so sibling
+  `task_complete_aio`/`task_fail_aio` events still land.
+
+#### New public API (additive; default no-op for existing implementations)
+
+- `TaskExecutorABC.cancel(task)` — optional best-effort cancel hook.
+  `RoutedTaskExecutor.cancel` routes to the matching child.
+- `RegistryABC.task_skip` / `task_skip_aio`.
+- `TaskCount.cancelled` and `TaskCount.skipped`; rendered by
+  `BuildSummary.__repr__` when non-zero.
+
+### Registry API
+
+- **New `POST /api/v1/builds/{build_id}/tasks/{task_id}/skip`** —
+  emits `TASK_SKIPPED`, mirroring the existing `/cancel` route.
+
+### Compatibility
+
+New SDK against an older Registry API (no `/skip` route): degrades
+gracefully via the existing `_is_route_not_found` pattern (warning
+logged, blocked tasks stay `PENDING` — pre-0.7.0 observable
+behaviour). Older SDK against the new API: unaffected (additive
+endpoint only).
+
 ## [0.6.1] — 2026-05-05
 
 Patch release covering the Modal-volume integration. No breaking changes;

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,62 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.7.0 — FAIL_FAST actually fails fast; explicit SKIPPED status for blocked tasks
+
+Two related fixes to the build loop's failure handling. No breaking
+changes — `pip install -U stardag` is sufficient. The behaviour change
+matters mainly if you've been running `FailMode.FAIL_FAST` builds with
+long-running tasks in flight (Modal worker calls, slow async tasks):
+those will now exit promptly on the first failure instead of silently
+abandoning the remote calls or blocking on in-flight work to drain.
+
+### What changed
+
+**FAIL_FAST cancels in-flight siblings.** When a task fails, the build
+loop processes the rest of the current `asyncio.wait` batch first (so
+sibling completions land), then cancels every remaining
+`pending_futures` entry. asyncio cancellation propagates into
+`modal.Function.remote.aio` and Modal terminates the remote container.
+Each cancelled task gets a `TASK_CANCELLED` event and any global lock
+it held is released with `completed=False`. Previously the build
+re-raised in place — the asyncio cancel never reached the executor,
+Modal containers kept running and billing, and the registry left them
+stuck in `RUNNING`.
+
+**Tasks blocked by a failed dep emit `TASK_SKIPPED`.** A fixed-point
+walk after the build loop emits `task_skip_aio` for any task whose
+dependency failed or was cancelled, including transitive descendants.
+Applies to both `FAIL_FAST` and `CONTINUE`. Previously they stayed
+`PENDING` in the registry forever.
+
+### New API surface (additive)
+
+For users writing custom executors or registries:
+
+- `TaskExecutorABC.cancel(task)` — optional best-effort cancel hook.
+  Default no-op. Override for executor-specific termination beyond
+  asyncio cooperation. `HybridConcurrentTaskExecutor`'s thread/process
+  pools rely on the asyncio.cancel of the wrapping future and the
+  inherited no-op (Python can't reliably terminate threads/subprocesses
+  anyway, and the existing `teardown(wait=True)` will still block
+  until they finish).
+- `RegistryABC.task_skip` / `task_skip_aio` — default no-op. The
+  `APIRegistry` impl POSTs to a new `/skip` route.
+- `TaskCount.cancelled` and `TaskCount.skipped` — new outcome counters
+  on `BuildSummary.task_count`, rendered by `__repr__` when non-zero.
+
+### Rollout
+
+The new SDK degrades gracefully against older Registry APIs that lack
+the `/skip` route (the SDK swallows the FastAPI default 404 with a
+warning — same pattern as `/dependencies`; blocked tasks stay
+`PENDING`, matching pre-0.7.0 observable behaviour). Older SDKs are
+compatible with the new API since `/skip` is additive. No coordination
+required, but the natural sequence is: deploy the API first, then bump
+the SDK.
+
+---
+
 ## v0.6.1 — Modal-volume disk cache (opt-in) and reload-staleness fix
 
 A small, Modal-focused patch release. Two changes, both isolated to the

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1471,9 +1471,23 @@ async def cancel_task(
     auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
     commit_hash: str | None = None,
 ):
-    """Cancel a task within a build."""
+    """Cancel a task within a build (by user, or by the build engine)."""
     return await _create_task_event(
         build_id, task_id, EventType.TASK_CANCELLED, db, auth, commit_hash=commit_hash
+    )
+
+
+@router.post("/{build_id}/tasks/{task_id}/skip", response_model=TaskEventResponse)
+async def skip_task(
+    build_id: UUID,
+    task_id: str,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
+    commit_hash: str | None = None,
+):
+    """Skip a task that won't run (e.g. its dependency failed)."""
+    return await _create_task_event(
+        build_id, task_id, EventType.TASK_SKIPPED, db, auth, commit_hash=commit_hash
     )
 
 

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -214,6 +214,39 @@ async def test_fail_task_in_build(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_skip_task_in_build(client: AsyncClient):
+    """Test skipping a task whose dependency failed."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    task_data = {
+        "task_id": "skip-task-123",
+        "task_namespace": "",
+        "task_name": "TestTask",
+        "task_data": {},
+    }
+    await client.post(f"/api/v1/builds/{build_id}/tasks", json=task_data)
+
+    response = await client.post(f"/api/v1/builds/{build_id}/tasks/skip-task-123/skip")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["task_id"] == "skip-task-123"
+    assert data["status"] == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_skip_unknown_task_returns_404(client: AsyncClient):
+    """Test that skipping an unregistered task returns 404."""
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tasks/never-registered/skip"
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_list_tasks_in_build(client: AsyncClient):
     """Test listing all tasks in a build."""
     # Create a build

--- a/lib/stardag/src/stardag/build/_base.py
+++ b/lib/stardag/src/stardag/build/_base.py
@@ -43,11 +43,20 @@ class TaskCount:
     previously_completed: int = 0
     succeeded: int = 0
     failed: int = 0
+    # In-flight tasks terminated by the build engine (e.g. fail-fast siblings).
+    cancelled: int = 0
+    # Tasks that never started because a dependency failed or was cancelled.
+    skipped: int = 0
 
     @property
     def pending(self) -> int:
         return (
-            self.discovered - self.previously_completed - self.succeeded - self.failed
+            self.discovered
+            - self.previously_completed
+            - self.succeeded
+            - self.failed
+            - self.cancelled
+            - self.skipped
         )
 
 
@@ -92,6 +101,10 @@ class BuildSummary:
                 f"  Failed: {tc.failed}",
             ]
         )
+        if tc.cancelled > 0:
+            lines.append(f"  Cancelled: {tc.cancelled}")
+        if tc.skipped > 0:
+            lines.append(f"  Skipped: {tc.skipped}")
         if tc.pending > 0:
             lines.append(f"  Pending: {tc.pending}")
         if self.error:
@@ -205,6 +218,22 @@ class TaskExecutorABC(ABC):
         """Teardown any resources used by the task executor."""
         ...
 
+    async def cancel(self, task: BaseTask) -> None:
+        """Best-effort cancel an in-flight task.
+
+        Default: no-op. The build loop also calls ``asyncio.Task.cancel()``
+        on the future wrapping ``submit()``, which propagates as
+        ``asyncio.CancelledError`` into cooperative awaitables (async
+        tasks, ``modal.Function.remote.aio``). Override this for executors
+        that need explicit teardown beyond asyncio cooperation (e.g.
+        cancelling a tracked remote handle).
+
+        Note: thread-pool and process-pool work cannot be reliably killed
+        from Python — the build will exit promptly but the underlying
+        thread/subprocess may continue to completion.
+        """
+        pass
+
 
 # Type variable for executor routing keys
 ExecutorKeyT = TypeVar("ExecutorKeyT")
@@ -265,6 +294,14 @@ class RoutedTaskExecutor(TaskExecutorABC, Generic[ExecutorKeyT]):
         """Teardown all child executors."""
         for executor in self.executors.values():
             await executor.teardown()
+
+    async def cancel(self, task: BaseTask) -> None:
+        """Route cancel to the executor that owns the task."""
+        key = self.router(task)
+        executor = self.executors.get(key)
+        if executor is None:
+            return
+        await executor.cancel(task)
 
 
 # =============================================================================

--- a/lib/stardag/src/stardag/build/_base.py
+++ b/lib/stardag/src/stardag/build/_base.py
@@ -228,9 +228,13 @@ class TaskExecutorABC(ABC):
         that need explicit teardown beyond asyncio cooperation (e.g.
         cancelling a tracked remote handle).
 
-        Note: thread-pool and process-pool work cannot be reliably killed
-        from Python — the build will exit promptly but the underlying
-        thread/subprocess may continue to completion.
+        Effectiveness depends on the executor and how it implements
+        ``teardown()``. For example, ``HybridConcurrentTaskExecutor``
+        cannot reliably terminate thread- or process-pool work from
+        Python, AND its ``teardown()`` calls ``shutdown(wait=True)`` —
+        so the build will block until the underlying thread/subprocess
+        finishes. Async-only tasks and Modal calls do propagate the
+        cancellation cooperatively and unblock the build promptly.
         """
         pass
 

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -48,6 +48,17 @@ from stardag.registry import RegistryABC, registry_provider
 logger = logging.getLogger(__name__)
 
 
+class _SkippedSentinel(Exception):
+    """Marker placed on TaskExecutionState.exception for skipped tasks.
+
+    Skipped tasks never executed (a dep failed or was cancelled). Setting
+    a sentinel exception lets ``find_ready_tasks`` and the skip-emission
+    fixed-point loop treat them like other terminal-state tasks without
+    confusing them with real failures (which contribute to BuildSummary.error).
+    Never raised — purely a state marker.
+    """
+
+
 # Number of tasks the build engine sends per ``task_register_bulk_aio``
 # HTTP call. Deliberately well under the API's hard cap (1000) so that
 # (a) DB transactions on the server stay short and don't contend with
@@ -549,6 +560,11 @@ async def build_aio(
     task_count = TaskCount()
     completion_cache: set[UUID] = set()
     error: BaseException | None = None
+    # Set when any task fails (or its lock acquisition fails). The main
+    # loop processes the whole batch first, then breaks out if FAIL_FAST.
+    # Lifting the raise out of process_result keeps sibling completions in
+    # the same wait-batch from being silently dropped.
+    fail_fast_triggered: bool = False
 
     # Task execution states
     task_states: dict[UUID, TaskExecutionState] = {}
@@ -751,8 +767,14 @@ async def build_aio(
         | TaskStruct
         | None,
     ):
-        """Process a single task result (including lock acquisition results)."""
-        nonlocal error
+        """Process a single task result (including lock acquisition results).
+
+        Never raises in FAIL_FAST mode — sets ``fail_fast_triggered`` so the
+        main loop can finish processing the current ``done`` batch first
+        (otherwise sibling completions in the same batch would be lost) and
+        then escalate.
+        """
+        nonlocal error, fail_fast_triggered
         state = task_states[task.id]
 
         # Handle lock acquisition results (lock was not acquired)
@@ -773,7 +795,7 @@ async def build_aio(
                 task_count.failed += 1
                 error = state.exception
                 if fail_mode == FailMode.FAIL_FAST:
-                    raise state.exception
+                    fail_fast_triggered = True
             return
 
         # Handle normal task execution results
@@ -792,7 +814,7 @@ async def build_aio(
             task_count.failed += 1
             error = result.exception
             if fail_mode == FailMode.FAIL_FAST:
-                raise result.exception
+                fail_fast_triggered = True
 
         elif isinstance(result, BaseException):
             # Backward compat: custom executor returned a bare exception
@@ -809,7 +831,7 @@ async def build_aio(
             task_count.failed += 1
             error = result
             if fail_mode == FailMode.FAIL_FAST:
-                raise result
+                fail_fast_triggered = True
 
         elif result is None:
             # Task completed - release lock (completed) and notify registry
@@ -1106,6 +1128,81 @@ async def build_aio(
         # Execute the task via the executor
         return await task_executor.submit(task)
 
+    async def cancel_pending_in_flight() -> None:
+        """Cancel any in-flight ``pending_futures`` and emit ``task_cancel``.
+
+        Called when escalating FAIL_FAST after the first failure, so
+        sibling tasks running concurrently (e.g. on Modal) terminate
+        promptly instead of being abandoned. Idempotent — safe to call
+        multiple times. The asyncio cancel is what propagates into the
+        executor (e.g. Modal's remote-call cancel); the explicit
+        ``task_executor.cancel`` hook is for executors that need extra
+        teardown (default no-op).
+        """
+        if not pending_futures:
+            return
+        snapshot = dict(pending_futures)
+        pending_futures.clear()
+        cancelled_tasks: list[BaseTask] = [task_states[tid].task for tid in snapshot]
+        for fut in snapshot.values():
+            fut.cancel()
+        for cancel_task in cancelled_tasks:
+            try:
+                await task_executor.cancel(cancel_task)
+            except Exception as e:
+                logger.warning(f"Executor cancel failed for {cancel_task.id}: {e}")
+        # Drain so cancelled futures don't dangle.
+        await asyncio.gather(*snapshot.values(), return_exceptions=True)
+        executing.clear()
+        for cancel_task in cancelled_tasks:
+            await release_lock_for_task(cancel_task, completed=False)
+            try:
+                await registry.task_cancel_aio(build_id, cancel_task)
+            except Exception as reg_err:
+                handle_registry_error(
+                    reg_err,
+                    f"Failed to mark task {cancel_task.id} as cancelled",
+                    on_registry_failure,
+                )
+            state = task_states[cancel_task.id]
+            if state.exception is None:
+                state.exception = asyncio.CancelledError(
+                    "Cancelled by build engine in FAIL_FAST mode"
+                )
+            task_count.cancelled += 1
+
+    async def emit_skips_for_blocked_tasks() -> None:
+        """Emit ``task_skip_aio`` for tasks blocked by failed/cancelled deps.
+
+        Iterates to a fixed point so transitive descendants are also
+        skipped. Idempotent: tasks already marked with ``state.exception``
+        are filtered out, so re-calling is a no-op.
+        """
+        while True:
+            skipped_this_pass = 0
+            for state in task_states.values():
+                if state.completed or state.exception is not None:
+                    continue
+                blocked = any(
+                    task_states[dep.id].exception is not None for dep in state.all_deps
+                )
+                if not blocked:
+                    continue
+                if state.registered:
+                    try:
+                        await registry.task_skip_aio(build_id, state.task)
+                    except Exception as reg_err:
+                        handle_registry_error(
+                            reg_err,
+                            f"Failed to mark task {state.task.id} as skipped",
+                            on_registry_failure,
+                        )
+                state.exception = _SkippedSentinel()
+                task_count.skipped += 1
+                skipped_this_pass += 1
+            if skipped_this_pass == 0:
+                return
+
     try:
         # Discover all tasks from roots concurrently. Inline-registration
         # makes the full DAG appear in the registry/UI immediately. If any
@@ -1202,6 +1299,12 @@ async def build_aio(
                     )
                 await process_result(task, result)
 
+            # Stop scheduling once any task has flagged FAIL_FAST escalation.
+            # Sibling completions in this same `done` batch were already
+            # processed above so their task_complete_aio events landed.
+            if fail_fast_triggered and fail_mode == FailMode.FAIL_FAST:
+                break
+
             # Check for exit-early condition: all remaining tasks waiting for locks
             if global_lock_config.exit_early_when_all_locked:
                 remaining_tasks = [
@@ -1232,6 +1335,20 @@ async def build_aio(
                             error=None,
                         )
 
+        # If FAIL_FAST escalated, terminate in-flight siblings before
+        # finalising. asyncio.cancel propagates CancelledError into
+        # cooperative awaitables (e.g. Modal's remote.aio), so remote
+        # containers stop billing rather than being abandoned. Skips
+        # are emitted for any task whose deps include a failed/cancelled
+        # task — covers both modes (no-op when nothing is blocked).
+        if fail_fast_triggered and fail_mode == FailMode.FAIL_FAST:
+            await cancel_pending_in_flight()
+        await emit_skips_for_blocked_tasks()
+
+        # FAIL_FAST: re-enter the outer except so build_fail_aio fires.
+        if error is not None and fail_mode == FailMode.FAIL_FAST:
+            raise error
+
         await registry.build_complete_aio(build_id)
         return BuildSummary(
             status=BuildExitStatus.SUCCESS
@@ -1243,6 +1360,15 @@ async def build_aio(
         )
 
     except Exception as e:
+        # Cancel any in-flight (covers exceptions raised mid-loop) and
+        # emit skips before recording the build failure. Both helpers
+        # are idempotent so it's safe even when reached via the
+        # FAIL_FAST escalation path that already called them.
+        try:
+            await cancel_pending_in_flight()
+            await emit_skips_for_blocked_tasks()
+        except Exception as cleanup_err:
+            logger.warning(f"Error during build cleanup: {cleanup_err}")
         await registry.build_fail_aio(build_id, str(e))
         if fail_mode == FailMode.FAIL_FAST:
             raise

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -1129,42 +1129,85 @@ async def build_aio(
         return await task_executor.submit(task)
 
     async def cancel_pending_in_flight() -> None:
-        """Cancel any in-flight ``pending_futures`` and emit ``task_cancel``.
+        """Cancel any still-running ``pending_futures`` and emit ``task_cancel``.
 
         Called when escalating FAIL_FAST after the first failure, so
         sibling tasks running concurrently (e.g. on Modal) terminate
         promptly instead of being abandoned. Idempotent — safe to call
-        multiple times. The asyncio cancel is what propagates into the
-        executor (e.g. Modal's remote-call cancel); the explicit
-        ``task_executor.cancel`` hook is for executors that need extra
-        teardown (default no-op).
+        multiple times.
+
+        Race-aware: the awaits inside ``process_result`` (registry calls,
+        artifact upload) can let other futures finish in the same loop
+        iteration. Those already-done futures are processed normally so
+        their actual outcome is recorded — only the futures still
+        running get cancel-marked.
+
+        The asyncio cancel is what propagates into the executor (e.g.
+        Modal's remote-call cancel); the explicit ``task_executor.cancel``
+        hook is for executors that need extra teardown (default no-op).
         """
         if not pending_futures:
             return
         snapshot = dict(pending_futures)
         pending_futures.clear()
-        cancelled_tasks: list[BaseTask] = [task_states[tid].task for tid in snapshot]
-        for fut in snapshot.values():
-            fut.cancel()
+
+        # Split: futures that already completed while process_result was
+        # awaiting (treat as their actual outcome) vs still-running ones
+        # (cancel and mark TASK_CANCELLED).
+        completed_tids: list[UUID] = []
+        running_tids: list[UUID] = []
+        for tid, fut in snapshot.items():
+            if fut.done():
+                completed_tids.append(tid)
+            else:
+                running_tids.append(tid)
+
+        for tid in completed_tids:
+            executing.discard(tid)
+            done_task = task_states[tid].task
+            try:
+                done_result = snapshot[tid].result()
+            except Exception as e:
+                done_result = TaskExecutionError(
+                    exception=e,
+                    traceback="".join(tb_module.format_exception(e)),
+                )
+            await process_result(done_task, done_result)
+
+        if not running_tids:
+            return
+
+        cancelled_tasks: list[BaseTask] = [
+            task_states[tid].task for tid in running_tids
+        ]
+        for tid in running_tids:
+            snapshot[tid].cancel()
         for cancel_task in cancelled_tasks:
             try:
                 await task_executor.cancel(cancel_task)
             except Exception as e:
                 logger.warning(f"Executor cancel failed for {cancel_task.id}: {e}")
         # Drain so cancelled futures don't dangle.
-        await asyncio.gather(*snapshot.values(), return_exceptions=True)
-        executing.clear()
+        await asyncio.gather(
+            *(snapshot[tid] for tid in running_tids), return_exceptions=True
+        )
+        for tid in running_tids:
+            executing.discard(tid)
         for cancel_task in cancelled_tasks:
             await release_lock_for_task(cancel_task, completed=False)
-            try:
-                await registry.task_cancel_aio(build_id, cancel_task)
-            except Exception as reg_err:
-                handle_registry_error(
-                    reg_err,
-                    f"Failed to mark task {cancel_task.id} as cancelled",
-                    on_registry_failure,
-                )
             state = task_states[cancel_task.id]
+            # Only call /cancel when the task was successfully registered;
+            # otherwise the endpoint 404s (warn-mode tolerates registration
+            # failures). Mirrors the guard pattern around /start, /resume.
+            if state.registered:
+                try:
+                    await registry.task_cancel_aio(build_id, cancel_task)
+                except Exception as reg_err:
+                    handle_registry_error(
+                        reg_err,
+                        f"Failed to mark task {cancel_task.id} as cancelled",
+                        on_registry_failure,
+                    )
             if state.exception is None:
                 state.exception = asyncio.CancelledError(
                     "Cancelled by build engine in FAIL_FAST mode"

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -642,13 +642,31 @@ class APIRegistry(RegistryABC):
         )
 
     def task_skip(self, build_id: UUID, task: "BaseTask") -> None:
-        """Skip a task whose dependency failed or was cancelled."""
-        self._request(
-            "POST",
-            f"{self.api_url}/api/v1/builds/{build_id}/tasks/{task.id}/skip",
-            params=self._get_event_params(),
-            operation=f"Skip task {task.id}",
-        )
+        """Skip a task whose dependency failed or was cancelled.
+
+        Backward-compat: an older Registry API that lacks the ``/skip``
+        endpoint returns FastAPI's default 404 with the generic
+        ``"Not Found"`` detail. We swallow that specific response with a
+        warning so a new SDK against an old API doesn't fail builds on
+        every fail-fast / blocked-dep path. All other 404s (e.g.
+        ``"Build not found"``) re-raise normally.
+        """
+        try:
+            self._request(
+                "POST",
+                f"{self.api_url}/api/v1/builds/{build_id}/tasks/{task.id}/skip",
+                params=self._get_event_params(),
+                operation=f"Skip task {task.id}",
+            )
+        except NotFoundError as e:
+            if not _is_route_not_found(e):
+                raise
+            logger.warning(
+                "Registry API does not support POST /skip; task %s will "
+                "remain PENDING in the registry. Upgrade the Registry API "
+                "to see SKIPPED status for tasks blocked by failed deps.",
+                task.id,
+            )
 
     def task_waiting_for_lock(
         self, build_id: UUID, task: "BaseTask", lock_owner: str | None = None
@@ -1021,13 +1039,26 @@ class APIRegistry(RegistryABC):
         )
 
     async def task_skip_aio(self, build_id: UUID, task: "BaseTask") -> None:
-        """Async version - skip a task whose dep failed or was cancelled."""
-        await self._arequest(
-            "POST",
-            f"{self.api_url}/api/v1/builds/{build_id}/tasks/{task.id}/skip",
-            params=self._get_event_params(),
-            operation=f"Skip task {task.id}",
-        )
+        """Async version - skip a task whose dep failed or was cancelled.
+
+        See :meth:`task_skip` for the backward-compat 404 handling.
+        """
+        try:
+            await self._arequest(
+                "POST",
+                f"{self.api_url}/api/v1/builds/{build_id}/tasks/{task.id}/skip",
+                params=self._get_event_params(),
+                operation=f"Skip task {task.id}",
+            )
+        except NotFoundError as e:
+            if not _is_route_not_found(e):
+                raise
+            logger.warning(
+                "Registry API does not support POST /skip; task %s will "
+                "remain PENDING in the registry. Upgrade the Registry API "
+                "to see SKIPPED status for tasks blocked by failed deps.",
+                task.id,
+            )
 
     async def task_waiting_for_lock_aio(
         self, build_id: UUID, task: "BaseTask", lock_owner: str | None = None

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -641,6 +641,15 @@ class APIRegistry(RegistryABC):
             operation=f"Cancel task {task.id}",
         )
 
+    def task_skip(self, build_id: UUID, task: "BaseTask") -> None:
+        """Skip a task whose dependency failed or was cancelled."""
+        self._request(
+            "POST",
+            f"{self.api_url}/api/v1/builds/{build_id}/tasks/{task.id}/skip",
+            params=self._get_event_params(),
+            operation=f"Skip task {task.id}",
+        )
+
     def task_waiting_for_lock(
         self, build_id: UUID, task: "BaseTask", lock_owner: str | None = None
     ) -> None:
@@ -1009,6 +1018,15 @@ class APIRegistry(RegistryABC):
             f"{self.api_url}/api/v1/builds/{build_id}/tasks/{task.id}/cancel",
             params=self._get_event_params(),
             operation=f"Cancel task {task.id}",
+        )
+
+    async def task_skip_aio(self, build_id: UUID, task: "BaseTask") -> None:
+        """Async version - skip a task whose dep failed or was cancelled."""
+        await self._arequest(
+            "POST",
+            f"{self.api_url}/api/v1/builds/{build_id}/tasks/{task.id}/skip",
+            params=self._get_event_params(),
+            operation=f"Skip task {task.id}",
         )
 
     async def task_waiting_for_lock_aio(

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -242,11 +242,25 @@ class RegistryABC(metaclass=abc.ABCMeta):
     def task_cancel(self, build_id: UUID, task: "BaseTask") -> None:
         """Cancel a task.
 
-        Called when a task is explicitly cancelled by the user.
+        Called when a task is cancelled — by the user, or by the build
+        engine when terminating in-flight siblings on a fail-fast failure.
 
         Args:
             build_id: The build UUID returned by build_start.
             task: The task to cancel.
+        """
+        pass
+
+    def task_skip(self, build_id: UUID, task: "BaseTask") -> None:
+        """Mark a task as skipped.
+
+        Called when a task will not run because a dependency failed or
+        was cancelled. Distinct from ``task_cancel``: skipped tasks
+        never started executing.
+
+        Args:
+            build_id: The build UUID returned by build_start.
+            task: The task to skip.
         """
         pass
 
@@ -373,6 +387,10 @@ class RegistryABC(metaclass=abc.ABCMeta):
     async def task_cancel_aio(self, build_id: UUID, task: "BaseTask") -> None:
         """Async version of task_cancel."""
         self.task_cancel(build_id, task)
+
+    async def task_skip_aio(self, build_id: UUID, task: "BaseTask") -> None:
+        """Async version of task_skip."""
+        self.task_skip(build_id, task)
 
     async def task_waiting_for_lock_aio(
         self, build_id: UUID, task: "BaseTask", lock_owner: str | None = None

--- a/lib/stardag/src/stardag/testing/modal/_tasks.py
+++ b/lib/stardag/src/stardag/testing/modal/_tasks.py
@@ -74,3 +74,21 @@ class AsyncDynamicRangeSumTask(sd.Task[int]):
         yield range_task
         values = await range_task.load_aio()
         await self._save_aio(sum(values))
+
+
+class SleepTask(sd.Task[int]):
+    """Long-sleeping sync task — used to verify Modal cancel propagation.
+
+    The build engine cancels the asyncio future awaiting
+    ``worker_function.remote.aio``. Modal translates that cancellation
+    into a remote-call cancel; if it didn't, this task would block for
+    ``seconds`` and the test would time out.
+    """
+
+    seconds: int = 60
+
+    def run(self) -> None:
+        import time
+
+        time.sleep(self.seconds)
+        self._save(self.seconds)

--- a/lib/stardag/tests/test_build/conftest.py
+++ b/lib/stardag/tests/test_build/conftest.py
@@ -1,7 +1,13 @@
 """Fixtures for build tests."""
 
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
 import pytest
 
+from stardag import BaseTask
 from stardag.registry import NoOpRegistry
 
 
@@ -12,3 +18,102 @@ def noop_registry():
     TODO remove? Could be wrapped by Mock to track called methods.
     """
     return NoOpRegistry()
+
+
+class RecordingRegistry(NoOpRegistry):
+    """NoOpRegistry that records every async lifecycle call.
+
+    Use in tests that need to assert which registry events fired (and in
+    what order). Each call is appended to ``self.calls`` as a tuple of
+    ``(method_name, task_id_or_None, extra)`` where ``task_id_or_None`` is
+    the ``BaseTask.id`` for task-scoped methods or ``None`` for build-
+    scoped methods.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[tuple[str, UUID | None, dict[str, Any]]] = []
+
+    def _record(
+        self,
+        method: str,
+        task_id: UUID | None = None,
+        **extra: Any,
+    ) -> None:
+        self.calls.append((method, task_id, extra))
+
+    def call_methods_for(self, task_id: UUID) -> list[str]:
+        return [m for (m, tid, _) in self.calls if tid == task_id]
+
+    def has_call(self, method: str, task_id: UUID | None = None) -> bool:
+        if task_id is None:
+            return any(m == method for (m, _, _) in self.calls)
+        return any(m == method and tid == task_id for (m, tid, _) in self.calls)
+
+    # ----- async lifecycle overrides -----
+    async def build_start_aio(
+        self,
+        root_tasks: list[BaseTask] | None = None,
+        description: str | None = None,
+    ) -> UUID:
+        bid = await super().build_start_aio(root_tasks, description)
+        self._record("build_start_aio")
+        return bid
+
+    async def build_complete_aio(self, build_id: UUID) -> None:
+        self._record("build_complete_aio")
+        await super().build_complete_aio(build_id)
+
+    async def build_fail_aio(
+        self, build_id: UUID, error_message: str | None = None
+    ) -> None:
+        self._record("build_fail_aio", None, error_message=error_message)
+        await super().build_fail_aio(build_id, error_message)
+
+    async def task_register_aio(self, build_id: UUID, task: BaseTask) -> None:
+        self._record("task_register_aio", task.id)
+        await super().task_register_aio(build_id, task)
+
+    async def task_register_bulk_aio(self, build_id: UUID, tasks) -> None:
+        for t in tasks:
+            self._record("task_register_aio", t.id, bulk=True)
+        # Skip super (would emit per-task again).
+
+    async def task_start_aio(self, build_id: UUID, task: BaseTask) -> None:
+        self._record("task_start_aio", task.id)
+        await super().task_start_aio(build_id, task)
+
+    async def task_complete_aio(self, build_id: UUID, task: BaseTask) -> None:
+        self._record("task_complete_aio", task.id)
+        await super().task_complete_aio(build_id, task)
+
+    async def task_fail_aio(
+        self,
+        build_id: UUID,
+        task: BaseTask,
+        error_message: str | None = None,
+    ) -> None:
+        self._record("task_fail_aio", task.id, error_message=error_message)
+        await super().task_fail_aio(build_id, task, error_message)
+
+    async def task_cancel_aio(self, build_id: UUID, task: BaseTask) -> None:
+        self._record("task_cancel_aio", task.id)
+        await super().task_cancel_aio(build_id, task)
+
+    async def task_skip_aio(self, build_id: UUID, task: BaseTask) -> None:
+        self._record("task_skip_aio", task.id)
+        await super().task_skip_aio(build_id, task)
+
+    async def task_suspend_aio(self, build_id: UUID, task: BaseTask) -> None:
+        self._record("task_suspend_aio", task.id)
+        await super().task_suspend_aio(build_id, task)
+
+    async def task_resume_aio(self, build_id: UUID, task: BaseTask) -> None:
+        self._record("task_resume_aio", task.id)
+        await super().task_resume_aio(build_id, task)
+
+
+@pytest.fixture
+def recording_registry() -> RecordingRegistry:
+    """Recording registry that tracks every lifecycle call for assertions."""
+    return RecordingRegistry()

--- a/lib/stardag/tests/test_build/test_concurrent.py
+++ b/lib/stardag/tests/test_build/test_concurrent.py
@@ -415,6 +415,63 @@ class TestFailFastCancelAndSkip:
         assert recording_registry.has_call("task_fail_aio", failing.id)
 
     @pytest.mark.asyncio
+    async def test_fail_fast_processes_sibling_done_during_fail_handling(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Race fix: a sibling that completes WHILE the failing task's
+        process_result is awaiting registry calls must be recorded as
+        completed, not silently treated as CANCELLED by
+        ``cancel_pending_in_flight``.
+
+        We trigger the race by stalling ``task_fail_aio`` long enough for
+        a short-running sibling to finish. After the for-loop breaks on
+        ``fail_fast_triggered``, ``cancel_pending_in_flight`` sees the
+        sibling's future as already-done — the race fix processes its
+        actual result instead of cancelling it.
+        """
+        from tests.test_build.conftest import RecordingRegistry
+
+        class StallingFailRegistry(RecordingRegistry):
+            async def task_fail_aio(self, build_id, task, error_message=None):
+                # Long enough for the success leaf (0.05s sleep) to finish.
+                await asyncio.sleep(0.2)
+                await super().task_fail_aio(build_id, task, error_message)
+
+        class ShortAsyncTask(Task[str]):
+            name: str
+
+            async def run_aio(self):
+                await asyncio.sleep(0.05)
+                self._save("ok")
+
+        class ImmediateFailingTask(Task[str]):
+            async def run_aio(self):
+                # Yield once so the wait awakes promptly with this in done.
+                await asyncio.sleep(0)
+                raise ValueError("Intentional failure")
+
+        registry = StallingFailRegistry()
+        success = ShortAsyncTask(name="finish-during-fail-handling")
+        failure = ImmediateFailingTask()
+
+        with pytest.raises(ValueError, match="Intentional failure"):
+            await build_aio(
+                [success, failure],
+                registry=registry,
+                fail_mode=FailMode.FAIL_FAST,
+            )
+
+        assert registry.has_call("task_complete_aio", success.id), (
+            "Sibling that completed during fail-handling must be "
+            "recorded as completed, not cancelled. "
+            f"Calls: {[c[0] for c in registry.calls]}"
+        )
+        assert not registry.has_call("task_cancel_aio", success.id), (
+            "Already-done sibling must not be marked CANCELLED"
+        )
+
+    @pytest.mark.asyncio
     async def test_fail_fast_records_sibling_completion_in_same_batch(
         self,
         default_in_memory_fs_target: typing.Type[InMemoryFileTarget],

--- a/lib/stardag/tests/test_build/test_concurrent.py
+++ b/lib/stardag/tests/test_build/test_concurrent.py
@@ -18,13 +18,17 @@ from stardag import Task, auto_namespace
 from stardag._core.base_task import _has_custom_run_aio
 from stardag.build import (
     BuildExitStatus,
+    BuildSummary,
     DefaultExecutionModeSelector,
     FailMode,
     GlobalLockConfig,
     HybridConcurrentTaskExecutor,
     LockAcquisitionResult,
     LockAcquisitionStatus,
+    RoutedTaskExecutor,
+    TaskCount,
     TaskExecutionError,
+    TaskExecutorABC,
     build,
     build_aio,
 )
@@ -349,6 +353,264 @@ class TestBuildAio:
 
         with pytest.raises(ValueError, match="Intentional failure"):
             await build_aio([task], registry=noop_registry)
+
+
+# ============================================================================
+# Test: FAIL_FAST cancellation + skip-propagation semantics
+# ============================================================================
+
+
+class TestFailFastCancelAndSkip:
+    """Tests for FAIL_FAST cancellation of in-flight siblings and the
+    transitive ``TASK_SKIPPED`` emission for blocked tasks."""
+
+    @pytest.mark.asyncio
+    async def test_fail_fast_cancels_in_flight_siblings(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        recording_registry,
+    ):
+        """FAIL_FAST: a slow in-flight sibling is cancelled with task_cancel_aio.
+
+        Without this behavior, the slow sibling would either run to
+        completion (FAIL_FAST being a lie) or be silently abandoned
+        (registry stuck in RUNNING). We assert (a) the build returns
+        promptly rather than waiting for the 5-second sleep and
+        (b) the slow task got task_cancel_aio fired against it.
+        """
+
+        class SlowAsyncTask(Task[str]):
+            name: str
+
+            async def run_aio(self):
+                await asyncio.sleep(5)
+                self._save("done")
+
+        class FailingAsyncTask(Task[str]):
+            async def run_aio(self):
+                # Yield once so we hit the wait point and Slow is in flight.
+                await asyncio.sleep(0)
+                raise ValueError("Intentional failure")
+
+        slow = SlowAsyncTask(name="slow")
+        failing = FailingAsyncTask()
+
+        t0 = time.monotonic()
+        with pytest.raises(ValueError, match="Intentional failure"):
+            await build_aio(
+                [slow, failing],
+                registry=recording_registry,
+                fail_mode=FailMode.FAIL_FAST,
+            )
+        elapsed = time.monotonic() - t0
+
+        # If we waited for slow to complete, this would be ~5s.
+        assert elapsed < 2.0, (
+            f"FAIL_FAST took {elapsed:.2f}s — cancellation did not kick in"
+        )
+        assert recording_registry.has_call("task_cancel_aio", slow.id), (
+            f"Expected task_cancel_aio for slow task; got calls: "
+            f"{[c[0] for c in recording_registry.calls]}"
+        )
+        assert recording_registry.has_call("task_fail_aio", failing.id)
+
+    @pytest.mark.asyncio
+    async def test_fail_fast_records_sibling_completion_in_same_batch(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        recording_registry,
+    ):
+        """FAIL_FAST: a sibling that succeeds in the same wait batch as a
+        failure still has its task_complete_aio recorded.
+
+        Pre-fix, ``process_result`` raised in-place inside the
+        ``for async_task in done:`` loop, so any sibling further along in
+        ``done`` had its result silently discarded. We gate both tasks on
+        the same asyncio.Event so they finish in the same loop tick and
+        land in the same wait batch.
+        """
+        gate = asyncio.Event()
+
+        class GatedSuccess(Task[str]):
+            async def run_aio(self):
+                await gate.wait()
+                self._save("ok")
+
+        class GatedFailure(Task[str]):
+            async def run_aio(self):
+                await gate.wait()
+                raise ValueError("Intentional failure")
+
+        success = GatedSuccess()
+        failure = GatedFailure()
+
+        async def trigger():
+            # Wait for both leaves to be submitted+blocked on gate.
+            await asyncio.sleep(0.05)
+            gate.set()
+
+        trigger_fut = asyncio.create_task(trigger())
+        try:
+            with pytest.raises(ValueError, match="Intentional failure"):
+                await build_aio(
+                    [success, failure],
+                    registry=recording_registry,
+                    fail_mode=FailMode.FAIL_FAST,
+                )
+        finally:
+            await trigger_fut
+
+        assert recording_registry.has_call("task_complete_aio", success.id), (
+            "Sibling completion in same `done` batch must not be lost"
+        )
+        assert recording_registry.has_call("task_fail_aio", failure.id)
+
+    @pytest.mark.asyncio
+    async def test_continue_mode_does_not_cancel_siblings(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        recording_registry,
+    ):
+        """CONTINUE: an in-flight sibling is allowed to run to completion."""
+
+        class ShortAsyncTask(Task[str]):
+            name: str
+
+            async def run_aio(self):
+                await asyncio.sleep(0.1)
+                self._save("done")
+
+        class FailingAsyncTask(Task[str]):
+            async def run_aio(self):
+                await asyncio.sleep(0)
+                raise ValueError("Intentional failure")
+
+        sibling = ShortAsyncTask(name="sibling")
+        failing = FailingAsyncTask()
+
+        summary = await build_aio(
+            [sibling, failing],
+            registry=recording_registry,
+            fail_mode=FailMode.CONTINUE,
+        )
+
+        assert summary.status == BuildExitStatus.FAILURE
+        assert sibling.complete()
+        assert recording_registry.has_call("task_complete_aio", sibling.id)
+        assert not recording_registry.has_call("task_cancel_aio", sibling.id), (
+            "CONTINUE must not cancel in-flight siblings"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_emitted_for_transitively_blocked_tasks_continue(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        recording_registry,
+    ):
+        """CONTINUE: tasks transitively blocked by a failure get TASK_SKIPPED."""
+        leaf = FailingTask(error_message="leaf fails")
+        mid = SyncOnlyTask(name="mid", deps=(leaf,))
+        root = SyncOnlyTask(name="root", deps=(mid,))
+
+        summary = await build_aio(
+            [root],
+            registry=recording_registry,
+            fail_mode=FailMode.CONTINUE,
+        )
+
+        assert summary.status == BuildExitStatus.FAILURE
+        assert summary.task_count.failed == 1
+        assert summary.task_count.skipped == 2, (
+            f"Expected 2 skipped (mid+root), got {summary.task_count}"
+        )
+        assert recording_registry.has_call("task_skip_aio", mid.id)
+        assert recording_registry.has_call("task_skip_aio", root.id)
+        assert recording_registry.has_call("task_fail_aio", leaf.id)
+
+    @pytest.mark.asyncio
+    async def test_skips_emitted_in_fail_fast_mode_too(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        recording_registry,
+    ):
+        """FAIL_FAST: blocked downstream tasks are still marked SKIPPED before the build is failed."""
+        leaf = FailingTask(error_message="leaf fails")
+        mid = SyncOnlyTask(name="mid-ff", deps=(leaf,))
+        root = SyncOnlyTask(name="root-ff", deps=(mid,))
+
+        with pytest.raises(ValueError, match="leaf fails"):
+            await build_aio(
+                [root],
+                registry=recording_registry,
+                fail_mode=FailMode.FAIL_FAST,
+            )
+
+        # Skip events fire BEFORE build_fail_aio so the registry is
+        # coherent at the moment the build is marked failed.
+        method_seq = [m for (m, _, _) in recording_registry.calls]
+        skip_idx = method_seq.index("task_skip_aio")
+        fail_idx = method_seq.index("build_fail_aio")
+        assert skip_idx < fail_idx, (
+            f"task_skip_aio must precede build_fail_aio; got order: {method_seq}"
+        )
+        assert recording_registry.has_call("task_skip_aio", mid.id)
+        assert recording_registry.has_call("task_skip_aio", root.id)
+
+    @pytest.mark.asyncio
+    async def test_routed_executor_cancel_routes_correctly(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        noop_registry,
+    ):
+        """RoutedTaskExecutor.cancel must dispatch to the routed child only."""
+
+        class _FakeExecutor(TaskExecutorABC):
+            def __init__(self, label: str) -> None:
+                self.label = label
+                self.cancelled: list = []
+
+            async def submit(self, task):
+                return None
+
+            async def setup(self):
+                pass
+
+            async def teardown(self):
+                pass
+
+            async def cancel(self, task):
+                self.cancelled.append(task)
+
+        task_a = SyncOnlyTask(name="to_a")
+        task_b = SyncOnlyTask(name="to_b")
+        a = _FakeExecutor("a")
+        b = _FakeExecutor("b")
+        routed = RoutedTaskExecutor(
+            executors={"a": a, "b": b},
+            router=lambda task: "a" if task.id == task_a.id else "b",
+        )
+
+        await routed.cancel(task_a)
+        await routed.cancel(task_b)
+
+        assert a.cancelled == [task_a]
+        assert b.cancelled == [task_b]
+
+    def test_build_summary_repr_includes_cancelled_skipped(self):
+        """BuildSummary repr renders the new counters when non-zero."""
+        summary = BuildSummary(
+            status=BuildExitStatus.FAILURE,
+            task_count=TaskCount(
+                discovered=5,
+                succeeded=1,
+                failed=1,
+                cancelled=1,
+                skipped=2,
+            ),
+        )
+        text = repr(summary)
+        assert "Cancelled: 1" in text
+        assert "Skipped: 2" in text
 
 
 # ============================================================================

--- a/lib/stardag/tests/test_build/test_concurrent.py
+++ b/lib/stardag/tests/test_build/test_concurrent.py
@@ -360,6 +360,36 @@ class TestBuildAio:
 # ============================================================================
 
 
+from tests.test_build.conftest import RecordingRegistry  # noqa: E402
+
+
+class _GatedFailRegistry(RecordingRegistry):
+    """RecordingRegistry that gates ``task_fail_aio`` on caller-controlled events.
+
+    Used by the race regression test to deterministically place a sibling's
+    completion inside ``cancel_pending_in_flight``'s race window without
+    relying on wall-clock timing. Tests set ``fail_aio_entered_event`` /
+    ``fail_aio_can_proceed_event`` on the instance, then arrange for one
+    task to await the entered event and another task's ``run_aio`` to set
+    the can-proceed event after the first finishes its work.
+    """
+
+    fail_aio_entered_event: asyncio.Event | None = None
+    fail_aio_can_proceed_event: asyncio.Event | None = None
+
+    async def task_fail_aio(
+        self,
+        build_id,
+        task,
+        error_message: str | None = None,
+    ) -> None:
+        if self.fail_aio_entered_event is not None:
+            self.fail_aio_entered_event.set()
+        if self.fail_aio_can_proceed_event is not None:
+            await self.fail_aio_can_proceed_event.wait()
+        await super().task_fail_aio(build_id, task, error_message)
+
+
 class TestFailFastCancelAndSkip:
     """Tests for FAIL_FAST cancellation of in-flight siblings and the
     transitive ``TASK_SKIPPED`` emission for blocked tasks."""
@@ -424,34 +454,42 @@ class TestFailFastCancelAndSkip:
         completed, not silently treated as CANCELLED by
         ``cancel_pending_in_flight``.
 
-        We trigger the race by stalling ``task_fail_aio`` long enough for
-        a short-running sibling to finish. After the for-loop breaks on
-        ``fail_fast_triggered``, ``cancel_pending_in_flight`` sees the
-        sibling's future as already-done — the race fix processes its
-        actual result instead of cancelling it.
+        Event-gated (no wall-clock dependency): the registry's
+        ``task_fail_aio`` blocks on ``fail_aio_can_proceed_event``; the
+        sibling's ``run_aio`` waits for ``fail_aio_entered_event``, runs
+        its work while ``process_result`` is suspended inside
+        ``task_fail_aio``, then unblocks ``task_fail_aio``. After the
+        for-loop breaks on ``fail_fast_triggered``,
+        ``cancel_pending_in_flight`` sees the sibling's future as
+        already-done — the race fix processes its actual result instead
+        of cancelling it.
         """
-        from tests.test_build.conftest import RecordingRegistry
-
-        class StallingFailRegistry(RecordingRegistry):
-            async def task_fail_aio(self, build_id, task, error_message=None):
-                # Long enough for the success leaf (0.05s sleep) to finish.
-                await asyncio.sleep(0.2)
-                await super().task_fail_aio(build_id, task, error_message)
+        registry = _GatedFailRegistry()
+        registry.fail_aio_entered_event = asyncio.Event()
+        registry.fail_aio_can_proceed_event = asyncio.Event()
 
         class ShortAsyncTask(Task[str]):
             name: str
 
             async def run_aio(self):
-                await asyncio.sleep(0.05)
+                # Wait until /fail starts processing the failing sibling —
+                # we are now inside the race window: process_result is
+                # suspended in task_fail_aio, and we're about to put
+                # ourselves in cancel_pending_in_flight's already-done
+                # bucket.
+                assert registry.fail_aio_entered_event is not None
+                await registry.fail_aio_entered_event.wait()
                 self._save("ok")
+                # Let task_fail_aio finish so the build can break out.
+                assert registry.fail_aio_can_proceed_event is not None
+                registry.fail_aio_can_proceed_event.set()
 
         class ImmediateFailingTask(Task[str]):
             async def run_aio(self):
-                # Yield once so the wait awakes promptly with this in done.
+                # Yield once so asyncio.wait awakes with this in done first.
                 await asyncio.sleep(0)
                 raise ValueError("Intentional failure")
 
-        registry = StallingFailRegistry()
         success = ShortAsyncTask(name="finish-during-fail-handling")
         failure = ImmediateFailingTask()
 
@@ -668,6 +706,69 @@ class TestFailFastCancelAndSkip:
         text = repr(summary)
         assert "Cancelled: 1" in text
         assert "Skipped: 2" in text
+
+    @pytest.mark.asyncio
+    async def test_fail_fast_releases_lock_for_cancelled_task(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        noop_registry,
+    ):
+        """FAIL_FAST cancel path releases a held global lock with completed=False.
+
+        Locks an in-flight task via the global concurrency lock manager,
+        then triggers a fail-fast on a sibling. Asserts the slow task's
+        lock is released and that the release is recorded as not-completed
+        (so external observers see the slot freed without a completion
+        record).
+        """
+
+        class SlowAsyncTask(Task[str]):
+            name: str
+
+            async def run_aio(self):
+                await asyncio.sleep(5)
+                self._save("done")
+
+        class FailingAsyncTask(Task[str]):
+            async def run_aio(self):
+                await asyncio.sleep(0)
+                raise ValueError("Intentional failure")
+
+        slow = SlowAsyncTask(name="slow-locked")
+        failing = FailingAsyncTask()
+
+        lock_manager = MockGlobalLockManager()
+        lock_manager.set_result(
+            str(slow.id),
+            LockAcquisitionResult(status=LockAcquisitionStatus.ACQUIRED, acquired=True),
+        )
+        lock_manager.set_result(
+            str(failing.id),
+            LockAcquisitionResult(status=LockAcquisitionStatus.ACQUIRED, acquired=True),
+        )
+
+        with pytest.raises(ValueError, match="Intentional failure"):
+            await build_aio(
+                [slow, failing],
+                registry=noop_registry,
+                fail_mode=FailMode.FAIL_FAST,
+                global_lock_manager=lock_manager,
+                global_lock_config=GlobalLockConfig(enabled=True),
+            )
+
+        slow_releases = [
+            (tid, completed)
+            for (tid, completed) in lock_manager.releases
+            if tid == str(slow.id)
+        ]
+        assert slow_releases, (
+            f"Expected lock release for cancelled slow task; got "
+            f"releases: {lock_manager.releases}"
+        )
+        assert all(completed is False for (_, completed) in slow_releases), (
+            f"Cancelled task lock must be released with completed=False; "
+            f"got: {slow_releases}"
+        )
 
 
 # ============================================================================

--- a/lib/stardag/tests/test_integration/test_modal/test__app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__app.py
@@ -480,16 +480,22 @@ class TestModalExecutorCancel:
             await executor.teardown()
 
     @pytest.mark.asyncio
-    async def test_executor_cancel_method_terminates_remote_call(
+    async def test_executor_cancel_method_callable_during_in_flight(
         self, isolated_modal_target_root
     ):
-        """``ModalTaskExecutor.cancel(task)`` terminates the in-flight call.
+        """``ModalTaskExecutor.cancel(task)`` is callable on an in-flight task.
 
-        Today this collapses to the ABC's no-op default — cancellation
-        works via ``asyncio.Task.cancel`` of the wrapping future. If a
-        future revision adds an explicit FunctionCall.cancel path to
-        ModalTaskExecutor (see TODO in its docstring), this test
-        becomes the primary safeguard for that path.
+        This is a placeholder regression-detector. Today
+        ``executor.cancel`` collapses to the ABC's no-op default — the
+        actual termination work happens in the asyncio.cancel below. If
+        a future revision adds an explicit FunctionCall.cancel path to
+        ModalTaskExecutor (see TODO in its docstring), the test guards
+        against breaking *both* paths.
+
+        Note: this test cannot distinguish "executor.cancel did the
+        work" from "asyncio.cancel did the work" today. Once the
+        explicit-cancel path lands, drop the ``submit_fut.cancel()`` line
+        below to make this assertion specific.
         """
         import asyncio
         import time

--- a/lib/stardag/tests/test_integration/test_modal/test__app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__app.py
@@ -34,10 +34,12 @@ try:
         StardagApp,
         get_default_volume_mount_path,
     )
+    from stardag.integration.modal._app import ModalTaskExecutor
     from stardag.integration.modal._config import with_stardag_on_image
     from stardag.testing.modal._tasks import (
         AsyncDoubleTask,
         AsyncDynamicRangeSumTask,
+        SleepTask,
         SyncDynamicRangeSumTask,
         make_range,
         sum_list,
@@ -427,3 +429,88 @@ class TestEndToEndDynamicDepsBuild:
         )
         assert root.target().exists()
         assert root.target().load() == sum(range(limit))
+
+
+class TestModalExecutorCancel:
+    """Real-Modal verification that cancelling the asyncio future awaiting
+    ``ModalTaskExecutor.submit`` actually terminates the remote container —
+    rather than letting it run to completion (and bill) while the build
+    has already failed-fast.
+
+    Each test sleeps a long-running task on Modal, then triggers cancel.
+    If propagation is broken, the test would block for ``SleepTask.seconds``;
+    the assertion catches that with an upper-bound elapsed-time check.
+    """
+
+    SLEEP_SECONDS = 60
+    # Generous upper bound: ~3s to start + a few s for Modal to confirm
+    # cancellation. Significantly less than SLEEP_SECONDS so the failure
+    # mode is unambiguous.
+    CANCEL_TIMEOUT_S = 20
+
+    @pytest.mark.asyncio
+    async def test_cancel_propagates_to_remote_container(
+        self, isolated_modal_target_root
+    ):
+        """Cancelling the asyncio future stops the remote SleepTask."""
+        import asyncio
+        import time
+
+        executor = ModalTaskExecutor(
+            modal_app_name=TEST_APP_NAME,
+            worker_selector=lambda t: "default",
+        )
+        await executor.setup()
+        try:
+            task = SleepTask(seconds=self.SLEEP_SECONDS)
+            submit_fut = asyncio.create_task(executor.submit(task))
+            # Give Modal a moment to spawn the container and start the task.
+            await asyncio.sleep(3)
+            t0 = time.monotonic()
+            submit_fut.cancel()
+            with pytest.raises((asyncio.CancelledError, Exception)):
+                await submit_fut
+            elapsed = time.monotonic() - t0
+            assert elapsed < self.CANCEL_TIMEOUT_S, (
+                f"Cancel propagation took {elapsed:.1f}s — Modal likely did "
+                f"not cancel the remote container (would have run for "
+                f"{self.SLEEP_SECONDS}s)"
+            )
+        finally:
+            await executor.teardown()
+
+    @pytest.mark.asyncio
+    async def test_executor_cancel_method_terminates_remote_call(
+        self, isolated_modal_target_root
+    ):
+        """``ModalTaskExecutor.cancel(task)`` terminates the in-flight call.
+
+        Today this collapses to the ABC's no-op default — cancellation
+        works via ``asyncio.Task.cancel`` of the wrapping future. If a
+        future revision adds an explicit FunctionCall.cancel path to
+        ModalTaskExecutor (see TODO in its docstring), this test
+        becomes the primary safeguard for that path.
+        """
+        import asyncio
+        import time
+
+        executor = ModalTaskExecutor(
+            modal_app_name=TEST_APP_NAME,
+            worker_selector=lambda t: "default",
+        )
+        await executor.setup()
+        try:
+            task = SleepTask(seconds=self.SLEEP_SECONDS)
+            submit_fut = asyncio.create_task(executor.submit(task))
+            await asyncio.sleep(3)
+            t0 = time.monotonic()
+            await executor.cancel(task)
+            submit_fut.cancel()  # also cancel the wrapping future
+            with pytest.raises((asyncio.CancelledError, Exception)):
+                await submit_fut
+            elapsed = time.monotonic() - t0
+            assert elapsed < self.CANCEL_TIMEOUT_S, (
+                f"executor.cancel() did not terminate the call: {elapsed:.1f}s"
+            )
+        finally:
+            await executor.teardown()

--- a/lib/stardag/tests/test_integration/test_modal/test__app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__app.py
@@ -468,7 +468,7 @@ class TestModalExecutorCancel:
             await asyncio.sleep(3)
             t0 = time.monotonic()
             submit_fut.cancel()
-            with pytest.raises((asyncio.CancelledError, Exception)):
+            with pytest.raises(asyncio.CancelledError):
                 await submit_fut
             elapsed = time.monotonic() - t0
             assert elapsed < self.CANCEL_TIMEOUT_S, (
@@ -506,7 +506,7 @@ class TestModalExecutorCancel:
             t0 = time.monotonic()
             await executor.cancel(task)
             submit_fut.cancel()  # also cancel the wrapping future
-            with pytest.raises((asyncio.CancelledError, Exception)):
+            with pytest.raises(asyncio.CancelledError):
                 await submit_fut
             elapsed = time.monotonic() - t0
             assert elapsed < self.CANCEL_TIMEOUT_S, (

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import gzip
 import json
 
+import pytest
+
 from stardag.exceptions import APIError, NotFoundError
 from stardag.registry._api_registry import (
     _GZIP_REQUEST_THRESHOLD_BYTES,
@@ -278,3 +280,144 @@ class TestIsRouteNotFound:
         # return True if detail matches — not our concern; call sites only pass
         # NotFoundError. This test documents the contract.
         assert _is_route_not_found(err) is True  # type: ignore[arg-type]
+
+
+class TestTaskSkip404Swallow:
+    """``task_skip`` / ``task_skip_aio`` swallow FastAPI's ``Not Found`` 404
+    with a warning so a new SDK against an old API (no ``/skip`` route)
+    does not fail builds on every fail-fast / blocked-dep path. Genuine
+    app-level 404s (e.g. unknown build_id) must still propagate.
+    """
+
+    def _make_registry_and_handler(self, response_factory):
+        """Build an APIRegistry with the sync httpx client routed to handler.
+
+        For async tests the caller must additionally inject the mock
+        AsyncClient *inside the test coroutine* (so the captured loop
+        matches the lazy-init check in ``_get_async_client``):
+
+            import asyncio, httpx
+            registry._async_client = httpx.AsyncClient(
+                transport=httpx.MockTransport(response_factory),
+                auth=registry._auth,
+            )
+            registry._async_client_loop = asyncio.get_running_loop()
+        """
+        import httpx
+
+        from stardag.registry._api_registry import APIRegistry
+
+        registry = APIRegistry(api_url="http://test.invalid", api_key="test-key")
+        registry._client = httpx.Client(
+            transport=httpx.MockTransport(response_factory),
+            auth=registry._auth,
+        )
+        return registry
+
+    @staticmethod
+    def _inject_async_mock(registry, response_factory):
+        import asyncio
+        import httpx
+
+        registry._async_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(response_factory),
+            auth=registry._auth,
+        )
+        registry._async_client_loop = asyncio.get_running_loop()
+
+    def _fake_task(self):
+        from uuid import uuid4
+
+        class _Fake:
+            id = uuid4()
+
+            def get_namespace(self):
+                return "test"
+
+            def get_name(self):
+                return "FakeTask"
+
+        return _Fake()
+
+    def test_sync_route_missing_404_is_swallowed(self, caplog):
+        """Old API: detail == 'Not Found' → warn + return, no exception."""
+        import httpx
+        import logging
+        from uuid import UUID
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Not Found"})
+
+        registry = self._make_registry_and_handler(handler)
+        task = self._fake_task()
+
+        with caplog.at_level(logging.WARNING):
+            # Should NOT raise.
+            registry.task_skip(
+                build_id=UUID("00000000-0000-0000-0000-000000000001"),
+                task=task,  # type: ignore[arg-type]
+            )
+
+        assert any(
+            "does not support POST /skip" in rec.message for rec in caplog.records
+        ), f"Expected route-missing warning; got: {[r.message for r in caplog.records]}"
+
+    def test_sync_app_level_404_propagates(self):
+        """New API: detail == 'Build not found' → raise NotFoundError as usual."""
+        import httpx
+        from uuid import UUID
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Build not found"})
+
+        registry = self._make_registry_and_handler(handler)
+        task = self._fake_task()
+
+        with pytest.raises(NotFoundError):
+            registry.task_skip(
+                build_id=UUID("00000000-0000-0000-0000-000000000001"),
+                task=task,  # type: ignore[arg-type]
+            )
+
+    @pytest.mark.asyncio
+    async def test_aio_route_missing_404_is_swallowed(self, caplog):
+        """Async path: detail == 'Not Found' → warn + return."""
+        import httpx
+        import logging
+        from uuid import UUID
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Not Found"})
+
+        registry = self._make_registry_and_handler(handler)
+        self._inject_async_mock(registry, handler)
+        task = self._fake_task()
+
+        with caplog.at_level(logging.WARNING):
+            await registry.task_skip_aio(
+                build_id=UUID("00000000-0000-0000-0000-000000000001"),
+                task=task,  # type: ignore[arg-type]
+            )
+
+        assert any(
+            "does not support POST /skip" in rec.message for rec in caplog.records
+        ), f"Expected route-missing warning; got: {[r.message for r in caplog.records]}"
+
+    @pytest.mark.asyncio
+    async def test_aio_app_level_404_propagates(self):
+        """Async path: app-level 404 propagates."""
+        import httpx
+        from uuid import UUID
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Build not found"})
+
+        registry = self._make_registry_and_handler(handler)
+        self._inject_async_mock(registry, handler)
+        task = self._fake_task()
+
+        with pytest.raises(NotFoundError):
+            await registry.task_skip_aio(
+                build_id=UUID("00000000-0000-0000-0000-000000000001"),
+                task=task,  # type: ignore[arg-type]
+            )


### PR DESCRIPTION
## Summary

- **FAIL_FAST now actually fails fast.** When a task fails, the build cancels in-flight sibling futures, emits `TASK_CANCELLED` for each (Modal containers terminate via asyncio cancel propagation; held global locks are released with `completed=False`), and emits `TASK_SKIPPED` for transitively-blocked downstream tasks before re-raising. Pre-PR, in-flight Modal calls were silently abandoned (containers kept running and billing; registry stuck in `RUNNING`).
- **`TASK_SKIPPED` events now fire for blocked tasks** in both modes. The API + SDK + event-pipeline already had `TaskStatus.SKIPPED` and `TASK_SKIPPED` event types — no endpoint was emitting them.
- **Bug fix in `process_result`:** sibling completions in the same `asyncio.wait` `done` batch as a failure are no longer lost. The for-loop processes the whole batch before evaluating fail-fast escalation.

## Approach

- **API**: new `POST /api/v1/builds/{build_id}/tasks/{task_id}/skip` (mirrors the existing `/cancel` route).
- **SDK Registry**: `task_skip` / `task_skip_aio` on `RegistryABC` (default no-op) + HTTP impl in `APIRegistry`. The new endpoint uses the same `_is_route_not_found` graceful-degrade pattern as `/dependencies` so a new SDK against an older Registry API doesn't crash builds — it warns and leaves blocked tasks `PENDING` (pre-0.7.0 behaviour).
- **`TaskExecutorABC.cancel(task)`**: optional best-effort hook (default no-op), routed through `RoutedTaskExecutor`. `ModalTaskExecutor` inherits the no-op — asyncio.cancel propagation does the actual work today; the hook is a TODO docstrings forward-compat slot for explicit `FunctionCall.cancel`.
- **`TaskCount`**: new `cancelled` and `skipped` fields. `BuildSummary.__repr__` renders them when non-zero.
- **`build_aio` refactor**: `process_result` sets a `fail_fast_triggered` flag instead of raising. The main loop finishes the current `done` batch, then breaks. Two helpers run on success / fail-fast / outer-except paths:
  - `cancel_pending_in_flight()` — race-aware: splits `pending_futures` into already-done (process via `process_result` so their actual outcome — complete/fail — is recorded) and still-running (cancel + emit `TASK_CANCELLED` + release lock with `completed=False`). Idempotent.
  - `emit_skips_for_blocked_tasks()` — fixed-point loop emitting `task_skip_aio` for transitively-blocked tasks. Idempotent.

## Compatibility

| SDK | API | Status |
|---|---|---|
| Old SDK | New API | ✅ Additive endpoint only |
| New SDK | New API | ✅ Design case |
| New SDK | Old API | ✅ Graceful 404 degrade — warning logged, blocked tasks stay `PENDING` (matches pre-0.7.0 observable behaviour) |

No coordination required for upgrade; natural sequence is API first then SDK to get full functionality.

## Versioning

Going to **0.7.0**, not 0.6.2. Reasons: meaningful additive public-API surface (`TaskExecutorABC.cancel`, `task_skip[_aio]`, `TaskCount.cancelled`/`skipped`, `TASK_SKIPPED` event), observable behaviour change in FAIL_FAST (correct fix, but builds with in-flight Modal calls now exit promptly — surprise vs old behaviour), and a coordinated-rollout signal even though degrade is graceful. Precedent matches 0.6.0's shape (build-loop overhaul + additive contract additions) more than 0.6.1's (Modal-only fixes).

## Test plan

- [x] `pre-commit run --files <touched files>` — ruff, prettier, pyright × 2 packages clean
- [x] `tests/test_build/` — 125 existing + 9 new (`TestFailFastCancelAndSkip`)
- [x] `tests/test_registry/` — 47 existing + 4 new (`TestTaskSkip404Swallow`, sync + async × route-missing + app-level)
- [x] `tests/test_integration/test_modal/test__app.py` (under `andhus` profile) — 11 existing + 2 new (`TestModalExecutorCancel`); cancel propagation verified in <20s vs the 60s `SleepTask` sleep
- [x] `lib/stardag` non-integration suite — 513+ passing
- [x] `app/stardag-api` — 252+ passing + 17 skipped (full suite)

### New tests added

`lib/stardag/tests/test_build/test_concurrent.py::TestFailFastCancelAndSkip` (9):

1. `test_fail_fast_cancels_in_flight_siblings` — slow task is cancelled, build returns in <2s vs 5s sleep.
2. `test_fail_fast_processes_sibling_done_during_fail_handling` — **race regression test**: event-gated (no wall-clock dependency); sibling that finishes during failing task's `process_result` gets `task_complete_aio`, not `task_cancel_aio`.
3. `test_fail_fast_records_sibling_completion_in_same_batch` — gated tasks land in same `done` batch; success leaf still gets `task_complete_aio` even though build raises.
4. `test_continue_mode_does_not_cancel_siblings`
5. `test_skips_emitted_for_transitively_blocked_tasks_continue` — A→B→C skip propagation
6. `test_skips_emitted_in_fail_fast_mode_too` — skips fire BEFORE `build_fail_aio`
7. `test_routed_executor_cancel_routes_correctly`
8. `test_build_summary_repr_includes_cancelled_skipped`
9. `test_fail_fast_releases_lock_for_cancelled_task` — global lock released with `completed=False` on cancel

`lib/stardag/tests/test_registry/test_api_registry.py::TestTaskSkip404Swallow` (4): sync + async × route-missing 404 (warn + return) + app-level 404 (re-raise).

`lib/stardag/tests/test_integration/test_modal/test__app.py::TestModalExecutorCancel` (2): cancel propagation via asyncio.cancel and via `executor.cancel()`.

`app/stardag-api/tests/test_builds.py`: 200 happy path + 404 unknown task for `/skip`.

## Commits

- `34bc634` — initial implementation
- `66b9800` — review v1: race-aware cancel split, registered guard, docstring rewrite, pytest.raises tightening
- `fff4a58` — review v2: deflake race test (event-gated), rename test #2, add lock-release-on-cancel test
- `d3cec7b` — graceful 404 degrade for `/skip` on older API
- `35df080` — v0.7.0 changelog + release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)