### PR TITLE
Reactive scheduling: skip tasks transitively blocked by failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,8 +59,27 @@ tick_settings=...)`. Current limitations (documented in
   between slot acquisition and spawn — so leaked slots always free; the
   watchdog is strongly recommended when limits are enforced.
 
+- Reactive scheduling: on a failure terminal, ticks now mark tasks
+  transitively blocked by the failure as **skipped** (server-computed via
+  `POST /builds/{id}/skip-blocked`) — mirroring the resident engine, so
+  blocked tasks no longer dangle pending in the UI while the build shows
+  failed. Together with the retry/roots endpoints below, reactive
+  re-triggers now have a complete recovery story: failed builds can be
+  re-triggered (failed tasks reset to pending) and roots added mid-build
+  are covered by completion detection.
+
 ### Registry API
 
+- New `POST /builds/{id}/skip-blocked`: emits `TASK_SKIPPED` for
+  pending/suspended tasks transitively downstream of a
+  failed/cancelled/skipped task (recursive dependency-edge closure, one
+  transaction).
+- New `TASK_RETRIED` event + `POST /builds/{id}/tasks/{task_id}/retry`:
+  resets a failed/cancelled/skipped task to pending (never downgrades
+  completed/running) — the retry path for reactive builds.
+- New `POST /builds/{id}/roots`: append root task ids to a build
+  (deduplicated), so completion detection covers roots added to an
+  active build.
 - New reactive-scheduling endpoints: `POST`/`DELETE /builds/{id}/notify`
   (scheduler wake-up flag, new `builds.needs_tick_at` column) and
   `GET /builds/{id}/frontier` — the build's actionable tasks (global status

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -968,7 +968,20 @@ async def skip_blocked_tasks(
         .scalar_subquery()
     )
 
-    # Transitive closure downward from terminal-blocking seeds.
+    # Transitive closure downward from terminal-blocking seeds. Blockage
+    # only propagates through nodes that will themselves never complete:
+    # the seeds (failed/cancelled/skipped) and pending/suspended nodes
+    # (which this call turns skipped). A COMPLETED intermediate satisfies
+    # its downstream regardless of its own upstreams (mirroring the
+    # resident engine, which only propagates skips through tasks that
+    # themselves become skipped); RUNNING intermediates may still complete.
+    _propagating_statuses = [
+        TaskStatus.FAILED,
+        TaskStatus.CANCELLED,
+        TaskStatus.SKIPPED,
+        TaskStatus.PENDING,
+        TaskStatus.SUSPENDED,
+    ]
     seeds = (
         select(Task.id)
         .where(
@@ -979,8 +992,11 @@ async def skip_blocked_tasks(
         )
         .cte("blocked_closure", recursive=True)
     )
-    downstream = select(TaskDependency.downstream_task_id.label("id")).join(
-        seeds, TaskDependency.upstream_task_id == seeds.c.id
+    downstream = (
+        select(TaskDependency.downstream_task_id.label("id"))
+        .join(seeds, TaskDependency.upstream_task_id == seeds.c.id)
+        .join(Task, Task.id == seeds.c.id)
+        .where(Task.latest_status.in_(_propagating_statuses))
     )
     closure = seeds.union(downstream)
 
@@ -993,6 +1009,10 @@ async def skip_blocked_tasks(
                     Task.id.in_(build_task_pks),
                     Task.latest_status.in_([TaskStatus.PENDING, TaskStatus.SUSPENDED]),
                 )
+                # Deterministic lock order (matching bulk-register's
+                # task_id ordering) so concurrent skip-blocked calls or
+                # skip-blocked vs bulk-register can't deadlock.
+                .order_by(Task.task_id.asc())
                 .with_for_update()
             )
         )

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1003,7 +1003,11 @@ async def skip_blocked_tasks(
     if blocked_tasks:
         _raise_if_limit_exceeded(
             await check_entity_creation_limit(
-                db, auth.workspace_id, "events", limits_settings
+                db,
+                auth.workspace_id,
+                "events",
+                limits_settings,
+                amount=len(blocked_tasks),
             )
         )
         metadata = _build_event_metadata(commit_hash)

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -41,6 +41,7 @@ from stardag_api.models import (
 from stardag_api.models.base import generate_uuid7, utc_now
 from stardag_api.schemas import (
     AddBuildRootsRequest,
+    SkipBlockedResponse,
     AddDependenciesRequest,
     AddDependenciesResponse,
     BuildCreate,
@@ -938,6 +939,91 @@ async def add_build_roots(
         completed_at=completed_at,
         status_triggered_by_user=triggered_by_user,
         is_resumed=is_resumed,
+    )
+
+
+@router.post("/{build_id}/skip-blocked", response_model=SkipBlockedResponse)
+async def skip_blocked_tasks(
+    build_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
+    commit_hash: str | None = None,
+):
+    """Emit TASK_SKIPPED for tasks transitively blocked by failures.
+
+    Computes (recursive CTE over dependency edges) the pending/suspended
+    tasks in the build that are downstream of a failed/cancelled/skipped
+    task, and records TASK_SKIPPED for each in one transaction. Called by
+    reactive scheduler ticks when a build reaches a failure terminal, so
+    blocked tasks show as skipped instead of dangling pending forever —
+    mirroring the resident engine's skip emission.
+    """
+    _raise_if_limit_exceeded(check_rate_limit(auth.workspace_id, limits_settings))
+    await _get_build_checked(build_id, db, auth)
+
+    build_task_pks = (
+        select(Event.task_id)
+        .where(Event.build_id == build_id, Event.task_id.is_not(None))
+        .distinct()
+        .scalar_subquery()
+    )
+
+    # Transitive closure downward from terminal-blocking seeds.
+    seeds = (
+        select(Task.id)
+        .where(
+            Task.id.in_(build_task_pks),
+            Task.latest_status.in_(
+                [TaskStatus.FAILED, TaskStatus.CANCELLED, TaskStatus.SKIPPED]
+            ),
+        )
+        .cte("blocked_closure", recursive=True)
+    )
+    downstream = select(TaskDependency.downstream_task_id.label("id")).join(
+        seeds, TaskDependency.upstream_task_id == seeds.c.id
+    )
+    closure = seeds.union(downstream)
+
+    blocked_tasks = (
+        (
+            await db.execute(
+                select(Task)
+                .where(
+                    Task.id.in_(select(closure.c.id)),
+                    Task.id.in_(build_task_pks),
+                    Task.latest_status.in_([TaskStatus.PENDING, TaskStatus.SUSPENDED]),
+                )
+                .with_for_update()
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    if blocked_tasks:
+        _raise_if_limit_exceeded(
+            await check_entity_creation_limit(
+                db, auth.workspace_id, "events", limits_settings
+            )
+        )
+        metadata = _build_event_metadata(commit_hash)
+        for task in blocked_tasks:
+            event = Event(
+                build_id=build_id,
+                task_id=task.id,
+                event_type=EventType.TASK_SKIPPED,
+                event_metadata=metadata,
+            )
+            db.add(event)
+            await db.flush()
+            apply_event_to_task(task, event)
+        await db.commit()
+        for _ in blocked_tasks:
+            record_entity_created(auth.workspace_id, "events")
+
+    return SkipBlockedResponse(
+        build_id=build_id,
+        skipped_task_ids=[t.task_id for t in blocked_tasks],
     )
 
 

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -274,6 +274,13 @@ class ConcurrencyLimitUpsert(BaseModel):
     max_concurrent: int = Field(ge=1)
 
 
+class SkipBlockedResponse(BaseModel):
+    """Tasks skipped by POST /builds/{id}/skip-blocked."""
+
+    build_id: UUID
+    skipped_task_ids: list[str]
+
+
 class BuildNotifyResponse(BaseModel):
     """Response of the build notify (scheduler wake-up flag) endpoints."""
 

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -2026,3 +2026,38 @@ async def test_skip_blocked_noop_without_failures(client: AsyncClient):
     response = await client.post(f"/api/v1/builds/{build_id}/skip-blocked")
     assert response.status_code == 200
     assert response.json()["skipped_task_ids"] == []
+
+
+@pytest.mark.asyncio
+async def test_skip_blocked_quota_check_covers_batch(client: AsyncClient):
+    """skip-blocked can emit many TASK_SKIPPED events in one call; the 24h
+    event-quota check must be performed with the full batch size, not the
+    default single-event amount (which would let a batch overshoot the
+    remaining quota)."""
+    from unittest.mock import patch
+
+    from stardag_api.limits import check_entity_creation_limit as real_check
+
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{build_id}/tasks", json=_register_payload("bad"))
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks", json=_register_payload("mid", deps=["bad"])
+    )
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks", json=_register_payload("top", deps=["mid"])
+    )
+    await client.post(f"/api/v1/builds/{build_id}/tasks/bad/start")
+    await client.post(f"/api/v1/builds/{build_id}/tasks/bad/fail")
+
+    checked: list[tuple[str, int]] = []
+
+    async def spy(db, workspace_id, entity_type, settings, amount=1):
+        checked.append((entity_type, amount))
+        return await real_check(db, workspace_id, entity_type, settings, amount=amount)
+
+    with patch("stardag_api.routes.builds.check_entity_creation_limit", spy):
+        response = await client.post(f"/api/v1/builds/{build_id}/skip-blocked")
+
+    assert response.status_code == 200
+    assert sorted(response.json()["skipped_task_ids"]) == ["mid", "top"]
+    assert checked == [("events", 2)]

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -1965,3 +1965,64 @@ async def test_concurrent_enforced_starts_respect_cap_postgres(pg_client):
     set — the Postgres CI job provides it)."""
     statuses = await _race_enforced_starts(pg_client)
     assert statuses == [200, 200, 409, 409, 409, 409]
+
+
+@pytest.mark.asyncio
+async def test_skip_blocked_transitive_chain_and_diamond(client: AsyncClient):
+    """skip-blocked marks pending/suspended tasks transitively downstream of
+    a failure as skipped; unrelated/terminal tasks are untouched."""
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    # chain: bad -> mid -> top ; diamond: bad -> d1, ok -> d1
+    # unrelated: free (pending), done (completed)
+    await client.post(f"/api/v1/builds/{build_id}/tasks", json=_register_payload("bad"))
+    await client.post(f"/api/v1/builds/{build_id}/tasks", json=_register_payload("ok"))
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        json=_register_payload("mid", deps=["bad"]),
+    )
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        json=_register_payload("top", deps=["mid"]),
+    )
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        json=_register_payload("d1", deps=["bad", "ok"]),
+    )
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks", json=_register_payload("free")
+    )
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks", json=_register_payload("done")
+    )
+    await client.post(f"/api/v1/builds/{build_id}/tasks/done/start")
+    await client.post(f"/api/v1/builds/{build_id}/tasks/done/complete")
+    # mid is SUSPENDED (also skippable), bad FAILED
+    await client.post(f"/api/v1/builds/{build_id}/tasks/mid/start")
+    await client.post(f"/api/v1/builds/{build_id}/tasks/mid/suspend")
+    await client.post(f"/api/v1/builds/{build_id}/tasks/bad/start")
+    await client.post(f"/api/v1/builds/{build_id}/tasks/bad/fail")
+
+    response = await client.post(f"/api/v1/builds/{build_id}/skip-blocked")
+    assert response.status_code == 200
+    assert sorted(response.json()["skipped_task_ids"]) == ["d1", "mid", "top"]
+
+    frontier = (await client.get(f"/api/v1/builds/{build_id}/frontier")).json()
+    assert frontier["status_counts"] == {
+        "failed": 1,
+        "skipped": 3,
+        "pending": 2,  # ok + free untouched
+        "completed": 1,
+    }
+
+    # Idempotent: nothing left to skip.
+    response = await client.post(f"/api/v1/builds/{build_id}/skip-blocked")
+    assert response.json()["skipped_task_ids"] == []
+
+
+@pytest.mark.asyncio
+async def test_skip_blocked_noop_without_failures(client: AsyncClient):
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{build_id}/tasks", json=_register_payload("t"))
+    response = await client.post(f"/api/v1/builds/{build_id}/skip-blocked")
+    assert response.status_code == 200
+    assert response.json()["skipped_task_ids"] == []

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -2061,3 +2061,69 @@ async def test_skip_blocked_quota_check_covers_batch(client: AsyncClient):
     assert response.status_code == 200
     assert sorted(response.json()["skipped_task_ids"]) == ["mid", "top"]
     assert checked == [("events", 2)]
+
+
+@pytest.mark.asyncio
+async def test_skip_blocked_cancelled_seed(client: AsyncClient):
+    """Cancelled tasks seed the closure the same way failed ones do."""
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{build_id}/tasks", json=_register_payload("c"))
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks", json=_register_payload("down", deps=["c"])
+    )
+    await client.post(f"/api/v1/builds/{build_id}/tasks/c/start")
+    await client.post(f"/api/v1/builds/{build_id}/tasks/c/cancel")
+
+    response = await client.post(f"/api/v1/builds/{build_id}/skip-blocked")
+    assert response.status_code == 200
+    assert response.json()["skipped_task_ids"] == ["down"]
+
+
+@pytest.mark.asyncio
+async def test_skip_blocked_stops_at_completed_intermediate(client: AsyncClient):
+    """Blockage does not propagate through a COMPLETED intermediate: its
+    downstream is satisfied regardless of the intermediate's own upstreams
+    (mirrors the resident engine, which only propagates skips through tasks
+    that themselves become skipped)."""
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{build_id}/tasks", json=_register_payload("bad"))
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks", json=_register_payload("mid", deps=["bad"])
+    )
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks", json=_register_payload("top", deps=["mid"])
+    )
+    # mid completed (e.g. in an earlier build) despite bad failing now.
+    await client.post(f"/api/v1/builds/{build_id}/tasks/mid/start")
+    await client.post(f"/api/v1/builds/{build_id}/tasks/mid/complete")
+    await client.post(f"/api/v1/builds/{build_id}/tasks/bad/start")
+    await client.post(f"/api/v1/builds/{build_id}/tasks/bad/fail")
+
+    response = await client.post(f"/api/v1/builds/{build_id}/skip-blocked")
+    assert response.status_code == 200
+    assert response.json()["skipped_task_ids"] == []  # top stays runnable
+
+
+@pytest.mark.asyncio
+async def test_skip_blocked_visible_to_other_builds(client: AsyncClient):
+    """Task status is env-scoped: a task skipped via build A's closure drops
+    out of build B's actionable frontier (loud, not silent — B hits the
+    blocked terminal and a re-trigger resets it via retry)."""
+    build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
+    for bid in (build_a, build_b):
+        await client.post(f"/api/v1/builds/{bid}/tasks", json=_register_payload("dep"))
+        await client.post(
+            f"/api/v1/builds/{bid}/tasks",
+            json=_register_payload("shared", deps=["dep"]),
+        )
+    await client.post(f"/api/v1/builds/{build_a}/tasks/dep/start")
+    await client.post(f"/api/v1/builds/{build_a}/tasks/dep/fail")
+
+    response = await client.post(f"/api/v1/builds/{build_a}/skip-blocked")
+    assert response.json()["skipped_task_ids"] == ["shared"]
+
+    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    actionable_ids = [t["task_id"] for t in frontier_b["actionable"]]
+    assert "shared" not in actionable_ids
+    assert frontier_b["status_counts"].get("skipped") == 1

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -120,7 +120,8 @@ tick(build_id):
     act: spawn pending/suspended tasks detached (recording refs)
          probe running refs — leave live ones; self-heal completions
          (target existence is ground truth); record failures
-    handle terminal states (all roots complete / failure / cancelled)
+    handle terminal states (all roots complete / failure — with blocked
+    tasks marked skipped / cancelled)
     linger briefly on the wake-up flag; exit when quiet
 ```
 

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -458,10 +458,10 @@ access to the default target root (task objects are persisted there for
 the ticks); the global concurrency lock and build-local
 `ConcurrencyConfig` limits are not applied by ticks (use the
 registry-backed named limits above; Modal's per-function
-`concurrency_limit` also still applies); and tasks blocked by a failure
-currently stay pending in the UI (the build itself is failed). Builds
-cancelled from the registry UI are picked up by the next tick (within the
-watchdog period), which cancels the running Modal function calls.
+`concurrency_limit` also still applies). Builds cancelled from the
+registry UI are picked up by the next tick (within the watchdog period),
+which cancels the running Modal function calls; on failure, tasks
+transitively blocked by the failed task are marked skipped.
 
 Two operational notes:
 

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -51,6 +51,7 @@ from stardag.build._base import (
 )
 from stardag.build._task_store import BuildTaskStore
 from stardag.exceptions import NotFoundError
