### PR TITLE
Worker-side lifecycle reporting for Modal tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,24 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   `RegisteredTaskInfo` (current global status + executor ref) used by the
   build engine for re-attach. Custom `RegistryABC` implementations with the
   old signatures keep working (refs are dropped gracefully).
+- **`stardag/integration/modal`: worker-side lifecycle reporting.** The
+  default `Runner` now reports the task's lifecycle from inside the worker —
+  TASK_STARTED (carrying the worker's own function call id as executor ref),
+  TASK_COMPLETED + artifact upload, TASK_SUSPENDED (dynamic deps), and
+  TASK_FAILED — whenever the executor forwarded a build id (via the
+  `STARDAG_BUILD_ID` env override; no worker signature change, older
+  deployed workers are unaffected) and the container has registry
+  credentials. Events therefore land even if the build orchestrator dies
+  mid-task, and each re-invocation records a fresh re-attachable ref. The
+  build engine suppresses its own completed/suspended/resumed reporting for
+  such tasks (`TaskExecutorABC.reports_lifecycle` seam), keeping started
+  (immediate detached-spawn re-attachability) and failed (fallback for
+  workers that die before reporting) — duplicate events are tolerated by
+  the event-sourced status derivation. Opt out with
+  `ModalTaskExecutor(worker_reports_lifecycle=False)` (required when driving
+  an app deployed with an older stardag from a newer local SDK) or
+  `Runner(report_lifecycle=False)`. New `stardag.build.get_current_build_id()`
+  exposes the ambient build id inside `build[_aio]()`.
 
 - **`stardag/integration/modal`**: New `StardagApp.build_trigger()` — triggers
   a build with the registry build id minted at the trigger point and passed to

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -414,6 +414,14 @@ cancelled, the tracked function calls are explicitly cancelled on Modal
 (with the legacy blocking mode, workers of a dead build kept running to
 completion).
 
+Workers additionally report their own lifecycle events (started, completed
+with artifacts, suspended, failed) directly to the registry when the app has
+registry credentials — so a task's registry state stays accurate even if the
+build function dies while the task is running. If you drive a deployed app
+built with an older stardag version from a newer local SDK, pass
+`ModalTaskExecutor(worker_reports_lifecycle=False)` (or redeploy the app) so
+the build engine doesn't skip events the old workers won't send.
+
 To opt out (legacy blocking `remote` calls), pass `detached=False`:
 
 ```{.python notest}

--- a/lib/stardag/src/stardag/build/__init__.py
+++ b/lib/stardag/src/stardag/build/__init__.py
@@ -43,6 +43,7 @@ from stardag.build._base import (
     TaskCount,
     TaskExecutionError,
     DetachedHandle,
+    get_current_build_id,
     TaskExecutorABC,
 )
 from stardag.build._concurrency import (
@@ -96,6 +97,7 @@ __all__ = [
     "RoutedTaskExecutor",
     "TaskExecutionError",
     "DetachedHandle",
+    "get_current_build_id",
     "TaskExecutorABC",
     # Build functions
     "build",

--- a/lib/stardag/src/stardag/build/_base.py
+++ b/lib/stardag/src/stardag/build/_base.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import traceback as tb_module
 from abc import ABC, abstractmethod
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from enum import StrEnum
 import logging
@@ -23,6 +24,20 @@ logger = logging.getLogger(__name__)
 
 # Type alias for the on_registry_failure parameter
 OnRegistryFailure = Literal["warn", "raise"]
+
+# Build id of the enclosing build_aio() call. Set for the duration of a
+# build so components invoked from within it (e.g. executors forwarding the
+# build id to self-reporting remote workers) can access it without threading
+# it through every signature.
+current_build_id_var: ContextVar[UUID | None] = ContextVar(
+    "stardag_current_build_id", default=None
+)
+
+
+def get_current_build_id() -> UUID | None:
+    """Return the build id of the enclosing ``build[_aio]()`` call, if any."""
+    return current_build_id_var.get()
+
 
 # =============================================================================
 # Data Structures
@@ -270,6 +285,22 @@ class TaskExecutorABC(ABC):
         """
         pass
 
+    def reports_lifecycle(self, task: BaseTask) -> bool:
+        """Whether the *execution side* reports this task's lifecycle events.
+
+        When True, the build engine does not emit TASK_COMPLETED /
+        TASK_SUSPENDED / TASK_RESUMED events or upload artifacts for the
+        task — the worker executing it reports those itself (e.g. the Modal
+        ``Runner``), which also survives an orchestrator crash mid-task.
+        The engine still emits TASK_STARTED at submission (immediate
+        re-attachability of detached spawns) and TASK_FAILED as a fallback
+        (the worker may die before reporting); duplicate events are
+        tolerated by the registry's event-sourced status derivation.
+
+        Default: False — the engine reports everything, as before.
+        """
+        return False
+
     # -------------------------------------------------------------------------
     # Optional detached-execution surface
     # -------------------------------------------------------------------------
@@ -384,6 +415,13 @@ class RoutedTaskExecutor(TaskExecutorABC, Generic[ExecutorKeyT]):
         if executor is None:
             return
         await executor.cancel(task)
+
+    def reports_lifecycle(self, task: BaseTask) -> bool:
+        """Route to the owning executor's lifecycle-reporting mode."""
+        executor = self.executors.get(self.router(task))
+        if executor is None:
+            return False
+        return executor.reports_lifecycle(task)
 
     def supports_detached(self, task: BaseTask) -> bool:
         """Route to the owning executor's detached support."""

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -31,6 +31,7 @@ from stardag.build._base import (
     BuildSummary,
     DefaultGlobalLockSelector,
     DetachedHandle,
+    current_build_id_var,
     FailMode,
     GlobalConcurrencyLockManager,
     GlobalLockConfig,
@@ -647,6 +648,11 @@ async def build_aio(
         build_id = await registry.build_start_aio(root_tasks=tasks)
         logger.info(f"Started build: {build_id}")
 
+    # Expose the build id ambiently for the duration of the build (e.g.
+    # executors forward it to self-reporting workers). Reset in the outer
+    # finally below.
+    _build_id_token = current_build_id_var.set(build_id)
+
     async def discover(task: BaseTask) -> None:
         """Recursively discover tasks, stopping at already-complete tasks.
 
@@ -896,27 +902,33 @@ async def build_aio(
                 fail_fast_triggered = True
 
         elif result is None:
-            # Task completed - release lock (completed) and notify registry
+            # Task completed - release lock (completed) and notify registry.
+            # When the worker self-reports lifecycle events, it has already
+            # emitted TASK_COMPLETED and uploaded artifacts from inside the
+            # worker (which also survives an orchestrator crash mid-await).
             await release_lock_for_task(task, completed=True)
-            try:
-                await registry.task_complete_aio(build_id, task)
-            except Exception as reg_err:
-                handle_registry_error(
-                    reg_err,
-                    f"Failed to notify registry of task {task.id} completion",
-                    on_registry_failure,
-                )
-            # Upload artifacts if any
-            try:
-                artifacts = await task.artifacts_aio()
-                if artifacts:
-                    await registry.task_upload_artifacts_aio(build_id, task, artifacts)
-            except Exception as artifact_err:
-                handle_registry_error(
-                    artifact_err,
-                    f"Failed to collect/upload artifacts for task {task.id}",
-                    on_registry_failure,
-                )
+            if not task_executor.reports_lifecycle(task):
+                try:
+                    await registry.task_complete_aio(build_id, task)
+                except Exception as reg_err:
+                    handle_registry_error(
+                        reg_err,
+                        f"Failed to notify registry of task {task.id} completion",
+                        on_registry_failure,
+                    )
+                # Upload artifacts if any
+                try:
+                    artifacts = await task.artifacts_aio()
+                    if artifacts:
+                        await registry.task_upload_artifacts_aio(
+                            build_id, task, artifacts
+                        )
+                except Exception as artifact_err:
+                    handle_registry_error(
+                        artifact_err,
+                        f"Failed to collect/upload artifacts for task {task.id}",
+                        on_registry_failure,
+                    )
             state.completed = True
             completion_cache.add(task.id)
             completion_events[task.id].set()
@@ -928,14 +940,18 @@ async def build_aio(
             dynamic_deps = flatten_task_struct(result)
 
             # Notify registry that task is suspended waiting for dynamic deps
-            try:
-                await registry.task_suspend_aio(build_id, task)
-            except Exception as reg_err:
-                handle_registry_error(
-                    reg_err,
-                    f"Failed to notify registry of task {task.id} suspension",
-                    on_registry_failure,
-                )
+            # (the worker already emitted TASK_SUSPENDED when it self-reports;
+            # dep registration/edges below stay engine-side either way — the
+            # engine must discover the full requires() subtrees anyway).
+            if not task_executor.reports_lifecycle(task):
+                try:
+                    await registry.task_suspend_aio(build_id, task)
+                except Exception as reg_err:
+                    handle_registry_error(
+                        reg_err,
+                        f"Failed to notify registry of task {task.id} suspension",
+                        on_registry_failure,
+                    )
 
             # Discover any new dynamic deps FIRST (which post-order-collects
             # them and their requires() subtree into pending_registrations).
@@ -1226,6 +1242,14 @@ async def build_aio(
                         )
                 # Skip /start if registration never succeeded — the endpoint
                 # would 404 and that hard-fails the build even in `warn` mode.
+                #
+                # Even when the worker self-reports lifecycle events
+                # (reports_lifecycle), the engine still emits TASK_STARTED
+                # for detached spawns: it lands immediately (the worker's own
+                # start event only fires once its container is up, which can
+                # be minutes later under cold start) so a crash in between
+                # still leaves a re-attachable ref. Duplicate started events
+                # are tolerated by the registry.
                 if state.registered:
                     try:
                         await registry_task_start(task, handle)
@@ -1239,10 +1263,11 @@ async def build_aio(
             elif state.dynamic_deps:
                 # Task was suspended waiting for dynamic deps, now resuming. Same
                 # warn-mode protection: no point firing /resume if registration
-                # never landed. (Known gap: a detached re-spawn on this path gets
-                # a fresh ref that TASK_RESUMED doesn't carry, so it isn't
-                # re-attachable until the next TASK_STARTED.)
-                if state.registered:
+                # never landed. When the worker self-reports, skip the resume
+                # event — the worker's own TASK_STARTED re-asserts RUNNING and
+                # carries the re-invocation's fresh executor ref (making the
+                # re-spawn re-attachable, which TASK_RESUMED wouldn't).
+                if state.registered and not task_executor.reports_lifecycle(task):
                     try:
                         await registry.task_resume_aio(build_id, task)
                     except Exception as reg_err:
@@ -1552,6 +1577,7 @@ async def build_aio(
         )
 
     finally:
+        current_build_id_var.reset(_build_id_token)
         await task_executor.teardown()
 
 

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -450,6 +450,8 @@ class ModalTaskExecutor(TaskExecutorABC):
         # invoked on every ``submit`` so we memoize it per worker name to avoid
         # recreating the handle for every task.
         self._worker_functions: dict[str, modal.Function] = {}
+        # One-time (per executor) skew-visibility log; see reports_lifecycle.
+        self._reports_lifecycle_logged = False
         # In-flight detached executions by task UUID, for explicit cancel().
         # Asyncio cancellation of ``FunctionCall.get`` does NOT stop the
         # remote call (unlike ``remote.aio``), so FAIL_FAST relies on this.
@@ -490,7 +492,24 @@ class ModalTaskExecutor(TaskExecutorABC):
 
     def reports_lifecycle(self, task: BaseTask) -> bool:
         """Workers self-report lifecycle when enabled and a build is active."""
-        return self.worker_reports_lifecycle and get_current_build_id() is not None
+        active = self.worker_reports_lifecycle and get_current_build_id() is not None
+        if active and not self._reports_lifecycle_logged:
+            # Make the version-skew failure mode visible: nothing verifies
+            # the deployed workers actually self-report. If the app was
+            # deployed with an older stardag (or uses a custom run function
+            # without lifecycle reporting), tasks will execute fine but sit
+            # RUNNING in the registry with artifacts lost.
+            self._reports_lifecycle_logged = True
+            logger.info(
+                "Engine-side lifecycle reporting is suppressed for "
+                f"Modal-routed tasks (app {self.modal_app_name!r}): workers "
+                "are assumed to self-report started/completed/suspended/"
+                "failed events. If the deployed app predates worker "
+                "self-reporting or uses a custom run function, pass "
+                "ModalTaskExecutor(worker_reports_lifecycle=False) — "
+                "otherwise tasks will appear stuck RUNNING in the registry."
+            )
+        return active
 
     async def submit(self, task: BaseTask) -> None | TaskStruct | TaskExecutionError:
         """Execute task on Modal (blocking remote call)."""
@@ -989,11 +1008,17 @@ class Runner(RunFunction):
             # process environment, i.e. deployment secrets, not overrides.)
             with temp_env_vars(env_overrides or {}):
                 # getattr: tolerate subclasses overriding __init__ w/o super()
-                reporter = (
-                    _WorkerLifecycleReporter.create(task, env_overrides)
-                    if getattr(self, "report_lifecycle", True)
-                    else None
-                )
+                reporter: _WorkerLifecycleReporter | None = None
+                if getattr(self, "report_lifecycle", True):
+                    try:
+                        reporter = _WorkerLifecycleReporter.create(task, env_overrides)
+                    except Exception:
+                        # Best-effort contract covers creation too: a broken
+                        # registry config must not fail a task before it runs.
+                        logger.exception(
+                            "Worker lifecycle reporter creation failed; "
+                            "running without lifecycle reporting."
+                        )
                 if reporter is not None:
                     reporter.started()
                 try:

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -53,6 +53,7 @@ from stardag.build import (
     DetachedHandle,
     TaskExecutionError,
     TaskExecutorABC,
+    get_current_build_id,
 )
 from stardag.build._base import BuildSummary
 from stardag.config import clear_config_cache, config_provider, load_config
@@ -376,6 +377,16 @@ def _callable_accepts_env_overrides(fn: typing.Callable[..., typing.Any]) -> boo
 MODAL_EXECUTOR_NAME = "modal"
 """Executor name recorded with detached executions (see DetachedHandle)."""
 
+STARDAG_BUILD_ID_ENV = "STARDAG_BUILD_ID"
+"""Env var through which the build id reaches Modal workers.
+
+Injected into ``env_overrides`` by :class:`ModalTaskExecutor` (so it is also
+set as a process env var around the task's run) and read by
+:class:`Runner` to report the task's lifecycle events from inside the
+worker. Riding on ``env_overrides`` keeps the worker function signature
+unchanged — older deployed workers simply apply it as a harmless env var.
+"""
+
 
 class ModalTaskExecutor(TaskExecutorABC):
     """Task executor that sends tasks to Modal for remote execution.
@@ -411,6 +422,7 @@ class ModalTaskExecutor(TaskExecutorABC):
         modal_app_name: str,
         worker_selector: WorkerSelector,
         detached: bool = True,
+        worker_reports_lifecycle: bool = True,
     ):
         """Initialize Modal executor.
 
@@ -420,10 +432,19 @@ class ModalTaskExecutor(TaskExecutorABC):
             detached: Execute tasks as detached spawned function calls
                 (restart-safe, re-attachable, explicitly cancellable).
                 False restores the legacy blocking ``remote`` calls.
+            worker_reports_lifecycle: Whether the deployed workers report the
+                task lifecycle (started/completed/suspended/failed events +
+                artifacts) themselves via the default :class:`Runner`. When
+                True the build engine skips its own completed/suspended/
+                resumed reporting for Modal-routed tasks. Set False when
+                driving an app deployed with an older stardag version whose
+                workers don't self-report, or when using a custom
+                ``run_function`` without lifecycle reporting.
         """
         self.modal_app_name = modal_app_name
         self.worker_selector = worker_selector
         self.detached = detached
+        self.worker_reports_lifecycle = worker_reports_lifecycle
         # Cache of worker name -> modal.Function. ``modal.Function.from_name``
         # returns a lazy handle (no network call until invoked), but it is
         # invoked on every ``submit`` so we memoize it per worker name to avoid
@@ -445,13 +466,36 @@ class ModalTaskExecutor(TaskExecutorABC):
             self._worker_functions[worker_name] = worker_function
         return worker_function
 
+    def _prepare_invocation(
+        self, task: BaseTask
+    ) -> tuple[modal.Function, dict[str, str] | None]:
+        """Resolve the worker function and env overrides for a task.
+
+        When ``worker_reports_lifecycle`` and an enclosing build is active,
+        the build id is injected as the ``STARDAG_BUILD_ID`` env override so
+        the worker-side :class:`Runner` can report lifecycle events.
+        """
+        worker_name, env_overrides = _normalize_worker_selection(
+            self.worker_selector(task)
+        )
+        worker_function = self._get_worker_function(worker_name)
+        if self.worker_reports_lifecycle:
+            build_id = get_current_build_id()
+            if build_id is not None:
+                env_overrides = {
+                    **(env_overrides or {}),
+                    STARDAG_BUILD_ID_ENV: str(build_id),
+                }
+        return worker_function, env_overrides
+
+    def reports_lifecycle(self, task: BaseTask) -> bool:
+        """Workers self-report lifecycle when enabled and a build is active."""
+        return self.worker_reports_lifecycle and get_current_build_id() is not None
+
     async def submit(self, task: BaseTask) -> None | TaskStruct | TaskExecutionError:
         """Execute task on Modal (blocking remote call)."""
         try:
-            worker_name, env_overrides = _normalize_worker_selection(
-                self.worker_selector(task)
-            )
-            worker_function = self._get_worker_function(worker_name)
+            worker_function, env_overrides = self._prepare_invocation(task)
             res = await worker_function.remote.aio(task, env_overrides=env_overrides)
             return res
         except Exception as e:
@@ -509,10 +553,7 @@ class ModalTaskExecutor(TaskExecutorABC):
 
     async def submit_detached(self, task: BaseTask) -> DetachedHandle:
         """Spawn the task on its worker function; return a re-attachable handle."""
-        worker_name, env_overrides = _normalize_worker_selection(
-            self.worker_selector(task)
-        )
-        worker_function = self._get_worker_function(worker_name)
+        worker_function, env_overrides = self._prepare_invocation(task)
         function_call = await worker_function.spawn.aio(
             task, env_overrides=env_overrides
         )
@@ -782,6 +823,100 @@ class Builder(BuildFunction):
         return build(tasks, task_executor=task_executor, **kwargs)
 
 
+class _WorkerLifecycleReporter:
+    """Reports a task's lifecycle events from inside a Modal worker.
+
+    Created by :class:`Runner` when a build id was forwarded (see
+    ``STARDAG_BUILD_ID_ENV``) and the container has a configured registry.
+    Reporting from the worker makes the events independent of the
+    orchestrator's lifetime: completion/failure land even if the build
+    function died mid-await, and each (re-)invocation's TASK_STARTED
+    carries its own function call id for re-attach.
+
+    All reporting is best-effort: a registry hiccup must never fail a task
+    whose actual work succeeded — failures are logged loudly and the
+    engine-side self-heal (target-existence check on the next build) covers
+    a lost completion event.
+    """
+
+    def __init__(self, registry: typing.Any, build_id: UUID, task: BaseTask):
+        self.registry = registry
+        self.build_id = build_id
+        self.task = task
+
+    @classmethod
+    def create(
+        cls, task: BaseTask, env_overrides: dict[str, str] | None
+    ) -> "_WorkerLifecycleReporter | None":
+        raw_build_id = (env_overrides or {}).get(
+            STARDAG_BUILD_ID_ENV
+        ) or os.environ.get(STARDAG_BUILD_ID_ENV)
+        if not raw_build_id:
+            return None
+        try:
+            build_id = UUID(raw_build_id)
+        except ValueError:
+            logger.warning(f"Invalid {STARDAG_BUILD_ID_ENV}: {raw_build_id!r}")
+            return None
+        registry = registry_provider.get()
+        # Exact-type check: only the literal do-nothing default suppresses
+        # reporting — NoOpRegistry *subclasses* may implement real behavior.
+        if type(registry) is NoOpRegistry:
+            return None
+        return cls(registry, build_id, task)
+
+    def _guard(self, fn: typing.Callable[[], None], what: str) -> None:
+        try:
+            fn()
+        except Exception as e:
+            logger.error(
+                f"Worker lifecycle report ({what}) failed for task {self.task.id}: {e}"
+            )
+
+    def started(self) -> None:
+        def _do() -> None:
+            ref: str | None = None
+            try:
+                ref = modal.current_function_call_id()
+            except Exception:
+                pass
+            self.registry.task_start(
+                self.build_id,
+                self.task,
+                executor=MODAL_EXECUTOR_NAME,
+                executor_ref=ref,
+            )
+
+        self._guard(_do, "start")
+
+    def completed(self) -> None:
+        self._guard(
+            lambda: self.registry.task_complete(self.build_id, self.task),
+            "complete",
+        )
+
+        def _artifacts() -> None:
+            artifacts = self.task.artifacts()
+            if artifacts:
+                self.registry.task_upload_artifacts(self.build_id, self.task, artifacts)
+
+        self._guard(_artifacts, "artifacts")
+
+    def suspended(self) -> None:
+        self._guard(
+            lambda: self.registry.task_suspend(self.build_id, self.task),
+            "suspend",
+        )
+
+    def failed(self, exception: Exception) -> None:
+        self._guard(
+            lambda: self.registry.task_fail(
+                self.build_id, self.task, error_message=str(exception)
+            ),
+            "fail",
+        )
+
+
 class Runner(RunFunction):
     """Default runner implementation with overridable setup/teardown.
 
@@ -803,6 +938,18 @@ class Runner(RunFunction):
             ...
         )
     """
+
+    def __init__(self, *, report_lifecycle: bool = True):
+        """Initialize the runner.
+
+        Args:
+            report_lifecycle: Report the task's lifecycle events
+                (started/completed/suspended/failed + artifacts) to the
+                registry from inside the worker, when a build id was
+                forwarded by the executor and the container has registry
+                credentials. See :class:`_WorkerLifecycleReporter`.
+        """
+        self.report_lifecycle = report_lifecycle
 
     def setup(self, task: BaseTask) -> None:
         """Optional setup logic before the task runs."""
@@ -829,17 +976,32 @@ class Runner(RunFunction):
                 provided, they are set temporarily around the ``run`` call and
                 the previous environment is restored afterwards.
         """
+        # getattr: tolerate subclasses overriding __init__ without super()
+        reporter = (
+            _WorkerLifecycleReporter.create(task, env_overrides)
+            if getattr(self, "report_lifecycle", True)
+            else None
+        )
         result: None | TaskStruct = None
         exception: Exception | None = None
         try:
             self.setup(task)
+            if reporter is not None:
+                reporter.started()
             with temp_env_vars(env_overrides or {}):
                 result = self.run(task)
         except Exception as e:
             exception = e
+            if reporter is not None:
+                reporter.failed(e)
             raise
         finally:
             self.teardown(task, exception)
+        if reporter is not None:
+            if result is None:
+                reporter.completed()
+            else:
+                reporter.suspended()
         return result
 
     def run(self, task: BaseTask) -> None | TaskStruct:

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -868,9 +868,9 @@ class _WorkerLifecycleReporter:
     def _guard(self, fn: typing.Callable[[], None], what: str) -> None:
         try:
             fn()
-        except Exception as e:
-            logger.error(
-                f"Worker lifecycle report ({what}) failed for task {self.task.id}: {e}"
+        except Exception:
+            logger.exception(
+                f"Worker lifecycle report ({what}) failed for task {self.task.id}"
             )
 
     def started(self) -> None:
@@ -977,31 +977,41 @@ class Runner(RunFunction):
                 the previous environment is restored afterwards.
         """
         # getattr: tolerate subclasses overriding __init__ without super()
-        reporter = (
-            _WorkerLifecycleReporter.create(task, env_overrides)
-            if getattr(self, "report_lifecycle", True)
-            else None
-        )
         result: None | TaskStruct = None
         exception: Exception | None = None
         try:
             self.setup(task)
-            if reporter is not None:
-                reporter.started()
+            # All lifecycle reporting happens inside the env-overrides
+            # context, so overrides carrying environment-sensitive config
+            # apply to reporting exactly as they do to run(). (Caveat:
+            # stardag's config/registry providers cache on first access —
+            # registry connection settings should come from the container's
+            # process environment, i.e. deployment secrets, not overrides.)
             with temp_env_vars(env_overrides or {}):
-                result = self.run(task)
+                # getattr: tolerate subclasses overriding __init__ w/o super()
+                reporter = (
+                    _WorkerLifecycleReporter.create(task, env_overrides)
+                    if getattr(self, "report_lifecycle", True)
+                    else None
+                )
+                if reporter is not None:
+                    reporter.started()
+                try:
+                    result = self.run(task)
+                except Exception as e:
+                    if reporter is not None:
+                        reporter.failed(e)
+                    raise
+                if reporter is not None:
+                    if result is None:
+                        reporter.completed()
+                    else:
+                        reporter.suspended()
         except Exception as e:
             exception = e
-            if reporter is not None:
-                reporter.failed(e)
             raise
         finally:
             self.teardown(task, exception)
-        if reporter is not None:
-            if result is None:
-                reporter.completed()
-            else:
-                reporter.suspended()
         return result
 
     def run(self, task: BaseTask) -> None | TaskStruct:

--- a/lib/stardag/tests/test_build/test_detached.py
+++ b/lib/stardag/tests/test_build/test_detached.py
@@ -349,3 +349,49 @@ class TestOldRegistrySignatureCompat:
 
         with pytest.raises(TypeError, match="bug inside the registry"):
             await build_aio([task], task_executor=executor, registry=BuggyRegistry())
+
+
+class TestWorkerReportsLifecycle:
+    """When the executor's workers self-report lifecycle events, the engine
+    suppresses its own completed-reporting but keeps started (immediate
+    detached-spawn re-attachability) and failed (fallback)."""
+
+    class ReportingExecutor(FakeDetachedExecutor):
+        def reports_lifecycle(self, task: BaseTask) -> bool:
+            return True
+
+    async def test_complete_suppressed_start_kept(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        recording_registry: RecordingRegistry,
+    ):
+        task = SyncOnlyTask(name="worker-reports")
+        executor = self.ReportingExecutor()
+
+        summary = await build_aio(
+            [task], task_executor=executor, registry=recording_registry
+        )
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert task.complete()
+        methods = recording_registry.call_methods_for(task.id)
+        assert "task_start_aio" in methods  # kept: immediate ref recording
+        assert "task_complete_aio" not in methods  # worker reports it
+        assert summary.task_count.succeeded == 1  # engine bookkeeping intact
+
+    async def test_fail_still_reported_by_engine(
+        self,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+        recording_registry: RecordingRegistry,
+    ):
+        """TASK_FAILED stays engine-side as a fallback — the worker may die
+        before reporting (spawn failure, OOM, preemption past retries)."""
+        task = SyncOnlyTask(name="worker-reports-fail")
+        executor = self.ReportingExecutor(
+            spawn_error=RuntimeError("worker never started")
+        )
+
+        with pytest.raises(RuntimeError, match="worker never started"):
+            await build_aio([task], task_executor=executor, registry=recording_registry)
+
+        assert recording_registry.has_call("task_fail_aio", task.id)

--- a/lib/stardag/tests/test_integration/test_modal/test_detached_executor.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_detached_executor.py
@@ -246,3 +246,65 @@ class TestCancel:
         await executor.submit_detached(task)
 
         await executor.cancel(task)  # logs a warning, does not raise
+
+
+class TestBuildIdInjection:
+    """The executor forwards the ambient build id to workers via the
+    STARDAG_BUILD_ID env override, so the worker-side Runner can report
+    lifecycle events. Riding on env_overrides keeps the worker function
+    signature unchanged (older workers apply it as a harmless env var)."""
+
+    async def test_injected_inside_build_context(self):
+        from stardag.build._base import current_build_id_var
+        from stardag.integration.modal._app import STARDAG_BUILD_ID_ENV
+
+        build_id = __import__("uuid").uuid4()
+        function_call = FakeFunctionCall()
+        worker = FakeWorkerFunction(function_call)
+        executor = _make_executor(worker)
+
+        token = current_build_id_var.set(build_id)
+        try:
+            await executor.submit_detached(_make_task())
+        finally:
+            current_build_id_var.reset(token)
+
+        _, env_overrides = worker.spawn_calls[0]
+        assert env_overrides[STARDAG_BUILD_ID_ENV] == str(build_id)
+
+    async def test_not_injected_outside_build_context(self):
+        from stardag.integration.modal._app import STARDAG_BUILD_ID_ENV
+
+        worker = FakeWorkerFunction(FakeFunctionCall())
+        executor = _make_executor(worker)
+
+        await executor.submit_detached(_make_task())
+
+        _, env_overrides = worker.spawn_calls[0]
+        assert env_overrides is None or STARDAG_BUILD_ID_ENV not in env_overrides
+
+    async def test_not_injected_when_worker_reporting_disabled(self):
+        from stardag.build._base import current_build_id_var
+        from stardag.integration.modal._app import STARDAG_BUILD_ID_ENV
+
+        worker = FakeWorkerFunction(FakeFunctionCall())
+        executor = ModalTaskExecutor(
+            modal_app_name="test-app",
+            worker_selector=lambda task: "default",
+            worker_reports_lifecycle=False,
+        )
+        executor._worker_functions["default"] = worker  # pyright: ignore[reportArgumentType]
+
+        token = current_build_id_var.set(__import__("uuid").uuid4())
+        try:
+            await executor.submit_detached(_make_task())
+            assert executor.reports_lifecycle(_make_task()) is False
+        finally:
+            current_build_id_var.reset(token)
+
+        _, env_overrides = worker.spawn_calls[0]
+        assert env_overrides is None or STARDAG_BUILD_ID_ENV not in env_overrides
+
+    async def test_reports_lifecycle_requires_build_context(self):
+        executor = _make_executor(FakeWorkerFunction(FakeFunctionCall()))
+        assert executor.reports_lifecycle(_make_task()) is False

--- a/lib/stardag/tests/test_integration/test_modal/test_runner_lifecycle.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_runner_lifecycle.py
@@ -1,0 +1,187 @@
+"""Unit tests for worker-side lifecycle reporting in ``Runner``.
+
+No real Modal account needed — ``modal.current_function_call_id`` and the
+registry are faked. Verifies that the worker reports started (with its own
+function call id as executor ref), completed (+ artifacts), suspended, and
+failed events when a build id is forwarded via ``STARDAG_BUILD_ID`` — and
+stays silent otherwise (no build id, NoOp registry, or opt-out).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest
+
+try:
+    import modal  # noqa: F401
+except ImportError:
+    pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
+
+from stardag.integration.modal._app import (
+    MODAL_EXECUTOR_NAME,
+    STARDAG_BUILD_ID_ENV,
+    Runner,
+    _WorkerLifecycleReporter,
+)
+from stardag.registry import NoOpRegistry, registry_provider
+from stardag.testing.modal._tasks import SyncDynamicRangeSumTask, make_range
+
+WORKER_CALL_ID = "fc-worker-call-1"
+
+
+class RecordingSyncRegistry(NoOpRegistry):
+    """Records the sync lifecycle calls the worker reporter makes."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls: list[tuple[str, dict]] = []
+        self.raise_on: set[str] = set()
+
+    def _record(self, method: str, **extra) -> None:
+        if method in self.raise_on:
+            raise ConnectionError(f"registry down during {method}")
+        self.calls.append((method, extra))
+
+    def task_start(self, build_id, task, executor=None, executor_ref=None) -> None:
+        self._record(
+            "task_start",
+            build_id=build_id,
+            executor=executor,
+            executor_ref=executor_ref,
+        )
+
+    def task_complete(self, build_id, task) -> None:
+        self._record("task_complete", build_id=build_id)
+
+    def task_suspend(self, build_id, task) -> None:
+        self._record("task_suspend", build_id=build_id)
+
+    def task_fail(self, build_id, task, error_message=None) -> None:
+        self._record("task_fail", build_id=build_id, error_message=error_message)
+
+    def task_upload_artifacts(self, build_id, task, artifacts) -> None:
+        self._record("task_upload_artifacts", artifacts=artifacts)
+
+    def methods(self) -> list[str]:
+        return [m for (m, _) in self.calls]
+
+
+@pytest.fixture
+def recording_registry():
+    registry = RecordingSyncRegistry()
+    with registry_provider.override(registry):
+        yield registry
+
+
+@pytest.fixture
+def fake_call_id(monkeypatch):
+    monkeypatch.setattr(modal, "current_function_call_id", lambda: WORKER_CALL_ID)
+    return WORKER_CALL_ID
+
+
+def _env(build_id: UUID) -> dict[str, str]:
+    return {STARDAG_BUILD_ID_ENV: str(build_id)}
+
+
+class TestRunnerLifecycleReporting:
+    def test_success_reports_start_and_complete(
+        self, recording_registry, fake_call_id, default_in_memory_fs_target
+    ):
+        build_id = uuid4()
+        task = make_range(limit=3)
+
+        result = Runner()(task, env_overrides=_env(build_id))
+
+        assert result is None
+        assert task.complete()
+        assert recording_registry.methods() == ["task_start", "task_complete"]
+        start_extra = recording_registry.calls[0][1]
+        assert start_extra["build_id"] == build_id
+        assert start_extra["executor"] == MODAL_EXECUTOR_NAME
+        assert start_extra["executor_ref"] == WORKER_CALL_ID
+
+    def test_failure_reports_fail_and_reraises(
+        self, recording_registry, fake_call_id, default_in_memory_fs_target
+    ):
+        class Boom(Exception):
+            pass
+
+        class FailingRunner(Runner):
+            def run(self, task):
+                raise Boom("task exploded")
+
+        with pytest.raises(Boom):
+            FailingRunner()(make_range(limit=2), env_overrides=_env(uuid4()))
+
+        assert recording_registry.methods() == ["task_start", "task_fail"]
+        assert "task exploded" in recording_registry.calls[1][1]["error_message"]
+
+    def test_dynamic_deps_yield_reports_suspend(
+        self, recording_registry, fake_call_id, default_in_memory_fs_target
+    ):
+        # First invocation: the yielded range task is incomplete → the
+        # runner returns the TaskStruct and the task is suspended.
+        task = SyncDynamicRangeSumTask(limit=3)
+
+        result = Runner()(task, env_overrides=_env(uuid4()))
+
+        assert result is not None  # TaskStruct of incomplete deps
+        assert recording_registry.methods() == ["task_start", "task_suspend"]
+
+    def test_no_build_id_no_reporting(
+        self, recording_registry, fake_call_id, default_in_memory_fs_target
+    ):
+        result = Runner()(make_range(limit=3))
+
+        assert result is None
+        assert recording_registry.calls == []
+
+    def test_opt_out_no_reporting(
+        self, recording_registry, fake_call_id, default_in_memory_fs_target
+    ):
+        result = Runner(report_lifecycle=False)(
+            make_range(limit=3), env_overrides=_env(uuid4())
+        )
+
+        assert result is None
+        assert recording_registry.calls == []
+
+    def test_registry_errors_never_fail_the_task(
+        self, recording_registry, fake_call_id, default_in_memory_fs_target
+    ):
+        recording_registry.raise_on = {"task_start", "task_complete"}
+        task = make_range(limit=3)
+
+        result = Runner()(task, env_overrides=_env(uuid4()))
+
+        assert result is None
+        assert task.complete()  # the actual work still succeeded
+
+
+class TestReporterCreate:
+    def test_none_without_build_id(self, recording_registry):
+        assert _WorkerLifecycleReporter.create(make_range(limit=1), None) is None
+        assert _WorkerLifecycleReporter.create(make_range(limit=1), {}) is None
+
+    def test_none_with_noop_registry(self):
+        with registry_provider.override(NoOpRegistry()):
+            reporter = _WorkerLifecycleReporter.create(
+                make_range(limit=1), _env(uuid4())
+            )
+        assert reporter is None
+
+    def test_none_with_invalid_build_id(self, recording_registry):
+        reporter = _WorkerLifecycleReporter.create(
+            make_range(limit=1), {STARDAG_BUILD_ID_ENV: "not-a-uuid"}
+        )
+        assert reporter is None
+
+    def test_build_id_from_process_env(self, recording_registry, monkeypatch):
+        """Older deployed apps apply env_overrides as process env vars around
+        the run call — the reporter also accepts the env-var form."""
+        build_id = uuid4()
+        monkeypatch.setenv(STARDAG_BUILD_ID_ENV, str(build_id))
+        reporter = _WorkerLifecycleReporter.create(make_range(limit=1), None)
+        assert reporter is not None
+        assert reporter.build_id == build_id

--- a/lib/stardag/tests/test_integration/test_modal/test_runner_lifecycle.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_runner_lifecycle.py
@@ -209,3 +209,25 @@ class TestReportingRunsInsideEnvOverrides:
         Runner()(make_range(limit=3), env_overrides=env)
 
         assert seen == {"task_start": "applied", "task_complete": "applied"}
+
+
+class TestReporterCreationGuard:
+    def test_broken_reporter_creation_never_fails_the_task(
+        self, monkeypatch, default_in_memory_fs_target
+    ):
+        """The best-effort contract covers creation itself: a broken registry
+        config in the worker env must not fail a task before it runs."""
+        from stardag.integration.modal import _app as app_module
+
+        def broken_create(task, env_overrides):
+            raise RuntimeError("malformed registry config")
+
+        monkeypatch.setattr(
+            app_module._WorkerLifecycleReporter, "create", staticmethod(broken_create)
+        )
+        task = make_range(limit=3)
+
+        result = Runner()(task, env_overrides=_env(uuid4()))
+
+        assert result is None
+        assert task.complete()  # the work still ran

--- a/lib/stardag/tests/test_integration/test_modal/test_runner_lifecycle.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_runner_lifecycle.py
@@ -185,3 +185,27 @@ class TestReporterCreate:
         reporter = _WorkerLifecycleReporter.create(make_range(limit=1), None)
         assert reporter is not None
         assert reporter.build_id == build_id
+
+
+class TestReportingRunsInsideEnvOverrides:
+    def test_reporting_sees_env_overrides(
+        self, recording_registry, fake_call_id, default_in_memory_fs_target
+    ):
+        """Lifecycle reporting runs inside the env-overrides context, so
+        overrides carrying environment-sensitive config apply to reporting
+        exactly as they do to run()."""
+        import os
+
+        seen: dict[str, str | None] = {}
+        original_record = recording_registry._record
+
+        def observing_record(method, **extra):
+            seen[method] = os.environ.get("MY_TEST_OVERRIDE")
+            return original_record(method, **extra)
+
+        recording_registry._record = observing_record
+        env = {**_env(uuid4()), "MY_TEST_OVERRIDE": "applied"}
+
+        Runner()(make_range(limit=3), env_overrides=env)
+
+        assert seen == {"task_start": "applied", "task_complete": "applied"}


### PR DESCRIPTION
> Stacked on #155 (base branch `modal-detached-execution`) — will retarget to `main` once that merges.

## Motivation

Phase 2 of making the execution layer orchestrator-independent: with detached execution (#155), tasks *run* independently of the build function, but their registry lifecycle events were still emitted by the orchestrator. If the build function died mid-await, completion/failure never got recorded (until a later build self-healed from target existence), and a re-invocation after dynamic deps didn't get a re-attachable ref.

## What changes

### Worker-side lifecycle reporting

The default `Runner` now reports the task's lifecycle from **inside the worker**, whenever a build id was forwarded and the container has registry credentials:

- `TASK_STARTED` carrying the worker's own function call id as executor ref — every (re-)invocation records a fresh re-attachable ref, closing the resume-reinvocation gap noted in #155
- `TASK_COMPLETED` + artifact upload
- `TASK_SUSPENDED` on a dynamic-deps yield
- `TASK_FAILED` on exceptions (event reported, exception still propagates)

Reporting is best-effort by design: a registry hiccup never fails a task whose actual work succeeded (logged loudly; the engine-side target-existence self-heal covers a lost completion event).

### Build-id transport — no signature changes

The build id reaches workers as a `STARDAG_BUILD_ID` env override, exposed on the orchestrator side via a new ambient `stardag.build.get_current_build_id()` contextvar. Riding on `env_overrides` keeps the worker function signature unchanged — older deployed workers simply apply it as a harmless env var.

### Engine-side suppression

New `TaskExecutorABC.reports_lifecycle(task)` seam (default False; `RoutedTaskExecutor` forwards). When True, the engine skips its own completed/artifacts/suspended/resumed reporting, but deliberately keeps:

- `TASK_STARTED` at submission — a detached spawn is re-attachable immediately, not only after worker cold start (duplicate started events are tolerated by the event-sourced status derivation)
- `TASK_FAILED` as fallback — the worker may die before reporting (spawn failure, OOM, preemption past retries)

## Backwards compatibility / version skew

- Old deployed workers + new SDK: workers ignore the env var; **pass `ModalTaskExecutor(worker_reports_lifecycle=False)`** (or redeploy) so the engine doesn't skip events old workers won't send. Documented in the how-to + changelog. The recommended deployed-`Builder` path is always version-consistent (builder and workers deploy together).
- New workers + old orchestrator: no build id forwarded → workers stay silent, orchestrator reports as before.
- Worker-side opt-out: `Runner(report_lifecycle=False)`.

## Testing

- `test_runner_lifecycle.py` (10 tests): started-with-call-id/completed/suspended/failed emission, no-build-id and NoOp-registry silence, opt-out, and registry-errors-never-fail-the-task.
- Engine suppression tests in `test_detached.py`: complete suppressed + started kept, failed kept as fallback.
- Build-id injection tests in `test_detached_executor.py`: injected inside a build context, absent outside, absent when disabled.
- Full suites green: SDK 672 passed, stardag-api 263 passed, live Modal tier 27 passed with the new Runner deployed in the worker image (including the crash-resume e2e, and graceful no-op reporting for registry-less containers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)