### PR TITLE
Build resume lifecycle + SKIPPED status UI polish

### DIFF
--- a/app/stardag-api/migrations/versions/20260507_121615_add_build_resumed_event_type_and_last_.py
+++ b/app/stardag-api/migrations/versions/20260507_121615_add_build_resumed_event_type_and_last_.py
@@ -1,0 +1,49 @@
+"""add build_resumed event type and last_active_at column
+
+Revision ID: c1ea60e468b8
+Revises: 226b6ba1fa16
+Create Date: 2026-05-07 12:16:15.511870
+
+The ``BUILD_RESUMED`` enum value lives only in Python (events.event_type
+is a free-form ``String(32)``) so this migration only touches the
+``builds`` schema:
+  * adds ``last_active_at`` (nullable=False) and backfills from
+    ``created_at`` so existing rows have a sensible ordering value
+  * adds an index on (environment_id, last_active_at) for the new
+    list-builds sort order
+
+The column is added nullable, backfilled, and then altered to NOT NULL
+in a single migration — this is safe because the table is small in
+practice (per-environment build counts) and we hold a transaction anyway.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "c1ea60e468b8"
+down_revision: Union[str, Sequence[str], None] = "226b6ba1fa16"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "builds",
+        sa.Column("last_active_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.execute("UPDATE builds SET last_active_at = created_at")
+    op.alter_column("builds", "last_active_at", nullable=False)
+    op.create_index(
+        "ix_builds_environment_last_active",
+        "builds",
+        ["environment_id", "last_active_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_builds_environment_last_active", table_name="builds")
+    op.drop_column("builds", "last_active_at")

--- a/app/stardag-api/src/stardag_api/models/build.py
+++ b/app/stardag-api/src/stardag_api/models/build.py
@@ -70,11 +70,20 @@ class Build(Base, TimestampMixin):
         default=list,
     )
 
-    # Bumped on every event creation that targets this build (build- or
-    # task-level). Drives the "Home" / list-builds ordering so that a
-    # resumed build (BUILD_RESUMED) jumps to the top instead of staying
-    # buried at its created_at position. See _touch_build_last_active in
-    # routes/builds.py.
+    # Bumped on build-level lifecycle events only (BUILD_RESUMED,
+    # BUILD_COMPLETED, BUILD_FAILED, BUILD_CANCELLED, BUILD_EXIT_EARLY) —
+    # initial creation sets it via DEFAULT. Task events do NOT touch this
+    # column, so the per-task hot path is free of contention on the build
+    # row.
+    #
+    # This column drives the "Home" / list-builds ordering: a resumed
+    # build (BUILD_RESUMED) jumps to the top instead of staying buried at
+    # its original ``created_at`` position. The trade-off vs touching on
+    # every task event is that a long-running build won't bump position
+    # while it's mid-execution — but its ``status=running`` badge already
+    # signals activity, and "most recent lifecycle change" is a cleaner
+    # sort key than "any event in the build's subtree." See
+    # ``_touch_build_last_active`` in ``routes/builds.py``.
     last_active_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=utc_now,

--- a/app/stardag-api/src/stardag_api/models/build.py
+++ b/app/stardag-api/src/stardag_api/models/build.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import ForeignKey, Index, JSON, String, Text, Uuid
+from sqlalchemy import DateTime, ForeignKey, Index, JSON, String, Text, Uuid
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from stardag_api.models.base import Base, TimestampMixin, generate_uuid7
+from stardag_api.models.base import Base, TimestampMixin, generate_uuid7, utc_now
 
 if TYPE_CHECKING:
     from stardag_api.models.event import Event
@@ -27,6 +28,11 @@ class Build(Base, TimestampMixin):
     __tablename__ = "builds"
     __table_args__ = (
         Index("ix_builds_environment_created", "environment_id", "created_at"),
+        Index(
+            "ix_builds_environment_last_active",
+            "environment_id",
+            "last_active_at",
+        ),
     )
 
     id: Mapped[UUID] = mapped_column(
@@ -62,6 +68,17 @@ class Build(Base, TimestampMixin):
         JSON().with_variant(JSONB(), "postgresql"),
         nullable=False,
         default=list,
+    )
+
+    # Bumped on every event creation that targets this build (build- or
+    # task-level). Drives the "Home" / list-builds ordering so that a
+    # resumed build (BUILD_RESUMED) jumps to the top instead of staying
+    # buried at its created_at position. See _touch_build_last_active in
+    # routes/builds.py.
+    last_active_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=utc_now,
+        nullable=False,
     )
 
     # Relationships

--- a/app/stardag-api/src/stardag_api/models/enums.py
+++ b/app/stardag-api/src/stardag_api/models/enums.py
@@ -49,6 +49,9 @@ class EventType(str, enum.Enum):
 
     # Build events
     BUILD_STARTED = "build_started"
+    BUILD_RESUMED = (
+        "build_resumed"  # Existing build picked up by sd.build(resume_build_id=...)
+    )
     BUILD_COMPLETED = "build_completed"
     BUILD_FAILED = "build_failed"
     BUILD_CANCELLED = "build_cancelled"

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import func, select
+from sqlalchemy import func, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -81,6 +81,23 @@ def _raise_if_limit_exceeded(error: LimitExceededError | None) -> None:
 
 
 # --- Helpers ---
+
+
+async def _touch_build_last_active(db: AsyncSession, build_id: UUID) -> None:
+    """Bump ``Build.last_active_at`` to now in the current transaction.
+
+    Called from every code path that emits an Event for a build (build- or
+    task-level), so the list-builds endpoint can sort by activity recency.
+    A resumed build (BUILD_RESUMED) thereby jumps to the top of the
+    "Home" list even if its ``created_at`` is old.
+
+    Issues a single UPDATE — for the bulk task-register path this is one
+    extra statement per call, not one per task. The caller is expected to
+    commit the surrounding transaction; we don't commit here.
+    """
+    await db.execute(
+        update(Build).where(Build.id == build_id).values(last_active_at=utc_now())
+    )
 
 
 async def _get_triggered_by_user(
@@ -195,6 +212,7 @@ async def _create_task_event(
     # event into apply_event_to_task. The whole bundle commits atomically.
     await db.flush()
     apply_event_to_task(db_task, event)
+    await _touch_build_last_active(db, build_id)
     await db.commit()
 
     record_entity_created(auth.workspace_id, "events")
@@ -262,9 +280,13 @@ async def create_build(
     record_entity_created(auth.workspace_id, "events")
 
     # Build response with derived status
-    status, started_at, completed_at, triggered_by_id = await get_build_status(
-        db, db_build.id
-    )
+    (
+        status,
+        started_at,
+        completed_at,
+        triggered_by_id,
+        is_resumed,
+    ) = await get_build_status(db, db_build.id)
     triggered_by_user = await _get_triggered_by_user(db, triggered_by_id)
 
     return BuildResponse(
@@ -280,6 +302,7 @@ async def create_build(
         started_at=started_at,
         completed_at=completed_at,
         status_triggered_by_user=triggered_by_user,
+        is_resumed=is_resumed,
     )
 
 
@@ -306,8 +329,12 @@ async def list_builds(
     total_result = await db.execute(count_query)
     total = total_result.scalar() or 0
 
+    # Sort by last_active_at so a resumed build (BUILD_RESUMED touches
+    # this column) jumps back to the top of the list. Falls back to
+    # created_at for builds that have had no activity yet (column is
+    # initialized to created_at on insert, so the fallback is implicit).
     result = await db.execute(
-        query.order_by(Build.created_at.desc())
+        query.order_by(Build.last_active_at.desc())
         .offset((page - 1) * page_size)
         .limit(page_size)
     )
@@ -316,9 +343,13 @@ async def list_builds(
     # Build responses with derived status
     build_responses = []
     for build in builds:
-        status, started_at, completed_at, triggered_by_id = await get_build_status(
-            db, build.id
-        )
+        (
+            status,
+            started_at,
+            completed_at,
+            triggered_by_id,
+            is_resumed,
+        ) = await get_build_status(db, build.id)
         triggered_by_user = await _get_triggered_by_user(db, triggered_by_id)
         build_responses.append(
             BuildResponse(
@@ -334,6 +365,7 @@ async def list_builds(
                 started_at=started_at,
                 completed_at=completed_at,
                 status_triggered_by_user=triggered_by_user,
+                is_resumed=is_resumed,
             )
         )
 
@@ -365,9 +397,13 @@ async def get_build(
             status_code=403, detail="Build does not belong to this environment"
         )
 
-    status, started_at, completed_at, triggered_by_id = await get_build_status(
-        db, build.id
-    )
+    (
+        status,
+        started_at,
+        completed_at,
+        triggered_by_id,
+        is_resumed,
+    ) = await get_build_status(db, build.id)
     triggered_by_user = await _get_triggered_by_user(db, triggered_by_id)
 
     return BuildResponse(
@@ -383,6 +419,7 @@ async def get_build(
         started_at=started_at,
         completed_at=completed_at,
         status_triggered_by_user=triggered_by_user,
+        is_resumed=is_resumed,
     )
 
 
@@ -438,13 +475,18 @@ async def complete_build(
         event_metadata=_build_event_metadata(commit_hash, triggered_by_user_id),
     )
     db.add(event)
+    await _touch_build_last_active(db, build_id)
     await db.commit()
 
     record_entity_created(auth.workspace_id, "events")
 
-    status, started_at, completed_at, triggered_by_id = await get_build_status(
-        db, build.id
-    )
+    (
+        status,
+        started_at,
+        completed_at,
+        triggered_by_id,
+        is_resumed,
+    ) = await get_build_status(db, build.id)
     triggered_by_user = await _get_triggered_by_user(db, triggered_by_id)
 
     return BuildResponse(
@@ -460,6 +502,7 @@ async def complete_build(
         started_at=started_at,
         completed_at=completed_at,
         status_triggered_by_user=triggered_by_user,
+        is_resumed=is_resumed,
     )
 
 
@@ -505,13 +548,18 @@ async def fail_build(
         event_metadata=_build_event_metadata(commit_hash, triggered_by_user_id),
     )
     db.add(event)
+    await _touch_build_last_active(db, build_id)
     await db.commit()
 
     record_entity_created(auth.workspace_id, "events")
 
-    status, started_at, completed_at, triggered_by_id = await get_build_status(
-        db, build.id
-    )
+    (
+        status,
+        started_at,
+        completed_at,
+        triggered_by_id,
+        is_resumed,
+    ) = await get_build_status(db, build.id)
     triggered_by_user = await _get_triggered_by_user(db, triggered_by_id)
 
     return BuildResponse(
@@ -527,6 +575,7 @@ async def fail_build(
         started_at=started_at,
         completed_at=completed_at,
         status_triggered_by_user=triggered_by_user,
+        is_resumed=is_resumed,
     )
 
 
@@ -569,13 +618,18 @@ async def cancel_build(
         event_metadata=_build_event_metadata(commit_hash, triggered_by_user_id),
     )
     db.add(event)
+    await _touch_build_last_active(db, build_id)
     await db.commit()
 
     record_entity_created(auth.workspace_id, "events")
 
-    status, started_at, completed_at, triggered_by_id = await get_build_status(
-        db, build.id
-    )
+    (
+        status,
+        started_at,
+        completed_at,
+        triggered_by_id,
+        is_resumed,
+    ) = await get_build_status(db, build.id)
     triggered_by_user = await _get_triggered_by_user(db, triggered_by_id)
 
     return BuildResponse(
@@ -591,6 +645,7 @@ async def cancel_build(
         started_at=started_at,
         completed_at=completed_at,
         status_triggered_by_user=triggered_by_user,
+        is_resumed=is_resumed,
     )
 
 
@@ -629,13 +684,18 @@ async def exit_early(
         event_metadata=_build_event_metadata(commit_hash),
     )
     db.add(event)
+    await _touch_build_last_active(db, build_id)
     await db.commit()
 
     record_entity_created(auth.workspace_id, "events")
 
-    status, started_at, completed_at, triggered_by_id = await get_build_status(
-        db, build.id
-    )
+    (
+        status,
+        started_at,
+        completed_at,
+        triggered_by_id,
+        is_resumed,
+    ) = await get_build_status(db, build.id)
     triggered_by_user = await _get_triggered_by_user(db, triggered_by_id)
 
     return BuildResponse(
@@ -651,6 +711,80 @@ async def exit_early(
         started_at=started_at,
         completed_at=completed_at,
         status_triggered_by_user=triggered_by_user,
+        is_resumed=is_resumed,
+    )
+
+
+@router.post("/{build_id}/resume", response_model=BuildResponse)
+async def resume_build(
+    build_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
+    commit_hash: str | None = None,
+):
+    """Mark an existing build as resumed.
+
+    Called by the SDK when ``sd.build(resume_build_id=...)`` reuses an
+    existing build that may have already terminated. Emits a
+    ``BUILD_RESUMED`` event so ``get_build_status`` flips the build back
+    to RUNNING and the UI shows a "running (resumed)" affordance.
+
+    Args:
+        commit_hash: Optional git commit hash of the resuming run.
+    """
+    # Limit checks
+    _raise_if_limit_exceeded(check_rate_limit(auth.workspace_id, limits_settings))
+    _raise_if_limit_exceeded(
+        await check_entity_creation_limit(
+            db, auth.workspace_id, "events", limits_settings
+        )
+    )
+
+    build = await db.get(Build, build_id)
+    if not build:
+        raise HTTPException(status_code=404, detail="Build not found")
+
+    # Verify build belongs to authenticated environment
+    if build.environment_id != auth.environment_id:
+        raise HTTPException(
+            status_code=403, detail="Build does not belong to this environment"
+        )
+
+    event = Event(
+        build_id=build_id,
+        task_id=None,
+        event_type=EventType.BUILD_RESUMED,
+        event_metadata=_build_event_metadata(commit_hash),
+    )
+    db.add(event)
+    await _touch_build_last_active(db, build_id)
+    await db.commit()
+
+    record_entity_created(auth.workspace_id, "events")
+
+    (
+        status,
+        started_at,
+        completed_at,
+        triggered_by_id,
+        is_resumed,
+    ) = await get_build_status(db, build.id)
+    triggered_by_user = await _get_triggered_by_user(db, triggered_by_id)
+
+    return BuildResponse(
+        id=build.id,
+        environment_id=build.environment_id,
+        user_id=build.user_id,
+        name=build.name,
+        description=build.description,
+        commit_hash=build.commit_hash,
+        root_task_ids=build.root_task_ids,
+        created_at=build.created_at,
+        status=status,
+        started_at=started_at,
+        completed_at=completed_at,
+        status_triggered_by_user=triggered_by_user,
+        is_resumed=is_resumed,
     )
 
 
@@ -918,6 +1052,7 @@ async def register_task(
     await db.flush()
     apply_event_to_task(db_task, event)
 
+    await _touch_build_last_active(db, build_id)
     await db.commit()
     await db.refresh(db_task)
 
@@ -1267,6 +1402,7 @@ async def register_tasks_bulk(
         # round-trip needed.
         for t, ev in zip(tasks_in, events):
             apply_event_to_task(db_task_by_task_id[t.task_id], ev)
+        await _touch_build_last_active(db, build_id)
 
     # One final flush + commit at the end. Earlier flushes (just the
     # task INSERT batch) populated the rows we need to FK against.

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -86,14 +86,17 @@ def _raise_if_limit_exceeded(error: LimitExceededError | None) -> None:
 async def _touch_build_last_active(db: AsyncSession, build_id: UUID) -> None:
     """Bump ``Build.last_active_at`` to now in the current transaction.
 