+from stardag.registry._api_registry import _is_route_not_found
 from stardag.registry import BuildFrontier, FrontierTaskRef, RegistryABC
 
 logger = logging.getLogger(__name__)
@@ -549,12 +550,16 @@ async def _skip_blocked(
 
     Cosmetic-but-important: without it, blocked tasks dangle PENDING in the
     registry/UI forever while the build shows failed. Old servers without
-    the endpoint are tolerated (404 → skip silently omitted).
+    the endpoint are tolerated (missing-route 404 → skip silently omitted);
+    app-level 404s (e.g. the build no longer exists) are re-raised — they
+    signal a registry inconsistency the tick must not paper over.
     """
     try:
         skipped = await registry.build_skip_blocked_aio(build_id)
         summary.skipped += len(skipped)
-    except NotFoundError:
+    except NotFoundError as e:
+        if not _is_route_not_found(e):
+            raise
         logger.warning(
             "Registry server does not support skip-blocked; tasks blocked "
             "by the failure will remain pending."

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -207,6 +207,7 @@ class TickSummary:
     cancelled_refs: int = 0
     iterations: int = 0
     limit_denied: int = 0
+    skipped: int = 0
 
 
 async def run_tick_aio(
@@ -504,6 +505,7 @@ async def _handle_terminal(
 
     if failed > 0 and config.fail_mode == FailMode.FAIL_FAST:
         await _cancel_running(frontier, build_id, task_executor, task_store, summary)
+        await _skip_blocked(registry, build_id, summary)
         await registry.build_fail_aio(
             build_id, f"{failed} task(s) failed (fail_mode=FAIL_FAST)"
         )
@@ -529,6 +531,7 @@ async def _handle_terminal(
         # Nothing runnable and nothing running: the build can't progress
         # (failed deps in CONTINUE mode, or a lost task pickle). Fail
         # rather than idle forever.
+        await _skip_blocked(registry, build_id, summary)
         await registry.build_fail_aio(
             build_id,
             "No runnable or running tasks left but roots are not complete "
@@ -537,6 +540,27 @@ async def _handle_terminal(
         return "failed"
 
     return None
+
+
+async def _skip_blocked(
+    registry: RegistryABC, build_id: UUID, summary: TickSummary
+) -> None:
+    """Mark tasks transitively blocked by failures as skipped (best-effort).
+
+    Cosmetic-but-important: without it, blocked tasks dangle PENDING in the
+    registry/UI forever while the build shows failed. Old servers without
+    the endpoint are tolerated (404 → skip silently omitted).
+    """
+    try:
+        skipped = await registry.build_skip_blocked_aio(build_id)
+        summary.skipped += len(skipped)
+    except NotFoundError:
+        logger.warning(
+            "Registry server does not support skip-blocked; tasks blocked "
+            "by the failure will remain pending."
+        )
+    except Exception as e:
+        logger.warning(f"Failed to skip blocked tasks for build {build_id}: {e}")
 
 
 async def _cancel_running(

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -496,7 +496,7 @@ async def _handle_terminal(
         if frontier.build_status == "cancelled":
             # Cancelled externally (e.g. UI): stop the running work.
             await _cancel_running(
-                frontier, build_id, task_executor, task_store, summary
+                frontier, build_id, registry, task_executor, task_store, summary
             )
         return frontier.build_status
 
@@ -505,7 +505,9 @@ async def _handle_terminal(
     failed = counts.get("failed", 0)
 
     if failed > 0 and config.fail_mode == FailMode.FAIL_FAST:
-        await _cancel_running(frontier, build_id, task_executor, task_store, summary)
+        await _cancel_running(
+            frontier, build_id, registry, task_executor, task_store, summary
+        )
         await _skip_blocked(registry, build_id, summary)
         await registry.build_fail_aio(
             build_id, f"{failed} task(s) failed (fail_mode=FAIL_FAST)"
@@ -571,6 +573,7 @@ async def _skip_blocked(
 async def _cancel_running(
     frontier: BuildFrontier,
     build_id: UUID,
+    registry: RegistryABC,
     task_executor: TaskExecutorABC,
     task_store: BuildTaskStore,
     summary: TickSummary,
@@ -581,6 +584,13 @@ async def _cancel_running(
     dynamic-dep registration window drops out of ``actionable`` but must
     still be cancelled. Falls back to ``actionable`` for servers predating
     the field.
+
+    Each successfully cancelled execution is also recorded as
+    TASK_CANCELLED (best-effort): a worker killed by the executor's cancel
+    can't reliably self-report, and without the event the task dangles
+    RUNNING — keeping its pending descendants out of the skip-blocked
+    closure (cancelled is a seed status) and holding any concurrency-limit
+    slots forever.
     """
     running_items = frontier.running or [
         item for item in frontier.actionable if item.latest_status in _RUNNING_STATUSES
@@ -603,4 +613,11 @@ async def _cancel_running(
                 logger.warning(
                     f"Failed to cancel detached execution "
                     f"{item.latest_executor_ref!r} for task {item.task_id}: {e}"
+                )
+                continue
+            try:
+                await registry.task_cancel_aio(build_id, task)
+            except Exception as e:
+                logger.warning(
+                    f"Failed to record cancellation of task {item.task_id}: {e}"
                 )

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -1077,6 +1077,26 @@ class APIRegistry(RegistryABC):
             operation=f"Retry task {task.id}",
         )
 
+    def build_skip_blocked(self, build_id: UUID) -> list[str]:
+        """Mark tasks transitively blocked by failures as skipped."""
+        response = self._request(
+            "POST",
+            f"{self.api_url}/api/v1/builds/{build_id}/skip-blocked",
+            params=self._get_event_params(),
+            operation=f"Skip blocked tasks in build {build_id}",
+        )
+        return list(response.json().get("skipped_task_ids", []))
+
+    async def build_skip_blocked_aio(self, build_id: UUID) -> list[str]:
+        """Async version - mark blocked tasks as skipped."""
+        response = await self._arequest(
+            "POST",
+            f"{self.api_url}/api/v1/builds/{build_id}/skip-blocked",
+            params=self._get_event_params(),
+            operation=f"Skip blocked tasks in build {build_id}",
+        )
+        return list(response.json().get("skipped_task_ids", []))
+
     def build_notify(self, build_id: UUID) -> None:
         """Set the build's scheduler wake-up flag."""
         self._request(

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -281,6 +281,17 @@ class RegistryABC(metaclass=abc.ABCMeta):
         """Async version of task_retry."""
         self.task_retry(build_id, task)
 
+    def build_skip_blocked(self, build_id: UUID) -> list[str]:
+        """Mark tasks transitively blocked by failures as skipped.
+
+        Returns the skipped task ids. Default: no-op (empty).
+        """
+        return []
+
+    async def build_skip_blocked_aio(self, build_id: UUID) -> list[str]:
+        """Async version of build_skip_blocked."""
+        return self.build_skip_blocked(build_id)
+
     def build_notify(self, build_id: UUID) -> None:
         """Set the build's scheduler wake-up flag (reactive scheduling).
 

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -182,6 +182,29 @@ class FakeReactiveRegistry(NoOpRegistry):
         self.calls.append(("build_fail", None))
         self.build_status = "failed"
 
+    async def build_skip_blocked_aio(self, build_id):
+        # Mirrors the API: pending/suspended tasks transitively downstream
+        # of a failed/cancelled/skipped task become skipped.
+        self.calls.append(("skip_blocked", None))
+        blocked = {
+            tid
+            for tid, status in self.statuses.items()
+            if status in ("failed", "cancelled", "skipped")
+        }
+        changed = True
+        while changed:
+            changed = False
+            for tid, ups in self.upstreams.items():
+                if tid not in blocked and ups & blocked:
+                    blocked.add(tid)
+                    changed = True
+        skipped = []
+        for tid in blocked:
+            if self.statuses.get(tid) in ("pending", "suspended"):
+                self.statuses[tid] = "skipped"
+                skipped.append(tid)
+        return skipped
+
     async def build_notify_aio(self, build_id):
         self.needs_tick = True
 
@@ -959,3 +982,53 @@ class TestStaleRunningNoRef:
         assert summary.failed_recorded == 0
         assert summary.outcome == "lingered_out"
         assert executor.spawned == []
+
+
+class TestSkipBlockedOnFailure:
+    async def test_fail_fast_skips_blocked_descendants(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """On a failure terminal the tick marks transitively blocked tasks
+        skipped — they no longer dangle pending while the build is failed."""
+        bad = SyncOnlyTask(name="skip-bad")
+        mid = SyncOnlyTask(name="skip-mid", deps=(bad,))
+        root = SyncOnlyTask(name="skip-root", deps=(mid,))
+        registry, locks, executor, store = _setup([bad, mid, root], auto_complete=False)
+        registry.add_task(str(bad.id), status="failed")
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,  # FAIL_FAST default
+        )
+
+        assert summary.terminal_status == "failed"
+        assert summary.skipped == 2
+        assert registry.statuses[str(mid.id)] == "skipped"
+        assert registry.statuses[str(root.id)] == "skipped"
+
+    async def test_blocked_terminal_in_continue_mode_also_skips(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        dep, root = _chain("skip-cont-dep", "skip-cont-root")
+        registry, locks, executor, store = _setup([dep, root], auto_complete=False)
+        registry.add_task(str(dep.id), status="failed")
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                fail_mode=FailMode.CONTINUE,
+            ),
+        )
+
+        assert summary.terminal_status == "failed"
+        assert registry.statuses[str(root.id)] == "skipped"

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -173,6 +173,11 @@ class FakeReactiveRegistry(NoOpRegistry):
         self.calls.append(("add_roots", ",".join(root_task_ids)))
         self.root_task_ids += [t for t in root_task_ids if t not in self.root_task_ids]
 
+    async def task_cancel_aio(self, build_id, task):
+        tid = str(task.id)
+        self.calls.append(("cancel", tid))
+        self.statuses[tid] = "cancelled"
+
     async def task_fail_aio(self, build_id, task, error_message=None):
         tid = str(task.id)
         self.calls.append(("fail", tid))
@@ -195,11 +200,17 @@ class FakeReactiveRegistry(NoOpRegistry):
             for tid, status in self.statuses.items()
             if status in ("failed", "cancelled", "skipped")
         }
+        # Blockage only propagates through nodes that will themselves never
+        # complete (mirrors the API's CTE gate): a completed intermediate
+        # satisfies its downstream; a running one may still complete.
+        propagating = ("failed", "cancelled", "skipped", "pending", "suspended")
         changed = True
         while changed:
             changed = False
             for tid, ups in self.upstreams.items():
-                if tid not in blocked and ups & blocked:
+                if tid not in blocked and any(
+                    up in blocked and self.statuses.get(up) in propagating for up in ups
+                ):
                     blocked.add(tid)
                     changed = True
         skipped = []
@@ -1012,6 +1023,44 @@ class TestSkipBlockedOnFailure:
         assert summary.terminal_status == "failed"
         assert summary.skipped == 2
         assert registry.statuses[str(mid.id)] == "skipped"
+        assert registry.statuses[str(root.id)] == "skipped"
+
+    async def test_cancelled_branch_descendants_also_skipped(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """FAIL_FAST with a second, still-running branch: the cancel pass
+        records TASK_CANCELLED (a cancelled task must not dangle RUNNING —
+        workers killed by the executor's cancel can't self-report), so the
+        cancelled branch's descendants land in the skip closure too."""
+        bad = SyncOnlyTask(name="cb-bad")
+        long_running = SyncOnlyTask(name="cb-running")
+        downstream = SyncOnlyTask(name="cb-downstream", deps=(long_running,))
+        root = SyncOnlyTask(name="cb-root", deps=(bad, downstream))
+        registry, locks, executor, store = _setup(
+            [bad, long_running, downstream, root], auto_complete=False
+        )
+        registry.add_task(str(bad.id), status="failed")
+        registry.add_task(
+            str(long_running.id),
+            status="running",
+            executor="fake",
+            executor_ref="ref-live",
+        )
+        store.save_task(long_running)
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,  # FAIL_FAST default
+        )
+
+        assert summary.terminal_status == "failed"
+        assert executor.cancelled_refs == ["ref-live"]
+        assert registry.statuses[str(long_running.id)] == "cancelled"
+        assert registry.statuses[str(downstream.id)] == "skipped"
         assert registry.statuses[str(root.id)] == "skipped"
 
     async def test_blocked_terminal_in_continue_mode_also_skips(

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -13,6 +13,8 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
 
 
+import pytest
+
 from stardag import BaseTask, auto_namespace, flatten_task_struct
 from stardag.build import (
     BuildTaskStore,
@@ -29,6 +31,8 @@ from stardag.build._base import (
     LockAcquisitionResult,
     LockAcquisitionStatus,
 )
+from stardag.build._reactive import TickSummary, _skip_blocked
+from stardag.exceptions import NotFoundError
 from stardag.registry import (
     BuildFrontier,
     FrontierTaskRef,
@@ -1032,3 +1036,35 @@ class TestSkipBlockedOnFailure:
 
         assert summary.terminal_status == "failed"
         assert registry.statuses[str(root.id)] == "skipped"
+
+
+class _SkipBlocked404Registry(NoOpRegistry):
+    """Registry whose skip-blocked endpoint 404s with a given detail."""
+
+    def __init__(self, detail: str):
+        super().__init__()
+        self.detail = detail
+
+    async def build_skip_blocked_aio(self, build_id) -> list[str]:
+        raise NotFoundError(
+            "Skip blocked tasks: resource not found", detail=self.detail
+        )
+
+
+class TestSkipBlockedErrorHandling:
+    async def test_missing_route_tolerated(self):
+        """Old server without the endpoint (FastAPI default 404) → skip
+        silently omitted, no raise."""
+        summary = TickSummary(outcome="noop")
+        await _skip_blocked(_SkipBlocked404Registry("Not Found"), uuid4(), summary)
+        assert summary.skipped == 0
+
+    async def test_app_level_404_reraised(self):
+        """A 404 raised inside the endpoint (e.g. build no longer exists)
+        signals a registry inconsistency and must propagate."""
+        with pytest.raises(NotFoundError):
+            await _skip_blocked(
+                _SkipBlocked404Registry("Build not found"),
+                uuid4(),
+                TickSummary(outcome="noop"),
+            )


### PR DESCRIPTION
> Stacked on #159 — Phase 4b follow-up closing the documented "blocked tasks stay pending" limitation of reactive mode.

## What changes

When a reactive build reaches a failure terminal (FAIL_FAST, or a blocked build in CONTINUE mode), the scheduler tick now marks the tasks that can no longer run as **skipped**, mirroring the resident engine's behavior — previously they dangled PENDING in the registry/UI forever while the build showed failed.

- **New `POST /builds/{id}/skip-blocked`**: computes — via a recursive CTE over dependency edges (static + dynamic) — the pending/suspended tasks in the build transitively downstream of any failed/cancelled/skipped task, and records `TASK_SKIPPED` for each in a single transaction. Server-side computation keeps it one round trip and atomic; the server records state, it doesn't schedule (consistent with the architecture's hard constraint).
- **SDK**: `RegistryABC.build_skip_blocked[_aio]` (default no-op) + `APIRegistry` implementation; the tick calls it on both failure-terminal paths before `BUILD_FAILED`. Old servers without the endpoint are tolerated (warning, skips omitted). `TickSummary.skipped` reports the count.
- Docs/changelog: the "tasks blocked by a failure stay pending" limitation is removed; the changelog also gains the retry/roots Registry-API entries from the review-fix round that were missing.

## Testing

- API: transitive chain + diamond skipping (suspended tasks included; completed/running/unrelated untouched), idempotence, no-failures no-op
- Engine: FAIL_FAST skips blocked descendants; CONTINUE-mode blocked terminal also skips (fake registry implements the closure semantics)
- Full suites green: SDK 717, stardag-api 279 (+ Postgres-tier serialization test from the review round), live Modal tier 28; pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)