### PR TITLE
Add granular concurrency limits for task execution

### DIFF
--- a/.claude/skills/stardag/sdk-core.md
+++ b/.claude/skills/stardag/sdk-core.md
@@ -241,6 +241,42 @@ sd.build(task, global_lock_config=GlobalLockConfig(enabled=True))
 
 Requires a configured Registry API connection.
 
+### Concurrency Limits
+
+Throttle how many tasks **execute** concurrently in a build, independent of the
+executor (applies uniformly to local, Modal, and routed executors). Two knobs,
+combinable:
+
+```python
+from stardag.build import ConcurrencyConfig
+
+sd.build(
+    task,
+    concurrency_config=ConcurrencyConfig(
+        max_concurrent_tasks=8,                       # overall cap (optional)
+        limits={"request-to-service-x": 10},          # named limits
+        # Map each task to its limit name(s); None = unlimited.
+        key_selector=lambda t: (
+            "request-to-service-x" if isinstance(t, ServiceXTask) else None
+        ),
+    ),
+)
+```
+
+- **`max_concurrent_tasks`**: overall cap on simultaneously executing tasks.
+  Composes with (is the min of) any executor-internal worker limits.
+- **`limits` + `key_selector`**: per-group caps. `key_selector` may return
+  `None`, a single name, or a sequence of names (a task can be subject to
+  several limits at once). Returning a name not present in `limits` raises
+  `ValueError`. Limit values must be `>= 1`.
+- A slot is held only while a task is _actively executing_: it is released when
+  a task suspends on its own dynamic deps and re-acquired on resume (unlike the
+  global lock, which is held across suspension).
+- These limits are currently **build-local**. The `ConcurrencyLimiter` protocol
+  is the seam for a future registry-backed/global implementation configured
+  from the Stardag API/UI — passing `concurrency_limiter=...` overrides
+  `concurrency_config`.
+
 ### Build Behavior
 
 1. Discovers all dependencies recursively from root task(s)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+- **`stardag/build`**: Add build-level concurrency limits for task execution
