### PR TITLE
Modal: restart-safe build triggering (build_trigger) + live-test tier restructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ All notable changes to the Stardag project (SDK, Registry API, and UI).
 
 For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
+## [Unreleased]
+
+### SDK
+
+- **`stardag/integration/modal`**: New `StardagApp.build_trigger()` — triggers
+  a build with the registry build id minted at the trigger point and passed to
+  the Modal build function as `resume_build_id`. Restarts of the build
+  function (Modal retries after preemption, or re-triggering with the returned
+  `build_id`) resume the same build instead of creating a new one:
+  already-completed task outputs are detected during discovery and skipped.
+  Returns a `BuildTriggerResult(build_id, function_call)`. Requires registry
+  credentials in the calling process; `build_spawn` remains available for
+  Modal-credentials-only triggering.
+- **`stardag/testing/modal`**: New `live_modal_guard()` centralizes gating of
+  live-Modal tests, controlled by `STARDAG_MODAL_LIVE_TESTS`
+  (`auto`/`1`/`0`) and an optional `STARDAG_MODAL_TEST_PROFILE` safety guard
+  (skip unless the active Modal profile matches — protects shared/production
+  workspaces from accidental test runs). Live test modules are now marked
+  `modal_live`, so `pytest -m "not modal_live"` runs the pure unit tier. A new
+  live-semantics test module pins the Modal platform behaviors stardag relies
+  on (detached spawned calls, `FunctionCall.from_id` re-attach, call-id
+  stability across retries, cancellation).
+
+### Registry API
+
+- `POST /builds/{id}/resume` no longer records a `BUILD_RESUMED` event for a
+  "fresh" build (no activity beyond `BUILD_STARTED`), so attaching to a
+  trigger-minted build id on the first run doesn't display the build as
+  resumed. Real resumes (any task activity or terminal state) are recorded as
+  before.
+
 ## [0.9.0] — 2026-06-16
 
 ### SDK

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -83,6 +83,31 @@ tox -e stardag-ui
 tox -e stardag-py311,stardag-examples-py311,stardag-api-py311
 ```
 
+#### Live Modal tests
+
+Modal integration tests come in two tiers. The unit tier (default) uses fakes
+and needs no credentials. Modules marked `modal_live` hit a real Modal
+workspace (deploy test apps, create volumes, run containers):
+
+```bash
+cd lib/stardag
+
+# Unit tier only
+uv run pytest tests/test_integration/test_modal -m "not modal_live"
+
+# Live tier — requires Modal credentials; use a personal/dev profile!
+STARDAG_MODAL_TEST_PROFILE=<your-dev-profile> \
+  uv run pytest tests/test_integration/test_modal -m modal_live
+```
+
+Gating (see `stardag.testing.modal.live_modal_guard`):
+
+- `STARDAG_MODAL_LIVE_TESTS`: `auto` (default: run if authenticated, else
+  skip), `1` (require: fail instead of skip — for CI), `0` (always skip).
+- `STARDAG_MODAL_TEST_PROFILE`: if set, live tests are skipped unless the
+  active Modal profile matches. Recommended to always set this locally, so
+  live tests can never run against a shared/production workspace by accident.
+
 ### Linting & Formatting
 
 ```bash

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -732,6 +732,12 @@ async def resume_build(
     ``BUILD_RESUMED`` event so ``get_build_status`` flips the build back
     to RUNNING and the UI shows a "running (resumed)" affordance.
 
+    A build with no recorded activity beyond its ``BUILD_STARTED`` event
+    is "fresh" — attaching to it is not a resume (e.g. a build id minted
+    at the trigger point handed to the first orchestrator invocation).
+    In that case no ``BUILD_RESUMED`` event is recorded, so the build's
+    first run doesn't show as resumed.
+
     Args:
         commit_hash: Optional git commit hash of the resuming run.
     """
@@ -753,17 +759,27 @@ async def resume_build(
             status_code=403, detail="Build does not belong to this environment"
         )
 
-    event = Event(
-        build_id=build_id,
-        task_id=None,
-        event_type=EventType.BUILD_RESUMED,
-        event_metadata=_build_event_metadata(commit_hash),
-    )
-    db.add(event)
-    await _touch_build_last_active(db, build_id)
-    await db.commit()
+    has_activity = (
+        await db.execute(
+            select(Event.id)
+            .where(Event.build_id == build_id)
+            .where(Event.event_type != EventType.BUILD_STARTED)
+            .limit(1)
+        )
+    ).first() is not None
 
-    record_entity_created(auth.workspace_id, "events")
+    if has_activity:
+        event = Event(
+            build_id=build_id,
+            task_id=None,
+            event_type=EventType.BUILD_RESUMED,
+            event_metadata=_build_event_metadata(commit_hash),
+        )
+        db.add(event)
+        await _touch_build_last_active(db, build_id)
+        await db.commit()
+
+        record_entity_created(auth.workspace_id, "events")
 
     (
         status,

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -138,6 +138,63 @@ async def test_resume_build_after_failure(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_resume_fresh_build_is_noop(client: AsyncClient):
+    """Resuming a build with no activity beyond BUILD_STARTED records nothing.
+
+    This is the trigger-minted-build-id flow: the client creates the build,
+    then the first orchestrator invocation attaches to it via the resume
+    endpoint (the SDK calls resume before task discovery/registration). The
+    first run must not show as resumed.
+    """
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    response = await client.post(f"/api/v1/builds/{build_id}/resume")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "running"
+    assert data["is_resumed"] is False
+
+    # No BUILD_RESUMED event was recorded
+    response = await client.get(f"/api/v1/builds/{build_id}/events")
+    event_types = [e["event_type"] for e in response.json()]
+    assert "build_resumed" not in event_types
+    assert "build_started" in event_types
+
+
+@pytest.mark.asyncio
+async def test_resume_build_with_task_activity_records_resumed(client: AsyncClient):
+    """Resuming a build that has task activity records BUILD_RESUMED.
+
+    E.g. the orchestrator was restarted mid-build (after registering/starting
+    tasks): the second invocation's resume call must flag the build as
+    resumed even though the build never reached a terminal state.
+    """
+    response = await client.post("/api/v1/builds", json={})
+    build_id = response.json()["id"]
+
+    task_data = {
+        "task_id": "resume-activity-task",
+        "task_namespace": "",
+        "task_name": "TestTask",
+        "task_data": {},
+    }
+    await client.post(f"/api/v1/builds/{build_id}/tasks", json=task_data)
+    await client.post(f"/api/v1/builds/{build_id}/tasks/resume-activity-task/start")
+
+    response = await client.post(f"/api/v1/builds/{build_id}/resume")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "running"
+    assert data["is_resumed"] is True
+
+    response = await client.get(f"/api/v1/builds/{build_id}/events")
+    event_types = [e["event_type"] for e in response.json()]
+    assert "build_resumed" in event_types
+    assert event_types.count("build_resumed") == 1
+
+
+@pytest.mark.asyncio
 async def test_resume_build_complete_clears_resumed_flag(client: AsyncClient):
     """A resumed build that subsequently completes shows is_resumed=False.
 
@@ -191,6 +248,9 @@ async def test_list_builds_orders_resumed_first(client: AsyncClient):
     import asyncio
 
     build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    # Give build_a activity so its later resume is a real resume (a fresh
+    # build's resume is a recorded-nothing no-op and wouldn't reorder).
+    await client.post(f"/api/v1/builds/{build_a}/fail")
     await asyncio.sleep(0.005)
     build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
     await asyncio.sleep(0.005)

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -356,6 +356,50 @@ If you connected to the Stardag Registry, you can also click the latest build to
 
 ![modal-poc dag in the Registry UI](https://github.com/user-attachments/assets/08e2d3b1-17f5-4b3d-b6ed-1b91c8a3f968)
 
+### Restart-safe triggering with `build_trigger` (recommended with Registry)
+
+With `build_spawn`, the registry build id is created _inside_ the Modal build
+container — if that container is restarted (preemption, timeout, a Modal-level
+retry), the new invocation starts a **new** build in the registry.
+
+When you use the Stardag Registry, prefer `build_trigger`: it creates the
+build in the registry from the calling process first, then passes the build id
+to the build function as `resume_build_id`. Any restart of the build function
+then _resumes_ the same build — tasks whose outputs already exist are detected
+during discovery and skipped:
+
+```{.python notest}
+result = app.build_trigger(root_task)
+print(result.build_id)       # registry build id, minted at the trigger point
+result.function_call.get()   # optionally block on the Modal build function
+```
+
+Re-triggering with the same build id re-attaches to the build (e.g. after a
+failure, or to bring a preempted build back up):
+
+```{.python notest}
+app.build_trigger(root_task, build_id=result.build_id)
+```
+
+To let Modal restart the build function automatically after infrastructure
+failures (and thereby auto-resume the build), configure retries on the
+builder:
+
+```{.python notest}
+app = sd_modal.StardagApp(
+    "stardag-poc",
+    builder_settings=sd_modal.FunctionSettings(image=image, retries=2),
+    worker_settings={"default": sd_modal.FunctionSettings(image=image)},
+)
+```
+
+Note that `build_trigger` requires registry credentials in the calling process
+(the active stardag profile), in addition to Modal credentials — unlike
+`build_spawn`, which only needs Modal credentials locally. Also note that
+tasks that were _mid-execution_ when the build function died are re-executed
+from scratch on resume; only tasks whose outputs were fully written are
+skipped.
+
 <!-- TODO below needs significant cleanup.
 ## Running the `stardag-examples` Examples
 

--- a/lib/stardag/pyproject.toml
+++ b/lib/stardag/pyproject.toml
@@ -86,3 +86,6 @@ known_local_folder = ["stardag"]
 [tool.pytest.ini_options]
 testpaths = ["tests", "src/stardag", "../../USER_GUIDE.md"]
 asyncio_mode = "auto"
+markers = [
+    "modal_live: hits a real Modal workspace (gated by STARDAG_MODAL_LIVE_TESTS / STARDAG_MODAL_TEST_PROFILE; see stardag.testing.modal)",
+]

--- a/lib/stardag/src/stardag/integration/modal/__init__.py
+++ b/lib/stardag/src/stardag/integration/modal/__init__.py
@@ -2,6 +2,7 @@ from stardag.integration.modal._app import (
     Builder,
     BuildFailedError,
     BuildFunction,
+    BuildTriggerResult,
     FinalizeResult,
     FunctionSettings,
     PrefectBuilder,
@@ -27,6 +28,7 @@ from stardag.integration.modal._target import (
 __all__ = [
     "BuildFailedError",
     "BuildFunction",
+    "BuildTriggerResult",
     "RunFunction",
     "StardagApp",
     "Builder",

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -42,6 +42,7 @@ import os
 import pathlib
 import traceback as tb_module
 import typing
+from uuid import UUID
 
 import modal
 
@@ -55,7 +56,11 @@ from stardag.integration.modal._target import (
     get_default_volume_mount_path,
     get_volume_name_and_path,
 )
-from stardag.registry._base import get_git_commit_hash
+from stardag.registry._base import (
+    NoOpRegistry,
+    get_git_commit_hash,
+    registry_provider,
+)
 from stardag.utils.env import temp_env_vars
 
 try:
@@ -242,6 +247,22 @@ class FinalizeResult(typing.NamedTuple):
 
 
 # --- Function settings ---
+
+
+class BuildTriggerResult(typing.NamedTuple):
+    """Result of :meth:`StardagApp.build_trigger`.
+
+    Attributes:
+        build_id: The registry build id minted (or reused) at the trigger
+            point. Pass it back to ``build_trigger(..., build_id=...)`` to
+            re-attach/resume the same build.
+        function_call: The Modal ``FunctionCall`` handle for the spawned
+            build function invocation. Call ``.get()`` to block on the
+            result if needed.
+    """
+
+    build_id: UUID
+    function_call: typing.Any
 
 
 class FunctionSettings(typing.TypedDict, total=False):
@@ -1152,6 +1173,87 @@ class StardagApp:
             app_name=self.name,
             build_kwargs=build_kwargs,
         )
+
+    def build_trigger(
+        self,
+        tasks: typing.Sequence[BaseTask] | BaseTask,
+        worker_selector: WorkerSelector | None = None,
+        *,
+        build_kwargs: dict[str, typing.Any] | None = None,
+        build_id: UUID | None = None,
+        description: str | None = None,
+    ) -> BuildTriggerResult:
+        """Trigger a build with a registry build id minted at the trigger point.
+
+        Unlike :meth:`build_spawn` — where the build id is created *inside*
+        the Modal build container — this method first creates (or reuses) the
+        build in the registry from the calling process, then spawns the
+        deployed build function with ``resume_build_id`` set to it. As a
+        result:
+
+        - Any restart of the build function (Modal retry after preemption, a
+          manual re-trigger with the returned ``build_id``) **resumes the
+          same build** instead of creating a new one: already-completed task
+          targets are detected during discovery and skipped.
+        - The build appears in the registry immediately, before the Modal
+          container has started.
+
+        Set ``retries`` in the app's ``builder_settings`` to let Modal
+        automatically re-run (and thereby resume) the build function after
+        infrastructure failures.
+
+        Requires registry credentials in the calling process (the active
+        stardag profile), in addition to Modal credentials. If no registry is
+        configured, use :meth:`build_spawn` instead.
+
+        Args:
+            tasks: A single root task or a sequence of root tasks to build.
+            worker_selector: Optional override for worker selection.
+            build_kwargs: Optional kwargs forwarded to the remote build
+                function (must not contain ``resume_build_id``; it is set by
+                this method).
+            build_id: Existing build id to re-attach to (e.g. from a previous
+                ``build_trigger`` call). If None, a new build is created.
+            description: Optional description for the new build (ignored when
+                ``build_id`` is given).
+
+        Returns:
+            BuildTriggerResult with the ``build_id`` and the spawned Modal
+            ``FunctionCall`` handle.
+        """
+        merged_kwargs = dict(build_kwargs or {})
+        if "resume_build_id" in merged_kwargs:
+            raise TypeError(
+                "build_kwargs must not contain 'resume_build_id'; pass "
+                "build_id=... to build_trigger instead"
+            )
+
+        if build_id is None:
+            registry = registry_provider.get()
+            if isinstance(registry, NoOpRegistry):
+                raise RuntimeError(
+                    "build_trigger requires a configured registry to mint the "
+                    "build id at the trigger point (run 'stardag auth login' "
+                    "or configure an API key). Use build_spawn to trigger a "
+                    "build without local registry credentials."
+                )
+            task_list = [tasks] if isinstance(tasks, BaseTask) else list(tasks)
+            build_id = registry.build_start(
+                root_tasks=task_list, description=description
+            )
+        merged_kwargs["resume_build_id"] = build_id
+
+        build_function = modal.Function.from_name(
+            app_name=self.name,
+            name="build",
+        )
+        function_call = build_function.spawn(
+            tasks=tasks,
+            worker_selector=worker_selector or self.worker_selector,
+            app_name=self.name,
+            build_kwargs=merged_kwargs,
+        )
+        return BuildTriggerResult(build_id=build_id, function_call=function_call)
 
     def build_remote(
         self,

--- a/lib/stardag/src/stardag/testing/modal/__init__.py
+++ b/lib/stardag/src/stardag/testing/modal/__init__.py
@@ -1,1 +1,8 @@
 """Modal integration test utilities (internal)."""
+
+from stardag.testing.modal._live import DEFAULT_TEST_VOLUME, live_modal_guard
+
+__all__ = [
+    "DEFAULT_TEST_VOLUME",
+    "live_modal_guard",
+]

--- a/lib/stardag/src/stardag/testing/modal/_live.py
+++ b/lib/stardag/src/stardag/testing/modal/_live.py
@@ -1,0 +1,92 @@
+"""Gating for live-Modal tests.
+
+Live tests hit a real Modal workspace: they deploy apps, create volumes and
+dicts, and run containers. They are gated centrally by
+:func:`live_modal_guard`, controlled via environment variables:
+
+- ``STARDAG_MODAL_LIVE_TESTS``:
+    - ``"auto"`` (default) — run if Modal credentials work, skip otherwise.
+    - ``"1"`` / ``"true"`` — require: *fail* (instead of skip) when
+      credentials are missing or the profile guard doesn't match. Use in CI
+      jobs that are supposed to run the live tier, so misconfiguration
+      doesn't silently skip it.
+    - ``"0"`` / ``"false"`` — always skip.
+- ``STARDAG_MODAL_TEST_PROFILE``: if set, the active Modal profile must
+  match, otherwise the live tests are skipped (or fail in require mode).
+  This guards against accidentally running live tests — which create
+  apps/volumes visible to the whole workspace — against a shared or
+  production-adjacent profile.
+
+All live test modules should also carry ``pytestmark = pytest.mark.modal_live``
+so the live tier can be excluded wholesale with ``pytest -m "not modal_live"``.
+"""
+
+from __future__ import annotations
+
+import os
+
+DEFAULT_TEST_VOLUME = "stardag-testing"
+
+_TRUE = ("1", "true", "require")
+_FALSE = ("0", "false", "skip")
+
+
+def _active_modal_profile() -> str | None:
+    """Best-effort lookup of the active Modal profile name.
+
+    Uses a private ``modal.config`` attribute (no public API exposes the
+    active profile); returns None if the import surface changes.
+    """
+    try:
+        from modal.config import _profile  # pyright: ignore[reportPrivateUsage]
+
+        return _profile
+    except Exception:
+        return None
+
+
+def live_modal_guard(volume_name: str = DEFAULT_TEST_VOLUME) -> None:
+    """Module-level guard for live-Modal test modules.
+
+    Call at import time (after the ``import modal`` guard). Skips or fails
+    the module according to ``STARDAG_MODAL_LIVE_TESTS`` and
+    ``STARDAG_MODAL_TEST_PROFILE`` (see module docstring), and verifies
+    working credentials by hydrating (creating if missing) the shared test
+    volume.
+
+    Args:
+        volume_name: Volume used for the credential check. Created if
+            missing, so live test environments need no manual volume setup.
+    """
+    import pytest  # deferred: stardag.testing must import without pytest installed
+
+    mode = os.environ.get("STARDAG_MODAL_LIVE_TESTS", "auto").strip().lower()
+    if mode in _FALSE:
+        pytest.skip(
+            "Live Modal tests disabled (STARDAG_MODAL_LIVE_TESTS=0)",
+            allow_module_level=True,
+        )
+    required = mode in _TRUE
+
+    expected_profile = os.environ.get("STARDAG_MODAL_TEST_PROFILE")
+    if expected_profile:
+        active = _active_modal_profile()
+        if active != expected_profile:
+            msg = (
+                f"Active Modal profile {active!r} does not match "
+                f"STARDAG_MODAL_TEST_PROFILE={expected_profile!r}"
+            )
+            if required:
+                pytest.fail(msg)
+            pytest.skip(msg, allow_module_level=True)
+
+    import modal
+    from modal.exception import AuthError
+
+    try:
+        modal.Volume.from_name(volume_name, create_if_missing=True).hydrate()
+    except AuthError as exc:
+        msg = f"Modal credentials not available: {exc}"
+        if required:
+            pytest.fail(msg)
+        pytest.skip(msg, allow_module_level=True)

--- a/lib/stardag/tests/test_integration/test_modal/conftest.py
+++ b/lib/stardag/tests/test_integration/test_modal/conftest.py
@@ -1,0 +1,50 @@
+"""Shared fixtures for Modal integration tests.
+
+Test tiers in this directory:
+
+- **Unit tier** (default): everything not marked ``modal_live``. Uses fakes
+  and monkeypatching; requires the ``modal`` package but no credentials.
+- **Live tier** (``pytest -m modal_live``): modules marked with
+  ``pytestmark = pytest.mark.modal_live`` that hit a real Modal workspace.
+  Gated by :func:`stardag.testing.modal.live_modal_guard` — see its module
+  docstring for the ``STARDAG_MODAL_LIVE_TESTS`` /
+  ``STARDAG_MODAL_TEST_PROFILE`` environment variables.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def modal_function_stub(monkeypatch):
+    """Patch ``modal.Function.from_name`` with a recording stub.
+
+    Returns a dict that captures the interaction:
+
+    - ``captured["from_name"]``: kwargs of the last ``Function.from_name``
+    - ``captured["op"]``: ``"spawn"`` or ``"remote"``
+    - ``captured["kwargs"]``: kwargs passed to the spawn/remote call
+
+    ``spawn`` returns ``"spawn-handle"`` and ``remote`` returns
+    ``"remote-result"`` so tests can assert pass-through of the handle.
+    """
+    import modal
+
+    captured: dict = {}
+
+    class _Stub:
+        def spawn(self, **kwargs):
+            captured["op"] = "spawn"
+            captured["kwargs"] = kwargs
+            return "spawn-handle"
+
+        def remote(self, **kwargs):
+            captured["op"] = "remote"
+            captured["kwargs"] = kwargs
+            return "remote-result"
+
+    def _from_name(**kwargs):
+        captured["from_name"] = kwargs
+        return _Stub()
+
+    monkeypatch.setattr(modal.Function, "from_name", staticmethod(_from_name))
+    return captured

--- a/lib/stardag/tests/test_integration/test_modal/test__app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__app.py
@@ -26,7 +26,6 @@ ROOT_DEFAULT = "stardag/root/default"
 
 try:
     import modal
-    from modal.exception import AuthError
 
     from stardag.integration.modal import (
         VOLUME_MOUNT_PATH_PREFIX,
@@ -36,6 +35,7 @@ try:
     )
     from stardag.integration.modal._app import ModalTaskExecutor
     from stardag.integration.modal._config import with_stardag_on_image
+    from stardag.testing.modal import live_modal_guard
     from stardag.testing.modal._tasks import (
         AsyncDoubleTask,
         AsyncDynamicRangeSumTask,
@@ -45,15 +45,12 @@ try:
         sum_list,
     )
 
-    # check if logged in and volume exists
-    try:
-        _volume_check = modal.Volume.from_name(VOLUME_NAME)
-        _volume_check.listdir("/")
-    except AuthError:
-        pytest.skip("Skipping modal tests (not authenticated)", allow_module_level=True)
+    live_modal_guard(VOLUME_NAME)
 
 except ImportError:
     pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+pytestmark = pytest.mark.modal_live
 
 
 # --- Module-level app setup (also used as Modal deploy entrypoint) ---

--- a/lib/stardag/tests/test_integration/test_modal/test__target.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__target.py
@@ -21,19 +21,17 @@ VOLUME_NAME = "stardag-testing"
 
 try:
     import modal
-    from modal.exception import AuthError
 
     from stardag.integration import modal as sd_modal
+    from stardag.testing.modal import live_modal_guard
 
-    # check if logged in and volume exists
-    try:
-        VOLUME = modal.Volume.from_name(VOLUME_NAME)
-        VOLUME.listdir("/")
-    except AuthError:
-        pytest.skip("Skipping modal tests (not authenticated)", allow_module_level=True)
+    live_modal_guard(VOLUME_NAME)
+    VOLUME = modal.Volume.from_name(VOLUME_NAME)
 
 except ImportError:
     pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+pytestmark = pytest.mark.modal_live
 
 
 MOUNT_PATH = "/data"

--- a/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__target_cache.py
@@ -39,30 +39,21 @@ VOLUME_NAME = "stardag-testing"
 
 try:
     import modal
-    from modal.exception import AuthError, NotFoundError
 
     from stardag.integration import modal as sd_modal
     from stardag.integration.modal._target import (
         ModalVolumeRemoteFileSystem,
         modal_volume_rfs_provider,
     )
+    from stardag.testing.modal import live_modal_guard
 
-    try:
-        VOLUME = modal.Volume.from_name(VOLUME_NAME)
-        VOLUME.listdir("/")
-    except AuthError:
-        pytest.skip("Skipping modal tests (not authenticated)", allow_module_level=True)
-    except NotFoundError:
-        pytest.skip(
-            f"Skipping modal cache round-trip tests: volume {VOLUME_NAME!r} "
-            "not found in the active Modal workspace/environment. Create it "
-            f"with `modal volume create {VOLUME_NAME}` (in a personal/dev "
-            "workspace — not a shared one) before running these tests.",
-            allow_module_level=True,
-        )
+    live_modal_guard(VOLUME_NAME)
+    VOLUME = modal.Volume.from_name(VOLUME_NAME)
 
 except ImportError:
     pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+pytestmark = pytest.mark.modal_live
 
 
 @pytest.fixture

--- a/lib/stardag/tests/test_integration/test_modal/test_live_semantics.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_live_semantics.py
@@ -1,0 +1,152 @@
+"""Live regression tests for the Modal semantics stardag's execution relies on.
+
+The (planned) detached-execution model — spawning workers with
+``Function.spawn`` and tracking them via function call ids — depends on
+specific Modal platform behaviors. These tests pin them against a real
+workspace so a Modal-side change is caught here rather than in production
+builds:
+
+1. A spawned call on a deployed app **survives the exit of the spawning
+   process** (detached execution).
+2. ``FunctionCall.from_id`` re-attaches to a call from a different process,
+   and ``get(timeout=0)`` is a usable non-blocking status poll.
+3. Modal-level retries of a spawned call **preserve the function call id**
+   (so the id can serve as a stable execution-claim owner).
+4. ``FunctionCall.cancel()`` on a re-attached handle terminates a running
+   call, and ``get()`` then raises.
+
+The probe app uses ``serialized=True`` functions (like ``StardagApp``) so no
+source files or extra packages are needed in the container image.
+"""
+
+import subprocess
+import sys
+import time
+import uuid
+
+import pytest
+
+try:
+    import modal
+    from modal.exception import RemoteError
+
+    from stardag.testing.modal import live_modal_guard
+
+    live_modal_guard()
+
+except ImportError:
+    pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+pytestmark = pytest.mark.modal_live
+
+PROBE_APP_NAME = "stardag-testing-probe"
+ATTEMPTS_DICT_NAME = "stardag-testing-probe-attempts"
+
+
+def _build_probe_app() -> modal.App:
+    """Build the probe app with functions defined as *closures*.
+
+    With ``serialized=True``, cloudpickle serializes module-level functions
+    **by reference** (module path + name) — the container would then try to
+    import this test module (pytest, stardag, ...) and crash-loop. Closures
+    are pickled by value, so the container needs nothing but ``modal``
+    itself. This mirrors why ``StardagApp.finalize()`` registers nested
+    wrapper functions instead of module-level callables.
+    """
+    app = modal.App(PROBE_APP_NAME)
+    image = modal.Image.debian_slim()
+
+    def probe_slow_ok(seconds: int) -> str:
+        import time as _time
+
+        import modal as _modal
+
+        call_id = _modal.current_function_call_id()
+        _time.sleep(seconds)
+        return f"done after {seconds}s inside call_id={call_id}"
+
+    def probe_flaky(key: str, dict_name: str) -> dict:
+        """Fail on the first attempt, succeed on the second, recording the
+        function call id seen by each attempt."""
+        import modal as _modal
+
+        call_id = _modal.current_function_call_id()
+        attempts_dict = _modal.Dict.from_name(dict_name, create_if_missing=True)
+        attempts = attempts_dict.get(key, []) + [call_id]
+        attempts_dict[key] = attempts
+        if len(attempts) < 2:
+            raise RuntimeError(f"deliberate failure on attempt {len(attempts)}")
+        return {"attempt_call_ids": attempts, "final_call_id": call_id}
+
+    app.function(image=image, timeout=300, name="probe_slow_ok", serialized=True)(
+        probe_slow_ok
+    )
+    app.function(
+        image=image, timeout=120, retries=2, name="probe_flaky", serialized=True
+    )(probe_flaky)
+    return app
+
+
+@pytest.fixture(scope="module")
+def deployed_probe_app() -> str:
+    """Deploy the probe app (idempotent, ~2s) and return its name."""
+    from modal.runner import deploy_app
+
+    deploy_app(_build_probe_app(), name=PROBE_APP_NAME)
+    return PROBE_APP_NAME
+
+
+def test_spawned_call_survives_caller_exit_and_reattaches(deployed_probe_app):
+    """Spawn in a subprocess that exits immediately; re-attach here by id.
+
+    Also verifies ``get(timeout=0)`` raises TimeoutError while the call is
+    still running (the non-blocking poll a scheduler tick would use).
+    """
+    code = (
+        "import modal; "
+        f"fn = modal.Function.from_name('{deployed_probe_app}', 'probe_slow_ok'); "
+        "print(fn.spawn(20).object_id)"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True
+    )
+    call_id = proc.stdout.strip().splitlines()[-1]
+    assert call_id.startswith("fc-")
+
+    # The spawning process is gone; re-attach from this process.
+    fc = modal.FunctionCall.from_id(call_id)
+
+    with pytest.raises(TimeoutError):
+        fc.get(timeout=0)  # still running — non-blocking poll
+
+    result = fc.get(timeout=180)
+    assert f"call_id={call_id}" in result
+
+
+def test_retries_preserve_function_call_id(deployed_probe_app):
+    """All retry attempts of a spawned call see the same function call id.
+
+    The detached-execution design keys execution claims on the call id;
+    retries must be re-entrant on the same claim.
+    """
+    key = f"probe-{uuid.uuid4().hex[:8]}"
+    fn = modal.Function.from_name(deployed_probe_app, "probe_flaky")
+    fc = fn.spawn(key, ATTEMPTS_DICT_NAME)
+
+    result = fc.get(timeout=180)
+
+    assert len(result["attempt_call_ids"]) == 2  # failed once, then succeeded
+    assert all(a == fc.object_id for a in result["attempt_call_ids"])
+
+
+def test_cancel_running_spawned_call(deployed_probe_app):
+    """A re-attached handle can cancel a running call; get() then raises."""
+    fn = modal.Function.from_name(deployed_probe_app, "probe_slow_ok")
+    fc = fn.spawn(180)
+    time.sleep(5)  # let it get scheduled/started
+
+    reattached = modal.FunctionCall.from_id(fc.object_id)
+    reattached.cancel()
+
+    with pytest.raises(RemoteError):
+        reattached.get(timeout=60)

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -8,7 +8,9 @@ except ImportError:
     pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
 
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
+from stardag import BaseTask
 from stardag.build._base import BuildSummary
 from stardag.integration.modal import (
     Builder,
@@ -19,6 +21,7 @@ from stardag.integration.modal import (
     StardagApp,
 )
 from stardag.integration.modal._app import _default_build, _default_run
+from stardag.registry import NoOpRegistry, RegistryABC, registry_provider
 
 
 def _make_image() -> modal.Image:
@@ -532,28 +535,8 @@ class TestStardagAppBuildSpawnRemote:
             worker_settings={"default": FunctionSettings(image=_make_image())},
         )
 
-    def _patch_function_from_name(self, monkeypatch):
-        """Patch modal.Function.from_name to return a recording stub."""
-        captured: dict = {}
-
-        class _Stub:
-            def spawn(self, **kwargs):
-                captured["op"] = "spawn"
-                captured["kwargs"] = kwargs
-                return "spawn-handle"
-
-            def remote(self, **kwargs):
-                captured["op"] = "remote"
-                captured["kwargs"] = kwargs
-                return "remote-result"
-
-        monkeypatch.setattr(
-            modal.Function, "from_name", staticmethod(lambda **_: _Stub())
-        )
-        return captured
-
-    def test_build_remote_single_task(self, monkeypatch):
-        captured = self._patch_function_from_name(monkeypatch)
+    def test_build_remote_single_task(self, modal_function_stub):
+        captured = modal_function_stub
         app = self._make_app()
         root = MagicMock()
 
@@ -565,8 +548,8 @@ class TestStardagAppBuildSpawnRemote:
         assert captured["kwargs"]["app_name"] == app.name
         assert captured["kwargs"]["build_kwargs"] is None
 
-    def test_build_remote_sequence_of_tasks(self, monkeypatch):
-        captured = self._patch_function_from_name(monkeypatch)
+    def test_build_remote_sequence_of_tasks(self, modal_function_stub):
+        captured = modal_function_stub
         app = self._make_app()
         roots = [MagicMock(), MagicMock()]
 
@@ -574,16 +557,16 @@ class TestStardagAppBuildSpawnRemote:
 
         assert captured["kwargs"]["tasks"] is roots
 
-    def test_build_remote_forwards_build_kwargs(self, monkeypatch):
-        captured = self._patch_function_from_name(monkeypatch)
+    def test_build_remote_forwards_build_kwargs(self, modal_function_stub):
+        captured = modal_function_stub
         app = self._make_app()
 
         app.build_remote(MagicMock(), build_kwargs={"fail_mode": "CONTINUE"})
 
         assert captured["kwargs"]["build_kwargs"] == {"fail_mode": "CONTINUE"}
 
-    def test_build_spawn_sequence_and_build_kwargs(self, monkeypatch):
-        captured = self._patch_function_from_name(monkeypatch)
+    def test_build_spawn_sequence_and_build_kwargs(self, modal_function_stub):
+        captured = modal_function_stub
         app = self._make_app()
         roots = [MagicMock(), MagicMock()]
 
@@ -593,3 +576,111 @@ class TestStardagAppBuildSpawnRemote:
         assert captured["op"] == "spawn"
         assert captured["kwargs"]["tasks"] is roots
         assert captured["kwargs"]["build_kwargs"] == {"register_all": True}
+
+
+# ---------------------------------------------------------------------------
+# StardagApp.build_trigger
+# ---------------------------------------------------------------------------
+
+
+class TestStardagAppBuildTrigger:
+    """build_trigger mints the build id at the trigger point and passes it
+    to the remote build function as ``resume_build_id``, so restarts of the
+    build function resume the same build."""
+
+    def _make_app(self):
+        return StardagApp(
+            "test-trigger-app",
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={"default": FunctionSettings(image=_make_image())},
+        )
+
+    def test_mints_build_id_and_injects_resume_build_id(self, modal_function_stub):
+        captured = modal_function_stub
+        app = self._make_app()
+        root = MagicMock(spec=BaseTask)
+        build_id = uuid4()
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_start.return_value = build_id
+
+        with registry_provider.override(registry):
+            result = app.build_trigger(root, description="a build")
+
+        registry.build_start.assert_called_once_with(
+            root_tasks=[root], description="a build"
+        )
+        assert result.build_id == build_id
+        assert result.function_call == "spawn-handle"
+        assert captured["op"] == "spawn"
+        assert captured["kwargs"]["tasks"] is root
+        assert captured["kwargs"]["build_kwargs"] == {"resume_build_id": build_id}
+
+    def test_sequence_of_roots_passed_as_list_to_registry(self, modal_function_stub):
+        app = self._make_app()
+        roots = [MagicMock(spec=BaseTask), MagicMock(spec=BaseTask)]
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_start.return_value = uuid4()
+
+        with registry_provider.override(registry):
+            app.build_trigger(roots)
+
+        registry.build_start.assert_called_once_with(root_tasks=roots, description=None)
+
+    def test_explicit_build_id_skips_registry(self, modal_function_stub):
+        captured = modal_function_stub
+        app = self._make_app()
+        build_id = uuid4()
+
+        # NoOpRegistry active — must not be consulted (and must not raise)
+        with registry_provider.override(NoOpRegistry()):
+            result = app.build_trigger(MagicMock(spec=BaseTask), build_id=build_id)
+
+        assert result.build_id == build_id
+        assert captured["kwargs"]["build_kwargs"] == {"resume_build_id": build_id}
+
+    def test_merges_build_kwargs(self, modal_function_stub):
+        captured = modal_function_stub
+        app = self._make_app()
+        build_id = uuid4()
+
+        with registry_provider.override(NoOpRegistry()):
+            app.build_trigger(
+                MagicMock(spec=BaseTask),
+                build_id=build_id,
+                build_kwargs={"register_all": True},
+            )
+
+        assert captured["kwargs"]["build_kwargs"] == {
+            "register_all": True,
+            "resume_build_id": build_id,
+        }
+
+    def test_raises_without_registry(self, modal_function_stub):
+        app = self._make_app()
+
+        with registry_provider.override(NoOpRegistry()):
+            with pytest.raises(RuntimeError, match="requires a configured registry"):
+                app.build_trigger(MagicMock(spec=BaseTask))
+
+    def test_rejects_resume_build_id_in_build_kwargs(self, modal_function_stub):
+        app = self._make_app()
+
+        with pytest.raises(TypeError, match="resume_build_id"):
+            app.build_trigger(
+                MagicMock(spec=BaseTask),
+                build_id=uuid4(),
+                build_kwargs={"resume_build_id": uuid4()},
+            )
+
+    def test_does_not_mutate_caller_build_kwargs(self, modal_function_stub):
+        app = self._make_app()
+        caller_kwargs: dict = {"register_all": True}
+
+        with registry_provider.override(NoOpRegistry()):
+            app.build_trigger(
+                MagicMock(spec=BaseTask),
+                build_id=uuid4(),
+                build_kwargs=caller_kwargs,
+            )
+
+        assert caller_kwargs == {"register_all": True}


### PR DESCRIPTION
## Motivation

On the Modal path today, the registry build id is minted *inside* the build-function container. When that container is restarted (preemption, timeout, Modal-level retry), the new invocation starts a brand-new build and re-executes every task whose target doesn't exist yet. This PR is the first step toward making Modal a first-class, restart-safe execution layer: mint the build identity at the trigger point so any restart *resumes* instead of forking.

## Changes

### SDK — `StardagApp.build_trigger()`

New trigger method that creates the build in the registry from the calling process, then spawns the deployed build function with `resume_build_id` set:

```python
result = app.build_trigger(root_task)     # BuildTriggerResult(build_id, function_call)
# re-attach / resume later:
app.build_trigger(root_task, build_id=result.build_id)
```

- Modal retries of the build function (recommended: `retries` on `builder_settings`) now auto-resume the same build; already-completed task targets are detected during discovery and skipped.
- `build_spawn` is unchanged and remains the option when the caller has only Modal credentials (`build_trigger` requires registry credentials locally).

### API — fresh-build resume is a no-op

`POST /builds/{id}/resume` no longer records `BUILD_RESUMED` when the build has no activity beyond `BUILD_STARTED`, so the first invocation attaching to a trigger-minted build id doesn't display the build as resumed. Real resumes (any task activity or terminal state) record the event as before.

### Modal test setup restructured into explicit tiers

- Live modules (`test__app`, `test__target`, `test__target_cache`, new `test_live_semantics`) are marked `modal_live` and gated centrally by `stardag.testing.modal.live_modal_guard`:
  - `STARDAG_MODAL_LIVE_TESTS`: `auto` (default: run if authenticated) / `1` (require — fail instead of skip, for CI) / `0` (skip)
  - `STARDAG_MODAL_TEST_PROFILE`: if set, live tests skip unless the active Modal profile matches — prevents accidental runs against shared workspaces
  - `pytest -m "not modal_live"` now gives a credential-free unit tier (~3s)
- Shared `modal_function_stub` fixture replaces duplicated per-class patch helpers.
- New `test_live_semantics.py` pins the Modal platform behaviors the execution layer depends on (verified against a live workspace): spawned calls survive caller-process exit, `FunctionCall.from_id` re-attach + `get(timeout=0)` polling, function-call-id stability across Modal retries, and cancellation via a re-attached handle.

## Testing

- Unit tier: 93 passed (modal dir), full lib suite green
- API: 261 passed (incl. new fresh-resume/activity-resume tests)
- Live tier: 26 passed against a personal Modal workspace (incl. the 3 new semantics tests)
- pre-commit (ruff, pyright, prettier): clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)