### PR TITLE
Pickle-free task rehydration from registry data

### DIFF
--- a/.claude/skills/stardag/SKILL.md
+++ b/.claude/skills/stardag/SKILL.md
@@ -123,6 +123,8 @@ sd.get_default_relpath(task)       # Construct default task output relpath
 sd.HashableSet[T]                  # Hashable frozenset for parameters
 sd.StardagField(...)               # Field annotation (hash_exclude, etc.)
 sd.StardagBaseModel                # Base Pydantic model
+sd.task_from_registry_data(data)   # Rebuild a task from registry task_data (pickle-free)
+sd.TaskRehydrationError            # Raised when reconstruction fails
 
 # Artifacts
 from stardag.artifact import MarkdownArtifact, JSONArtifact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### SDK
 
+- **Pickle-free task rehydration from registry data.** New
+  `stardag.task_from_registry_data(task_data, expected_task_id=...)`
+  reconstructs a task instance from the payload stored at registration
+  (`TaskMetadata.body`) via the polymorphic validator — the payload is
+  self-describing (embedded namespace/name discriminators, recursively
+  for nested `TaskLoads`/`SubClass` fields). Requirements/limits: the
+  defining module must be imported; nested task fields must use the
+  polymorphic annotations; the optional identity check guards against
+  non-round-trippable custom serializers. Reactive scheduler ticks now
+  use it as a fallback when a task's stored pickle is missing or
+  unloadable (healing the store on success) — an app redeploy with
+  compatible task definitions no longer breaks in-flight reactive
+  builds. This is also the foundation for UI-triggered task retries.
+
 - **Reactive (tick-based) build scheduling for Modal — experimental.** A
   build can now run with **no resident orchestrator**:
   `StardagApp.build_trigger(tasks, reactive=True)` runs discovery at the

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -134,7 +134,9 @@ runs but your tasks**.
 
 The registry is the scheduler state (the frontier is computed from
 recorded task statuses and dependency edges); task _objects_ are
-rehydrated from a per-build task store persisted at trigger time. The
+rehydrated from a per-build task store persisted at trigger time, with a
+pickle-free fallback that reconstructs them from the registry's stored
+task data (`stardag.task_from_registry_data`). The
 registry never pushes or executes anything — only user-deployed code
 (which has the DAG-defining code) spawns work.
 

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -465,12 +465,14 @@ transitively blocked by the failed task are marked skipped.
 
 Two operational notes:
 
-- **Don't redeploy the app with changed task definitions while reactive
-  builds are in flight.** Task objects are persisted as pickles and loaded
-  by later ticks/workers of the same deployed app version — a mid-build
-  redeploy that changes task classes can make the stored tasks
-  unloadable (such tasks are failed by the next tick rather than
-  silently stalling; re-trigger the build after the redeploy).
+- **Avoid redeploying the app with changed task definitions while
+  reactive builds are in flight.** Task objects are persisted as pickles
+  for the scheduler; if a stored pickle becomes unloadable (e.g. after a
+  redeploy), the tick falls back to **reconstructing the task from the
+  registry's stored data** — which works as long as the task class is
+  still importable and its fields are compatible (nested task fields
+  must use `sd.TaskLoads`/`sd.SubClass` annotations). Only if both paths
+  fail is the task failed by the next tick (never a silent stall).
 - **The watchdog sweep runs one quick scheduling pass per running build**
   (it skips the linger), so its per-period cost is one short function
   invocation plus a frontier query per running build.

--- a/lib/stardag/src/stardag/__init__.py
+++ b/lib/stardag/src/stardag/__init__.py
@@ -48,6 +48,7 @@ from stardag._core.base_task import (
 )
 from stardag._core.decorator import Depends, task
 from stardag._core.hashable_set import HashableSet, HashSafeSetSerializer
+from stardag._core.rehydrate import TaskRehydrationError, task_from_registry_data
 from stardag._core.task import Task, get_default_relpath
 from stardag._core.validate import LoadValidator
 from stardag._core.task_loads import TaskLoads
