### PR TITLE
CLI: surface API detail on 403 in environment commands

### DIFF
--- a/lib/stardag/src/stardag/_cli/environment.py
+++ b/lib/stardag/src/stardag/_cli/environment.py
@@ -75,10 +75,11 @@ def _handle_api_error(response: httpx.Response, resource: str = "resource") -> N
             err=True,
         )
     elif response.status_code == 403:
-        typer.echo(
-            f"Error: Permission denied. Admin role or higher is required to modify {resource}.",
-            err=True,
-        )
+        try:
+            detail = response.json().get("detail", "Permission denied")
+        except ValueError:
+            detail = "Permission denied"
+        typer.echo(f"Error: {detail}", err=True)
     elif response.status_code == 404:
         typer.echo(f"Error: {resource.capitalize()} not found.", err=True)
     elif response.status_code == 409:


### PR DESCRIPTION
## Summary

`stardag/_cli/environment.py::_handle_api_error` hard-coded the 403 message to:

> Error: Permission denied. Admin role or higher is required to modify {resource}.

That's only one of several 403 paths the API can hit. The most surprising one is the workspace env-count cap in `routes/workspaces.create_environment`:

```python
raise HTTPException(
    status_code=status.HTTP_403_FORBIDDEN,
    detail=f"Workspace can have at most {Workspace.MAX_ENVIRONMENTS_PER_WORKSPACE} environments",
)
```

— so an admin who hits the cap gets "you're not admin", which is doubly confusing because the API's actual `detail` says exactly what's wrong.

## Fix

Read `response.json().get("detail")` and surface it, like the 409 branch right below it does. Wrapped the `.json()` call in `try/except ValueError` to be defensive against non-JSON 403 bodies (e.g. proxy errors).

Before:

```
$ uv run stardag environment create my-env
Error: Permission denied. Admin role or higher is required to modify environment.
```

After (for the env-cap case):

```
$ uv run stardag environment create my-env
Error: Workspace can have at most 15 environments
```

After (for an actual role-shortage):

```
$ uv run stardag environment create my-env
Error: Requires admin role or higher
```

(That string comes from `require_workspace_access` in the API.)

## Test plan

- [ ] CI green.
- [ ] Manual: as a non-admin member, `stardag environment create x` → shows "Requires admin role or higher".
- [ ] Manual: in a workspace at the env cap, as admin, `stardag environment create x` → shows "Workspace can have at most N environments".

## Related

- Limit constant change: #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)