### PR TITLE
CDK: rename LIMITS_MAX_ASSET(S)_* env vars to ARTIFACT(S)_* to match LimitsSettings

### DIFF
--- a/infra/aws-cdk/lib/api-stack.ts
+++ b/infra/aws-cdk/lib/api-stack.ts
@@ -201,14 +201,14 @@ export class ApiStack extends cdk.Stack {
         EMAIL_APP_URL: `https://${config.uiDomain}`,
         // SaaS guardrails (rate limits and entity creation limits)
         LIMITS_MAX_TASK_DATA_BYTES: "102400",
-        LIMITS_MAX_ASSET_BODY_BYTES: "1048576",
+        LIMITS_MAX_ARTIFACT_BODY_BYTES: "1048576",
         LIMITS_MAX_REQUESTS_PER_MINUTE: "300",
         LIMITS_MAX_BUILDS_PER_WORKSPACE_24H: "200",
         LIMITS_MAX_TASKS_PER_WORKSPACE_24H: "10000",
         LIMITS_MAX_EVENTS_PER_WORKSPACE_24H: "50000",
-        LIMITS_MAX_ASSETS_PER_WORKSPACE_24H: "1000",
+        LIMITS_MAX_ARTIFACTS_PER_WORKSPACE_24H: "1000",
         LIMITS_MAX_DEPENDENCY_IDS_PER_TASK: "500",
-        LIMITS_MAX_ASSETS_PER_TASK: "10",
+        LIMITS_MAX_ARTIFACTS_PER_TASK: "10",
         LIMITS_MAX_WORKSPACES_PER_USER: "3",
         LIMITS_MAX_ENVIRONMENTS_PER_WORKSPACE: "15",
         // Worker count is read by the Dockerfile CMD; keep undefined here


### PR DESCRIPTION
## Summary

The ECS task environment in `infra/aws-cdk/lib/api-stack.ts` set three `LIMITS_MAX_ASSET(S)_*` env vars, but the corresponding fields in `app/stardag-api/src/stardag_api/limits.py::LimitsSettings` are `max_artifact(s)_*`. With `env_prefix="LIMITS_"` and no field aliases, pydantic-settings never matched them, so the three caps silently defaulted to `None` (disabled) on deployments using the bundled CDK template.

Renames (values unchanged):

| Old (dead) | New (matches Python) | Intended cap |
| --- | --- | --- |
| `LIMITS_MAX_ASSET_BODY_BYTES` | `LIMITS_MAX_ARTIFACT_BODY_BYTES` | 1 MiB per artifact body |
| `LIMITS_MAX_ASSETS_PER_WORKSPACE_24H` | `LIMITS_MAX_ARTIFACTS_PER_WORKSPACE_24H` | 1000 artifacts / workspace / 24h |
| `LIMITS_MAX_ASSETS_PER_TASK` | `LIMITS_MAX_ARTIFACTS_PER_TASK` | 10 artifacts per task |

## Background

Spotted by Copilot during the review of #144 (which only added the new `MAX_WORKSPACES_PER_USER` / `MAX_ENVIRONMENTS_PER_WORKSPACE` quotas — those env var names already matched their Python field names). Filed separately because this PR activates previously-disabled limits, which is a real behavior change for deployments using this CDK template, while #144 was purely additive — different review/deploy cadence is appropriate.

## Effect

For deployments using this CDK template (and not overriding via their own env), this re-activates the intended SaaS guardrails:

- API enforces the per-artifact body-size cap (returns the existing `ARTIFACT_BODY_SIZE_LIMIT` error if the body is too large).
- API enforces the 24h artifact-creation cap per workspace (returns the existing `ARTIFACT_CREATION_LIMIT` error once the rolling 24h count is reached).
- API enforces the per-task artifact-count cap (returns the existing `ARTIFACTS_PER_TASK_LIMIT` error).

The error code names, structures, and CONTACT_SUFFIX hint are all pre-existing in `limits.py` — only the wiring changes.

Self-hosted / OSS deployments not using this CDK template are unaffected (they never set these env vars and the Python defaults remain `None`).

## Test plan

- [ ] CI green.
- [ ] After deploy, inspect the ECS task definition for the new env var names.
- [ ] Optional spot-check: a small request that previously would have exceeded one of the caps now returns the expected limit error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)