-    Called from every code path that emits an Event for a build (build- or
-    task-level), so the list-builds endpoint can sort by activity recency.
-    A resumed build (BUILD_RESUMED) thereby jumps to the top of the
-    "Home" list even if its ``created_at`` is old.
+    Called only from the five build-level lifecycle endpoints
+    (``/resume``, ``/complete``, ``/fail``, ``/cancel``, ``/exit-early``)
+    — task events deliberately do NOT call this. Touching on every task
+    event would issue an ``UPDATE builds`` against the same row from
+    every concurrent task worker, serialising on a row-level exclusive
+    lock and bloating ``builds`` with MVCC versions. Confining the touch
+    to lifecycle events caps it at ≤ 5 UPDATEs per build lifetime, with
+    no contention.
 
-    Issues a single UPDATE — for the bulk task-register path this is one
-    extra statement per call, not one per task. The caller is expected to
-    commit the surrounding transaction; we don't commit here.
+    The caller is expected to commit the surrounding transaction; we
+    don't commit here.
     """
     await db.execute(
         update(Build).where(Build.id == build_id).values(last_active_at=utc_now())
@@ -212,7 +215,6 @@ async def _create_task_event(
     # event into apply_event_to_task. The whole bundle commits atomically.
     await db.flush()
     apply_event_to_task(db_task, event)
-    await _touch_build_last_active(db, build_id)
     await db.commit()
 
     record_entity_created(auth.workspace_id, "events")
@@ -330,11 +332,12 @@ async def list_builds(
     total = total_result.scalar() or 0
 
     # Sort by last_active_at so a resumed build (BUILD_RESUMED touches
-    # this column) jumps back to the top of the list. Falls back to
-    # created_at for builds that have had no activity yet (column is
-    # initialized to created_at on insert, so the fallback is implicit).
+    # this column) jumps back to the top of the list. ``Build.id`` is a
+    # UUID7 (time-sortable) so it's a stable tiebreaker for builds that
+    # share a timestamp — without it, paginating across a tie can yield
+    # duplicates or skips.
     result = await db.execute(
-        query.order_by(Build.last_active_at.desc())
+        query.order_by(Build.last_active_at.desc(), Build.id.desc())
         .offset((page - 1) * page_size)
         .limit(page_size)
     )
@@ -1052,7 +1055,6 @@ async def register_task(
     await db.flush()
     apply_event_to_task(db_task, event)
 
-    await _touch_build_last_active(db, build_id)
     await db.commit()
     await db.refresh(db_task)
 
@@ -1402,7 +1404,6 @@ async def register_tasks_bulk(
         # round-trip needed.
         for t, ev in zip(tasks_in, events):
             apply_event_to_task(db_task_by_task_id[t.task_id], ev)
-        await _touch_build_last_active(db, build_id)
 
     # One final flush + commit at the end. Earlier flushes (just the
     # task INSERT batch) populated the rows we need to FK against.

--- a/app/stardag-api/src/stardag_api/routes/search.py
+++ b/app/stardag-api/src/stardag_api/routes/search.py
@@ -879,13 +879,20 @@ async def get_value_suggestions(
     """
     environment_id = auth.environment_id
 
