### PR TITLE
Make tenancy quotas (workspaces/user, environments/workspace) configurable via LIMITS_* env vars

### DIFF
--- a/app/stardag-api/src/stardag_api/limits.py
+++ b/app/stardag-api/src/stardag_api/limits.py
@@ -40,6 +40,10 @@ class LimitsSettings(BaseSettings):
     max_dependency_ids_per_task: Annotated[int, Field(ge=1)] | None = None
     max_artifacts_per_task: Annotated[int, Field(ge=1)] | None = None
 
+    # Tenancy quotas (enforced in routes/workspaces.py)
+    max_workspaces_per_user: Annotated[int, Field(ge=1)] | None = None
+    max_environments_per_workspace: Annotated[int, Field(ge=1)] | None = None
+
     # Cache TTL for DB count queries (seconds)
     entity_count_cache_ttl: Annotated[int, Field(ge=1)] = 60
 

--- a/app/stardag-api/src/stardag_api/models/workspace.py
+++ b/app/stardag-api/src/stardag_api/models/workspace.py
@@ -25,10 +25,6 @@ class Workspace(Base, TimestampMixin):
 
     __tablename__ = "workspaces"
 
-    # Limits
-    MAX_WORKSPACES_PER_USER = 3
-    MAX_ENVIRONMENTS_PER_WORKSPACE = 6
-
     id: Mapped[UUID] = mapped_column(
         Uuid,
         primary_key=True,

--- a/app/stardag-api/src/stardag_api/routes/workspaces.py
+++ b/app/stardag-api/src/stardag_api/routes/workspaces.py
@@ -17,6 +17,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from stardag_api.auth import get_current_user, get_current_user_flexible
+from stardag_api.config import limits_settings
 from stardag_api.db import get_db
 from stardag_api.models import (
     Invite,
@@ -231,10 +232,11 @@ async def create_workspace(
         )
     )
     workspace_count = workspace_count_result.scalar() or 0
-    if workspace_count >= Workspace.MAX_WORKSPACES_PER_USER:
+    max_workspaces = limits_settings.max_workspaces_per_user
+    if max_workspaces is not None and workspace_count >= max_workspaces:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"You can create at most {Workspace.MAX_WORKSPACES_PER_USER} workspaces",
+            detail=f"You can create at most {max_workspaces} workspaces",
         )
 
     # Check if slug is taken
@@ -760,10 +762,11 @@ async def create_environment(
         )
     )
     environment_count = environment_count_result.scalar() or 0
-    if environment_count >= Workspace.MAX_ENVIRONMENTS_PER_WORKSPACE:
+    max_environments = limits_settings.max_environments_per_workspace
+    if max_environments is not None and environment_count >= max_environments:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=f"Workspace can have at most {Workspace.MAX_ENVIRONMENTS_PER_WORKSPACE} environments",
+            detail=f"Workspace can have at most {max_environments} environments",
         )
 
     # Check if slug exists in this workspace

--- a/app/stardag-api/tests/test_workspaces.py
+++ b/app/stardag-api/tests/test_workspaces.py
@@ -1,5 +1,6 @@
 """Tests for workspace management routes."""
 
+from unittest.mock import patch
 from uuid import UUID
 
 import pytest
@@ -9,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from stardag_api.auth.dependencies import get_current_user_flexible, get_token
 from stardag_api.auth.tokens import InternalTokenPayload
 from stardag_api.db import get_db
+from stardag_api.limits import LimitsSettings
 from stardag_api.main import app
 from stardag_api.models import Environment, Workspace, WorkspaceMember, User
 from stardag_api.models.enums import WorkspaceRole
@@ -213,6 +215,61 @@ async def test_create_workspace_duplicate_slug(
             )
 
         assert response.status_code == 409
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_create_workspace_quota(
+    async_engine, test_user: User, test_workspace_with_owner: Workspace
+):
+    """`limits_settings.max_workspaces_per_user` enforces a per-user cap."""
+    async_session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    async def override_get_db():
+        async with async_session_maker() as session:
+            yield session
+
+    async def override_get_current_user_flexible():
+        return test_user
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user_flexible] = (
+        override_get_current_user_flexible
+    )
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            # None (default): cap is not enforced — two creates succeed.
+            with patch(
+                "stardag_api.routes.workspaces.limits_settings",
+                LimitsSettings(max_workspaces_per_user=None),
+            ):
+                r1 = await client.post(
+                    "/api/v1/ui/workspaces",
+                    json={"name": "Free 1", "slug": "free-1"},
+                )
+                r2 = await client.post(
+                    "/api/v1/ui/workspaces",
+                    json={"name": "Free 2", "slug": "free-2"},
+                )
+                assert r1.status_code == 201
+                assert r2.status_code == 201
+
+            # Cap of 1: the user already owns two workspaces with
+            # created_by_id set above, so the next create must return 403.
+            with patch(
+                "stardag_api.routes.workspaces.limits_settings",
+                LimitsSettings(max_workspaces_per_user=1),
+            ):
+                r3 = await client.post(
+                    "/api/v1/ui/workspaces",
+                    json={"name": "Capped", "slug": "capped"},
+                )
+                assert r3.status_code == 403
+                assert "at most 1 workspaces" in r3.json()["detail"]
     finally:
         app.dependency_overrides.clear()
 
