### PR TITLE
Docs: execution model concepts page + skill bundle update

### DIFF
--- a/.claude/skills/stardag/registry-and-platform.md
+++ b/.claude/skills/stardag/registry-and-platform.md
@@ -14,21 +14,24 @@ The SDK integrates with the API optionally — tasks work standalone without it.
 
 ### Key Endpoints
 
-| Endpoint                       | Method          | Purpose                             |
-| ------------------------------ | --------------- | ----------------------------------- |
-| `/api/v1/builds`               | POST            | Create a new build                  |
-| `/api/v1/builds`               | GET             | List builds with pagination         |
-| `/api/v1/builds/{id}`          | GET             | Get build details                   |
-| `/api/v1/builds/{id}/tasks`    | POST            | Register task in build              |
-| `/api/v1/tasks`                | GET             | List tasks (workspace-scoped)       |
-| `/api/v1/tasks/{id}`           | GET             | Get task details                    |
-| `/api/v1/tasks/graph`          | POST            | Get DAG graph (upstream/downstream) |
-| `/api/v1/tasks/{id}/artifacts` | GET             | List task artifacts                 |
-| `/api/v1/tasks/{id}/events`    | GET             | Task lifecycle events               |
-| `/api/v1/tasks/{id}/metadata`  | GET             | Task metadata (for AliasTask)       |
-| `/api/v1/tasks/search`         | POST            | Full-text search with filters       |
-| `/api/v1/locks`                | POST/PUT/DELETE | Distributed lock management         |
-| `/api/v1/auth/exchange`        | POST            | OIDC token exchange                 |
+| Endpoint                       | Method          | Purpose                              |
+| ------------------------------ | --------------- | ------------------------------------ |
+| `/api/v1/builds`               | POST            | Create a new build                   |
+| `/api/v1/builds`               | GET             | List builds with pagination          |
+| `/api/v1/builds/{id}`          | GET             | Get build details                    |
+| `/api/v1/builds/{id}/tasks`    | POST            | Register task in build               |
+| `/api/v1/tasks`                | GET             | List tasks (workspace-scoped)        |
+| `/api/v1/tasks/{id}`           | GET             | Get task details                     |
+| `/api/v1/tasks/graph`          | POST            | Get DAG graph (upstream/downstream)  |
+| `/api/v1/tasks/{id}/artifacts` | GET             | List task artifacts                  |
+| `/api/v1/tasks/{id}/events`    | GET             | Task lifecycle events                |
+| `/api/v1/tasks/{id}/metadata`  | GET             | Task metadata (for AliasTask)        |
+| `/api/v1/tasks/search`         | POST            | Full-text search with filters        |
+| `/api/v1/locks`                | POST/PUT/DELETE | Distributed lock management          |
+| `/api/v1/builds/{id}/frontier` | GET             | Scheduling frontier (reactive ticks) |
+| `/api/v1/builds/{id}/notify`   | POST/DELETE     | Scheduler wake-up flag (reactive)    |
+| `/api/v1/concurrency-limits`   | GET/PUT/DELETE  | Named env concurrency limits         |
+| `/api/v1/auth/exchange`        | POST            | OIDC token exchange                  |
 
 ### Authentication Methods
 

--- a/.claude/skills/stardag/sdk-advanced.md
+++ b/.claude/skills/stardag/sdk-advanced.md
@@ -310,12 +310,45 @@ run_as_prefect_flow(root_task)
 
 ### Modal
 
-```python
-from stardag.integration.modal import ModalExecutor
+The packaged setup is `StardagApp` (deploys a `build` function, per-worker
+`worker_<name>` functions, a reactive scheduler `tick` function, and an
+optional watchdog cron):
 
-# Execute tasks on Modal.com infrastructure
-sd.build(task, task_executor=ModalExecutor(...))
+```python
+from stardag.integration.modal import StardagApp, FunctionSettings
+
+app = StardagApp(
+    "my-app",
+    builder_settings=FunctionSettings(image=image),
+    worker_settings={"default": FunctionSettings(image=image)},
+    watchdog_period_minutes=5,          # recommended with reactive mode
+    limit_key_selector=lambda t: [],    # named concurrency-limit keys per task
+)
+
+# After `stardag modal deploy`:
+result = app.build_trigger(root_task)              # restart-safe (build id
+                                                   # minted at the trigger,
+                                                   # restarts resume)
+result = app.build_trigger(root_task, reactive=True)  # experimental: no
+                                                   # resident orchestrator —
+                                                   # scheduler ticks drive it
+app.build_spawn(root_task)                         # legacy fire-and-forget
 ```
+
+Worker executions are **detached** Modal function calls by default: they
+survive orchestrator restarts (resumed builds re-attach instead of
+re-executing), are explicitly cancellable, and workers self-report their
+lifecycle events to the registry. Low-level executor:
+`ModalTaskExecutor(modal_app_name=..., worker_selector=..., detached=True)`
+implements the `TaskExecutorABC` detached surface (`submit_detached` /
+`reattach` / `detached_status` / `cancel_detached`).
+
+Key `stardag.build` exports for the execution layer: `DetachedHandle`,
+`DetachedExecutionStatus`, `get_current_build_id`, `run_tick_aio`,
+`TickConfig`, `TickSummary`, `BuildTaskStore`, `discover_and_register_aio`.
+
+See `docs/docs/concepts/build-execution.md` and
+`docs/docs/how-to/integrate-modal.md` for the full model.
 
 ### AWS S3
 

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -26,18 +26,147 @@ Step 6: Execute C, save output
 
 ```
 