-    # Handle status specially (no caching needed - static values)
+    # Handle status specially (no caching needed - static values).
+    # Keep this list in sync with TaskStatus on the API side and the
+    # TaskStatus type on the UI side. "unregistered" is intentionally
+    # excluded — it's an internal phantom-row marker, not a status users
+    # filter on.
     if key == "status":
         values = [
             ValueSuggestion(value="pending"),
             ValueSuggestion(value="running"),
+            ValueSuggestion(value="suspended"),
             ValueSuggestion(value="completed"),
             ValueSuggestion(value="failed"),
+            ValueSuggestion(value="skipped"),
+            ValueSuggestion(value="cancelled"),
         ]
         if prefix:
             values = [v for v in values if v.value.startswith(prefix)]

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -118,6 +118,12 @@ class BuildResponse(BaseModel):
     completed_at: datetime | None = None
     # User who triggered the status change (for manual overrides)
     status_triggered_by_user: StatusTriggeredByUser | None = None
+    # True if the most-recent build-level event is BUILD_RESUMED — i.e.
+    # the build was picked up via sd.build(resume_build_id=...) after
+    # finishing/failing. UI surfaces this as "running (resumed)".
+    # Defaulted to False so older API responses (pre-resume support)
+    # deserialize cleanly into clients that expect the field.
+    is_resumed: bool = False
 
 
 class BuildListResponse(BaseModel):

