### PR TITLE
Fix compat_default hash-skip to compare raw value, not serialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+- **`stardag/base_model.py`**: fixed `StardagField(compat_default=...)` so the
+  hash-mode drop compares the field's **raw Python value** against
+  `compat_default` instead of the already-serialized value. Previously the
+  feature silently no-opped for any field whose serialized form differs from
+  its Python value — enums (→ `.value`), tuples (→ lists), or fields with a
+  custom/hash-only serializer — so adding such a field with a compat default
+  still changed existing task IDs/hashes. The comparison is now symmetric with
+  the compat-validation path (which also uses the raw value), and
+  `compat_default` is given in its natural Python form rather than the
+  serialized form.
+  ([#146](https://github.com/stardag-dev/stardag/issues/146))
+
 ## [0.7.3] — 2026-05-08
 
 `stardag modal deploy` and `stardag modal stardag-api-key create` now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,19 +6,29 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.8.0] — 2026-06-11
+
+Behaviour fix to `StardagField(compat_default=...)` that can change task
+IDs/hashes for fields with non-trivially-serialized types. See
+[RELEASE_NOTES.md](RELEASE_NOTES.md#v080--compat_default-compares-the-raw-python-value)
+for the migration guide.
+
 ### SDK
 
-- **`stardag/base_model.py`**: fixed `StardagField(compat_default=...)` so the
-  hash-mode drop compares the field's **raw Python value** against
-  `compat_default` instead of the already-serialized value. Previously the
-  feature silently no-opped for any field whose serialized form differs from
-  its Python value — enums (→ `.value`), tuples (→ lists), or fields with a
-  custom/hash-only serializer — so adding such a field with a compat default
-  still changed existing task IDs/hashes. The comparison is now symmetric with
-  the compat-validation path (which also uses the raw value), and
-  `compat_default` is given in its natural Python form rather than the
-  serialized form.
-  ([#146](https://github.com/stardag-dev/stardag/issues/146))
+- **`stardag/base_model.py`**: `StardagField(compat_default=...)`'s hash-mode
+  drop now compares the field's **raw Python value** against `compat_default`
+  instead of the already-serialized value. Previously the feature silently
+  no-opped for any field whose serialized form differs from its Python value —
+  enums (→ `.value`), tuples (→ lists), or fields with a custom/hash-only
+  serializer — so adding such a field with a compat default still changed
+  existing task IDs/hashes. The comparison is now symmetric with the
+  compat-validation path (which also uses the raw value): `compat_default` is
+  supplied in its natural validated Python form rather than the serialized
+  form. **Breaking** for the affected types — see the migration guide.
+  ([#146](https://github.com/stardag-dev/stardag/issues/146),
+  [#147](https://github.com/stardag-dev/stardag/pull/147))
+- Documented `StardagField.compat_default` / `hash_exclude` (previously a
+  `TODO` docstring).
 
 ## [0.7.3] — 2026-05-08
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,76 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.8.0 — `compat_default` compares the raw Python value
+
+Fixes `StardagField(compat_default=...)` so it works for all field types.
+The hash-mode drop now compares a field's **raw Python value** against
+`compat_default`, instead of the already-serialized value.
+
+`compat_default` exists so adding a field with a backward-compatible default
+keeps existing task IDs/hashes unchanged: in hash-mode serialization, a field
+whose value equals its `compat_default` is dropped from the hash dump. But the
+drop previously compared `compat_default` against the _serialized_ field value.
+For any field whose serialized form differs from its Python value — enums
+(→ `.value`), tuples (→ lists), or a field with a custom/hash-only serializer —
+the comparison failed even at the default, so the field was **not** dropped and
+the hash changed anyway. The feature silently no-opped for those types.
+
+It now compares the raw value (`getattr(self, name)`), which works for every
+type and is symmetric with the compat-validation path (which already injects
+the raw `compat_default`).
+
+### Breaking change
+
+Task IDs/hashes can change for any model that uses `compat_default` on a
+non-trivially-serialized field (enum, tuple, custom serializer). Fields with
+serialization-invariant types (`int`, `bool`, `str`, plain `float`) are
+unaffected. There are two cases:
+
+- **You worked around the bug by passing the serialized form** (e.g.
+  `compat_default=["red"]` for a `tuple[Color, ...]` field). That no longer
+  matches the raw value, so the field stops being dropped — switch to the
+  natural Python form to restore the old hashes (see migration below).
+- **You passed the natural form and it silently did nothing.** Adding the field
+  had already shifted your task IDs. With the fix the field is now correctly
+  dropped, shifting them again — back to the pre-field values you originally
+  intended.
+
+If either applies and you need to keep already-materialised outputs reachable,
+re-pin via `__version__` or rebuild the affected tasks.
+
+### Migration
+
+Supply `compat_default` in the field's **natural, validated Python form** — the
+value the field holds after validation, not its serialized form:
+
+```python
+import enum
+from typing import Annotated
+import stardag as sd
+
+class Color(str, enum.Enum):
+    RED = "red"
+
+class Config(sd.Task[None]):
+    # before (serialized-form workaround — no longer drops the field):
+    colors: Annotated[
+        tuple[Color, ...], sd.StardagField(compat_default=["red"])
+    ] = (Color.RED,)
+
+    # after (natural Python form — drops the field at its default):
+    colors: Annotated[
+        tuple[Color, ...], sd.StardagField(compat_default=(Color.RED,))
+    ] = (Color.RED,)
+```
+
+Note `compat_default` must be **idempotent under validation**: if validation
+coerces it (e.g. `[1, 2]` → `(1, 2)` for a `tuple[int, ...]` field), pass the
+coerced form (`(1, 2)`), or the serialize-side equality check fails and the
+field is not dropped.
+
+---
+
 ## v0.7.3 — Correct slug display in `stardag modal` CLI
 
 Fixes a misleading display in `stardag modal deploy` and

--- a/lib/stardag-examples/src/stardag_examples/ml_pipeline/base.py
+++ b/lib/stardag-examples/src/stardag_examples/ml_pipeline/base.py
@@ -1,4 +1,5 @@
 import datetime
+import hashlib
 import json
 import logging
 import pickle
@@ -23,6 +24,7 @@ Segment = Literal["X", "Y", "Z"]
 def generate_data(
     num_samples: int = 1000,
     segment_flip_probs: tuple[float, float, float] = (0.1, 0.2, 0.3),
+    seed: int | None = None,
 ) -> pd.DataFrame:
     """Simulates export from a *mutable* data source.
     Returns data frame with index of UUIDs and columns:
@@ -34,10 +36,18 @@ def generate_data(
     - Segment "X": p(random flip) = 0.1
     - Segment "Y": p(random flip) = 0.2
     - Segment "Z": p(random flip) = 0.3
+
+    Args:
+        seed: If given, the output (including the UUID index) is fully
+            reproducible. If ``None`` (the default), a time-based seed is used so
+            each export yields fresh data — simulating a mutable source.
     """
 
-    # set seed based on current time
-    np.random.seed(int((pd.Timestamp.now().timestamp() * 1e6) % 2**32))
+    if seed is None:
+        # Time-based seed: simulates a mutable source that yields fresh data on
+        # every export. Pass an explicit `seed` for reproducible output.
+        seed = int((pd.Timestamp.now().timestamp() * 1e6) % 2**32)
+    np.random.seed(seed)
 
     logger.info("Generating data...")
     df = pd.DataFrame(
@@ -46,7 +56,10 @@ def generate_data(
             "category": np.random.choice(["A", "B", "C"], num_samples),
             "segment": np.random.choice(["X", "Y", "Z"], num_samples),
         },
-        index=[str(uuid.uuid4()) for _ in range(num_samples)],  # type: ignore
+        # Derive UUIDs from the seeded RNG (not uuid.uuid4, which draws from OS
+        # entropy) so the index — and therefore the RandomPartition split — is
+        # reproducible under `seed`.
+        index=[str(uuid.UUID(bytes=np.random.bytes(16))) for _ in range(num_samples)],  # type: ignore
     )
     # add random target flip
     df["_target_flip"] = 0
@@ -89,6 +102,16 @@ def process_data(df: pd.DataFrame, params: ProcessParams):
     return df
 
 
+def _stable_bucket(key: str, num_buckets: int) -> int:
+    """Map a string key to a bucket reproducibly across processes.
+
+    `hash(str)` is randomised per-process via PYTHONHASHSEED, which made the
+    train/test split non-deterministic; a content hash keeps it stable.
+    """
+    digest = hashlib.sha256(key.encode()).digest()
+    return int.from_bytes(digest[:8], "big") % num_buckets
+
+
 class RandomPartition(BaseModel):
     num_buckets: int
     include_buckets: tuple[int, ...]
@@ -111,7 +134,7 @@ class DatasetFilter(BaseModel):
             rp: RandomPartition = self.random_partition
             dataset = dataset[  # type: ignore
                 dataset.index.map(
-                    lambda x: hash(x + rp.seed_salt) % rp.num_buckets
+                    lambda x: _stable_bucket(x + rp.seed_salt, rp.num_buckets)
                     in rp.include_buckets
                 )
             ]

--- a/lib/stardag-examples/src/stardag_examples/ml_pipeline/decorator_api.py
+++ b/lib/stardag-examples/src/stardag_examples/ml_pipeline/decorator_api.py
@@ -25,6 +25,7 @@ base_task = partial(sd.task, version="0")
 def dump(
     date: datetime.date = base.utc_today(),
     snapshot_slug: str = "default",
+    seed: int | None = None,
 ) -> pd.DataFrame:
     """Dump data.
 
@@ -32,11 +33,13 @@ def dump(
         date: The date of the dump.
         snapshot_slug: The slug for the dump. If you want to create multiple dumps
             for the same date, this must be used to differentiate them.
+        seed: Optional seed for reproducible data generation. Defaults to a
+            time-based seed (a fresh export each run).
     """
     if not date == base.utc_today():
         raise ValueError("Date must be today")
 
-    data = base.generate_data()
+    data = base.generate_data(seed=seed)
     return data
 
 
@@ -99,8 +102,8 @@ def metrics(
     return base.get_metrics(dataset, predictions)
 
 
-def get_metrics_dag():
-    dataset_ = dataset(dump=dump(), params=base.ProcessParams())
+def get_metrics_dag(seed: int | None = None):
+    dataset_ = dataset(dump=dump(seed=seed), params=base.ProcessParams())
     train_filter = base.DatasetFilter(
         random_partition=base.RandomPartition(
             num_buckets=3,

--- a/lib/stardag-examples/tests/test_ml_pipeline/test_decorator_api.py
+++ b/lib/stardag-examples/tests/test_ml_pipeline/test_decorator_api.py
@@ -12,7 +12,9 @@ except ImportError:
 
 @pytest.mark.skipif(pd is None, reason="pandas is not installed")
 def test_build_metrics_dag(default_in_memory_fs_target):
-    metrics = get_metrics_dag()
+    # Fixed seed -> reproducible data, partition split, and metrics (regardless
+    # of PYTHONHASHSEED), so the f1 assertion below is deterministic.
+    metrics = get_metrics_dag(seed=0)
     assert isinstance(metrics._serializer, JSONSerializer)
     assert metrics.target().uri.endswith(".json")
     assert metrics.target().uri.startswith(
@@ -25,4 +27,5 @@ def test_build_metrics_dag(default_in_memory_fs_target):
     assert metrics.target().exists()
     metrics_dict = metrics.target().load()
     assert set(metrics_dict.keys()) == {"accuracy", "precision", "recall", "f1"}
-    assert metrics_dict["f1"] > 0.50  # TODO fix seeds!
+    # f1 ≈ 0.64 with seed=0; assert a safe lower bound (better than random).
+    assert metrics_dict["f1"] > 0.55

--- a/lib/stardag/src/stardag/base_model.py
+++ b/lib/stardag/src/stardag/base_model.py
@@ -37,10 +37,25 @@ _UNSET = object()
 
 @dataclass(frozen=True)
 class StardagField:
-    """TODO"""
+    """Per-field annotation controlling hash-mode serialization and compat
+    validation. Attach via ``Annotated[T, StardagField(...)]``."""
 
     compat_default: Any = _UNSET
+    """Backward-compatible default. In compat-validation mode a missing field is
+    populated with this value; in hash-mode serialization a field whose value
+    equals this is dropped from the hash dump, so adding the field doesn't change
+    existing hashes / task identities.
+
+    Supply it in the field's *natural, validated Python form* — i.e. what the
+    field holds after validation, not its serialized form. Both the validate and
+    serialize sides compare against this raw value, so a non-idempotent input
+    (e.g. ``[1, 2]`` for a ``tuple[int, ...]`` field, which validation coerces to
+    ``(1, 2)``) would fail the serialize-side equality check and silently not be
+    dropped.
+    """
     hash_exclude: bool = False
+    """Drop this field from the hash dump entirely (e.g. runtime-only params that
+    must not affect the task identity)."""
 
 
 class StardagBaseModel(BaseModel):
@@ -125,11 +140,12 @@ class StardagBaseModel(BaseModel):
                 # serialized value would silently fail to drop the field for
                 # those types. Using getattr(self, name) is also symmetric with
                 # _check_add_compatibility_defaults, which injects the raw
-                # compat_default on the validate side.
-                if (
+                # compat_default on the validate side. hash_exclude is checked
+                # first to short-circuit before the attribute read.
+                if stardag_field.hash_exclude or (
                     stardag_field.compat_default is not _UNSET
                     and getattr(self, name) == stardag_field.compat_default
-                ) or stardag_field.hash_exclude:
+                ):
                     continue
 
             out[name] = value

--- a/lib/stardag/src/stardag/base_model.py
+++ b/lib/stardag/src/stardag/base_model.py
@@ -118,7 +118,18 @@ class StardagBaseModel(BaseModel):
             maybe_stardag_field = _get_annotation(field, StardagField)
             if maybe_stardag_field is not None:
                 stardag_field: StardagField = maybe_stardag_field
-                if stardag_field.compat_default == value or stardag_field.hash_exclude:
+                # Compare the *raw* Python value (not the already-serialized
+                # `value`) against compat_default. The serialized form differs
+                # from the Python value for enums (-> .value), tuples (-> list),
+                # and fields with custom/hash-only serializers, so comparing the
+                # serialized value would silently fail to drop the field for
+                # those types. Using getattr(self, name) is also symmetric with
+                # _check_add_compatibility_defaults, which injects the raw
+                # compat_default on the validate side.
+                if (
+                    stardag_field.compat_default is not _UNSET
+                    and getattr(self, name) == stardag_field.compat_default
+                ) or stardag_field.hash_exclude:
                     continue
 
             out[name] = value

--- a/lib/stardag/tests/test_base_model.py
+++ b/lib/stardag/tests/test_base_model.py
@@ -1,7 +1,8 @@
-from typing import Annotated, Type
+import enum
+from typing import Annotated, Any, Type
 
 import pytest
-from pydantic import ValidationError
+from pydantic import ValidationError, WrapSerializer
 
 from stardag.base_model import (
     CONTEXT_MODE_KEY,
@@ -204,6 +205,37 @@ class ModelWithHashExclude(StardagBaseModel):
     b: int
 
 
+class Color(enum.StrEnum):
+    RED = "red"
+    GREEN = "green"
+
+
+class ModelWithEnumTupleCompatDefault(StardagBaseModel):
+    """Enum-tuple field whose serialized form (list of strings) differs from
+    its Python value (tuple of enums). See issue #146."""
+
+    colors: Annotated[tuple[Color, ...], StardagField(compat_default=(Color.RED,))] = (
+        Color.RED,
+    )
+
+
+def _hash_serialize(value: Any, handler, info):
+    """Hash-only custom serializer producing a form != the Python value."""
+    if info.context and info.context.get(CONTEXT_MODE_KEY) == "hash":
+        return f"<{value}>"
+    return handler(value)
+
+
+Canonical = Annotated[float, WrapSerializer(_hash_serialize)]
+
+
+class ModelWithCustomSerializerCompatDefault(StardagBaseModel):
+    """Field with a hash-only custom serializer; the serialized form
+    (``"<0.0>"``) differs from the Python value (``0.0``). See issue #146."""
+
+    weight: Annotated[Canonical, StardagField(compat_default=0.0)] = 0.0
+
+
 @pytest.mark.parametrize(
     "description,instance,mode,expected",
     [
@@ -236,6 +268,47 @@ class ModelWithHashExclude(StardagBaseModel):
             ModelWithHashExclude(a=5, b=10),
             "hash",
             {"b": 10},
+        ),
+        # Enum-tuple compat default (issue #146): serialized form is a list of
+        # strings, but the field is at its compat default -> dropped in hash
+        # mode, kept (serialized) otherwise.
+        (
+            "enum-tuple compat default no mode at default",
+            ModelWithEnumTupleCompatDefault(colors=(Color.RED,)),
+            None,
+            {"colors": ["red"]},
+        ),
+        (
+            "enum-tuple compat default hash mode at default",
+            ModelWithEnumTupleCompatDefault(colors=(Color.RED,)),
+            "hash",
+            {},
+        ),
+        (
+            "enum-tuple compat default hash mode not at default",
+            ModelWithEnumTupleCompatDefault(colors=(Color.GREEN,)),
+            "hash",
+            {"colors": ["green"]},
+        ),
+        # Custom hash-only serializer compat default (issue #146): serialized
+        # form ("<0.0>") differs from the Python value (0.0).
+        (
+            "custom serializer compat default no mode at default",
+            ModelWithCustomSerializerCompatDefault(weight=0.0),
+            None,
+            {"weight": 0.0},
+        ),
+        (
+            "custom serializer compat default hash mode at default",
+            ModelWithCustomSerializerCompatDefault(weight=0.0),
+            "hash",
+            {},
+        ),
+        (
+            "custom serializer compat default hash mode not at default",
+            ModelWithCustomSerializerCompatDefault(weight=1.5),
+            "hash",
+            {"weight": "<1.5>"},
         ),
     ],
 )

--- a/lib/stardag/tests/test_base_model.py
+++ b/lib/stardag/tests/test_base_model.py
@@ -205,7 +205,7 @@ class ModelWithHashExclude(StardagBaseModel):
     b: int
 
 
-class Color(enum.StrEnum):
+class Color(str, enum.Enum):  # `str, Enum` for Python 3.10 (StrEnum is 3.11+)
     RED = "red"
     GREEN = "green"
 


### PR DESCRIPTION
## Summary

Fixes #146.

`StardagField(compat_default=...)` keeps a config that predates a newly-added
field hashing identically: in hash-mode serialization, a field whose value
equals its `compat_default` is dropped from the hash dump, so adding the field
with a backward-compatible default doesn't change existing task IDs/hashes.

The drop comparison in `StardagBaseModel._handle_hash_mode` compared
`compat_default` against the **already-serialized** field value:

```python
data = handler(self)                      # fields serialized (mode="hash")
...
if stardag_field.compat_default == value or stardag_field.hash_exclude:
    continue                              # drop the field
```

For any field whose serialized form differs from its Python value — enums
(→ `.value`), tuples (→ lists), or a field with a custom/hash-only serializer —
this comparison failed *even when the field was at its compat default*, so the
field was **not** dropped and the hash changed anyway. The feature silently
no-opped for those types.

## Fix

Compare the **raw Python value** (`getattr(self, name)`) against
`compat_default` (option 1 in the issue):

- Works transparently for all field types, regardless of serialized form.
- Symmetric with `_check_add_compatibility_defaults`, which already injects the
  raw `compat_default` on the validate side — so the same value is now consumed
  in one representation on both sides.
- `compat_default` is supplied in its natural Python form, not the
  serialization format.

Also guards the comparison with `compat_default is not _UNSET` so a sentinel
default is never matched.

## Tests

Added serialize cases for the two reported scenarios, each covering both
at-default (dropped in hash mode) and not-at-default (kept):

- enum-tuple field (`tuple[Color, ...]` serializing to a list of strings)
- field with a hash-only custom `WrapSerializer`

Both repros from the issue now produce `{}` as expected. Full unit suite passes;
ruff + pyright clean.