### PR TITLE
Fix `stardag modal deploy` on modal >= 1.4.3 (`ensure_env` import)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ client-code changes required.
   avoiding any dependency on modal-internal modules.
   ([#148](https://github.com/stardag-dev/stardag/issues/148),
   [#150](https://github.com/stardag-dev/stardag/pull/150))
+- Dev lockfile: bump modal 1.3.3 → 1.5.0 so CI continuously tests against a
+  modal version affected by the import breakage. The supported range is
+  unchanged (`modal>=1.0.0`).
 
 ## [0.8.0] — 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+- **`stardag/_cli/modal.py`**: Fix `stardag modal deploy` crashing with
+  `ImportError: cannot import name 'ensure_env' from 'modal.environments'` on
+  modal >= 1.4.3, where `ensure_env` moved to a private module. The small
+  environment-resolution logic is now inlined using modal's public config API,
+  avoiding any dependency on modal-internal modules.
+  ([#148](https://github.com/stardag-dev/stardag/issues/148))
+
 ## [0.8.0] — 2026-06-11
 
 Behaviour fix to `StardagField(compat_default=...)` that can change task

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.8.1] — 2026-06-12
+
+Compatibility fix for `stardag modal deploy` on modal >= 1.4.3. No
+client-code changes required.
+
 ### SDK
 
 - **`stardag/_cli/modal.py`**: Fix `stardag modal deploy` crashing with
@@ -13,7 +18,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   modal >= 1.4.3, where `ensure_env` moved to a private module. The small
   environment-resolution logic is now inlined using modal's public config API,
   avoiding any dependency on modal-internal modules.
-  ([#148](https://github.com/stardag-dev/stardag/issues/148))
+  ([#148](https://github.com/stardag-dev/stardag/issues/148),
+  [#150](https://github.com/stardag-dev/stardag/pull/150))
 
 ## [0.8.0] — 2026-06-11
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,28 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.8.1 — Fix `stardag modal deploy` on modal >= 1.4.3
+
+Fixes `stardag modal deploy` crashing at import time when the installed
+`modal` SDK is >= 1.4.3:
+
+```
+ImportError: cannot import name 'ensure_env' from 'modal.environments'
+```
+
+modal 1.4.3 moved `ensure_env` into a private module
+(`modal._environments`) without a public re-export. The CLI now inlines
+the small environment-resolution logic using modal's public config API
+instead, removing the dependency on modal internals. Behaviour is
+identical across the full supported modal range (`modal>=1.0.0`).
+
+If you pinned `modal==1.4.2` as a workaround, you can remove the pin
+after upgrading.
+
+**No client-code changes** — `pip install -U stardag` is sufficient.
+
+---
+
 ## v0.8.0 — `compat_default` compares the raw Python value
 
 Fixes `StardagField(compat_default=...)` so it works for all field types.

--- a/lib/stardag/src/stardag/_cli/modal.py
+++ b/lib/stardag/src/stardag/_cli/modal.py
@@ -538,7 +538,7 @@ def deploy(
     # Import modal dependencies now that we know modal is available
     import modal
     from modal.cli.utils import stream_app_logs
-    from modal.environments import ensure_env
+    from modal.config import config as modal_config
     from modal.output import enable_output
     from modal.runner import deploy_app
 
@@ -547,8 +547,12 @@ def deploy(
     # Parse the app reference
     file_or_module, object_path = _parse_app_ref(app_ref)
 
-    # Ensure environment is set (this affects lookups)
-    env = ensure_env(env)
+    # Ensure environment is set (this affects lookups). Inlined equivalent of
+    # modal's `ensure_env`, which is no longer publicly importable in
+    # modal >= 1.4.3 (moved to the private `modal._environments` module).
+    if env is not None:
+        modal_config.override_locally("environment", env)
+    env = modal_config.get("environment")
 
     # Import the module
     try:

--- a/lib/stardag/tests/test__cli/test_modal.py
+++ b/lib/stardag/tests/test__cli/test_modal.py
@@ -1,0 +1,34 @@
+"""Tests for the `stardag modal` CLI.
+
+Regression test for https://github.com/stardag-dev/stardag/issues/148
+where `from modal.environments import ensure_env` broke on modal >= 1.4.3
+because `ensure_env` moved to the private `modal._environments` module.
+"""
+
+import pytest
+from typer.testing import CliRunner
+
+try:
+    import modal  # noqa: F401
+except ImportError:
+    pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+from stardag._cli.modal import app
+
+runner = CliRunner()
+
+
+def test_deploy_reaches_module_import():
+    """`deploy` should get past its modal imports and env resolution.
+
+    With a nonexistent script path, the command must fail with the
+    "Error importing module" message — not an ImportError from the
+    modal imports that precede it (issue #148).
+    """
+    result = runner.invoke(app, ["deploy", "nonexistent_script_xyz.py"])
+
+    assert result.exception is None or isinstance(result.exception, SystemExit), (
+        f"deploy raised unexpectedly: {result.exception!r}"
+    )
+    assert result.exit_code == 1
+    assert "Error importing module" in result.output

--- a/lib/stardag/uv.lock
+++ b/lib/stardag/uv.lock
@@ -1114,6 +1114,7 @@ dependencies = [
     { name = "griffecli" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/04/56/28a0accac339c164b52a92c6cfc45a903acc0c174caa5c1713803467b533/griffe-2.0.0.tar.gz", hash = "sha256:c68979cd8395422083a51ea7cf02f9c119d889646d99b7b656ee43725de1b80f", size = 293906, upload-time = "2026-03-23T21:06:53.402Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
 ]
@@ -1126,6 +1127,7 @@ dependencies = [
     { name = "colorama" },
     { name = "griffelib" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/f8/2e129fd4a86e52e58eefe664de05e7d502decf766e7316cc9e70fdec3e18/griffecli-2.0.0.tar.gz", hash = "sha256:312fa5ebb4ce6afc786356e2d0ce85b06c1c20d45abc42d74f0cda65e159f6ef", size = 56213, upload-time = "2026-03-23T21:06:54.8Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
 ]
@@ -1134,6 +1136,7 @@ wheels = [
 name = "griffelib"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ad/06/eccbd311c9e2b3ca45dbc063b93134c57a1ccc7607c5e545264ad092c4a9/griffelib-2.0.0.tar.gz", hash = "sha256:e504d637a089f5cab9b5daf18f7645970509bf4f53eda8d79ed71cce8bd97934", size = 166312, upload-time = "2026-03-23T21:06:55.954Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
@@ -1669,7 +1672,7 @@ wheels = [
 
 [[package]]
 name = "modal"
-version = "1.3.3"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1681,15 +1684,14 @@ dependencies = [
     { name = "rich" },
     { name = "synchronicity" },
     { name = "toml" },
-    { name = "typer" },
     { name = "types-certifi" },
     { name = "types-toml" },
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/af/ba0e202391df212156497cccd89a4ede5a3f4c35af9dadcb58ed3c2e7f92/modal-1.3.3.tar.gz", hash = "sha256:082678664817425dda59190fdfc6330903ebcaf721a36c8f8c1e6c2a2524a5f6", size = 671199, upload-time = "2026-02-12T16:08:46.105Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/f9/87425e60db2a8597b248417772b409c49ca3a05ff6b1282a21cd7d856f09/modal-1.5.0.tar.gz", hash = "sha256:15033cf84f5f4f9f8a3dcf47a768cfcca36d1ad38ab7b3459fd3cbc29aa84a77", size = 771722, upload-time = "2026-06-09T22:37:27.5Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cd/29/d3c8624c2a9cf79e951062e2f7497496ae001d7ab600276cd726cb5c76c1/modal-1.3.3-py3-none-any.whl", hash = "sha256:aacd6d2f0b2ebe442abd25d81810dd5df504c092d787b35a7a37165a3d8a0f5f", size = 770209, upload-time = "2026-02-12T16:08:44.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/71/85e476e7d32c0a648d5aa97c4335ac02357d059c2bb734cf175b08446597/modal-1.5.0-py3-none-any.whl", hash = "sha256:9c5687eff775d1372bd70b87e43499e40777a1de160f23786c00807bf342fcb6", size = 882122, upload-time = "2026-06-09T22:37:24.608Z" },
 ]
 
 [[package]]
@@ -3665,14 +3667,14 @@ wheels = [
 
 [[package]]
 name = "synchronicity"
-version = "0.11.1"
+version = "0.12.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/26/8874d34755691994266d4a844ba8d53d10c2690ec67f246ca4d6b6f34cbb/synchronicity-0.11.1.tar.gz", hash = "sha256:3628df9ab34bd7be89b729104114841c62612c5d5ec43b76f4b7b243185ec1a8", size = 58131, upload-time = "2025-12-19T18:28:42.291Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/d5/e96e6082790c92480380f28aa53e111844cdac7b0f75846f4772cb535a43/synchronicity-0.12.3.tar.gz", hash = "sha256:0d4228b85eaf2805f23b4615b2039a9d24ea811646e2d9f8d0c033094eb85841", size = 60261, upload-time = "2026-05-28T12:33:50.206Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/b9/71153db12f4ad029cfe9b7fbf9792ef3fc9ade4485d31a13470b52954e62/synchronicity-0.11.1-py3-none-any.whl", hash = "sha256:53959c7f8b9b852fb5ea4d3d290a47a04310ede483a4cf0f8452cb4b5fa09db2", size = 40399, upload-time = "2025-12-19T18:28:40.972Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ea/531a6ea751cbd989da386144810b1b8f529b0aae8c1a9beda8b40966c9c2/synchronicity-0.12.3-py3-none-any.whl", hash = "sha256:e476818cd14102136f41622c619de548f0000c024485fc18521c8fe908ea7574", size = 40982, upload-time = "2026-05-28T12:33:49.125Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`stardag modal deploy` crashed at import time on modal >= 1.4.3:

```
ImportError: cannot import name 'ensure_env' from 'modal.environments'
```

modal 1.4.3 refactored `modal/environments.py` into a thin re-export wrapper around the new private `modal/_environments.py`, and `ensure_env` is no longer re-exported publicly.

Fixes #148

## Approach

Instead of a `try/except` import fallback onto the private module, this inlines the small env-resolution logic using modal's **public** config API:

```python
if env is not None:
    modal_config.override_locally("environment", env)
env = modal_config.get("environment")
```

The body of modal's `ensure_env` is byte-identical across modal 1.0.0, 1.3.3, and 1.4.3 (verified against installed wheels), so this matches behavior across the full supported range (`modal>=1.0.0`) while removing any dependency on modal-internal modules going forward — the same class of breakage as #113.

## Testing

- New CLI regression test (`tests/test__cli/test_modal.py`) drives the `deploy` command past its modal imports and env resolution. Verified it **fails** with the old import on modal 1.4.3 (reproducing the exact `ImportError`) and **passes** with the fix on both modal 1.3.3 (lockfile) and 1.4.3.
- All other `modal.*` imports in the deploy path and integration module verified importable on 1.4.3.
- `tests/test__cli/` + non-network modal tests pass; pre-commit hooks (ruff, pyright, prettier) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)