@@ -115,6 +116,8 @@ __all__ = [
     "StardagField",
     "SubClass",
     "Task",
+    "TaskRehydrationError",
+    "task_from_registry_data",
     "TaskRef",
     "TaskLoads",
     "TaskStruct",

--- a/lib/stardag/src/stardag/_core/rehydrate.py
+++ b/lib/stardag/src/stardag/_core/rehydrate.py
@@ -1,0 +1,159 @@
+"""Reconstruct task instances from registry-stored task data — pickle-free.
+
+The ``task_data`` persisted at registration (``model_dump(mode="json")``) is
+self-describing: the polymorphic serializer embeds the ``__namespace`` /
+``__name`` discriminator keys, and nested task fields carry their own. That
+makes the registry's stored payload sufficient to rebuild the concrete task
+instance via the polymorphic validator — provided the module defining the
+task class has been imported (class registration happens at class-definition
+time).
+
+This unlocks orchestration flows that don't depend on same-process (or
+same-deployment pickle) state: scheduler ticks re-hydrating tasks whose
+pickle is missing, UI-triggered retries, and non-Python-adjacent tooling
+that only has the registry payload.
+
+Known limitations:
+
+- The defining module must be imported in the reconstructing process (a
+  clear error is raised otherwise).
+- ``AliasTask`` embeds a pickled ``loads_type`` and is therefore not
+  pickle-free — payloads containing ``__aliased`` data (at any nesting
+  level) are **rejected**: unpickling registry-supplied bytes without
+  user action would let a compromised registry execute code in the
+  reconstructing process. Use ``BaseTask.from_registry`` for the explicit,
+  user-invoked path.
+- Fields whose custom serializers are not losslessly round-trippable
+  reconstruct to a *different* task identity — guarded by the optional
+  ``expected_task_id`` check.
+- Nested task fields must use the polymorphic annotations
+  (``sd.TaskLoads[T]`` / ``sd.SubClass[...]``) — a plain task-typed
+  annotation validates children into the abstract base class.
+"""
+
+from __future__ import annotations
+
+import typing
+from uuid import UUID
+
+from pydantic import TypeAdapter
+
+from stardag._core.base_task import BaseTask
+from stardag.base_model import CONTEXT_MODE_KEY
+from stardag.exceptions import StardagError
+from stardag.polymorphic import NAME_KEY, NAMESPACE_KEY, SubClass, TypeId
+
+
+class TaskRehydrationError(StardagError):
+    """A task could not be reconstructed from its registry data."""
+
+
+# Marker for AliasTask payloads (see BaseTask.resolve): their ``loads_type``
+# field is pickled bytes, which must never be unpickled automatically from
+# registry-supplied data.
+_ALIASED_KEY = "__aliased"
+
+
+def _contains_aliased(value: typing.Any) -> bool:
+    if isinstance(value, typing.Mapping):
+        return _ALIASED_KEY in value or any(
+            _contains_aliased(v) for v in value.values()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_aliased(v) for v in value)
+    return False
+
+
+# Validates any dict carrying the polymorphic discriminator keys into the
+# registered concrete BaseTask subclass (same machinery as nested task
+# fields). Module-level: TypeAdapter construction is not free.
+_TASK_ADAPTER: TypeAdapter[BaseTask] = TypeAdapter(SubClass[BaseTask])
+
+
+def task_from_registry_data(
+    task_data: typing.Mapping[str, typing.Any],
+    *,
+    expected_task_id: str | UUID | None = None,
+) -> BaseTask:
+    """Reconstruct a task instance from its registry ``task_data`` payload.
+
+    Args:
+        task_data: The payload stored at registration (also available as
+            ``TaskMetadata.body`` from ``task_get_metadata``): a full
+            ``model_dump(mode="json")`` including the polymorphic
+            discriminator keys.
+        expected_task_id: When given, the reconstructed task's
+            (recomputed) deterministic id must match — catching lossy
+            serialization round-trips that would otherwise silently yield
+            a different task identity.
+
+    Raises:
+        TaskRehydrationError: If the task class is not registered (module
+            not imported), the payload doesn't validate, or the identity
+            check fails.
+    """
+    namespace = task_data.get(NAMESPACE_KEY)
+    name = task_data.get(NAME_KEY)
+    if name is None or namespace is None:
+        # Both keys are always present in a full dump (the root namespace
+        # serializes as "", not as an absent key).
+        raise TaskRehydrationError(
+            "task_data is missing the polymorphic discriminator keys "
+            f"({NAMESPACE_KEY!r}/{NAME_KEY!r}) — it must be the full "
+            "payload stored at registration, not a partial dump."
+        )
+    # Security: AliasTask payloads carry a pickled loads_type that the
+    # polymorphic resolve path would unpickle — from registry-supplied
+    # bytes, with no user action when called from scheduler ticks. Reject
+    # them anywhere in the payload (nested task fields resolve through the
+    # same path, so a top-level check is not enough).
+    if _contains_aliased(task_data):
+        raise TaskRehydrationError(
+            "task_data contains AliasTask ('__aliased') payloads, which "
+            "embed pickled bytes and cannot be rehydrated from registry "
+            "data. AliasTask is pickle-bound; use the explicit "
+            "BaseTask.from_registry path if you trust the source."
+        )
+    # Pre-resolve for a clear module-not-imported error (the adapter's own
+    # KeyError is less actionable).
+    try:
+        BaseTask._registry().get_class(TypeId(namespace=namespace, name=name))
+    except KeyError as e:
+        raise TaskRehydrationError(
+            f"No task class registered for namespace={namespace!r}, "
+            f"name={name!r}. The module defining the task class must be "
+            "imported before rehydration (task classes register at "
+            "definition time)."
+        ) from e
+
+    try:
+        task = _TASK_ADAPTER.validate_python(
+            dict(task_data), context={CONTEXT_MODE_KEY: "compat"}
+        )
+    except Exception as e:
+        raise TaskRehydrationError(
+            f"Failed to validate task_data for {namespace!r}.{name!r}: {e}"
+        ) from e
+
+    if expected_task_id is not None:
+        try:
+            rehydrated_id = task.id
+        except Exception as e:
+            # Typically a nested task field with a PLAIN task annotation
+            # (e.g. ``deps: tuple[Task, ...]``): the child validates into
+            # the abstract base instead of the concrete class and fails on
+            # serialization. Polymorphic annotations (``sd.TaskLoads[T]`` /
+            # ``sd.SubClass[...]``) reconstruct correctly.
+            raise TaskRehydrationError(
+                f"Rehydrated {namespace!r}.{name!r} is not serializable "
+                f"({e}). Nested task fields must use polymorphic "
+                "annotations (sd.TaskLoads / sd.SubClass) to be "
+                "reconstructable from registry data."
+            ) from e
+        if str(rehydrated_id) != str(expected_task_id):
+            raise TaskRehydrationError(
+                f"Rehydrated task id {rehydrated_id} does not match the "
+                f"expected id {expected_task_id} — a field's serialization "
+                "is likely not losslessly round-trippable."
+            )
+    return task

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -41,7 +41,12 @@ from datetime import datetime, timezone
 from typing import Callable, Sequence
 from uuid import UUID
 
-from stardag import BaseTask, TaskStruct, flatten_task_struct
+from stardag import (
+    BaseTask,
+    TaskStruct,
+    flatten_task_struct,
+    task_from_registry_data,
+)
 from stardag.build._base import (
     DetachedExecutionStatus,
     FailMode,
@@ -315,6 +320,52 @@ async def run_tick_aio(
     return summary  # unreachable: the loop above always returns
 
 
+async def _load_task(
+    task_id: str,
+    registry: RegistryABC,
+    task_store: BuildTaskStore,
+    *,
+    quiet: bool = False,
+) -> BaseTask | None:
+    """Load a task object: store pickle first, registry rehydration second.
+
+    The pickle-free fallback reconstructs the task from the registry's
+    stored ``task_data`` (see ``stardag.task_from_registry_data``) — which
+    also survives cases the pickle store can't (e.g. an app redeploy with
+    compatible task definitions invalidating stored pickles). Successful
+    rehydrations are written back to the store (best-effort: the task
+    object is already in hand, so a transient store error must not abort
+    the caller).
+
+    With ``quiet=True`` a rehydration failure logs a single warning without
+    the stack trace — for callers where a missing object is tolerated (a
+    RUNNING task resolves via its worker's self-reporting), the repeated
+    per-tick ``logger.exception`` would be noise.
+    """
+    task = task_store.load_task(task_id)
+    if task is not None:
+        return task
+    try:
+        metadata = await registry.task_get_metadata_aio(UUID(task_id))
+        task = task_from_registry_data(metadata.body, expected_task_id=task_id)
+    except Exception as e:
+        message = (
+            f"Task {task_id} is missing from the task store and could not "
+            f"be rehydrated from registry data"
+        )
+        if quiet:
+            logger.warning(f"{message}: {e}")
+        else:
+            logger.exception(f"{message}.")
+        return None
+    logger.info(f"Rehydrated task {task_id} from registry data.")
+    try:
+        task_store.save_task(task)
+    except Exception as e:
+        logger.warning(f"Failed to write rehydrated task {task_id} back: {e}")
+    return task
+
+
 async def _act_on_frontier(
     frontier: BuildFrontier,
     *,
@@ -337,19 +388,25 @@ async def _act_on_frontier(
     acted = False
     denied_this_round = 0
     for item in frontier.actionable:
-        task = task_store.load_task(item.task_id)
+        task = await _load_task(
+            item.task_id,
+            registry,
+            task_store,
+            quiet=item.latest_status in _RUNNING_STATUSES,
+        )
         if task is None:
             if item.latest_status in _RUNNING_STATUSES:
                 # Can't probe without the object, but the worker reports its
                 # own terminal events — leave it to resolve itself.
                 continue
-            # A pending/suspended task without a stored object can never be
-            # scheduled: fail it (rather than leaving it in the frontier
-            # forever, where it would block terminal detection and stall
-            # the build across endless watchdog ticks).
+            # A pending/suspended task with no stored object AND no
+            # rehydratable registry data can never be scheduled: fail it
+            # (rather than leaving it in the frontier forever, where it
+            # would block terminal detection and stall the build across
+            # endless watchdog ticks).
             logger.error(
                 f"Task {item.task_id} of build {build_id} has no stored "
-                "task object; failing it."
+                "task object and could not be rehydrated; failing it."
             )
             try:
                 from uuid import UUID as _UUID
@@ -601,7 +658,7 @@ async def _cancel_running(
             and item.latest_executor is not None
             and item.latest_executor_ref is not None
         ):
-            task = task_store.load_task(item.task_id)
+            task = await _load_task(item.task_id, registry, task_store, quiet=True)
             if task is None:
                 continue
             try:

--- a/lib/stardag/tests/test__core/test_rehydrate.py
+++ b/lib/stardag/tests/test__core/test_rehydrate.py
@@ -1,0 +1,168 @@
+"""Tests for pickle-free task rehydration from registry task_data."""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+import stardag as sd
+from stardag import TaskRehydrationError, task_from_registry_data
+from stardag.polymorphic import NAME_KEY, NAMESPACE_KEY
+from stardag.target import InMemoryFileTarget
+
+sd.auto_namespace(__name__)
+
+
+@sd.task
+def rehydrate_range(limit: int) -> list[int]:
+    return list(range(limit))
+
+
+@sd.task
+def rehydrate_sum(values: sd.Depends[list[int]]) -> int:
+    return sum(values)
+
+
+class RehydrateClassTask(sd.Task[int]):
+    factor: int
+    values: sd.TaskLoads[list[int]]
+
+    def requires(self):
+        return self.values
+
+    def run(self):
+        self._save(self.factor * sum(self.values.load()))
+
+
+class RehydrateDynamicTask(sd.Task[int]):
+    limit: int
+
+    def run(self):
+        dep = rehydrate_range(limit=self.limit)
+        yield dep
+        self._save(sum(dep.load()))
+
+
+class TestRoundTrip:
+    def test_decorator_api_with_nested_dep(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        root = rehydrate_sum(values=rehydrate_range(limit=5))
+        data = root.model_dump(mode="json")
+
+        back = task_from_registry_data(data, expected_task_id=root.id)
+
+        assert type(back) is type(root)
+        assert back.id == root.id
+        # nested dep reconstructed too (getattr: decorator-generated task
+        # classes expose params dynamically, opaque to the type checker)
+        assert getattr(back, "values").id == getattr(root, "values").id
+
+    def test_class_api_taskloads(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        root = RehydrateClassTask(factor=3, values=rehydrate_range(limit=4))
+        back = task_from_registry_data(
+            root.model_dump(mode="json"), expected_task_id=root.id
+        )
+        assert isinstance(back, RehydrateClassTask)
+        assert back.factor == 3
+        assert back.id == root.id
+
+    def test_dynamic_deps_task(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        task = RehydrateDynamicTask(limit=3)
+        back = task_from_registry_data(
+            task.model_dump(mode="json"), expected_task_id=task.id
+        )
+        assert back.id == task.id
+
+    def test_rehydrated_task_is_runnable(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """The reconstructed instance is a fully functional task."""
+        dep = rehydrate_range(limit=3)
+        dep.run()
+        root = rehydrate_sum(values=dep)
+
+        back = task_from_registry_data(root.model_dump(mode="json"))
+        back.run()
+
+        assert back.complete()
+        assert root.load() == 3  # 0+1+2, via the original instance's target
+
+
+class TestErrors:
+    def test_missing_discriminators(self):
+        with pytest.raises(TaskRehydrationError, match="discriminator keys"):
+            task_from_registry_data({"limit": 3})
+
+    def test_missing_namespace_only(self):
+        """A payload with __name but no __namespace is a partial dump too —
+        must raise the missing-discriminators error, not a misleading
+        unregistered-class error for the root namespace."""
+        with pytest.raises(TaskRehydrationError, match="discriminator keys"):
+            task_from_registry_data({NAME_KEY: "SomeTask", "limit": 3})
+
+    def test_unregistered_class_clear_error(self):
+        with pytest.raises(TaskRehydrationError, match="module defining the task"):
+            task_from_registry_data(
+                {
+                    NAMESPACE_KEY: "no.such.namespace",
+                    NAME_KEY: "NoSuchTask",
+                    "version": "",
+                }
+            )
+
+    def test_id_mismatch_detected(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        task = rehydrate_range(limit=3)
+        other = rehydrate_range(limit=4)
+        with pytest.raises(TaskRehydrationError, match="does not match"):
+            task_from_registry_data(
+                task.model_dump(mode="json"), expected_task_id=other.id
+            )
+
+    def test_aliased_payload_rejected(self):
+        """AliasTask payloads embed pickled bytes ('loads_type') that the
+        resolve path would unpickle — automatic rehydration from
+        registry-supplied data must refuse them."""
+        with pytest.raises(TaskRehydrationError, match="aliased"):
+            task_from_registry_data(
+                {
+                    NAMESPACE_KEY: "stardag",
+                    NAME_KEY: "AliasTask",
+                    "version": "",
+                    "__aliased": {"loads_type": "cG93bmVk"},
+                }
+            )
+
+    def test_nested_aliased_payload_rejected(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """Nested task fields resolve through the same path — an __aliased
+        dict at any depth must be rejected, not just at the top level."""
+        root = rehydrate_sum(values=rehydrate_range(limit=2))
+        data = root.model_dump(mode="json")
+        data["values"]["__aliased"] = {"loads_type": "cG93bmVk"}
+        with pytest.raises(TaskRehydrationError, match="aliased"):
+            task_from_registry_data(data)
+
+    def test_plain_task_annotation_fails_clearly(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """Nested task fields with plain (non-polymorphic) annotations can't
+        reconstruct — the identity check surfaces it with a pointer to
+        TaskLoads/SubClass instead of an opaque serialization error."""
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        dep = SyncOnlyTask(name="plain-dep")
+        root = SyncOnlyTask(name="plain-root", deps=(dep,))
+
+        with pytest.raises(TaskRehydrationError, match="TaskLoads"):
+            task_from_registry_data(
+                root.model_dump(mode="json"), expected_task_id=root.id
+            )

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -80,6 +80,9 @@ class FakeReactiveRegistry(NoOpRegistry):
         self.limits: dict[str, int] = {}
         self.task_limit_keys: dict[str, set[str]] = {}
         self.status_at: dict[str, datetime] = {}
+        # task_id -> task_data body, served by task_get_metadata_aio
+        # (rehydration fallback); missing key -> KeyError, like a 404.
+        self.metadata_bodies: dict[str, dict] = {}
 
     # --- test setup helpers ---
 
@@ -190,6 +193,24 @@ class FakeReactiveRegistry(NoOpRegistry):
     async def build_fail_aio(self, build_id, error_message=None):
         self.calls.append(("build_fail", None))
         self.build_status = "failed"
+
+    async def task_get_metadata_aio(self, task_id):
+        from stardag.registry._base import TaskMetadata
+
+        body = self.metadata_bodies[str(task_id)]
+        return TaskMetadata(
+            id=task_id,
+            body=body,
+            name=body.get("__name", ""),
+            namespace=body.get("__namespace", ""),
+            version=body.get("version", ""),
+            output_uri=None,
+            status=self.statuses.get(str(task_id), "pending"),
+            registered_at=None,
+            started_at=None,
+            completed_at=None,
+            error_message=None,
+        )
 
     async def build_skip_blocked_aio(self, build_id):
         # Mirrors the API: pending/suspended tasks transitively downstream
@@ -1117,3 +1138,61 @@ class TestSkipBlockedErrorHandling:
                 uuid4(),
                 TickSummary(outcome="noop"),
             )
+
+
+class TestRehydrationFallback:
+    async def test_store_miss_rehydrates_from_registry(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """A task missing from the pickle store is reconstructed from the
+        registry's stored task_data and scheduled — instead of being failed."""
+        import stardag as sd
+
+        @sd.task(name="RehydrateFallbackTask")
+        def fallback_task(limit: int) -> list[int]:
+            return list(range(limit))
+
+        root = fallback_task(limit=3)
+        registry = FakeReactiveRegistry(
+            root_task_ids=[str(root.id)], auto_complete=True
+        )
+        registry.add_task(str(root.id))
+        registry.metadata_bodies[str(root.id)] = root.model_dump(mode="json")
+        store = InMemoryTaskStore(uuid4())  # empty: no pickle for the task
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=(executor := FakeTickExecutor()),
+            lock_manager=_lock_manager(),
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert executor.spawned == [root.id]
+        assert summary.terminal_status == "completed"
+        assert summary.failed_recorded == 0
+        # Healed back into the store for subsequent ticks.
+        assert store.load_task(root.id) is not None
+
+    async def test_store_miss_and_no_metadata_still_fails_task(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """Without rehydratable data either, the stall-prevention failure
+        path is preserved."""
+        (root,) = _chain("no-rehydrate-root")
+        registry, locks, executor, store = _setup([root], auto_complete=False)
+        store._tasks.clear()
+        # no metadata_bodies entry -> fallback raises -> task failed
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.failed_recorded == 1
+        assert summary.terminal_status == "failed"


### PR DESCRIPTION
## Summary

Stacked on #160. Phase 4b follow-up: reconstruct task instances from the registry's stored `task_data` payload — no pickle required.

- New `stardag.task_from_registry_data(task_data, *, expected_task_id=None)` + `TaskRehydrationError`: validates the self-describing registration payload (polymorphic `__namespace`/`__name` discriminators) into the concrete task class via the same `SubClass[BaseTask]` machinery nested task fields use. Pre-resolves the class for a clear module-not-imported error; optional identity check catches lossy serializer round-trips.
- Reactive scheduling now uses it as a fallback: when a frontier task's pickle is missing from the build task store, `_load_task` rehydrates from the registry metadata body instead of failing the task outright. A build whose store was lost (volume wipe, retention expiry) can now still tick to completion, provided the defining modules are importable.

## Known limitations (documented in the module docstring)

- The defining module must be imported in the reconstructing process.
- `AliasTask` remains pickle-bound (embedded `loads_type`).
- Nested task fields must use the polymorphic annotations (`sd.TaskLoads[T]` / `sd.SubClass[...]`); plain task-typed annotations raise a `TaskRehydrationError` with a pointer to the fix.

## Testing

- 8 new unit tests (`tests/test__core/test_rehydrate.py`): round-trips for decorator/class/dynamic-deps tasks, runnability of the reconstructed instance, and all error paths.
- 2 new reactive tests: pickle-missing frontier item rehydrates and proceeds; unrecoverable payload still fails the task.
- Full non-live suite green; live Modal tier (28 tests) green against a real workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)