+Two properties follow from this model and hold across every execution mode
+described below:
+
+- **Completeness is target existence.** A task is done when its output
+  exists in storage — not when some scheduler says so. Storage is the
+  ground truth, which is what makes resumption, retries and de-duplication
+  safe: re-running a build never re-executes work whose outputs exist.
+- **Idempotent re-execution.** Tasks (including those with dynamic
+  dependencies) are written so that re-running them from scratch is safe.
+  The engine relies on this whenever execution crosses a process or
+  machine boundary.
+
 ## The Build Functions
 
 The primary way to execute tasks is `sd.build` or `await sd.build_aio`.
 
-Mostly for testing and debugging, there is also `sd.build_sequential` and `sd.build_sequential_aio`.
+Mostly for testing and debugging, there is also `sd.build_sequential` and
+`sd.build_sequential_aio`.
 
-!!! info "🚧 **Work in progress** 🚧"
+## Local Concurrency
 
-    This documentation is still taking shape. It should soon cover:
+`sd.build` runs an asyncio scheduling loop: it discovers the DAG, then
+repeatedly submits every _ready_ task (all dependencies complete) to a
+**task executor** and processes results as they arrive. The default
+`HybridConcurrentTaskExecutor` runs each task in one of four modes,
+selected per task (async-native tasks on the event loop; sync tasks in a
+thread pool by default, optionally a process pool):
 
