### PR TITLE
Registry-backed concurrency limiter for resident builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### SDK
 
+- **Registry-backed concurrency limits for resident builds.** New
+  `stardag.build.RegistryConcurrencyLimiter` implements the
+  `ConcurrencyLimiter` seam on top of the registry's named environment
+  limits: pass a `RegistryConcurrencyLimiter(key_selector=...)` as
+  `concurrency_limiter` to `build`/`build_aio` and the named caps are
+  enforced server-side — shared with reactive builds and other resident
+  builds, across processes and machines (the "future global,
+  server-driven limiter" the seam was reserved for). Acquisition is an
+  enforced task start (slot = RUNNING status; freed on completion,
+  failure, cancellation, or dynamic-deps suspension — parity with
+  `LocalConcurrencyLimiter`); denials block-and-retry at a configurable
+  poll interval (with jitter), transient registry errors retry with
+  exponential backoff, and an optional timeout fails the task. Requires
+  a matching stardag-api version. Note: unlike reactive scheduling,
+  resident mode has no automatic healer for slots held by a crashed
+  build process — see the concurrency-limits docs.
+
 - **Pickle-free task rehydration from registry data.** New
   `stardag.task_from_registry_data(task_data, expected_task_id=...)`
   reconstructs a task instance from the payload stored at registration

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -161,15 +161,24 @@ Two mechanisms, by scope:
 
 - **Build-local** (`ConcurrencyConfig`): asyncio-semaphore limits inside
   one build process — an overall cap plus named limits via a
-  `key_selector`. Uniform across local and remote executors.
-- **Registry-backed named limits** (reactive scheduling): caps configured
+  `key_selector`. Uniform across local and remote executors. Resident
+  builds can instead enforce the registry-backed limits below by passing
+  `concurrency_limiter=RegistryConcurrencyLimiter(key_selector=...)`.
+- **Registry-backed named limits**: caps configured
   per environment in the registry
   (`PUT /api/v1/concurrency-limits/{key}`), enforced atomically when a
   task starts — **across all builds** in the environment. A task occupies
   a slot simply by being RUNNING with the key recorded; the slot frees on
-  any terminal status (no leases — status liveness is maintained by worker
-  reporting and tick self-healing). Denied tasks stay pending and proceed
-  when a slot frees.
+  any terminal status (no leases). In reactive scheduling denied tasks
+  stay pending and proceed when a slot frees, and status liveness — hence
+  slot honesty — is maintained by worker reporting and tick self-healing.
+  In resident builds the `RegistryConcurrencyLimiter` blocks-and-retries
+  the submission, but **no automatic healer exists for resident mode**: a
+  resident build killed after acquiring leaves its task RUNNING, holding
+  the slot until the task or build is explicitly failed/cancelled via the
+  API/UI. Prefer reactive scheduling for unattended limited runs. Both
+  modes share the same slots — limits hold across processes, machines
+  and scheduling modes.
 
 Infrastructure-level limits (e.g. Modal's per-function
 `concurrency_limit`) apply independently underneath either mechanism.

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -513,14 +513,24 @@ a whole) needs a stardag-api version matching this SDK — an **older
 server silently ignores the enforcement parameters**, so upgrade the
 server before relying on limits.
 
+The same named limits can be enforced from resident (non-reactive)
+builds via `stardag.build.RegistryConcurrencyLimiter` — both modes share
+the slots. Two caveats when mixing modes: a crashed _resident_ build has
+no automatic healer (its RUNNING task holds the slot until explicitly
+failed/cancelled via the API/UI — the worker-reporting/tick self-healing
+story above is reactive-only), and a legitimately long-running ref-less
+resident task that also appears in a concurrently ticking reactive build
+can be force-failed by that build's `stale_running_no_ref_seconds`
+escape hatch — raise the bound if you mix modes over the same long
+tasks.
+
 Requirements and current limitations: the app must be deployed with this
 stardag version (scheduler `tick` function + self-reporting workers); the
 triggering process needs registry credentials and access to the default
 target root (task objects are persisted there for the ticks); the global
 concurrency lock and build-local `ConcurrencyConfig` limits are not applied
 by ticks (use the registry-backed named limits above; Modal's per-function
-`concurrency_limit` also still applies); and tasks blocked by a failure
-currently stay pending in the UI (the build itself is failed). Builds cancelled from the registry UI are picked up by
+`concurrency_limit` also still applies). Builds cancelled from the registry UI are picked up by
 the next tick (within the watchdog period), which cancels the running
 Modal function calls.
 