+  via a new `ConcurrencyConfig` accepted by `build` / `build_aio`. Supports an
+  overall cap (`max_concurrent_tasks`) and named limits mapped to tasks through
+  a callback (`limits={"request-to-service-x": 10}` with a `key_selector`); a
+  task may be subject to multiple named limits at once. Enforced uniformly
+  across all executors (local, Modal, routed) by gating the executor submit
+  call. The slot is released while a task is suspended on its own dynamic deps
+  and re-acquired on resume (unlike the global lock, which is held across
+  suspension), and composes with the global concurrency lock.
+  `ConcurrencyLimiter` is a protocol seam for a future global, server-configured
+  limiter. Local to a single build for now.
+  ([#151](https://github.com/stardag-dev/stardag/pull/151))
+
 ## [0.8.1] — 2026-06-12
 
 Compatibility fix for `stardag modal deploy` on modal >= 1.4.3. No

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -39,4 +39,5 @@ Mostly for testing and debugging, there is also `sd.build_sequential` and `sd.bu
     - How concurrency is achieved via asyncio, threads and or processes
     - Transfer of execution (e.g. -> Modal)
     - Global concurrency lock
+    - Concurrency limits (overall and named, via `ConcurrencyConfig`)
     - ...

--- a/lib/stardag/src/stardag/build/__init__.py
+++ b/lib/stardag/src/stardag/build/__init__.py
@@ -20,6 +20,10 @@ Global concurrency locking:
 - GlobalConcurrencyLockManager: Protocol for distributed lock implementations
 - LockHandle: Protocol for lock handles (async context manager)
 - GlobalLockConfig: Configuration for global locking behavior
+
+Granular concurrency limiting:
+- ConcurrencyConfig: Overall and named limits on concurrently executing tasks
+- ConcurrencyLimiter: Protocol for custom/distributed limiters
 """
 
 from stardag.build._base import (
@@ -39,6 +43,13 @@ from stardag.build._base import (
     TaskCount,
     TaskExecutionError,
     TaskExecutorABC,
+)
+from stardag.build._concurrency import (
+    ConcurrencyConfig,
+    ConcurrencyKeySelector,
+    ConcurrencyLimiter,
+    LocalConcurrencyLimiter,
+    NoOpConcurrencyLimiter,
 )
 from stardag.build._concurrent import (
     DefaultExecutionModeSelector,
@@ -73,6 +84,12 @@ __all__ = [
     "LockAcquisitionStatus",
     "LockHandle",
     "OnRegistryFailure",
+    # Granular concurrency limiting
+    "ConcurrencyConfig",
+    "ConcurrencyKeySelector",
+    "ConcurrencyLimiter",
+    "LocalConcurrencyLimiter",
+    "NoOpConcurrencyLimiter",
     # Task executors
     "HybridConcurrentTaskExecutor",
     "RoutedTaskExecutor",

--- a/lib/stardag/src/stardag/build/_concurrency.py
+++ b/lib/stardag/src/stardag/build/_concurrency.py
@@ -1,0 +1,193 @@
+"""Granular concurrency limiting for executing tasks.
+
+This module provides build-level control over how many tasks run
+concurrently, independent of which ``TaskExecutor`` is used. It offers:
+
+- An overall cap on concurrently executing tasks (``max_concurrent_tasks``).
+- A collection of **named** limits mapped to tasks via a callback, e.g.
+  ``limits={"request-to-service-X": 10}`` with a ``key_selector`` returning
+  ``"request-to-service-X"`` for the tasks that hit that service.
+
+Enforcement lives in ``build_aio``: it wraps the executor ``submit`` call in
+``async with limiter.slot(task)`` so the same throttle applies to every
+executor (local hybrid, Modal, Routed).
+
+Relationship to the global lock (``GlobalConcurrencyLockManager``):
+- A **lock** is about exactly-once *identity* (one execution per task-id
+  globally) and is held across dynamic-deps suspension.
+- A **slot** is about *active execution* capacity. It is released when a task
+  suspends waiting for its own dynamic deps and re-acquired on resume —
+  required for correctness, since a task holding a slot while suspended on its
+  own deps would deadlock under a tight limit.
+
+The ``ConcurrencyLimiter`` protocol is the seam for a future registry-backed
+implementation that enforces the named limits *globally* (acquiring a named
+slot server-side and polling on a concurrency-limit response), configured from
+the Stardag API/UI. Switching to it needs no change in ``build_aio``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import (
+    AbstractAsyncContextManager,
+    AsyncExitStack,
+    asynccontextmanager,
+)
+from dataclasses import dataclass, field
+from typing import (
+    AsyncIterator,
+    Callable,
+    Protocol,
+    Sequence,
+)
+
+from stardag import BaseTask
+
+logger = logging.getLogger(__name__)
+
+
+# Maps a task to zero or more named limit keys. ``None`` (or an empty
+# sequence) means the task is not subject to any named limit. A bare ``str``
+# is shorthand for a single key.
+ConcurrencyKeySelector = Callable[[BaseTask], "str | Sequence[str] | None"]
+
+
+@dataclass
+class ConcurrencyConfig:
+    """Configuration for granular, build-local concurrency limiting.
+
+    Attributes:
+        limits: Named limits — ``{name: max_concurrent_tasks}``. Every value
+            must be ``>= 1`` (a value below 1 can never admit a task and would
+            deadlock the build).
+        key_selector: Maps each task to the limit name(s) that apply to it.
+            Returns ``None`` for "no named limit", a ``str`` for a single
+            limit, or a sequence of names for multiple. Any returned name must
+            be present in ``limits`` (an unknown name raises ``ValueError`` at
+            execution time).
+        max_concurrent_tasks: Optional overall cap on the number of tasks
+            executing concurrently in the build, across all executors and
+            execution modes. ``None`` means no overall cap. Composes with (is
+            the min of) any executor-internal worker limits.
+    """
+
+    limits: dict[str, int] = field(default_factory=dict)
+    key_selector: ConcurrencyKeySelector | None = None
+    max_concurrent_tasks: int | None = None
+
+
+class ConcurrencyLimiter(Protocol):
+    """Protocol for limiting concurrent task execution.
+
+    Implementations return an async context manager that admits the task into
+    an execution slot on entry (blocking if necessary) and releases it on exit.
+    """
+
+    def slot(self, task: BaseTask) -> AbstractAsyncContextManager[None]:
+        """Return an async context manager guarding one execution slot.
+
+        Entering blocks until the task may execute (respecting all applicable
+        limits); exiting releases the held slot(s).
+        """
+        ...
+
+
+class NoOpConcurrencyLimiter:
+    """Limiter that never throttles. Used when no limits are configured."""
+
+    @asynccontextmanager
+    async def slot(self, task: BaseTask) -> AsyncIterator[None]:
+        yield
+
+
+class LocalConcurrencyLimiter:
+    """Semaphore-backed, build-local concurrency limiter.
+
+    Holds one :class:`asyncio.Semaphore` per named limit plus an optional
+    overall semaphore. ``slot()`` acquires the overall semaphore first, then
+    the task's named semaphores in **sorted key order** so that tasks sharing
+    multiple limits can never deadlock on acquisition ordering.
+
+    Construct inside the running event loop that the build uses (``build_aio``
+    does this from ``ConcurrencyConfig``); a single instance is not safe to
+    reuse across event loops.
+    """
+
+    def __init__(self, config: ConcurrencyConfig) -> None:
+        for name, value in config.limits.items():
+            if value < 1:
+                raise ValueError(
+                    f"Concurrency limit {name!r} must be >= 1, got {value}."
+                )
+        if config.max_concurrent_tasks is not None and config.max_concurrent_tasks < 1:
+            raise ValueError(
+                f"max_concurrent_tasks must be >= 1, got {config.max_concurrent_tasks}."
+            )
+
+        self._key_selector = config.key_selector
+        self._named: dict[str, asyncio.Semaphore] = {
+            name: asyncio.Semaphore(value) for name, value in config.limits.items()
+        }
+        self._overall: asyncio.Semaphore | None = (
+            asyncio.Semaphore(config.max_concurrent_tasks)
+            if config.max_concurrent_tasks is not None
+            else None
+        )
+
+    def _keys_for(self, task: BaseTask) -> list[str]:
+        if self._key_selector is None:
+            return []
+        raw = self._key_selector(task)
+        if raw is None:
+            return []
+        keys = [raw] if isinstance(raw, str) else list(raw)
+        for key in keys:
+            if key not in self._named:
+                raise ValueError(
+                    f"Concurrency limit {key!r} (returned by key_selector for "
+                    f"task {task.id}) is not defined in ConcurrencyConfig.limits "
+                    f"(known limits: {sorted(self._named)})."
+                )
+        # Sorted + de-duplicated: stable ordering avoids acquisition deadlock,
+        # de-dup avoids acquiring the same semaphore twice (which would
+        # self-deadlock a limit of 1).
+        return sorted(set(keys))
+
+    @asynccontextmanager
+    async def slot(self, task: BaseTask) -> AsyncIterator[None]:
+        keys = self._keys_for(task)
+        async with AsyncExitStack() as stack:
+            if self._overall is not None:
+                await stack.enter_async_context(self._overall)
+            for key in keys:
+                await stack.enter_async_context(self._named[key])
+            yield
+
+
+def build_concurrency_limiter(
+    config: ConcurrencyConfig | None,
+    limiter: ConcurrencyLimiter | None,
+) -> ConcurrencyLimiter:
+    """Resolve the limiter for a build.
+
+    An explicit ``limiter`` wins; otherwise a :class:`LocalConcurrencyLimiter`
+    is built from ``config``; otherwise a :class:`NoOpConcurrencyLimiter`
+    (zero overhead) is used.
+    """
+    if limiter is not None:
+        return limiter
+    if config is not None:
+        return LocalConcurrencyLimiter(config)
+    return NoOpConcurrencyLimiter()
+
+
+__all__ = [
+    "ConcurrencyConfig",
+    "ConcurrencyKeySelector",
+    "ConcurrencyLimiter",
+    "LocalConcurrencyLimiter",
+    "NoOpConcurrencyLimiter",
+    "build_concurrency_limiter",
+]

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -1500,17 +1500,17 @@ def build(
         return asyncio.run(
             build_aio(
                 tasks,
-                task_executor,
-                fail_mode,
-                registry,
-                max_concurrent_discover,
-                global_lock_manager,
-                global_lock_config,
-                resume_build_id,
-                register_all,
-                on_registry_failure,
-                concurrency_config,
-                concurrency_limiter,
+                task_executor=task_executor,
+                fail_mode=fail_mode,
+                registry=registry,
+                max_concurrent_discover=max_concurrent_discover,
+                global_lock_manager=global_lock_manager,
+                global_lock_config=global_lock_config,
+                resume_build_id=resume_build_id,
+                register_all=register_all,
+                on_registry_failure=on_registry_failure,
+                concurrency_config=concurrency_config,
+                concurrency_limiter=concurrency_limiter,
             )
         )
     except RuntimeError as e:

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -43,6 +43,11 @@ from stardag.build._base import (
     TaskExecutorABC,
     handle_registry_error,
 )
+from stardag.build._concurrency import (
+    ConcurrencyConfig,
+    ConcurrencyLimiter,
+    build_concurrency_limiter,
+)
 from stardag.registry import RegistryABC, registry_provider
 
 logger = logging.getLogger(__name__)
@@ -492,6 +497,8 @@ async def build_aio(
     resume_build_id: UUID | None = None,
     register_all: bool = False,
     on_registry_failure: OnRegistryFailure = "raise",
+    concurrency_config: ConcurrencyConfig | None = None,
+    concurrency_limiter: ConcurrencyLimiter | None = None,
 ) -> BuildSummary:
     """Build tasks concurrently using hybrid async/thread/process execution.
 
@@ -527,6 +534,14 @@ async def build_aio(
             for performance — skipping complete subgraphs avoids unnecessary I/O.
         on_registry_failure: How to handle registry call failures. "raise" (default)
             propagates the exception; "warn" logs a warning and continues.
+        concurrency_config: Build-local concurrency limiting — an overall cap
+            (``max_concurrent_tasks``) and/or named limits mapped to tasks via
+            a callback. Applied to every executor by gating the executor
+            ``submit`` call. Ignored if ``concurrency_limiter`` is given.
+        concurrency_limiter: An explicit ConcurrencyLimiter (e.g. a custom or
+            future registry-backed/global implementation). Takes precedence
+            over ``concurrency_config``. When neither is set, no throttle is
+            applied (zero overhead).
 
     Returns:
         BuildSummary with status, task counts, and build_id
@@ -553,6 +568,13 @@ async def build_aio(
     if global_lock_config is None:
         global_lock_config = GlobalLockConfig()
     lock_selector: GlobalLockSelector = DefaultGlobalLockSelector(global_lock_config)
+
+    # Resolve the concurrency limiter (explicit limiter > config > no-op). The
+    # LocalConcurrencyLimiter builds its semaphores here, inside the running
+    # build loop, so they bind to the correct event loop.
+    limiter: ConcurrencyLimiter = build_concurrency_limiter(
+        concurrency_config, concurrency_limiter
+    )
 
     # Track locks held by this build for manual release
     held_locks: set[str] = set()
@@ -1096,49 +1118,56 @@ async def build_aio(
             # Lock acquired - track it for release later
             held_locks.add(task_id_str)
 
-        # Now we have the lock (or locking wasn't needed)
-        # Start the task in registry. The task was already registered during
-        # discover; if registration failed in `warn` mode we retry once here so
-        # the /start endpoint doesn't 404.
-        if not state.started:
-            if not state.registered:
-                try:
-                    await registry.task_register_aio(build_id, task)
-                    state.registered = True
-                except Exception as reg_err:
-                    handle_registry_error(
-                        reg_err,
-                        f"Failed to register task {task.id} before start",
-                        on_registry_failure,
-                    )
-            # Skip /start if registration never succeeded — the endpoint
-            # would 404 and that hard-fails the build even in `warn` mode.
-            if state.registered:
-                try:
-                    await registry.task_start_aio(build_id, task)
-                    state.started = True
-                except Exception as reg_err:
-                    handle_registry_error(
-                        reg_err,
-                        f"Failed to start task {task.id}",
-                        on_registry_failure,
-                    )
-        elif state.dynamic_deps:
-            # Task was suspended waiting for dynamic deps, now resuming. Same
-            # warn-mode protection: no point firing /resume if registration
-            # never landed.
-            if state.registered:
-                try:
-                    await registry.task_resume_aio(build_id, task)
-                except Exception as reg_err:
-                    handle_registry_error(
-                        reg_err,
-                        f"Failed to resume task {task.id}",
-                        on_registry_failure,
-                    )
+        # Now we have the lock (or locking wasn't needed). Acquire a
+        # concurrency slot before marking the task started/executing so the
+        # registry/UI reflects actual execution (a task queued behind the limit
+        # is not shown as "started"). The slot is acquired *after* the global
+        # lock so tasks don't burn execution slots while blocked on a
+        # distributed lock, and released automatically on every exit path
+        # (completion, failure, cancellation, dynamic-deps suspension).
+        async with limiter.slot(task):
+            # Start the task in registry. The task was already registered during
+            # discover; if registration failed in `warn` mode we retry once here
+            # so the /start endpoint doesn't 404.
+            if not state.started:
+                if not state.registered:
+                    try:
+                        await registry.task_register_aio(build_id, task)
+                        state.registered = True
+                    except Exception as reg_err:
+                        handle_registry_error(
+                            reg_err,
+                            f"Failed to register task {task.id} before start",
+                            on_registry_failure,
+                        )
+                # Skip /start if registration never succeeded — the endpoint
+                # would 404 and that hard-fails the build even in `warn` mode.
+                if state.registered:
+                    try:
+                        await registry.task_start_aio(build_id, task)
+                        state.started = True
+                    except Exception as reg_err:
+                        handle_registry_error(
+                            reg_err,
+                            f"Failed to start task {task.id}",
+                            on_registry_failure,
+                        )
+            elif state.dynamic_deps:
+                # Task was suspended waiting for dynamic deps, now resuming. Same
+                # warn-mode protection: no point firing /resume if registration
+                # never landed.
+                if state.registered:
+                    try:
+                        await registry.task_resume_aio(build_id, task)
+                    except Exception as reg_err:
+                        handle_registry_error(
+                            reg_err,
+                            f"Failed to resume task {task.id}",
+                            on_registry_failure,
+                        )
 
-        # Execute the task via the executor
-        return await task_executor.submit(task)
+            # Execute the task via the executor
+            return await task_executor.submit(task)
 
     async def cancel_pending_in_flight() -> None:
         """Cancel any still-running ``pending_futures`` and emit ``task_cancel``.
@@ -1454,6 +1483,8 @@ def build(
     resume_build_id: UUID | None = None,
     register_all: bool = False,
     on_registry_failure: OnRegistryFailure = "raise",
+    concurrency_config: ConcurrencyConfig | None = None,
+    concurrency_limiter: ConcurrencyLimiter | None = None,
 ) -> BuildSummary:
     """Build tasks concurrently (sync wrapper for build_aio).
 
@@ -1478,6 +1509,8 @@ def build(
                 resume_build_id,
                 register_all,
                 on_registry_failure,
+                concurrency_config,
+                concurrency_limiter,
             )
         )
     except RuntimeError as e:
@@ -1491,6 +1524,8 @@ def build(
 
 
 __all__ = [
+    "ConcurrencyConfig",
+    "ConcurrencyLimiter",
     "DefaultExecutionModeSelector",
     "ExecutionMode",
     "ExecutionModeSelector",

--- a/lib/stardag/src/stardag/integration/prefect/_build.py
+++ b/lib/stardag/src/stardag/integration/prefect/_build.py
@@ -213,6 +213,15 @@ async def build_aio(
 
     Returns:
         Dict mapping task IDs to Prefect futures
+
+    Note:
+        This is a distinct, Prefect-orchestrated build path — not a wrapper
+        around :func:`stardag.build.build_aio`. Concurrency is governed by
+        Prefect's task runners, so the core build's ``concurrency_config`` /
+        ``concurrency_limiter`` (and other core-only options) are intentionally
+        not accepted here; passing them raises ``TypeError``. Configure
+        concurrency via Prefect (e.g. task-runner settings or global concurrency
+        limits) instead.
     """
     # Normalize input to list
     if isinstance(tasks, BaseTask):

--- a/lib/stardag/tests/test_build/test_concurrency_limits.py
+++ b/lib/stardag/tests/test_build/test_concurrency_limits.py
@@ -1,0 +1,294 @@
+"""Tests for granular concurrency limiting in build_aio / build.
+
+Covers ConcurrencyConfig + LocalConcurrencyLimiter:
+- overall cap (max_concurrent_tasks)
+- named limits (key_selector -> str)
+- multiple keys per task (sorted, deadlock-free acquisition)
+- slot released across dynamic-deps suspension (no deadlock under tight cap)
+- unknown limit name raises
+- invalid limit value raises at construction
+- composition with the global lock
+"""
+
+from __future__ import annotations
+
+import asyncio
+import typing
+from collections import defaultdict
+
+import pytest
+
+from stardag import Task, auto_namespace
+from stardag.build import (
+    BuildExitStatus,
+    ConcurrencyConfig,
+    GlobalLockConfig,
+    LocalConcurrencyLimiter,
+    build_aio,
+)
+from stardag.build._base import (
+    GlobalConcurrencyLockManager,
+    LockAcquisitionResult,
+    LockAcquisitionStatus,
+)
+from stardag.target import InMemoryFileTarget
+from stardag.utils.testing.dynamic_deps_dag import (
+    assert_dynamic_deps_task_complete_recursive,
+    get_dynamic_deps_dag,
+)
+
+auto_namespace(__name__)
+
+
+# ============================================================================
+# Concurrency tracking
+# ============================================================================
+
+
+class _ConcurrencyTracker:
+    """Records concurrent-execution counts per group (asyncio: no locking)."""
+
+    def __init__(self) -> None:
+        self.current: dict[str, int] = defaultdict(int)
+        self.max_seen: dict[str, int] = defaultdict(int)
+        self.total_current = 0
+        self.total_max = 0
+
+    def enter(self, group: str) -> None:
+        self.total_current += 1
+        self.total_max = max(self.total_max, self.total_current)
+        self.current[group] += 1
+        self.max_seen[group] = max(self.max_seen[group], self.current[group])
+
+    def exit(self, group: str) -> None:
+        self.current[group] -= 1
+        self.total_current -= 1
+
+
+# Reset per test by the ``tracker`` fixture.
+_TRACKER = _ConcurrencyTracker()
+
+
+@pytest.fixture
+def tracker() -> _ConcurrencyTracker:
+    global _TRACKER
+    _TRACKER = _ConcurrencyTracker()
+    return _TRACKER
+
+
+class TrackedTask(Task[dict]):
+    """Async task that records its concurrent-execution window in _TRACKER."""
+
+    name: str
+    group: str = "default"
+    # Limit key(s) returned by the key_selector for this task; None = unlimited.
+    limit_key: str | tuple[str, ...] | None = None
+    delay: float = 0.05
+    deps: tuple["TrackedTask", ...] = ()
+
+    def requires(self):
+        return self.deps
+
+    async def run_aio(self):
+        _TRACKER.enter(self.group)
+        try:
+            await asyncio.sleep(self.delay)
+        finally:
+            _TRACKER.exit(self.group)
+        self._save({"name": self.name})
+
+
+def _key_selector(task) -> str | tuple[str, ...] | None:
+    return getattr(task, "limit_key", None)
+
+
+# ============================================================================
+# Overall cap
+# ============================================================================
+
+
+async def test_overall_cap_throttles_total_concurrency(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    tracker: _ConcurrencyTracker,
+    noop_registry,
+):
+    tasks = [TrackedTask(name=f"t{i}", group="g") for i in range(6)]
+
+    summary = await build_aio(
+        tasks,
+        registry=noop_registry,
+        concurrency_config=ConcurrencyConfig(max_concurrent_tasks=2),
+    )
+
+    assert summary.status == BuildExitStatus.SUCCESS
+    assert tracker.total_max == 2, f"expected cap of 2, saw {tracker.total_max}"
+
+
+async def test_no_config_does_not_throttle(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    tracker: _ConcurrencyTracker,
+    noop_registry,
+):
+    tasks = [TrackedTask(name=f"t{i}", group="g") for i in range(5)]
+
+    summary = await build_aio(tasks, registry=noop_registry)
+
+    assert summary.status == BuildExitStatus.SUCCESS
+    # All five are independent and async -> run concurrently on the main loop.
+    assert tracker.total_max == 5
+
+
+# ============================================================================
+# Named limits
+# ============================================================================
+
+
+async def test_named_limit_throttles_only_its_group(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    tracker: _ConcurrencyTracker,
+    noop_registry,
+):
+    limited = [
+        TrackedTask(name=f"l{i}", group="limited", limit_key="limited")
+        for i in range(4)
+    ]
+    free = [TrackedTask(name=f"f{i}", group="free") for i in range(4)]
+
+    summary = await build_aio(
+        limited + free,
+        registry=noop_registry,
+        concurrency_config=ConcurrencyConfig(
+            limits={"limited": 2},
+            key_selector=_key_selector,
+        ),
+    )
+
+    assert summary.status == BuildExitStatus.SUCCESS
+    assert tracker.max_seen["limited"] == 2
+    # The un-keyed group is unaffected and runs fully concurrently.
+    assert tracker.max_seen["free"] == 4
+
+
+async def test_multiple_keys_respects_tightest_and_no_deadlock(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    tracker: _ConcurrencyTracker,
+    noop_registry,
+):
+    # Each task is bound to both "x" (limit 1) and "y" (limit 5); the key
+    # order is intentionally unsorted to exercise sorted acquisition.
+    tasks = [
+        TrackedTask(name=f"m{i}", group="m", limit_key=("y", "x")) for i in range(4)
+    ]
+
+    summary = await build_aio(
+        tasks,
+        registry=noop_registry,
+        concurrency_config=ConcurrencyConfig(
+            limits={"x": 1, "y": 5},
+            key_selector=_key_selector,
+        ),
+    )
+
+    assert summary.status == BuildExitStatus.SUCCESS
+    # "x" caps at 1 -> these tasks are fully serialized.
+    assert tracker.max_seen["m"] == 1
+
+
+# ============================================================================
+# Dynamic deps: slot released on suspend (no deadlock under tight cap)
+# ============================================================================
+
+
+async def test_dynamic_deps_under_tight_cap_does_not_deadlock(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    noop_registry,
+):
+    # With max_concurrent_tasks=1, a parent that suspends on its own dynamic
+    # deps must release its slot, or the dep could never acquire one. Wrap in
+    # wait_for so a regression fails fast instead of hanging.
+    dag = get_dynamic_deps_dag()
+    assert_dynamic_deps_task_complete_recursive(dag, False)
+
+    summary = await asyncio.wait_for(
+        build_aio(
+            [dag],
+            registry=noop_registry,
+            concurrency_config=ConcurrencyConfig(max_concurrent_tasks=1),
+        ),
+        timeout=10,
+    )
+
+    assert summary.status == BuildExitStatus.SUCCESS
+    assert_dynamic_deps_task_complete_recursive(dag, True)
+
+
+# ============================================================================
+# Validation / error handling
+# ============================================================================
+
+
+async def test_unknown_limit_key_raises(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    noop_registry,
+):
+    task = TrackedTask(name="t", limit_key="not-defined")
+
+    with pytest.raises(ValueError, match="not defined"):
+        await build_aio(
+            [task],
+            registry=noop_registry,
+            concurrency_config=ConcurrencyConfig(
+                limits={"known": 1},
+                key_selector=_key_selector,
+            ),
+        )
+
+
+def test_invalid_limit_value_raises_at_construction():
+    with pytest.raises(ValueError, match=">= 1"):
+        LocalConcurrencyLimiter(ConcurrencyConfig(limits={"bad": 0}))
+
+    with pytest.raises(ValueError, match="max_concurrent_tasks"):
+        LocalConcurrencyLimiter(ConcurrencyConfig(max_concurrent_tasks=0))
+
+
+# ============================================================================
+# Composition with the global lock
+# ============================================================================
+
+
+class _AlwaysAcquireLockManager:
+    """Minimal lock manager that always grants the lock (no real locking)."""
+
+    async def acquire(self, task_id: str) -> LockAcquisitionResult:
+        return LockAcquisitionResult(
+            status=LockAcquisitionStatus.ACQUIRED, acquired=True
+        )
+
+    async def release(self, task_id: str, task_completed: bool = False) -> bool:
+        return True
+
+    def lock(self, task_id: str):  # pragma: no cover - unused by build_aio
+        raise NotImplementedError
+
+
+async def test_cap_composes_with_global_lock(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    tracker: _ConcurrencyTracker,
+    noop_registry,
+):
+    lock_manager: GlobalConcurrencyLockManager = (
+        _AlwaysAcquireLockManager()  # type: ignore[assignment]
+    )
+    tasks = [TrackedTask(name=f"t{i}", group="g") for i in range(6)]
+
+    summary = await build_aio(
+        tasks,
+        registry=noop_registry,
+        global_lock_manager=lock_manager,
+        global_lock_config=GlobalLockConfig(enabled=True),
+        concurrency_config=ConcurrencyConfig(max_concurrent_tasks=2),
+    )
+
+    assert summary.status == BuildExitStatus.SUCCESS
+    assert tracker.total_max == 2


### PR DESCRIPTION
## Summary

Adds build-level throttling of how many tasks **execute** concurrently, enforced uniformly across every executor (local hybrid, Modal, routed) by gating the executor `submit` call in `build_aio`.

New `ConcurrencyConfig`:
- **`max_concurrent_tasks`** — an overall cap on simultaneously executing tasks. Composes with (is the min of) any executor-internal worker limits.
- **`limits` + `key_selector`** — named limits mapped to tasks via a callback, e.g. `limits={"request-to-service-x": 10}`. A task may belong to multiple named limits; the selector returns `str | Sequence[str] | None`. An unknown limit name raises `ValueError`; limit values must be `>= 1`.

```python
from stardag.build import ConcurrencyConfig

sd.build(task, concurrency_config=ConcurrencyConfig(
    max_concurrent_tasks=8,
    limits={"request-to-service-x": 10},
    key_selector=lambda t: "request-to-service-x" if isinstance(t, ServiceXTask) else None,
))
```

## Design

- Enforcement is `async with limiter.slot(task)` around registry start/resume + `executor.submit`, acquired **after** the global lock so tasks don't burn execution slots while blocked on a distributed lock.
- The slot is released when a task suspends on its own dynamic deps and re-acquired on resume (unlike the global lock, which is held across suspension). This is required for correctness — a parent holding a slot while suspended on its own dynamic dep would deadlock under a tight cap.
- Registry `start`/`resume` moved inside the slot so tasks queued behind the limit aren't reported as "started".
- `ConcurrencyLimiter` is a protocol seam: a future global, server-driven limiter can replace `LocalConcurrencyLimiter` without changing `build_aio`. `LocalConcurrencyLimiter` acquires multiple named semaphores in sorted, de-duplicated order (deadlock-free).

## Tests

New `tests/test_build/test_concurrency_limits.py` (8 tests): overall cap, named-limit isolation, multi-key serialization, dynamic-deps under a cap of 1 (deadlock guard, `wait_for`-bounded), unknown-key and invalid-value errors, and composition with the global lock. Full build suite (137) green; ruff/pyright/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)