-    - How concurrency is achieved via asyncio, threads and or processes
-    - Transfer of execution (e.g. -> Modal)
-    - Global concurrency lock
-    - Concurrency limits (overall and named, via `ConcurrencyConfig`)
-    - ...
+- `ASYNC_MAIN_LOOP` — `await task.run_aio()` on the main event loop
+- `SYNC_THREAD` — `task.run()` in a thread pool (default for sync tasks)
+- `SYNC_PROCESS` — `task.run()` in a process pool (CPU-bound work)
+- `SYNC_BLOCKING` — inline (debugging)
+
+Build-local concurrency limits — an overall cap and named limits mapped to
+tasks via a `key_selector` — are configured with `ConcurrencyConfig` and
+enforced by gating executor submission. These are scoped to the one build
+process; see [Concurrency Limits](#concurrency-limits) below for limits
+that hold across builds.
+
+## Transfer of Execution (Remote Executors)
+
+The scheduling loop is decoupled from _where_ tasks run through the
+`TaskExecutorABC` seam. A remote executor — `ModalTaskExecutor` is the
+first-class implementation — submits each task to remote infrastructure
+instead of a local pool, and a `RoutedTaskExecutor` can mix executors
+(e.g. GPU tasks to Modal, the rest locally). See
+[Integrate with Modal](../how-to/integrate-modal.md) for the packaged
+setup.
+
+### Detached execution
+
+Remote executions are **detached** by default: the worker invocation
+survives the process that spawned it. The execution's backend reference
+(e.g. a Modal function call id) is recorded in the registry together with
+the task's started event, which buys three things:
+
+- **Re-attach instead of re-execute.** A resumed build (or a concurrent
+  build wanting the same task) finds the task RUNNING with a live ref and
+  attaches to that execution rather than starting a duplicate. An
+  orchestrator restart no longer restarts your long-running tasks.
+- **Real cancellation.** Fail-fast and user cancellation cancel the
+  tracked remote executions — workers of a failed or cancelled build
+  don't keep running. (A _crashed_ orchestrator's workers deliberately
+  keep running — that's the re-attach premise above.)
+- **Liveness probing.** Schedulers can ask the backend whether a recorded
+  execution is still running, finished, or gone — no lease/heartbeat
+  machinery needed.
+
+### Worker-side lifecycle reporting
+
+Workers report their own lifecycle to the registry — started (with their
+own execution ref), completed (plus artifacts), suspended (dynamic
+dependencies), failed — whenever the build id is forwarded to them and the
+container has registry credentials. Reporting is best-effort by design: a
+registry hiccup never fails a task whose actual work succeeded, and a lost
+completion event self-heals from target existence. The consequence: a
+task's registry state stays accurate **independent of any orchestrator's
+lifetime**.
+
+## Reactive Scheduling (No Resident Orchestrator)
+
+With detached executions and self-reporting workers, the build process
+itself is optional. In _reactive scheduling_ the build is driven by
+short-lived, idempotent scheduler **ticks** instead of a resident process:
+
+```
+tick(build_id):
+  acquire the build's scheduler lease (single-flight; held → exit)
+  loop:
+    clear the build's wake-up flag
+    frontier = registry state: tasks whose upstreams are all complete
+    act: spawn pending/suspended tasks detached (recording refs)
+         probe running refs — leave live ones; self-heal completions
+         (target existence is ground truth); record failures
+    handle terminal states (all roots complete / failure / cancelled)
+    linger briefly on the wake-up flag; exit when quiet
+```
+
+Ticks are triggered when the build starts, by workers finishing tasks
+(flag-then-spawn, so wake-ups are never lost), and by an optional periodic
+watchdog that also picks up externally-cancelled builds and silently-lost
+workers. While a DAG churns, one lingering tick behaves like a tight
+scheduling loop; when only long-running tasks remain in flight, **nothing
+runs but your tasks**.
+
+The registry is the scheduler state (the frontier is computed from
+recorded task statuses and dependency edges); task _objects_ are
+rehydrated from a per-build task store persisted at trigger time. The
+registry never pushes or executes anything — only user-deployed code
+(which has the DAG-defining code) spawns work.
+
+Reactive scheduling is experimental and currently Modal-first — see
+[Integrate with Modal](../how-to/integrate-modal.md#reactive-scheduling-no-resident-build-function-experimental)
+for usage, requirements and limitations.
+
+## Global Concurrency Lock
+
+Within one build, the engine guarantees each task executes at most once.
+Across builds (started from anywhere), the optional **global concurrency
+lock** extends that guarantee: a lease-based lock per task id, scoped to
+the environment, acquired before execution and released together with the
+completion record in one transaction (which also absorbs eventually-
+consistent storage). Enable it per build or per task via
+`GlobalLockConfig`; it adds a few registry roundtrips per task, so prefer
+enabling it selectively for expensive or non-idempotent tasks.
+
+## Concurrency Limits
+
+Two mechanisms, by scope:
+
+- **Build-local** (`ConcurrencyConfig`): asyncio-semaphore limits inside
+  one build process — an overall cap plus named limits via a
+  `key_selector`. Uniform across local and remote executors.
+- **Registry-backed named limits** (reactive scheduling): caps configured
+  per environment in the registry
+  (`PUT /api/v1/concurrency-limits/{key}`), enforced atomically when a
+  task starts — **across all builds** in the environment. A task occupies
+  a slot simply by being RUNNING with the key recorded; the slot frees on
+  any terminal status (no leases — status liveness is maintained by worker
+  reporting and tick self-healing). Denied tasks stay pending and proceed
+  when a slot frees.
+
+Infrastructure-level limits (e.g. Modal's per-function
+`concurrency_limit`) apply independently underneath either mechanism.


### PR DESCRIPTION
> Stacked on #158 — docs only, describing the model introduced across #155–#158.

Replaces the WIP stub in `concepts/build-execution.md` with the full execution model: local concurrency (executor modes + build-local limits), transfer of execution and **detached executions** (re-attach, real cancellation, liveness probing), **worker-side lifecycle reporting**, **reactive scheduling** (ticks, frontier, wake-ups, watchdog, self-heal), the global concurrency lock, and the two concurrency-limit mechanisms by scope — with the two invariants everything hangs on stated up front (target existence is ground truth; idempotent re-execution).

Also updates the SDK skill bundle per the repo policy: the stale `ModalExecutor` example in `sdk-advanced.md` is replaced with the current `StardagApp`/`build_trigger`/detached/reactive surface, and the registry endpoint table gains the frontier/notify/concurrency-limits endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)