--- a/lib/stardag/src/stardag/build/__init__.py
+++ b/lib/stardag/src/stardag/build/__init__.py
@@ -47,6 +47,7 @@ from stardag.build._base import (
     get_current_build_id,
     TaskExecutorABC,
 )
+from stardag.build._registry_limiter import RegistryConcurrencyLimiter
 from stardag.build._reactive import (
     DiscoveryResult,
     TickConfig,
@@ -112,6 +113,7 @@ __all__ = [
     "TickSummary",
     "discover_and_register_aio",
     "run_tick_aio",
+    "RegistryConcurrencyLimiter",
     "DetachedHandle",
     "get_current_build_id",
     "TaskExecutorABC",

--- a/lib/stardag/src/stardag/build/_concurrent.py
+++ b/lib/stardag/src/stardag/build/_concurrent.py
@@ -9,6 +9,7 @@ This module contains:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import logging
 import traceback as tb_module
@@ -1193,7 +1194,18 @@ async def build_aio(
         # lock so tasks don't burn execution slots while blocked on a
         # distributed lock, and released automatically on every exit path
         # (completion, failure, cancellation, dynamic-deps suspension).
-        async with limiter.slot(task):
+        async with contextlib.AsyncExitStack() as slot_stack:
+            try:
+                await slot_stack.enter_async_context(limiter.slot(task))
+            except Exception as e:
+                # A limiter enforcing external state can fail acquisition
+                # (e.g. the registry-backed limiter's max_wait timeout or a
+                # non-transient registry error) — that fails THIS task,
+                # never the whole build.
+                return TaskExecutionError(
+                    exception=e,
+                    traceback="".join(tb_module.format_exception(e)),
+                )
             # Detached execution: first try re-attaching to a live execution
             # recorded in the registry (from a previous orchestrator run, or
             # a concurrently running build); otherwise spawn detached when

--- a/lib/stardag/src/stardag/build/_registry_limiter.py
+++ b/lib/stardag/src/stardag/build/_registry_limiter.py
@@ -1,0 +1,221 @@
+"""Registry-backed concurrency limiter for resident builds.
+
+Implements the :class:`~stardag.build._concurrency.ConcurrencyLimiter`
+protocol on top of the registry's named environment concurrency limits —
+the same server-side primitive reactive scheduler ticks enforce with — so
+resident ``build()``/``build_aio()`` builds share slots with each other
+and with reactive builds, **across processes and machines**. This fills
+the seam ``_concurrency.py`` reserved for a "global, server-driven
+limiter".
+
+Semantics (mirroring the reactive tick's acquisition):
+
+- A slot is acquired by an *enforced task start*
+  (``task_start_with_limits_aio``): the server atomically counts RUNNING
+  holders per key against the environment caps and records TASK_STARTED
+  on success (the engine's own later start-with-executor-refs is a
+  tolerated duplicate).
+- The slot is released by the task leaving RUNNING status — the engine's
+  completed/failed/cancelled events, or TASK_SUSPENDED while a task waits
+  on its dynamic deps (parity with ``LocalConcurrencyLimiter``, which
+  also releases during suspension). ``slot()``'s exit therefore does
+  nothing; there is no lease to renew or leak.
+- A denied acquire blocks and retries at a fixed poll interval with a
+  small jitter (there is no push channel to resident builds; slot
+  releases in other builds/processes are observed by polling, and the
+  jitter avoids N denied waiters hammering the limit rows in lockstep).
+  Transient registry errors (5xx/429/network) are retried with
+  exponential backoff instead of failing the task — a registry restart
+  mid-build must not cascade into task/build failures. Non-transient
+  errors (auth, validation) raise.
+
+Operational caveats:
+
+- **A slot leaked by a crashed resident build has no automatic healer.**
+  The reactive-mode liveness story (worker self-reporting + tick
+  staleness self-heal) does not apply here: if a resident build process
+  is killed after acquiring, its task stays RUNNING and holds the slot
+  until the task (or build) is explicitly failed/cancelled via the
+  API/UI. Prefer reactive scheduling for unattended runs; an admin
+  eviction path is planned.
+- The acquiring start is recorded without an executor ref. If the same
+  task is RUNNING with a ref in another build, this transiently clears
+  ``latest_executor_ref`` (until the engine's ref-recording start lands)
+  and refreshes the staleness clock other ticks are watching — a small
+  churn-only window.
+- Conversely, a legitimately long-running limited resident task (no
+  executor ref — local executors never record one) that also appears in
+  a concurrently *ticking reactive* build can be force-failed by that
+  build's ``stale_running_no_ref_seconds`` heal once it exceeds the
+  bound. Raise the bound in that build's ``TickConfig`` if you mix modes
+  over the same long tasks.
+
+Requires a registry server with concurrency-limit support; against an
+older server, enforcement parameters are ignored and acquisition always
+succeeds (see the Modal how-to's server-requirement note).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import random
+import typing
+from uuid import UUID
+
+from stardag import BaseTask
+from stardag.build._base import current_build_id_var
+from stardag.exceptions import APIError, RateLimitError
+from stardag.build._concurrency import ConcurrencyKeySelector
+from stardag.registry import RegistryABC, registry_provider
+
+logger = logging.getLogger(__name__)
+
+
+class RegistryConcurrencyLimiter:
+    """ConcurrencyLimiter enforcing the registry's named environment limits.
+
+    Example::
+
+        import stardag as sd
+        from stardag.build import RegistryConcurrencyLimiter
+
+        sd.build(
+            root,
+            concurrency_limiter=RegistryConcurrencyLimiter(
+                key_selector=lambda task: ["gpu"] if needs_gpu(task) else [],
+            ),
+        )
+
+    Args:
+        key_selector: Maps a task to the named limit key(s) it runs under —
+            a single key, a sequence of keys, or None/empty (same contract
+            as ``ConcurrencyConfig.key_selector``). Tasks mapping to no
+            keys are admitted without any registry call.
+        registry: Registry backend; defaults to the configured provider.
+        poll_interval_seconds: Retry interval while a key is at capacity.
+        max_wait_seconds: Give up (raise TimeoutError) after this long
+            waiting for a slot; None waits indefinitely.
+    """
+
+    def __init__(
+        self,
+        key_selector: ConcurrencyKeySelector,
+        *,
+        registry: RegistryABC | None = None,
+        poll_interval_seconds: float = 2.0,
+        max_wait_seconds: float | None = None,
+    ) -> None:
+        self.key_selector = key_selector
+        self._registry = registry
+        self.poll_interval_seconds = poll_interval_seconds
+        self.max_wait_seconds = max_wait_seconds
+
+    @property
+    def registry(self) -> RegistryABC:
+        if self._registry is None:
+            self._registry = registry_provider.get()
+        return self._registry
+
+    def slot(self, task: BaseTask) -> typing.AsyncContextManager[None]:
+        return self._slot(task)
+
+    def _keys_for(self, task: BaseTask) -> list[str]:
+        raw = self.key_selector(task)
+        if raw is None:
+            return []
+        keys = [raw] if isinstance(raw, str) else list(raw)
+        # Sorted + de-duplicated, mirroring LocalConcurrencyLimiter (and the
+        # server's sorted-key lock ordering); duplicates would double-count
+        # the task against a single cap.
+        return sorted(set(keys))
+
+    @contextlib.asynccontextmanager
+    async def _slot(self, task: BaseTask) -> typing.AsyncIterator[None]:
+        limit_keys = self._keys_for(task)
+        if not limit_keys:
+            yield
+            return
+
+        build_id = current_build_id_var.get()
+        if build_id is None:
+            # Outside a build context there is no build to record the
+            # acquiring TASK_STARTED against — admit without enforcement
+            # rather than failing the caller.
+            logger.warning(
+                f"RegistryConcurrencyLimiter used outside a build context; "
+                f"admitting task {task.id} without limit enforcement."
+            )
+            yield
+            return
+
+        await self._acquire(build_id, task, limit_keys)
+        # No release action: the slot is the task's RUNNING status — freed
+        # by the engine's completed/failed/cancelled/suspended events.
+        yield
+
+    # Transient registry failures back off exponentially from
+    # poll_interval_seconds up to this bound.
+    _ERROR_BACKOFF_MAX_SECONDS = 30.0
+
+    @staticmethod
+    def _is_transient(error: Exception) -> bool:
+        """Errors worth retrying: rate limits, server errors, network."""
+        if isinstance(error, RateLimitError):
+            return True
+        if isinstance(error, APIError):
+            return error.status_code is None or error.status_code >= 500
+        return isinstance(error, (TimeoutError, OSError))
+
+    async def _acquire(
+        self, build_id: UUID, task: BaseTask, limit_keys: list[str]
+    ) -> None:
+        loop = asyncio.get_running_loop()
+        deadline = (
+            loop.time() + self.max_wait_seconds
+            if self.max_wait_seconds is not None
+            else None
+        )
+        error_backoff = self.poll_interval_seconds
+        while True:
+            try:
+                # Note: this acquiring start carries no executor ref — if
+                # the task is already RUNNING with a ref in another build it
+                # transiently clears latest_executor_ref until the engine's
+                # ref-recording start lands (churn-only; see module docs).
+                started = await self.registry.task_start_with_limits_aio(
+                    build_id, task, limit_keys=limit_keys
+                )
+            except Exception as e:
+                # A registry blip must not cascade into task/build failures
+                # (every other engine registry call is best-effort): retry
+                # transient errors with backoff; raise the rest (auth,
+                # validation — retrying can't help).
+                if not self._is_transient(e):
+                    raise
+                delay = error_backoff
+                error_backoff = min(error_backoff * 2, self._ERROR_BACKOFF_MAX_SECONDS)
+                logger.warning(
+                    f"Registry error acquiring concurrency-limit slot(s) "
+                    f"{limit_keys} for task {task.id} (retrying in "
+                    f"{delay:.1f}s): {e}"
+                )
+            else:
+                if started:
+                    return
+                error_backoff = self.poll_interval_seconds  # healthy again
+                delay = self.poll_interval_seconds
+                logger.debug(
+                    f"Task {task.id} denied by concurrency limits "
+                    f"{limit_keys}; retrying in {delay:.1f}s"
+                )
+            # Jitter so N waiters don't re-take the server's limit rows
+            # (FOR UPDATE) in lockstep.
+            delay += random.uniform(0, delay * 0.25)
+            if deadline is not None and loop.time() + delay >= deadline:
+                raise TimeoutError(
+                    f"Timed out after {self.max_wait_seconds}s waiting for "
+                    f"concurrency-limit slot(s) {limit_keys} for task {task.id}"
+                )
+            await asyncio.sleep(delay)

--- a/lib/stardag/tests/test_build/test_registry_limiter.py
+++ b/lib/stardag/tests/test_build/test_registry_limiter.py
@@ -1,0 +1,330 @@
+"""Tests for the registry-backed resident-build concurrency limiter."""
+
+from __future__ import annotations
+
+import asyncio
+import typing
+from uuid import uuid4
+
+import pytest
+
+from stardag import auto_namespace
+from stardag.exceptions import APIError, AuthenticationError
+from stardag.build import (
+    BuildExitStatus,
+    FailMode,
+    RegistryConcurrencyLimiter,
+    build_aio,
+)
+from stardag.build._base import current_build_id_var
+from stardag.registry import NoOpRegistry
+from stardag.target import InMemoryFileTarget
+from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+auto_namespace(__name__)
+
+
+class CountingLimitRegistry(NoOpRegistry):
+    """Fake registry with the enforced-start slot semantics."""
+
+    def __init__(self, caps: dict[str, int]):
+        super().__init__()
+        self.caps = caps
+        self.running_keys: dict[str, set[str]] = {}  # task_id -> keys
+        self.acquire_attempts = 0
+        self.acquires_by_task: dict[str, int] = {}
+        self.max_active_by_key: dict[str, int] = {}
+        # Exceptions to raise on upcoming acquire attempts (fifo).
+        self.pending_errors: list[Exception] = []
+
+    async def task_start_with_limits_aio(
+        self, build_id, task, executor=None, executor_ref=None, limit_keys=None
+    ) -> bool:
+        self.acquire_attempts += 1
+        if self.pending_errors:
+            raise self.pending_errors.pop(0)
+        for key in limit_keys or []:
+            cap = self.caps.get(key)
+            if cap is None:
+                continue
+            active = sum(
+                1
+                for tid, keys in self.running_keys.items()
+                if key in keys and tid != str(task.id)
+            )
+            if active >= cap:
+                return False
+        self.running_keys[str(task.id)] = set(limit_keys or [])
+        self.acquires_by_task[str(task.id)] = (
+            self.acquires_by_task.get(str(task.id), 0) + 1
+        )
+        for key in limit_keys or []:
+            active = sum(1 for keys in self.running_keys.values() if key in keys)
+            self.max_active_by_key[key] = max(
+                self.max_active_by_key.get(key, 0), active
+            )
+        return True
+
+    # Slot freed on ANY transition out of RUNNING (mirrors the server:
+    # slot = RUNNING status + key rows).
+    async def task_complete_aio(self, build_id, task) -> None:
+        self.running_keys.pop(str(task.id), None)
+
+    async def task_fail_aio(self, build_id, task, error_message=None) -> None:
+        self.running_keys.pop(str(task.id), None)
+
+    async def task_cancel_aio(self, build_id, task) -> None:
+        self.running_keys.pop(str(task.id), None)
+
+    async def task_suspend_aio(self, build_id, task) -> None:
+        self.running_keys.pop(str(task.id), None)
+
+
+class TestRegistryConcurrencyLimiter:
+    async def test_no_keys_no_registry_calls(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        registry = CountingLimitRegistry(caps={})
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: [], registry=registry
+        )
+        token = current_build_id_var.set(uuid4())
+        try:
+            async with limiter.slot(SyncOnlyTask(name="nokeys")):
+                pass
+        finally:
+            current_build_id_var.reset(token)
+        assert registry.acquire_attempts == 0
+
+    async def test_key_normalization(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """A plain-string selector result is one key (not iterated into
+        characters) and duplicates are de-duplicated — same contract as
+        ConcurrencyConfig.key_selector."""
+        registry = CountingLimitRegistry(caps={"one": 5})
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: "one", registry=registry
+        )
+        task = SyncOnlyTask(name="strkey")
+        token = current_build_id_var.set(uuid4())
+        try:
+            async with limiter.slot(task):
+                assert registry.running_keys[str(task.id)] == {"one"}
+            dup_limiter = RegistryConcurrencyLimiter(
+                key_selector=lambda t: ["one", "one"], registry=registry
+            )
+            task2 = SyncOnlyTask(name="dupkeys")
+            async with dup_limiter.slot(task2):
+                assert registry.running_keys[str(task2.id)] == {"one"}
+        finally:
+            current_build_id_var.reset(token)
+        assert limiter._keys_for(task) == ["one"]
+        assert (
+            RegistryConcurrencyLimiter(
+                key_selector=lambda t: None, registry=registry
+            )._keys_for(task)
+            == []
+        )
+
+    async def test_blocks_until_slot_frees(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        registry = CountingLimitRegistry(caps={"one": 1})
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: ["one"],
+            registry=registry,
+            poll_interval_seconds=0.01,
+        )
+        holder = SyncOnlyTask(name="holder")
+        waiter = SyncOnlyTask(name="waiter")
+        build_id = uuid4()
+        token = current_build_id_var.set(build_id)
+        try:
+            async with limiter.slot(holder):
+                waiter_started = asyncio.Event()
+
+                async def acquire_waiter():
+                    async with limiter.slot(waiter):
+                        waiter_started.set()
+
+                acquire_task = asyncio.create_task(acquire_waiter())
+                await asyncio.sleep(0.05)
+                assert not waiter_started.is_set()  # blocked at capacity
+                # Slot frees when the holder leaves RUNNING:
+                await registry.task_complete_aio(build_id, holder)
+                await asyncio.wait_for(acquire_task, timeout=2)
+                assert waiter_started.is_set()
+        finally:
+            current_build_id_var.reset(token)
+
+    async def test_timeout_raises(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        registry = CountingLimitRegistry(caps={"one": 1})
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: ["one"],
+            registry=registry,
+            poll_interval_seconds=0.01,
+            max_wait_seconds=0.05,
+        )
+        token = current_build_id_var.set(uuid4())
+        try:
+            async with limiter.slot(SyncOnlyTask(name="t-holder")):
+                with pytest.raises(TimeoutError, match="concurrency-limit"):
+                    async with limiter.slot(SyncOnlyTask(name="t-waiter")):
+                        pass
+        finally:
+            current_build_id_var.reset(token)
+
+    async def test_end_to_end_build_respects_cap(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """A resident build with the registry limiter completes a fan-out
+        while never holding more than the cap concurrently."""
+        registry = CountingLimitRegistry(caps={"db": 1})
+        deps = tuple(SyncOnlyTask(name=f"fan-{i}") for i in range(4))
+        root = SyncOnlyTask(name="fan-root", deps=deps)
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: ["db"] if t.id != root.id else [],
+            registry=registry,
+            poll_interval_seconds=0.01,
+        )
+
+        summary = await build_aio(
+            [root], registry=registry, concurrency_limiter=limiter
+        )
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert root.complete()
+        # The invariant: never more than the cap held concurrently.
+        assert registry.max_active_by_key["db"] == 1
+
+
+class TestAcquireErrorHandling:
+    async def test_transient_error_retried(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """A registry blip (5xx/network/429) during acquire is retried with
+        backoff instead of failing the task."""
+        registry = CountingLimitRegistry(caps={"one": 1})
+        registry.pending_errors = [
+            APIError("boom", status_code=503),
+            APIError("conn reset"),  # no status: network-level
+        ]
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: ["one"],
+            registry=registry,
+            poll_interval_seconds=0.01,
+        )
+        task = SyncOnlyTask(name="blip")
+        token = current_build_id_var.set(uuid4())
+        try:
+            async with limiter.slot(task):
+                pass
+        finally:
+            current_build_id_var.reset(token)
+        assert registry.acquire_attempts == 3  # 2 errors + 1 success
+        assert registry.acquires_by_task[str(task.id)] == 1
+
+    async def test_non_transient_error_raises(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """Auth/validation errors raise immediately — retrying can't help."""
+        registry = CountingLimitRegistry(caps={"one": 1})
+        registry.pending_errors = [AuthenticationError("bad token")]
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: ["one"], registry=registry
+        )
+        token = current_build_id_var.set(uuid4())
+        try:
+            with pytest.raises(AuthenticationError):
+                async with limiter.slot(SyncOnlyTask(name="denied")):
+                    pass
+        finally:
+            current_build_id_var.reset(token)
+        assert registry.acquire_attempts == 1
+
+
+class TestReleasePathsInBuild:
+    async def test_failed_task_frees_slot(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """A task failure releases the slot (slot = RUNNING status): the
+        next task under the same cap can proceed."""
+        from stardag.utils.testing.helper_tasks import FailingTask
+
+        registry = CountingLimitRegistry(caps={"one": 1})
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: ["one"],
+            registry=registry,
+            poll_interval_seconds=0.01,
+        )
+        failing = FailingTask(error_message="rel-fail")
+        ok = SyncOnlyTask(name="rel-ok")
+
+        summary = await build_aio(
+            [failing, ok],
+            registry=registry,
+            concurrency_limiter=limiter,
+            fail_mode=FailMode.CONTINUE,
+        )
+
+        assert summary.status == BuildExitStatus.FAILURE  # failing failed...
+        assert ok.complete()  # ...but its slot was freed for ok
+        assert registry.max_active_by_key["one"] == 1
+        assert str(failing.id) not in registry.running_keys
+
+    async def test_suspension_frees_slot_and_resume_reacquires(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """Dynamic-deps suspension releases the slot; resuming re-acquires
+        (parity with LocalConcurrencyLimiter)."""
+        from stardag.utils.testing.helper_tasks import DynamicDiamondTask
+
+        registry = CountingLimitRegistry(caps={"gpu": 1})
+        dep = DynamicDiamondTask(name="susp-dep", test_id="rl-susp")
+        root = DynamicDiamondTask(
+            name="susp-root", test_id="rl-susp", dynamic_task_deps=(dep,)
+        )
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: ["gpu"] if t.id == root.id else [],
+            registry=registry,
+            poll_interval_seconds=0.01,
+        )
+
+        summary = await build_aio(
+            [root], registry=registry, concurrency_limiter=limiter
+        )
+
+        assert summary.status == BuildExitStatus.SUCCESS
+        assert root.complete()
+        # Acquired before the first run segment AND again after resuming.
+        assert registry.acquires_by_task[str(root.id)] == 2
+
+    async def test_timeout_fails_task_not_build_crash(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """max_wait exceeded inside a build → the waiting task fails like
+        any task error (no deadlock; under FAIL_FAST it would re-raise per
+        the engine's normal contract)."""
+        registry = CountingLimitRegistry(caps={"one": 1})
+        # Slot pre-held by a task outside this build (e.g. another process).
+        registry.running_keys["some-other-task"] = {"one"}
+        limiter = RegistryConcurrencyLimiter(
+            key_selector=lambda t: ["one"],
+            registry=registry,
+            poll_interval_seconds=0.01,
+            max_wait_seconds=0.05,
+        )
+        starved = SyncOnlyTask(name="starved")
+
+        summary = await build_aio(
+            [starved],
+            registry=registry,
+            concurrency_limiter=limiter,
+            fail_mode=FailMode.CONTINUE,
+        )
+
+        assert summary.status == BuildExitStatus.FAILURE
+        assert not starved.complete()


### PR DESCRIPTION
## Summary

Stacked on the rehydration PR. Phase 4b follow-up: resident `build()`/`build_aio()` builds can now enforce the registry's named environment concurrency limits — the same server-side caps reactive scheduling enforces — so slots are shared across processes, machines, and scheduling modes. This fills the seam `_concurrency.py` reserved for a "future global, server-driven limiter".

```python
sd.build(
    root,
    concurrency_limiter=RegistryConcurrencyLimiter(
        key_selector=lambda task: ["gpu"] if needs_gpu(task) else [],
    ),
)
```

## Semantics (mirrors the reactive tick's acquisition)

- A slot is acquired via an enforced task start (`task_start_with_limits_aio`): the server atomically counts RUNNING holders per key against the caps.
- Release is implicit — the task leaving RUNNING via the engine's completed/failed/cancelled/suspended events (suspension parity with `LocalConcurrencyLimiter`). No lease to renew or leak.
- Denials block-and-retry with configurable poll interval and optional `max_wait_seconds` (→ `TimeoutError`); no push channel exists to resident builds, so releases in other processes are observed by polling.
- Tasks mapping to no keys are admitted without any registry call; outside a build context the limiter warns and admits (no build to record the acquiring start against).

Requires a stardag-api version with concurrency-limit support (#158).

## Testing

4 new unit tests: no-keys fast path, cross-holder block-until-released, timeout, and an end-to-end `build_aio` fan-out under a cap of 1 against a counting fake registry. Full non-live suite + live Modal tier green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)