@@ -467,6 +524,59 @@ async def test_create_environment(
         data = response.json()
         assert data["name"] == "New Environment"
         assert data["slug"] == "new-environment"
+    finally:
+        app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_create_environment_quota(
+    async_engine, test_user: User, test_workspace_with_owner: Workspace
+):
+    """`limits_settings.max_environments_per_workspace` enforces the cap."""
+    async_session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+    mock_token = _create_mock_internal_token(
+        user_id=test_user.id,
+        workspace_id=test_workspace_with_owner.id,
+    )
+
+    async def override_get_db():
+        async with async_session_maker() as session:
+            yield session
+
+    async def override_get_token():
+        return mock_token
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_token] = override_get_token
+
+    try:
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            # None (default): cap is not enforced. The fixture already
+            # created one "default" environment in this workspace.
+            with patch(
+                "stardag_api.routes.workspaces.limits_settings",
+                LimitsSettings(max_environments_per_workspace=None),
+            ):
+                r1 = await client.post(
+                    f"/api/v1/ui/workspaces/{test_workspace_with_owner.id}/environments",
+                    json={"name": "Two", "slug": "two"},
+                )
+                assert r1.status_code == 201
+
+            # Cap of 2: the workspace now has 2 environments (default + Two),
+            # so the next create must return 403.
+            with patch(
+                "stardag_api.routes.workspaces.limits_settings",
+                LimitsSettings(max_environments_per_workspace=2),
+            ):
+                r2 = await client.post(
+                    f"/api/v1/ui/workspaces/{test_workspace_with_owner.id}/environments",
+                    json={"name": "Three", "slug": "three"},
+                )
+                assert r2.status_code == 403
+                assert "at most 2 environments" in r2.json()["detail"]
     finally:
         app.dependency_overrides.clear()
 

--- a/infra/aws-cdk/lib/api-stack.ts
+++ b/infra/aws-cdk/lib/api-stack.ts
@@ -209,6 +209,8 @@ export class ApiStack extends cdk.Stack {
         LIMITS_MAX_ASSETS_PER_WORKSPACE_24H: "1000",
         LIMITS_MAX_DEPENDENCY_IDS_PER_TASK: "500",
         LIMITS_MAX_ASSETS_PER_TASK: "10",
+        LIMITS_MAX_WORKSPACES_PER_USER: "3",
+        LIMITS_MAX_ENVIRONMENTS_PER_WORKSPACE: "15",
         // Worker count is read by the Dockerfile CMD; keep undefined here
         // to fall through to the image's default (sized for 1 vCPU).
         ...(apiGunicornWorkers ? { GUNICORN_WORKERS: apiGunicornWorkers } : {}),


### PR DESCRIPTION
## Summary

Moves the two hardcoded class constants on `Workspace` —
`MAX_WORKSPACES_PER_USER` (3) and `MAX_ENVIRONMENTS_PER_WORKSPACE` (6) —
into the existing `LimitsSettings` (pydantic-settings, `LIMITS_*` env
vars), so they follow the same OSS-safe + env-overridable pattern as
the other SaaS guardrails in `app/stardag-api/src/stardag_api/limits.py`.

## Why

Re-using `LimitsSettings` instead of constants:

- **OSS-safe defaults.** `None` = no enforcement, matching the rest of
  the file's "all limits default to disabled" contract. Self-hosted
  users hit no hidden cap.
- **Env-overridable per deployment.** Operators tune quotas without a
  code release.
- **Single source of truth for SaaS quotas.** The two quotas now live
  next to `max_*_per_workspace_24h` etc., not as anonymous class-level
  ints inside an ORM model.

## What changed

| File | Change |
| --- | --- |
| `app/stardag-api/src/stardag_api/limits.py` | Add `max_workspaces_per_user` and `max_environments_per_workspace` fields to `LimitsSettings` (None default). |
| `app/stardag-api/src/stardag_api/models/workspace.py` | Remove the two `MAX_*` class constants. |
| `app/stardag-api/src/stardag_api/routes/workspaces.py` | Read from `limits_settings.max_*` in `create_workspace` and `create_environment`; skip the check when value is None. |
| `infra/aws-cdk/lib/api-stack.ts` | Add `LIMITS_MAX_WORKSPACES_PER_USER: "3"` and `LIMITS_MAX_ENVIRONMENTS_PER_WORKSPACE: "15"` to the ECS task `environment` block, next to the other `LIMITS_*` values. |

## Backwards-compat

- **Self-hosted / OSS deployments without `LIMITS_*` set**: behaviour
  changes from "3 workspaces, 6 environments" to "unlimited". This
  matches the documented contract for `limits.py` ("all limits default
  to None / disabled for OSS-safe operation").
- **Deployments using the bundled CDK template**: pick up the explicit
  `3` / `15` values. The env-cap goes from 6 → 15.

## Notes

- The env-cap bump (6 → 15) is the motivating fix here: a deployed
  workspace had hit the old cap.
- Pure config / wiring change. No DB migration. No schema change.
- No tests reference the old constants directly.

## Test plan

- [ ] CI green.
- [ ] After deploy with the new CDK values, `POST /api/v1/ui/workspaces/{id}/environments` succeeds in a workspace that previously had exactly 6 envs.
- [ ] Unset `LIMITS_MAX_ENVIRONMENTS_PER_WORKSPACE` locally → no env cap enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)