### PR TITLE
Modal: support multiple root tasks in build_spawn/build_remote + build_kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.7.1] — 2026-05-05
+
+Modal: `StardagApp.build_spawn` / `build_remote` now accept multiple root
+tasks (`Sequence[BaseTask] | BaseTask`) and a new `build_kwargs` dict
+forwarded to `stardag.build(...)`. **Breaking**: first parameter renamed
+`task` → `tasks` for consistency with `stardag.build()` and
+`Builder.__call__`; the `BuildFunction` protocol gains a 4th
+`build_kwargs=None` parameter (custom implementations must accept it).
+See
+[RELEASE_NOTES.md](RELEASE_NOTES.md#v071--multi-root-builds-and-build_kwargs-on-stardagapp)
+for the migration.
+([#140](https://github.com/stardag-dev/stardag/pull/140))
+
 ## [0.7.0] — 2026-05-05
 
 `FailMode.FAIL_FAST` now actually fails fast: in-flight sibling tasks

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,46 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.7.1 — Multi-root builds and `build_kwargs` on `StardagApp`
+
+Two additive changes to `stardag.integration.modal`, plus one renamed
+parameter for consistency with `stardag.build()`.
+
+### What changed
+
+- **Multi-root `build_spawn` / `build_remote`.** Both methods now accept
+  either a single `BaseTask` or a `Sequence[BaseTask]`, matching what
+  `Builder.__call__` and `stardag.build()` already supported.
+- **`build_kwargs` passthrough.** `BuildFunction`, `Builder.__call__` /
+  `Builder.build`, `PrefectBuilder.build`, and
+  `StardagApp.build_spawn` / `build_remote` all gained a new
+  `build_kwargs: dict[str, Any] | None` argument. The default `Builder`
+  splats it into `stardag.build(...)`:
+
+  ```python
+  stardag_app.build_remote(
+      task,
+      build_kwargs={"fail_mode": FailMode.CONTINUE},
+  )
+  ```
+
+  `Builder.build` rejects reserved keys (`tasks`, `task_executor`) with
+  `TypeError`.
+
+### Breaking changes
+
+- **`build_spawn` / `build_remote`'s first parameter is renamed
+  `task` → `tasks`.** Motivated by consistency with `stardag.build()` and
+  the existing `Builder` entry points. Positional callers
+  (`build_spawn(my_task)`) are unaffected; only callers using the keyword
+  form (`build_spawn(task=my_task)`) need to update.
+- **`BuildFunction` protocol gained a 4th parameter, `build_kwargs=None`.**
+  Custom build functions passed to `StardagApp(build_function=...)`, and
+  `Builder` subclasses overriding `build()`, must accept it (default to
+  `None`).
+
+---
+
 ## v0.7.0 — FAIL_FAST actually fails fast; explicit SKIPPED status for blocked tasks
 
 Two related fixes to the build loop's failure handling. No breaking

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -380,8 +380,17 @@ class BuildFunction(typing.Protocol):
     """Protocol for the function registered as the Modal "build" function.
 
     This function is called remotely on Modal to orchestrate a DAG build.
-    It receives the root task, a worker selector, and the Modal app name,
-    then coordinates task execution across Modal worker functions.
+    It receives one or more root tasks, a worker selector, the Modal app
+    name, and an optional ``build_kwargs`` dict, then coordinates task
+    execution across Modal worker functions.
+
+    Args (of ``__call__``):
+        tasks: A single root ``BaseTask`` or a sequence of root tasks.
+        worker_selector: Function picking a worker name per task.
+        app_name: Name of the Modal app hosting the worker functions.
+        build_kwargs: Optional dict of extra kwargs forwarded to the
+            underlying build engine (the default ``Builder`` splats them
+            into :func:`stardag.build`). ``None`` means "no extra kwargs".
 
     The default implementation (``Builder``) creates a ``ModalTaskExecutor``
     and calls ``stardag.build()``. Custom implementations can subclass
@@ -712,7 +721,12 @@ class PrefectBuilder(Builder):
             task = tasks[0]
 
         flow_kwargs = dict(build_kwargs or {})
+        # ``task`` is reserved because the flow is invoked as
+        # ``_flow(...)(task, ...)`` below — letting the user pass another
+        # ``task`` via build_kwargs would surface as a confusing
+        # "got multiple values for argument 'task'" TypeError.
         for reserved in (
+            "task",
             "task_executor",
             "before_run_callback",
             "on_complete_callback",
@@ -946,7 +960,7 @@ class StardagApp:
             app_name: str,
             build_kwargs: dict[str, typing.Any] | None = None,
         ) -> BuildSummary | None:
-            return build_fn(tasks, worker_selector, app_name, build_kwargs)
+            return build_fn(tasks, worker_selector, app_name, build_kwargs=build_kwargs)
 
         run_fn = self._run_function
 

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -398,6 +398,7 @@ class BuildFunction(typing.Protocol):
         tasks: typing.Sequence[BaseTask] | BaseTask,
         worker_selector: WorkerSelector,
         app_name: str,
+        build_kwargs: dict[str, typing.Any] | None = None,
     ) -> BuildSummary | None: ...
 
 
@@ -479,6 +480,7 @@ class Builder(BuildFunction):
         tasks: typing.Sequence[BaseTask] | BaseTask,
         worker_selector: WorkerSelector,
         app_name: str,
+        build_kwargs: dict[str, typing.Any] | None = None,
     ) -> BuildSummary | None:
         """Core build logic to orchestrate the DAG build."""
         modal_executor = ModalTaskExecutor(
@@ -491,7 +493,7 @@ class Builder(BuildFunction):
 
         try:
             self.setup(tasks)
-            summary = self.build(tasks, modal_executor)
+            summary = self.build(tasks, modal_executor, build_kwargs=build_kwargs)
             summary_or_exception = summary
             return summary
         except Exception as exception:
@@ -504,9 +506,21 @@ class Builder(BuildFunction):
         self,
         tasks: typing.Sequence[BaseTask] | BaseTask,
         task_executor: ModalTaskExecutor,
+        build_kwargs: dict[str, typing.Any] | None = None,
     ) -> BuildSummary | None:
-        """Default build logic using stardag.build() with the ModalTaskExecutor."""
-        return build(tasks, task_executor=task_executor)
+        """Default build logic using stardag.build() with the ModalTaskExecutor.
+
+        ``build_kwargs`` are forwarded to :func:`stardag.build` (e.g. ``fail_mode``,
+        ``register_all``, ``global_lock_config``). Conflicting keys (``tasks``,
+        ``task_executor``) are reserved and rejected.
+        """
+        kwargs = dict(build_kwargs or {})
+        for reserved in ("tasks", "task_executor"):
+            if reserved in kwargs:
+                raise TypeError(
+                    f"build_kwargs must not contain reserved key '{reserved}'"
+                )
+        return build(tasks, task_executor=task_executor, **kwargs)
 
 
 class Runner(RunFunction):
@@ -677,6 +691,7 @@ class PrefectBuilder(Builder):
         self,
         tasks: typing.Sequence[BaseTask] | BaseTask,
         task_executor: ModalTaskExecutor,
+        build_kwargs: dict[str, typing.Any] | None = None,
     ) -> BuildSummary | None:
         if prefect_build_flow is None:
             raise ImportError("Prefect is not installed")
@@ -696,6 +711,17 @@ class PrefectBuilder(Builder):
                 )
             task = tasks[0]
 
+        flow_kwargs = dict(build_kwargs or {})
+        for reserved in (
+            "task_executor",
+            "before_run_callback",
+            "on_complete_callback",
+        ):
+            if reserved in flow_kwargs:
+                raise TypeError(
+                    f"build_kwargs must not contain reserved key '{reserved}'"
+                )
+
         async def _run():
             await _flow.with_options(
                 name=f"stardag-build-{task.get_namespace()}:{task.get_name()}"
@@ -706,6 +732,7 @@ class PrefectBuilder(Builder):
                 on_complete_callback=(
                     self.on_complete_callback or upload_task_on_complete_artifacts
                 ),
+                **flow_kwargs,
             )
 
         asyncio.run(_run())
@@ -917,8 +944,9 @@ class StardagApp:
             tasks: typing.Sequence[BaseTask] | BaseTask,
             worker_selector: WorkerSelector,
             app_name: str,
+            build_kwargs: dict[str, typing.Any] | None = None,
         ) -> BuildSummary | None:
-            return build_fn(tasks, worker_selector, app_name)
+            return build_fn(tasks, worker_selector, app_name, build_kwargs)
 
         run_fn = self._run_function
 
@@ -969,7 +997,11 @@ class StardagApp:
         )
 
     def build_spawn(
-        self, task: BaseTask, worker_selector: WorkerSelector | None = None
+        self,
+        tasks: typing.Sequence[BaseTask] | BaseTask,
+        worker_selector: WorkerSelector | None = None,
+        *,
+        build_kwargs: dict[str, typing.Any] | None = None,
     ):
         """Spawn a build job on a deployed Modal app (non-blocking).
 
@@ -977,15 +1009,19 @@ class StardagApp:
         a new execution. Use this for fire-and-forget builds.
 
         Args:
-            task: The root task to build.
+            tasks: A single root task or a sequence of root tasks to build.
             worker_selector: Optional override for worker selection.
+            build_kwargs: Optional kwargs forwarded to the remote build function
+                (e.g. ``{"fail_mode": FailMode.CONTINUE}``). The
+                default ``Builder`` passes these to :func:`stardag.build`.
 
         Returns:
             A Modal FunctionCall handle for the spawned build.
 
         Example:
             handle = stardag_app.build_spawn(my_task)
-            # Build is running in the background
+            # Or multiple roots:
+            handle = stardag_app.build_spawn([task_a, task_b])
             # Optionally wait for result:
             result = handle.get()
         """
@@ -994,13 +1030,18 @@ class StardagApp:
             name="build",
         )
         return build_function.spawn(
-            tasks=task,
+            tasks=tasks,
             worker_selector=worker_selector or self.worker_selector,
             app_name=self.name,
+            build_kwargs=build_kwargs,
         )
 
     def build_remote(
-        self, task: BaseTask, worker_selector: WorkerSelector | None = None
+        self,
+        tasks: typing.Sequence[BaseTask] | BaseTask,
+        worker_selector: WorkerSelector | None = None,
+        *,
+        build_kwargs: dict[str, typing.Any] | None = None,
     ):
         """Run a build on a deployed Modal app (blocking).
 
@@ -1008,24 +1049,29 @@ class StardagApp:
         it synchronously. Use this when you need to wait for the build result.
 
         Args:
-            task: The root task to build.
+            tasks: A single root task or a sequence of root tasks to build.
             worker_selector: Optional override for worker selection.
+            build_kwargs: Optional kwargs forwarded to the remote build function
+                (e.g. ``{"fail_mode": FailMode.CONTINUE}``). The
+                default ``Builder`` passes these to :func:`stardag.build`.
 
         Returns:
             The result of the build.
 
         Example:
             result = stardag_app.build_remote(my_task)
-            print(f"Build completed: {result}")
+            # Or multiple roots:
+            result = stardag_app.build_remote([task_a, task_b])
         """
         build_function = modal.Function.from_name(
             app_name=self.name,
             name="build",
         )
         return build_function.remote(
-            tasks=task,
+            tasks=tasks,
             worker_selector=worker_selector or self.worker_selector,
             app_name=self.name,
+            build_kwargs=build_kwargs,
         )
 
     def local_entrypoint(self, *args, **kwargs):

--- a/lib/stardag/tests/test_integration/test_modal/test__app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__app.py
@@ -321,6 +321,27 @@ class TestEndToEndBuild:
         assert root.target().exists()
         assert root.target().load() == 10  # sum(range(5)) = 0+1+2+3+4
 
+    def test_build_remote_multiple_roots(self, isolated_modal_target_root):
+        """build_remote accepts a sequence of root tasks (not just one)."""
+        from stardag.build._base import BuildSummary
+
+        # Two independent roots — distinct limits so no shared deps and so
+        # task IDs don't collide with other tests' make_range(...) outputs.
+        root_a = sum_list(values=make_range(limit=3))
+        root_b = sum_list(values=make_range(limit=4))
+        assert not root_a.target().exists()
+        assert not root_b.target().exists()
+
+        result = stardag_app.build_remote([root_a, root_b])
+
+        assert isinstance(result, BuildSummary)
+        # 4 tasks: 2× make_range, 2× sum_list (each pair has different params)
+        assert result.task_count.succeeded == 4, (
+            f"Expected 4 succeeded, got {result.task_count}"
+        )
+        assert root_a.target().load() == sum(range(3))  # 3
+        assert root_b.target().load() == sum(range(4))  # 6
+
 
 @pytest.fixture
 def isolated_modal_target_root():

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -39,7 +39,9 @@ class TestStardagAppCustomFunctions:
     def test_custom_build_function(self):
         """Custom build_function is stored."""
 
-        def my_build(tasks, worker_selector, app_name) -> BuildSummary:  # type: ignore[empty-body]
+        def my_build(
+            tasks, worker_selector, app_name, build_kwargs=None
+        ) -> BuildSummary:  # type: ignore[empty-body]
             ...
 
         app = StardagApp(
@@ -103,7 +105,9 @@ class TestStardagAppCustomFunctions:
 
         calls = []
 
-        def my_build(tasks, worker_selector, app_name) -> BuildSummary:  # type: ignore[empty-body]
+        def my_build(
+            tasks, worker_selector, app_name, build_kwargs=None
+        ) -> BuildSummary:  # type: ignore[empty-body]
             calls.append(("build", tasks, app_name))
 
         app = StardagApp(
@@ -132,7 +136,7 @@ class TestStardagAppCustomFunctions:
 
         assert inspect.isfunction(registered_fns["build"])
         # Calling it delegates to my_build
-        registered_fns["build"]("task", "selector", "app")
+        registered_fns["build"]("task", "selector", "app", None)
         assert calls == [("build", "task", "app")]
 
     @patch("stardag.integration.modal._app.get_target_roots_volumes")
@@ -224,7 +228,9 @@ class TestBuilderAndRunnerProtocols:
     def test_plain_function_satisfies_build_function(self):
         """A plain function with matching signature satisfies BuildFunction."""
 
-        def my_build(tasks, worker_selector, app_name) -> BuildSummary:  # type: ignore[empty-body]
+        def my_build(
+            tasks, worker_selector, app_name, build_kwargs=None
+        ) -> BuildSummary:  # type: ignore[empty-body]
             ...
 
         fn: BuildFunction = my_build
@@ -255,7 +261,7 @@ class TestBuilderOrchestration:
             def setup(self, tasks):
                 calls.append("setup")
 
-            def build(self, tasks, task_executor):
+            def build(self, tasks, task_executor, build_kwargs=None):
                 calls.append("build")
                 return mock_summary
 
@@ -275,7 +281,7 @@ class TestBuilderOrchestration:
             def setup(self, tasks):
                 calls.append("setup")
 
-            def build(self, tasks, task_executor):
+            def build(self, tasks, task_executor, build_kwargs=None):
                 calls.append("build")
                 raise RuntimeError("boom")
 
@@ -299,7 +305,7 @@ class TestBuilderOrchestration:
             def setup(self, tasks):
                 pass
 
-            def build(self, tasks, task_executor):
+            def build(self, tasks, task_executor, build_kwargs=None):
                 return mock_summary
 
             def teardown(self, tasks, summary_or_exception):
@@ -373,3 +379,177 @@ class TestRunnerOrchestration:
         runner(MagicMock())
 
         assert received["exception"] is None
+
+
+# ---------------------------------------------------------------------------
+# Builder.build_kwargs forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestBuilderBuildKwargs:
+    """Builder forwards ``build_kwargs`` to ``stardag.build``."""
+
+    def test_default_build_forwards_build_kwargs(self, monkeypatch):
+        from stardag.build import FailMode
+        from stardag.integration.modal import _app as modal_app_module
+
+        captured: dict = {}
+
+        def fake_build(tasks, **kwargs):
+            captured["tasks"] = tasks
+            captured["kwargs"] = kwargs
+            return None
+
+        monkeypatch.setattr(modal_app_module, "build", fake_build)
+
+        builder = modal_app_module.Builder()
+        executor = MagicMock()
+        root = MagicMock()
+        builder.build(
+            root,
+            executor,
+            build_kwargs={
+                "fail_mode": FailMode.CONTINUE,
+                "register_all": True,
+            },
+        )
+        assert captured["tasks"] is root
+        assert captured["kwargs"]["task_executor"] is executor
+        assert captured["kwargs"]["fail_mode"] == FailMode.CONTINUE
+        assert captured["kwargs"]["register_all"] is True
+
+    def test_default_build_no_build_kwargs(self, monkeypatch):
+        """Backwards-compat: omitting build_kwargs still works."""
+        from stardag.integration.modal import _app as modal_app_module
+
+        captured: dict = {}
+
+        def fake_build(tasks, **kwargs):
+            captured["kwargs"] = kwargs
+            return None
+
+        monkeypatch.setattr(modal_app_module, "build", fake_build)
+
+        builder = modal_app_module.Builder()
+        builder.build(MagicMock(), MagicMock())
+        # Only task_executor — no leaked kwargs from a None build_kwargs.
+        assert set(captured["kwargs"].keys()) == {"task_executor"}
+
+    @pytest.mark.parametrize("reserved_key", ["tasks", "task_executor"])
+    def test_default_build_rejects_reserved_keys(self, reserved_key):
+        builder = Builder()
+        with pytest.raises(TypeError, match=reserved_key):
+            builder.build(MagicMock(), MagicMock(), build_kwargs={reserved_key: "x"})
+
+    def test_call_forwards_build_kwargs_to_build(self):
+        """Builder.__call__ passes build_kwargs through to Builder.build()."""
+        captured: dict = {}
+
+        class CapturingBuilder(Builder):
+            def build(self, tasks, task_executor, build_kwargs=None):
+                captured["tasks"] = tasks
+                captured["build_kwargs"] = build_kwargs
+                return None
+
+        builder = CapturingBuilder()
+        root = MagicMock()
+        builder(
+            root,
+            lambda t: "default",
+            "test-app",
+            build_kwargs={"fail_mode": "FAIL_FAST"},
+        )
+        assert captured["tasks"] is root
+        assert captured["build_kwargs"] == {"fail_mode": "FAIL_FAST"}
+
+    def test_call_default_build_kwargs_is_none(self):
+        """When build_kwargs is omitted, Builder.build receives None."""
+        captured: dict = {}
+
+        class CapturingBuilder(Builder):
+            def build(self, tasks, task_executor, build_kwargs=None):
+                captured["build_kwargs"] = build_kwargs
+                return None
+
+        builder = CapturingBuilder()
+        builder(MagicMock(), lambda t: "default", "test-app")
+        assert captured["build_kwargs"] is None
+
+
+# ---------------------------------------------------------------------------
+# StardagApp.build_spawn / build_remote dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestStardagAppBuildSpawnRemote:
+    """build_spawn / build_remote forward tasks (single or sequence) and
+    build_kwargs to the remote Modal function."""
+
+    def _make_app(self):
+        return StardagApp(
+            "test-spawn-remote-app",
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={"default": FunctionSettings(image=_make_image())},
+        )
+
+    def _patch_function_from_name(self, monkeypatch):
+        """Patch modal.Function.from_name to return a recording stub."""
+        captured: dict = {}
+
+        class _Stub:
+            def spawn(self, **kwargs):
+                captured["op"] = "spawn"
+                captured["kwargs"] = kwargs
+                return "spawn-handle"
+
+            def remote(self, **kwargs):
+                captured["op"] = "remote"
+                captured["kwargs"] = kwargs
+                return "remote-result"
+
+        monkeypatch.setattr(
+            modal.Function, "from_name", staticmethod(lambda **_: _Stub())
+        )
+        return captured
+
+    def test_build_remote_single_task(self, monkeypatch):
+        captured = self._patch_function_from_name(monkeypatch)
+        app = self._make_app()
+        root = MagicMock()
+
+        result = app.build_remote(root)
+
+        assert result == "remote-result"
+        assert captured["op"] == "remote"
+        assert captured["kwargs"]["tasks"] is root
+        assert captured["kwargs"]["app_name"] == app.name
+        assert captured["kwargs"]["build_kwargs"] is None
+
+    def test_build_remote_sequence_of_tasks(self, monkeypatch):
+        captured = self._patch_function_from_name(monkeypatch)
+        app = self._make_app()
+        roots = [MagicMock(), MagicMock()]
+
+        app.build_remote(roots)
+
+        assert captured["kwargs"]["tasks"] is roots
+
+    def test_build_remote_forwards_build_kwargs(self, monkeypatch):
+        captured = self._patch_function_from_name(monkeypatch)
+        app = self._make_app()
+
+        app.build_remote(MagicMock(), build_kwargs={"fail_mode": "CONTINUE"})
+
+        assert captured["kwargs"]["build_kwargs"] == {"fail_mode": "CONTINUE"}
+
+    def test_build_spawn_sequence_and_build_kwargs(self, monkeypatch):
+        captured = self._patch_function_from_name(monkeypatch)
+        app = self._make_app()
+        roots = [MagicMock(), MagicMock()]
+
+        result = app.build_spawn(roots, build_kwargs={"register_all": True})
+
+        assert result == "spawn-handle"
+        assert captured["op"] == "spawn"
+        assert captured["kwargs"]["tasks"] is roots
+        assert captured["kwargs"]["build_kwargs"] == {"register_all": True}

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -140,6 +140,46 @@ class TestStardagAppCustomFunctions:
         assert calls == [("build", "task", "app")]
 
     @patch("stardag.integration.modal._app.get_target_roots_volumes")
+    def test_finalize_wrapper_forwards_build_kwargs_as_keyword(self, mock_volumes):
+        """The Modal wrapper forwards ``build_kwargs`` to the user's build_fn
+        as a keyword arg, so custom functions with keyword-only build_kwargs
+        are also supported."""
+        mock_volumes.return_value = MagicMock(by_volume_name={}, by_root_key={})
+
+        captured: dict = {}
+
+        # build_kwargs is keyword-only — would TypeError if forwarded
+        # positionally. (This deliberately diverges from BuildFunction's
+        # exact protocol signature, which has build_kwargs positional-or-
+        # keyword; the test verifies the wrapper supports either shape.)
+        def my_build(tasks, worker_selector, app_name, *, build_kwargs=None):
+            captured["build_kwargs"] = build_kwargs
+
+        app = StardagApp(
+            "test-app",
+            build_function=my_build,  # type: ignore[arg-type]
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={"default": FunctionSettings(image=_make_image())},
+        )
+
+        registered_fns: dict = {}
+
+        def capture_function(**kwargs):
+            name = kwargs.get("name", "unknown")
+
+            def decorator(fn):
+                registered_fns[name] = fn
+                return fn
+
+            return decorator
+
+        app.modal_app.function = capture_function  # type: ignore[assignment]
+        app.finalize()
+
+        registered_fns["build"]("task", "selector", "app", {"fail_mode": "x"})
+        assert captured["build_kwargs"] == {"fail_mode": "x"}
+
+    @patch("stardag.integration.modal._app.get_target_roots_volumes")
     def test_finalize_registers_run_wrapper_for_all_workers(self, mock_volumes):
         """finalize() registers run wrappers for all workers."""
         mock_volumes.return_value = MagicMock(by_volume_name={}, by_root_key={})


### PR DESCRIPTION
## Summary

- `StardagApp.build_spawn` / `build_remote` now accept a `Sequence[BaseTask]` in addition to a single `BaseTask`, matching what `Builder.__call__` / `Builder.build` already supported. Backwards-compatible — positional single-task callers (the only kind in-repo) keep working.
- Added `build_kwargs: dict[str, Any] | None = None` plumbing through:
  - `BuildFunction` protocol
  - `Builder.__call__` → `Builder.build` → `stardag.build(...)`
  - `PrefectBuilder.build` → Prefect flow
  - The `_modal_build` wrapper inside `finalize`
  - `StardagApp.build_spawn` / `build_remote` (keyword-only)

  `Builder.build` splats `build_kwargs` into `stardag.build(...)`; reserved keys (`tasks`, `task_executor`) raise `TypeError`. `PrefectBuilder.build` does the same for the keys it owns.

## Test plan

- [x] New unit tests in `test_stardag_app.py` cover `build_kwargs` forwarding (default, omitted, reserved-key rejection, `__call__` → `build` propagation) and multi-task / `build_kwargs` dispatch through `build_spawn` / `build_remote` — no Modal deploy required, all 28 tests pass locally.
- [x] New `test_build_remote_multiple_roots` end-to-end test in `test__app.py` builds two independent root DAGs through deployed Modal and asserts both targets land on the volume.
- [x] Existing `Builder` subclasses and plain-function fixtures updated to match the new protocol signature.
- [x] Pre-commit (prettier, ruff, ruff-format, pyright) passes.
- [ ] Modal end-to-end tests verified on `andhus` profile (please run before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)