### PR TITLE
Draft v0.7.2 changelog and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,74 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.7.2] — 2026-05-08
+
+`sd.build(resume_build_id=...)` now fires a `BUILD_RESUMED` event so
+resumed builds flip back to **running (resumed)** in the UI and jump to
+the top of the Home list, instead of silently keeping their previous
+terminal status. No client-code changes — `pip install -U stardag` is
+sufficient. See
+[RELEASE_NOTES.md](RELEASE_NOTES.md#v072--build-resume-status-fix-and-skipped-ui-polish)
+for details.
+([#141](https://github.com/stardag-dev/stardag/pull/141))
+
+### SDK
+
+- **`RegistryABC.build_resume` / `build_resume_aio`** added (default
+  no-op for older registry backends). `build`, `build_aio`,
+  `build_sequential`, `build_sequential_aio` call it whenever
+  `resume_build_id` is set, immediately after adopting the existing
+  build id. `APIRegistry` swallows the missing-route 404 from older
+  servers via the existing `_is_route_not_found` pattern (warning
+  logged, build runs to completion locally).
+
+### Registry API
+
+- **New `EventType.BUILD_RESUMED`** + **`POST
+/api/v1/builds/{build_id}/resume`** endpoint, mirroring the existing
+  `/complete` / `/fail` / `/cancel` shape. Status replay treats
+  `BUILD_RESUMED` like `BUILD_STARTED` (flips status to `RUNNING`,
+  clears `completed_at`) and exposes a derived `is_resumed: bool` flag
+  on `BuildResponse` — true while the latest build-level event is
+  `BUILD_RESUMED`, cleared by any subsequent terminal or
+  `BUILD_STARTED` event.
+- **New `Build.last_active_at` column** (Alembic migration backfills
+  from `created_at`). Touched only on build-level lifecycle events
+  (`BUILD_RESUMED` / `BUILD_COMPLETED` / `BUILD_FAILED` /
+  `BUILD_CANCELLED` / `BUILD_EXIT_EARLY`) — task events deliberately
+  skip this write to avoid row-lock contention against the build row
+  under high task concurrency. `GET /builds` now sorts by
+  `(last_active_at desc, id desc)` so resumed builds rise to the top
+  while `Build.id` (UUID7) keeps pagination stable across timestamp
+  ties.
+- **`/tasks/search/values?key=status`** autocomplete returns the full
+  filterable status set (was hardcoded to `pending`/`running`/
+  `completed`/`failed`; now includes `suspended`/`skipped`/`cancelled`).
+  `unregistered` is still excluded — it's an internal phantom-row
+  marker, not a status users filter on.
+
+### UI
+
+- **"running (resumed)" badge** in `BuildStatusBadge` (Home list and
+  build-view breadcrumb) when the API reports `is_resumed`.
+- **`skipped` task status** added to `TaskStatus` (was previously
+  unhandled). Renders in **amber** across `StatusBadge`, the DAG node
+  border (`TaskNode`), and the Task Explorer table — was effectively
+  near-invisible black-on-dark-blue before. The build-view status
+  filter dropdown also gained the missing **Skipped** and
+  **Cancelled** options.
+
+### Compatibility
+
+- **New SDK against an older Registry API** (no `/resume` route):
+  degrades gracefully via `_is_route_not_found`. The build still runs
+  to completion locally; the registry-side status flip is the only
+  thing missing until the API is upgraded.
+- **Older SDK against the new API**: unaffected. The new SDK call is
+  additive, and `last_active_at` is initialised on insert by the column
+  default plus bumped by the new build-level handlers, so list
+  ordering is correct without SDK cooperation.
+
 ## [0.7.1] — 2026-05-05
 
 Modal: `StardagApp.build_spawn` / `build_remote` now accept multiple root

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,50 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.7.2 — Build resume status fix and SKIPPED UI polish
+
+Fixes a UX bug where `sd.build(resume_build_id=...)` silently reused the
+build id without notifying the registry — so a build that previously
+terminated (`failed` / `cancelled` / `completed` / `exit_early`) kept
+showing its old terminal status while the SDK actively ran tasks under
+it again. The SDK now fires a `BUILD_RESUMED` event immediately after
+adopting the resumed id, so the registry flips the build back to
+`running` and the UI surfaces a **"running (resumed)"** badge with the
+build pinned to the top of the Home list.
+
+**No client-code changes** — `pip install -U stardag` is sufficient.
+
+### What changed in the SDK
+
+- `RegistryABC.build_resume` / `build_resume_aio` (default no-op)
+  added. `build`, `build_aio`, `build_sequential`, and
+  `build_sequential_aio` invoke it whenever `resume_build_id` is set.
+- `APIRegistry.build_resume[_aio]` posts to
+  `POST /api/v1/builds/{build_id}/resume`. Older registry servers that
+  don't expose this route return FastAPI's default `Not Found` body;
+  the SDK swallows that with a warning (same `_is_route_not_found`
+  pattern used by `task_skip` and `add_dependencies`) so resumed builds
+  still run to completion against an un-upgraded registry — only the
+  status-flip in the UI is missing in that combination.
+
+### Compatibility
+
+| SDK / API combination               | Behaviour                                                                                                                                              |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| New SDK + new API (≥ 0.7.2 on both) | Resumed build flips to `running (resumed)` and rises to top of Home list.                                                                              |
+| New SDK + old API                   | SDK fires `build_resume[_aio]` → 404 → swallowed with a warning. Build runs to completion; UI shows the old terminal status until the API is upgraded. |
+| Old SDK + new API                   | Unchanged behaviour. The new API additions (`/resume`, `last_active_at`, `is_resumed`) are additive.                                                   |
+
+### Drive-by UI polish
+
+The same release also fixes `TaskStatus = "skipped"` rendering across
+the UI — previously near-invisible (black-on-dark-blue) on the
+build-view task table and missing from the build-view status filter
+dropdown. These are UI-only changes and don't affect the SDK; see
+[CHANGELOG.md](CHANGELOG.md#072--2026-05-08) for the full list.
+
+---
+
 ## v0.7.1 — Multi-root builds and `build_kwargs` on `StardagApp`
 
 Two additive changes to `stardag.integration.modal`, plus one renamed


### PR DESCRIPTION
## Summary

Patch release for the build-resume lifecycle fix + SKIPPED status UI polish merged in [#141](https://github.com/stardag-dev/stardag/pull/141). Adds a `[0.7.2]` section to `CHANGELOG.md` and a `v0.7.2` entry to `RELEASE_NOTES.md`. No code changes — release notes only.

No breaking changes; `pip install -U stardag` is sufficient. `New SDK + old API` degrades gracefully via the existing missing-route 404 swallow pattern (build still runs to completion; only the registry-side status flip is missing until the API is upgraded).

## Test plan

- [x] Pre-commit clean (prettier, ruff, ruff-format, pyright)
- [ ] Merge → tag `v0.7.2` on main → CI publishes to PyPI + creates GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)