--- a/app/stardag-api/src/stardag_api/services/status.py
+++ b/app/stardag-api/src/stardag_api/services/status.py
@@ -146,6 +146,13 @@ async def get_build_status(
             status = BuildStatus.RUNNING
             started_at = event.created_at
             status_triggered_by_user_id = None  # Not user-triggered
+            # Reset is_resumed so the flag stays consistent with its
+            # documented semantic (latest build-level event is
+            # BUILD_RESUMED). The SDK never emits BUILD_STARTED after a
+            # BUILD_RESUMED in normal flow, but the replay shouldn't rely
+            # on event ordering — admin/manual event inserts could
+            # produce any sequence.
+            is_resumed = False
         elif event.event_type == EventType.BUILD_RESUMED:
             # Treat like BUILD_STARTED, but flip the is_resumed flag and
             # clear completed_at so the UI doesn't keep showing a stale

--- a/app/stardag-api/src/stardag_api/services/status.py
+++ b/app/stardag-api/src/stardag_api/services/status.py
@@ -112,11 +112,18 @@ def apply_event_to_task(task: Task, event: Event) -> None:
 
 async def get_build_status(
     db: AsyncSession, build_id: UUID
-) -> tuple[BuildStatus, datetime | None, datetime | None, str | None]:
+) -> tuple[BuildStatus, datetime | None, datetime | None, str | None, bool]:
     """Get derived build status from events.
 
     Returns:
-        Tuple of (status, started_at, completed_at, status_triggered_by_user_id)
+        Tuple of (status, started_at, completed_at,
+                  status_triggered_by_user_id, is_resumed).
+
+    ``is_resumed`` is True iff the build has at least one BUILD_RESUMED
+    event AND that event is more recent than any terminal event — i.e. the
+    build was picked up again after finishing/failing and is currently
+    treated as RUNNING under the resume semantics. The UI uses this to
+    surface a "running (resumed)" affordance.
     """
     # Get build-level events (task_id is NULL)
     result = await db.execute(
@@ -131,6 +138,7 @@ async def get_build_status(
     started_at: datetime | None = None
     completed_at: datetime | None = None
     status_triggered_by_user_id: str | None = None
+    is_resumed = False
 
     # Process events from oldest to newest to build final state
     for event in reversed(events):
@@ -138,9 +146,20 @@ async def get_build_status(
             status = BuildStatus.RUNNING
             started_at = event.created_at
             status_triggered_by_user_id = None  # Not user-triggered
+        elif event.event_type == EventType.BUILD_RESUMED:
+            # Treat like BUILD_STARTED, but flip the is_resumed flag and
+            # clear completed_at so the UI doesn't keep showing a stale
+            # "completed at" from the previous terminal event.
+            status = BuildStatus.RUNNING
+            completed_at = None
+            status_triggered_by_user_id = None
+            is_resumed = True
+            # Don't overwrite started_at — the build started when it first
+            # started; resume is a separate concept.
         elif event.event_type == EventType.BUILD_COMPLETED:
             status = BuildStatus.COMPLETED
             completed_at = event.created_at
+            is_resumed = False
             # Check if this was user-triggered (manual override)
             status_triggered_by_user_id = (
                 event.event_metadata.get("triggered_by_user_id")
@@ -150,6 +169,7 @@ async def get_build_status(
         elif event.event_type == EventType.BUILD_FAILED:
             status = BuildStatus.FAILED
             completed_at = event.created_at
+            is_resumed = False
             status_triggered_by_user_id = (
                 event.event_metadata.get("triggered_by_user_id")
                 if event.event_metadata
@@ -158,6 +178,7 @@ async def get_build_status(
         elif event.event_type == EventType.BUILD_CANCELLED:
             status = BuildStatus.CANCELLED
             completed_at = event.created_at
+            is_resumed = False
             status_triggered_by_user_id = (
                 event.event_metadata.get("triggered_by_user_id")
                 if event.event_metadata
@@ -166,9 +187,10 @@ async def get_build_status(
         elif event.event_type == EventType.BUILD_EXIT_EARLY:
             status = BuildStatus.EXIT_EARLY
             completed_at = event.created_at
+            is_resumed = False
             status_triggered_by_user_id = None  # Not user-triggered
 
-    return status, started_at, completed_at, status_triggered_by_user_id
+    return status, started_at, completed_at, status_triggered_by_user_id, is_resumed
 
 
 async def get_task_status_in_build(

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -111,6 +111,91 @@ async def test_fail_build(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_resume_build_after_failure(client: AsyncClient):
+    """Resuming a failed build flips its status back to running.
+
+    Reproduces the bug we fixed: previously, sd.build(resume_build_id=...)
+    silently reused the build_id but never told the registry — so a build
+    that had previously emitted BUILD_FAILED kept showing as failed in the
+    UI even though the SDK was actively running tasks under it again.
+    """
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    # Build fails
+    await client.post(f"/api/v1/builds/{build_id}/fail")
+    response = await client.get(f"/api/v1/builds/{build_id}")
+    assert response.json()["status"] == "failed"
+    assert response.json()["is_resumed"] is False
+
+    # Now resume — this is what the SDK fires on sd.build(resume_build_id=...)
+    response = await client.post(f"/api/v1/builds/{build_id}/resume")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "running"
+    assert data["completed_at"] is None  # cleared by BUILD_RESUMED replay
+    assert data["is_resumed"] is True
+
+
+@pytest.mark.asyncio
+async def test_resume_build_complete_clears_resumed_flag(client: AsyncClient):
+    """A resumed build that subsequently completes shows is_resumed=False.
+
+    Once a terminal event lands after BUILD_RESUMED, the resumed-flag
+    semantic is gone — get_build_status only flags is_resumed when the
+    most recent build-level event is BUILD_RESUMED.
+    """
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    await client.post(f"/api/v1/builds/{build_id}/fail")
+    await client.post(f"/api/v1/builds/{build_id}/resume")
+    await client.post(f"/api/v1/builds/{build_id}/complete")
+
+    response = await client.get(f"/api/v1/builds/{build_id}")
+    data = response.json()
+    assert data["status"] == "completed"
+    assert data["is_resumed"] is False
+
+
+@pytest.mark.asyncio
+async def test_resume_build_not_found(client: AsyncClient):
+    """Resume on a non-existent build returns 404 (resource-not-found)."""
+    fake_uuid = "00000000-0000-0000-0000-000000000099"
+    response = await client.post(f"/api/v1/builds/{fake_uuid}/resume")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_list_builds_orders_resumed_first(client: AsyncClient):
+    """A resumed build jumps to the top of the list (sorted by last_active_at).
+
+    Without this, the resumed build would stay buried at its original
+    created_at position — the whole UX point of the fix.
+    """
+    # Create three builds, each becomes "older" in created_at terms
+    build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
+    build_c = (await client.post("/api/v1/builds", json={})).json()["id"]
+
+    # Default order (by last_active_at desc, populated from created_at):
+    response = await client.get(
+        "/api/v1/builds", params={"environment_id": DEFAULT_ENVIRONMENT_ID_STR}
+    )
+    ids = [b["id"] for b in response.json()["builds"]]
+    assert ids[:3] == [build_c, build_b, build_a]
+
+    # Resume the oldest — it should jump to the top.
+    await client.post(f"/api/v1/builds/{build_a}/resume")
+
+    response = await client.get(
+        "/api/v1/builds", params={"environment_id": DEFAULT_ENVIRONMENT_ID_STR}
+    )
+    ids = [b["id"] for b in response.json()["builds"]]
+    assert ids[0] == build_a, f"Expected resumed build at top, got {ids}"
+
+
+@pytest.mark.asyncio
 async def test_register_task_to_build(client: AsyncClient):
     """Test registering a task within a build."""
     # Create a build

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -160,10 +160,18 @@ async def test_resume_build_complete_clears_resumed_flag(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_resume_build_not_found(client: AsyncClient):
-    """Resume on a non-existent build returns 404 (resource-not-found)."""
+    """Resume on a non-existent build returns 404 with a resource-level body.
+
+    The SDK's missing-route fallback (APIRegistry.build_resume_aio)
+    distinguishes FastAPI's default ``{"detail": "Not Found"}`` (route
+    doesn't exist on this server) from app-level 404s like the one this
+    test exercises. Pinning the response body here keeps that contract
+    explicit on the API side.
+    """
     fake_uuid = "00000000-0000-0000-0000-000000000099"
     response = await client.post(f"/api/v1/builds/{fake_uuid}/resume")
     assert response.status_code == 404
+    assert response.json()["detail"] == "Build not found"
 
 
 @pytest.mark.asyncio
@@ -172,20 +180,32 @@ async def test_list_builds_orders_resumed_first(client: AsyncClient):
 
     Without this, the resumed build would stay buried at its original
     created_at position — the whole UX point of the fix.
+
+    A small ``asyncio.sleep`` between creates guarantees distinct
+    ``last_active_at`` timestamps even on coarse-resolution CI clocks
+    where back-to-back ``utc_now()`` calls can collide. The pre-resume
+    ordering assertion uses a set membership check so it doesn't depend
+    on ``Build.id.desc()`` (the UUID7 tiebreaker) for builds that did
+    happen to tie.
     """
-    # Create three builds, each becomes "older" in created_at terms
+    import asyncio
+
     build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await asyncio.sleep(0.005)
     build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await asyncio.sleep(0.005)
     build_c = (await client.post("/api/v1/builds", json={})).json()["id"]
 
-    # Default order (by last_active_at desc, populated from created_at):
     response = await client.get(
         "/api/v1/builds", params={"environment_id": DEFAULT_ENVIRONMENT_ID_STR}
     )
     ids = [b["id"] for b in response.json()["builds"]]
+    assert set(ids[:3]) == {build_a, build_b, build_c}
+    # Newest first when timestamps are distinct.
     assert ids[:3] == [build_c, build_b, build_a]
 
     # Resume the oldest — it should jump to the top.
+    await asyncio.sleep(0.005)
     await client.post(f"/api/v1/builds/{build_a}/resume")
 
     response = await client.get(

--- a/app/stardag-api/tests/test_search.py
+++ b/app/stardag-api/tests/test_search.py
@@ -117,6 +117,32 @@ async def test_deep_keys_in_key_suggestions(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_status_values_includes_all_filterable_statuses(client: AsyncClient):
+    """The status autocomplete returns every status users can filter on.
+
+    Previously only {pending, running, completed, failed} were exposed,
+    so suspended / skipped / cancelled were undiscoverable in the
+    search-bar autocomplete. Pin the full set so future additions to
+    TaskStatus on the API side don't silently drift.
+    """
+    resp = await client.get(
+        "/api/v1/tasks/search/values",
+        params={"key": "status"},
+    )
+    assert resp.status_code == 200
+    values = {v["value"] for v in resp.json()["values"]}
+    assert values == {
+        "pending",
+        "running",
+        "suspended",
+        "completed",
+        "failed",
+        "skipped",
+        "cancelled",
+    }
+
+
+@pytest.mark.asyncio
 async def test_sort_by_core_field(client: AsyncClient):
     """Sorting by core fields (task_name) works."""
     await _create_task(client, "sort-a", {"v": 1})

--- a/app/stardag-ui/src/components/BuildStatusBadge.tsx
+++ b/app/stardag-ui/src/components/BuildStatusBadge.tsx
@@ -8,13 +8,34 @@ const STATUS_STYLES: Record<string, string> = {
   pending: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-400",
 };
 
-export function BuildStatusBadge({ status }: { status: string }) {
+export function BuildStatusBadge({
+  status,
+  isResumed = false,
+}: {
+  status: string;
+  // True when the build's RUNNING state was triggered by a BUILD_RESUMED
+  // event (sd.build resume_build_id flow). Used to render
+  // "running (resumed)" in place of plain "running".
+  isResumed?: boolean;
+}) {
   const style = STATUS_STYLES[status] ?? STATUS_STYLES.pending;
-  const label = status === "exit_early" ? "exited early" : status;
+  let label: string;
+  if (status === "exit_early") {
+    label = "exited early";
+  } else if (status === "running" && isResumed) {
+    label = "running (resumed)";
+  } else {
+    label = status;
+  }
+  const title =
+    status === "running" && isResumed
+      ? "Build was resumed via sd.build(resume_build_id=...)"
+      : undefined;
 
   return (
     <span
       className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${style}`}
+      title={title}
     >
       {label}
     </span>

--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -278,7 +278,9 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
       { label: "Builds", onClick: onBack },
       {
         label: build?.name ?? buildId.slice(0, 8),
-        detail: build ? <BuildStatusBadge status={build.status} /> : undefined,
+        detail: build ? (
+          <BuildStatusBadge status={build.status} isResumed={build.is_resumed} />
+        ) : undefined,
       },
     ];
     if (selectedTask) {

--- a/app/stardag-ui/src/components/BuildsList.tsx
+++ b/app/stardag-ui/src/components/BuildsList.tsx
@@ -2,7 +2,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchBuilds } from "../api/tasks";
 import { useBreadcrumb } from "../context/BreadcrumbContext";
 import { useEnvironment } from "../context/EnvironmentContext";
-import type { Build, BuildStatus } from "../types/task";
+import type { Build } from "../types/task";
+import { BuildStatusBadge } from "./BuildStatusBadge";
 
 interface BuildsListProps {
   onSelectBuild: (buildId: string) => void;
@@ -26,21 +27,6 @@ function formatRelativeTime(dateString: string): string {
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 7) return `${diffDays}d ago`;
   return date.toLocaleDateString();
-}
-
-function getBuildStatusStyle(status: BuildStatus): string {
-  switch (status) {
-    case "completed":
-      return "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300";
-    case "failed":
-      return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300";
-    case "running":
-      return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
-    case "cancelled":
-      return "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300";
-    default:
-      return "bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300";
-  }
 }
 
 function formatDuration(startedAt: string | null, completedAt: string | null): string {
@@ -184,13 +170,7 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
             >
               {/* Status indicator */}
               <div className="flex-shrink-0">
-                <span
-                  className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${getBuildStatusStyle(
-                    build.status,
-                  )}`}
-                >
-                  {build.status}
-                </span>
+                <BuildStatusBadge status={build.status} isResumed={build.is_resumed} />
               </div>
 
               {/* Build info */}

--- a/app/stardag-ui/src/components/StatusBadge.tsx
+++ b/app/stardag-ui/src/components/StatusBadge.tsx
@@ -12,6 +12,9 @@ interface StatusBadgeProps {
   onStatusBuildClick?: (buildId: string) => void;
 }
 
+// Skipped uses amber (warmer than pending's yellow) to be visible against
+// dark-blue table rows where it previously rendered near-invisible black-
+// on-dark, while staying distinct from pending which is plain yellow.
 const statusStyles: Record<TaskStatus, string> = {
   unregistered:
     "bg-gray-200 text-gray-500 dark:bg-gray-700 dark:text-gray-400 border border-dashed border-gray-400 dark:border-gray-500",
@@ -20,6 +23,7 @@ const statusStyles: Record<TaskStatus, string> = {
   suspended: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-300",
   completed: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300",
   failed: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300",
+  skipped: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300",
   cancelled: "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300",
 };
 
@@ -34,6 +38,8 @@ const statusStylesMuted: Record<TaskStatus, string> = {
   completed:
     "bg-green-100/50 text-green-800/60 dark:bg-green-900/20 dark:text-green-400/50",
   failed: "bg-red-100/50 text-red-800/60 dark:bg-red-900/20 dark:text-red-400/50",
+  skipped:
+    "bg-amber-100/50 text-amber-800/60 dark:bg-amber-900/20 dark:text-amber-400/50",
   cancelled:
     "bg-gray-100/50 text-gray-800/60 dark:bg-gray-900/20 dark:text-gray-400/50",
 };

--- a/app/stardag-ui/src/components/TaskExplorerTable.tsx
+++ b/app/stardag-ui/src/components/TaskExplorerTable.tsx
@@ -93,8 +93,15 @@ function getStatusColor(status: TaskStatus): string {
       return "bg-red-100 text-red-700 dark:bg-red-900/50 dark:text-red-400";
     case "running":
       return "bg-blue-100 text-blue-700 dark:bg-blue-900/50 dark:text-blue-400";
+    case "suspended":
+      return "bg-purple-100 text-purple-700 dark:bg-purple-900/50 dark:text-purple-400";
+    case "skipped":
+      return "bg-amber-100 text-amber-700 dark:bg-amber-900/50 dark:text-amber-400";
+    case "cancelled":
+      return "bg-gray-100 text-gray-700 dark:bg-gray-900/50 dark:text-gray-400";
     case "unregistered":
       return "bg-gray-50 text-gray-400 dark:bg-gray-900/30 dark:text-gray-500";
+    case "pending":
     default:
       return "bg-yellow-100 text-yellow-700 dark:bg-yellow-900/50 dark:text-yellow-400";
   }

--- a/app/stardag-ui/src/components/TaskFilters.tsx
+++ b/app/stardag-ui/src/components/TaskFilters.tsx
@@ -33,6 +33,8 @@ export function TaskFilters({
         <option value="suspended">Suspended</option>
         <option value="completed">Completed</option>
         <option value="failed">Failed</option>
+        <option value="skipped">Skipped</option>
+        <option value="cancelled">Cancelled</option>
       </select>
     </>
   );

--- a/app/stardag-ui/src/components/TaskNode.tsx
+++ b/app/stardag-ui/src/components/TaskNode.tsx
@@ -25,6 +25,7 @@ const statusBorderColors: Record<TaskStatus, string> = {
   suspended: "border-purple-400",
   completed: "border-green-400",
   failed: "border-red-400",
+  skipped: "border-amber-400",
   cancelled: "border-gray-400",
 };
 
@@ -35,6 +36,7 @@ const statusBorderColorsMuted: Record<TaskStatus, string> = {
   suspended: "border-purple-400/40",
   completed: "border-green-400/40",
   failed: "border-red-400/40",
+  skipped: "border-amber-400/40",
   cancelled: "border-gray-400/40",
 };
 

--- a/app/stardag-ui/src/types/task.ts
+++ b/app/stardag-ui/src/types/task.ts
@@ -5,6 +5,7 @@ export type TaskStatus =
   | "suspended"
   | "completed"
   | "failed"
+  | "skipped"
   | "cancelled";
 export type BuildStatus =
   | "pending"
@@ -36,6 +37,12 @@ export interface Build {
   completed_at: string | null;
   // User who triggered the status change (for manual overrides)
   status_triggered_by_user: StatusTriggeredByUser | null;
+  // True iff the latest build-level event is BUILD_RESUMED — set when
+  // the SDK reused this build via sd.build(resume_build_id=...). Used
+  // by the UI to render "running (resumed)" instead of plain "running".
+  // Optional in the type so older API responses (without the field)
+  // deserialize without runtime errors.
+  is_resumed?: boolean;
 }
 
 export interface BuildListResponse {

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -601,6 +601,18 @@ async def build_aio(
     if resume_build_id is not None:
         build_id = resume_build_id
         logger.info(f"Resuming build: {build_id}")
+        # Emit a BUILD_RESUMED event so the registry flips a previously
+        # terminal build back to RUNNING and the UI surfaces "running
+        # (resumed)". On older registry servers this is a no-op (the
+        # endpoint 404s and APIRegistry swallows it with a warning).
+        try:
+            await registry.build_resume_aio(build_id)
+        except Exception as reg_err:
+            handle_registry_error(
+                reg_err,
+                f"Failed to mark build {build_id} as resumed",
+                on_registry_failure,
+            )
     else:
         build_id = await registry.build_start_aio(root_tasks=tasks)
         logger.info(f"Started build: {build_id}")

--- a/lib/stardag/src/stardag/build/_sequential.py
+++ b/lib/stardag/src/stardag/build/_sequential.py
@@ -205,6 +205,17 @@ def build_sequential(
     # register tasks against.
     if resume_build_id is not None:
         build_id = resume_build_id
+        # Emit a BUILD_RESUMED event so the registry flips a previously
+        # terminal build back to RUNNING. On older registry servers this
+        # is a no-op (the endpoint 404s and APIRegistry swallows it).
+        try:
+            registry.build_resume(build_id)
+        except Exception as reg_err:
+            handle_registry_error(
+                reg_err,
+                f"Failed to mark build {build_id} as resumed",
+                on_registry_failure,
+            )
     else:
         build_id = registry.build_start(root_tasks=tasks_list)
 
@@ -751,6 +762,17 @@ async def build_sequential_aio(
     # register tasks against.
     if resume_build_id is not None:
         build_id = resume_build_id
+        # Emit a BUILD_RESUMED event so the registry flips a previously
+        # terminal build back to RUNNING. On older registry servers this
+        # is a no-op (the endpoint 404s and APIRegistry swallows it).
+        try:
+            await registry.build_resume_aio(build_id)
+        except Exception as reg_err:
+            handle_registry_error(
+                reg_err,
+                f"Failed to mark build {build_id} as resumed",
+                on_registry_failure,
+            )
     else:
         build_id = await registry.build_start_aio(root_tasks=tasks_list)
 

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -424,6 +424,37 @@ class APIRegistry(RegistryABC):
         logger.info(f"Started build: {data['name']} (ID: {build_id})")
         return build_id
 
+    def build_resume(self, build_id: UUID) -> None:
+        """Mark an existing build as resumed.
+
+        Emits a BUILD_RESUMED event server-side so a build that previously
+        terminated (FAILED / COMPLETED / CANCELLED / EXIT_EARLY) flips
+        back to RUNNING. The endpoint is new in the post-resume API; on
+        older servers the request 404s with FastAPI's missing-route body,
+        which we swallow with a warning so the SDK keeps working against
+        an un-upgraded registry. Resource-level 404s (build does not
+        exist) are re-raised.
+        """
+        try:
+            self._request(
+                "POST",
+                f"{self.api_url}/api/v1/builds/{build_id}/resume",
+                params=self._get_event_params(),
+                operation="Resume build",
+            )
+        except NotFoundError as e:
+            if not _is_route_not_found(e):
+                raise
+            logger.warning(
+                "Registry API does not support POST /builds/%s/resume; "
+                "the resumed build will keep its previous status in the "
+                "registry until you upgrade the API. Build will still run "
+                "to completion locally.",
+                build_id,
+            )
+            return
+        logger.info(f"Resumed build: {build_id}")
+
     def build_complete(self, build_id: UUID) -> None:
         """Mark a build as completed."""
         self._request(
@@ -832,6 +863,31 @@ class APIRegistry(RegistryABC):
         build_id = UUID(data["id"])
         logger.info(f"Started build: {data['name']} (ID: {build_id})")
         return build_id
+
+    async def build_resume_aio(self, build_id: UUID) -> None:
+        """Async version - mark an existing build as resumed.
+
+        See :meth:`build_resume` for the backward-compat 404 handling.
+        """
+        try:
+            await self._arequest(
+                "POST",
+                f"{self.api_url}/api/v1/builds/{build_id}/resume",
+                params=self._get_event_params(),
+                operation="Resume build",
+            )
+        except NotFoundError as e:
+            if not _is_route_not_found(e):
+                raise
+            logger.warning(
+                "Registry API does not support POST /builds/%s/resume; "
+                "the resumed build will keep its previous status in the "
+                "registry until you upgrade the API. Build will still run "
+                "to completion locally.",
+                build_id,
+            )
+            return
+        logger.info(f"Resumed build: {build_id}")
 
     async def build_complete_aio(self, build_id: UUID) -> None:
         """Async version - mark a build as completed."""

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -74,6 +74,23 @@ class RegistryABC(metaclass=abc.ABCMeta):
         """
         return UUID("00000000-0000-0000-0000-000000000000")
 
+    def build_resume(self, build_id: UUID) -> None:
+        """Mark an existing build as resumed.
+
+        Called when ``sd.build(resume_build_id=...)`` reuses an existing
+        build (potentially in a terminal state) instead of starting a new
+        one. The registry should record a BUILD_RESUMED event so the
+        build flips back to RUNNING and the UI can surface a
+        "running (resumed)" affordance.
+
+        Default implementation is a no-op so older registry backends
+        keep working unchanged.
+
+        Args:
+            build_id: The build UUID being resumed.
+        """
+        pass
+
     def build_complete(self, build_id: UUID) -> None:
         """Mark a build as completed successfully.
 
@@ -315,6 +332,10 @@ class RegistryABC(metaclass=abc.ABCMeta):
     ) -> UUID:
         """Async version of build_start."""
         return self.build_start(root_tasks, description)
+
+    async def build_resume_aio(self, build_id: UUID) -> None:
+        """Async version of build_resume."""
+        self.build_resume(build_id)
 
     async def build_complete_aio(self, build_id: UUID) -> None:
         """Async version of build_complete."""

--- a/lib/stardag/tests/test_build/conftest.py
+++ b/lib/stardag/tests/test_build/conftest.py
@@ -60,6 +60,14 @@ class RecordingRegistry(NoOpRegistry):
         self._record("build_start_aio")
         return bid
 
+    async def build_resume_aio(self, build_id: UUID) -> None:
+        self._record("build_resume_aio")
+        await super().build_resume_aio(build_id)
+
+    def build_resume(self, build_id: UUID) -> None:
+        self._record("build_resume")
+        super().build_resume(build_id)
+
     async def build_complete_aio(self, build_id: UUID) -> None:
         self._record("build_complete_aio")
         await super().build_complete_aio(build_id)

--- a/lib/stardag/tests/test_build/test_concurrent.py
+++ b/lib/stardag/tests/test_build/test_concurrent.py
@@ -166,6 +166,41 @@ class TestBuildAio:
         assert task.target().load()["mode"] == "sync"
 
     @pytest.mark.asyncio
+    async def test_resume_build_id_calls_build_resume(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Passing resume_build_id fires build_resume_aio (not build_start_aio).
+
+        Regression: previously the SDK silently reused the build_id with
+        no registry call, so a previously-failed build kept showing as
+        FAILED in the UI even while the SDK ran tasks under it.
+        """
+        from tests.test_build.conftest import RecordingRegistry
+
+        recording_registry = RecordingRegistry()
+        existing_build_id = UUID("11111111-2222-3333-4444-555555555555")
+        task = SyncOnlyTask(name="resumed-task")
+
+        summary = await build_aio(
+            [task],
+            registry=recording_registry,
+            resume_build_id=existing_build_id,
+        )
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert summary.build_id == existing_build_id, (
+            "Resume should preserve the supplied build_id"
+        )
+
+        method_calls = [c[0] for c in recording_registry.calls]
+        assert "build_resume_aio" in method_calls, (
+            f"Expected build_resume_aio fired on resume; got {method_calls}"
+        )
+        assert "build_start_aio" not in method_calls, (
+            "build_start_aio must NOT fire when resuming"
+        )
+
+    @pytest.mark.asyncio
     async def test_dynamic_deps(
         self,
         default_in_memory_fs_target: typing.Type[InMemoryFileTarget],

--- a/lib/stardag/tests/test_build/test_sequential.py
+++ b/lib/stardag/tests/test_build/test_sequential.py
@@ -69,6 +69,38 @@ class TestBuildSequential:
         assert dag.complete()
         assert dag.target().load() == expected_output
 
+    def test_resume_build_id_calls_build_resume(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Sequential resume fires build_resume (not build_start).
+
+        Mirrors the concurrent test for the sync code path. Verifies that
+        the regression fix (silent reuse → explicit BUILD_RESUMED event)
+        applies to build_sequential as well.
+        """
+        from tests.test_build.conftest import RecordingRegistry
+
+        recording_registry = RecordingRegistry()
+        existing_build_id = UUID("66666666-7777-8888-9999-aaaaaaaaaaaa")
+        task = SyncOnlyTask(name="resumed-task-seq")
+
+        summary = build_sequential(
+            [task],
+            registry=recording_registry,
+            resume_build_id=existing_build_id,
+        )
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert summary.build_id == existing_build_id
+
+        method_calls = [c[0] for c in recording_registry.calls]
+        assert "build_resume" in method_calls, (
+            f"Expected build_resume fired on resume; got {method_calls}"
+        )
+        assert "build_start" not in method_calls, (
+            "build_start must NOT fire when resuming"
+        )
+
     def test_uses_registry_provider_when_registry_not_passed(
         self,
         default_in_memory_fs_target: typing.Type[InMemoryFileTarget],

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -421,3 +421,108 @@ class TestTaskSkip404Swallow:
                 build_id=UUID("00000000-0000-0000-0000-000000000001"),
                 task=task,  # type: ignore[arg-type]
             )
+
+
+class TestBuildResume404Swallow:
+    """``build_resume`` / ``build_resume_aio`` follow the same backward-
+    compat 404 pattern as ``task_skip``: an old API that does not yet
+    expose the ``/builds/{id}/resume`` route returns FastAPI's default
+    ``Not Found`` body, which the SDK swallows with a warning so resumed
+    builds keep working (just without the registry-side status flip).
+    Genuine app-level 404s (e.g. unknown build_id) still propagate.
+    """
+
+    def _make_registry_and_handler(self, response_factory):
+        import httpx
+
+        from stardag.registry._api_registry import APIRegistry
+
+        registry = APIRegistry(api_url="http://test.invalid", api_key="test-key")
+        registry._client = httpx.Client(
+            transport=httpx.MockTransport(response_factory),
+            auth=registry._auth,
+        )
+        return registry
+
+    @staticmethod
+    def _inject_async_mock(registry, response_factory):
+        import asyncio
+        import httpx
+
+        registry._async_client = httpx.AsyncClient(
+            transport=httpx.MockTransport(response_factory),
+            auth=registry._auth,
+        )
+        registry._async_client_loop = asyncio.get_running_loop()
+
+    def test_sync_route_missing_404_is_swallowed(self, caplog):
+        """Old API: detail == 'Not Found' → warn + return, no exception."""
+        import httpx
+        import logging
+        from uuid import UUID
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Not Found"})
+
+        registry = self._make_registry_and_handler(handler)
+
+        with caplog.at_level(logging.WARNING):
+            registry.build_resume(UUID("00000000-0000-0000-0000-000000000001"))
+
+        assert any(
+            "does not support POST" in rec.message and "/resume" in rec.message
+            for rec in caplog.records
+        ), f"Expected route-missing warning; got: {[r.message for r in caplog.records]}"
+
+    def test_sync_app_level_404_propagates(self):
+        """New API: detail == 'Build not found' → raise NotFoundError."""
+        import httpx
+        from uuid import UUID
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Build not found"})
+
+        registry = self._make_registry_and_handler(handler)
+
+        with pytest.raises(NotFoundError):
+            registry.build_resume(UUID("00000000-0000-0000-0000-000000000001"))
+
+    @pytest.mark.asyncio
+    async def test_aio_route_missing_404_is_swallowed(self, caplog):
+        """Async path: detail == 'Not Found' → warn + return."""
+        import httpx
+        import logging
+        from uuid import UUID
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Not Found"})
+
+        registry = self._make_registry_and_handler(handler)
+        self._inject_async_mock(registry, handler)
+
+        with caplog.at_level(logging.WARNING):
+            await registry.build_resume_aio(
+                UUID("00000000-0000-0000-0000-000000000001")
+            )
+
+        assert any(
+            "does not support POST" in rec.message and "/resume" in rec.message
+            for rec in caplog.records
+        ), f"Expected route-missing warning; got: {[r.message for r in caplog.records]}"
+
+    @pytest.mark.asyncio
+    async def test_aio_app_level_404_propagates(self):
+        """Async path: app-level 404 propagates."""
+        import httpx
+        from uuid import UUID
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, json={"detail": "Build not found"})
+
+        registry = self._make_registry_and_handler(handler)
+        self._inject_async_mock(registry, handler)
+
+        with pytest.raises(NotFoundError):
+            await registry.build_resume_aio(
+                UUID("00000000-0000-0000-0000-000000000001")
+            )


### PR DESCRIPTION
## Summary

Fixes a UX bug where `sd.build(resume_build_id=...)` silently reused the build_id without notifying the registry — so a previously-failed build kept showing as **failed** in the UI even while the SDK was actively running tasks under it. Resumed builds now flip back to RUNNING with a "running (resumed)" badge and jump to the top of the Home list.

## What's in the PR

- **SDK**: emits a `BUILD_RESUMED` event when `resume_build_id` is set (in `build`, `build_aio`, `build_sequential`, `build_sequential_aio`).
- **API**: new `POST /builds/{id}/resume` endpoint, new `EventType.BUILD_RESUMED`, status replay treats it like `BUILD_STARTED` (flips status to `RUNNING`, clears `completed_at`, sets `is_resumed: true` until the next terminal event).
- **DB**: new `Build.last_active_at` column, touched only on build-level lifecycle events (`BUILD_RESUMED` / `BUILD_COMPLETED` / `BUILD_FAILED` / `BUILD_CANCELLED` / `BUILD_EXIT_EARLY`). Build list sorts by `(last_active_at desc, id desc)` — UUID7 tiebreaker keeps pagination stable across timestamp ties. Migration backfills existing rows from `created_at`.
- **UI**: `BuildStatusBadge` shows `running (resumed)` when applicable.

### `last_active_at` write semantics

Touching is intentionally confined to lifecycle events, not every task event. With the high task concurrency stardag supports (Modal/Prefect distributed runners can fan out hundreds of concurrent task events against one build), an UPDATE per task event would serialise workers on a row-level exclusive lock against the build row and bloat `builds` with MVCC versions. The trade-off is that a long-running mid-execution build won't bump its position from intermediate task events — but its `status=running` badge already signals activity, and "most recent lifecycle change" is the cleaner sort key. The bug-fix goal (resumed build pops to the top) is preserved because `BUILD_RESUMED` is itself a lifecycle event.

A read-time JOIN against `MAX(events.created_at)` was also considered but rejected: it would add an O(builds_in_env) cost to every list query (≈100ms for a 1k-build environment, scaling poorly with workspace size), versus the column-based design's sub-millisecond list latency at any scale.

### Backwards compatibility

- **New SDK + old API**: `POST /resume` 404s; the registry client swallows the missing-route 404 with a warning (same `_is_route_not_found` pattern as `task_skip` / `dependencies`). Build still runs to completion; only the registry-side status flip is missing until the API is upgraded.
- **Old SDK + new API**: no-op — old SDK doesn't call resume. `last_active_at` is set on insert by DEFAULT and gets bumped by the new build-level handlers, so list ordering is correct without SDK cooperation.

### Drive-by UI polish (same PR by request)

- `TaskStatus` type now includes `"skipped"` (was missing → `StatusBadge` rendered black on default for skipped, near-invisible on dark rows). `skipped` now uses **amber** (warmer than `pending`'s yellow, distinct from `cancelled`'s grey) consistently across `StatusBadge`, `TaskNode` (DAG), and `TaskExplorerTable`.
- `TaskFilters` dropdown: added missing `Skipped` and `Cancelled` options.
- `/tasks/search/values?key=status` autocomplete: was hardcoded to `{pending, running, completed, failed}`; now returns the full filterable set (still excludes the internal `unregistered` phantom marker).

## Test plan

- [x] API unit tests pass (`pytest app/stardag-api/tests/`) — 257 passed including 4 new resume tests + 1 status-values pin
- [x] SDK unit tests pass (`pytest lib/stardag/tests/ --ignore=tests/test_integration`) — 525 passed including 2 new build_resume tests + 4 new 404-fallback tests
- [x] UI vitest passes
- [x] Pre-commit clean: prettier, ruff, ruff-format, pyright (lib + api), eslint, tsc
- [x] Alembic migration round-trips (upgrade → downgrade → upgrade)
- [ ] Manual: trigger `sd.build(resume_build_id=<failed-build-id>)` and verify the UI badge flips to "running (resumed)" and the build moves to the top of Home

🤖 Generated with [Claude Code](https://claude.com/claude-code)