### PR TITLE
Reactive builds are owned by their triggering app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,18 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 - **Reactive builds are owned by their triggering app.** With multiple
   `StardagApp`s deployed in one environment, a scheduler tick from an
   app that doesn't own the build (per the `app_name` recorded at trigger
-  time) now no-ops with `outcome="foreign_app"` instead of driving the
-  build with the wrong app's code — previously whichever app's watchdog
-  won the scheduler lease would tick every reactive build in the
-  environment. Same-name redeploys are unaffected; move a build to a new
-  app by re-triggering it from that app (rewrites ownership and
-  re-persists the task objects). Builds triggered by older SDK versions
-  (no recorded owner) are ticked by any app, as before.
+  time) now forwards the wake-up to the owner app's tick (best-effort)
+  and returns `outcome="foreign_app"` instead of driving the build with
+  the wrong app's code — previously whichever app's watchdog won the
+  scheduler lease would tick every reactive build in the environment.
+  Forwarding means wake-ups landing on the wrong app (e.g. a previous
+  owner's still-running worker finishing after a takeover) are not
+  dropped, and every app's watchdog doubles as cross-app coverage.
+  Same-name redeploys are unaffected; move a build to a new app by
+  re-triggering it from that app (rewrites ownership and re-persists the
+  task objects — new ticks only: a mid-linger tick of the old owner
+  drains first). Builds triggered by older SDK versions (no recorded
+  owner) are ticked by any app, as before.
 
 - **Registry-backed concurrency limits for resident builds.** New
   `stardag.build.RegistryConcurrencyLimiter` implements the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### SDK
 
+- **Reactive builds are owned by their triggering app.** With multiple
+  `StardagApp`s deployed in one environment, a scheduler tick from an
+  app that doesn't own the build (per the `app_name` recorded at trigger
+  time) now no-ops with `outcome="foreign_app"` instead of driving the
+  build with the wrong app's code — previously whichever app's watchdog
+  won the scheduler lease would tick every reactive build in the
+  environment. Same-name redeploys are unaffected; move a build to a new
+  app by re-triggering it from that app (rewrites ownership and
+  re-persists the task objects). Builds triggered by older SDK versions
+  (no recorded owner) are ticked by any app, as before.
+
 - **Registry-backed concurrency limits for resident builds.** New
   `stardag.build.RegistryConcurrencyLimiter` implements the
   `ConcurrencyLimiter` seam on top of the registry's named environment

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -142,9 +142,9 @@ registry never pushes or executes anything — only user-deployed code
 
 Each reactive build is **owned by the app that triggered it** (recorded
 at trigger time): ticks from any other deployed app in the environment —
-typically another app's watchdog sweep — no-op instead of driving the
-build with the wrong code. Ownership moves only by an explicit
-re-trigger from the new app.
+typically another app's watchdog sweep — forward the wake-up to the
+owner's tick instead of driving the build with the wrong code. Ownership
+moves only by an explicit re-trigger from the new app.
 
 Reactive scheduling is experimental and currently Modal-first — see
 [Integrate with Modal](../how-to/integrate-modal.md#reactive-scheduling-no-resident-build-function-experimental)

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -140,6 +140,12 @@ task data (`stardag.task_from_registry_data`). The
 registry never pushes or executes anything — only user-deployed code
 (which has the DAG-defining code) spawns work.
 
+Each reactive build is **owned by the app that triggered it** (recorded
+at trigger time): ticks from any other deployed app in the environment —
+typically another app's watchdog sweep — no-op instead of driving the
+build with the wrong code. Ownership moves only by an explicit
+re-trigger from the new app.
+
 Reactive scheduling is experimental and currently Modal-first — see
 [Integrate with Modal](../how-to/integrate-modal.md#reactive-scheduling-no-resident-build-function-experimental)
 for usage, requirements and limitations.

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -513,6 +513,18 @@ a whole) needs a stardag-api version matching this SDK — an **older
 server silently ignores the enforcement parameters**, so upgrade the
 server before relying on limits.
 
+**App ownership.** Each reactive build is owned by the `StardagApp`
+that triggered it (`app_name` recorded in the build's store meta). With
+several apps deployed in one environment, every watchdog sweeps all
+running reactive builds — but a tick from a non-owning app no-ops with
+`outcome="foreign_app"` instead of driving the build with its own
+commit's code and selectors (and unpickling the owner's task store,
+which may not match its code). Redeploying the **same** app name is the
+normal upgrade path and unaffected. To migrate a build to a different
+app, re-trigger it from that app (`build_trigger(tasks, reactive=True,
+build_id=<existing id>)`): the re-trigger rewrites the meta and
+re-persists the task objects under the new app's code.
+
 The same named limits can be enforced from resident (non-reactive)
 builds via `stardag.build.RegistryConcurrencyLimiter` — both modes share
 the slots. Two caveats when mixing modes: a crashed _resident_ build has

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -516,14 +516,26 @@ server before relying on limits.
 **App ownership.** Each reactive build is owned by the `StardagApp`
 that triggered it (`app_name` recorded in the build's store meta). With
 several apps deployed in one environment, every watchdog sweeps all
-running reactive builds — but a tick from a non-owning app no-ops with
-`outcome="foreign_app"` instead of driving the build with its own
-commit's code and selectors (and unpickling the owner's task store,
-which may not match its code). Redeploying the **same** app name is the
-normal upgrade path and unaffected. To migrate a build to a different
-app, re-trigger it from that app (`build_trigger(tasks, reactive=True,
-build_id=<existing id>)`): the re-trigger rewrites the meta and
-re-persists the task objects under the new app's code.
+running reactive builds — but a tick from a non-owning app never drives
+the build with its own commit's code and selectors (or unpickles the
+owner's task store, which may not match its code). Instead it
+**forwards**: it spawns the owner app's tick (best-effort) and returns
+`outcome="foreign_app"` — so wake-ups that land on the wrong app are
+not lost, and every app's watchdog doubles as cross-app coverage (the
+owner-side scheduler lease collapses duplicate forwards). Redeploying
+the **same** app name is the normal upgrade path and unaffected.
+
+To migrate a build to a different app, re-trigger it from that app
+(`build_trigger(tasks, reactive=True, build_id=<existing id>)`): the
+re-trigger rewrites the meta and re-persists the task objects under the
+new app's code. Two handoff details: ownership takes effect for _new_
+ticks — a tick of the previous owner that is mid-linger keeps driving
+the build until its linger deadline passes (bounded by its
+`linger_seconds`); and wake-ups from the previous owner's still-running
+workers reach the new owner via the forwarding above. Symptom worth
+knowing: a build not progressing while tick logs show `foreign_app`
+with failed forwards means the owning app was **deleted** — the build
+is orphaned; re-trigger it from a live app to adopt it.
 
 The same named limits can be enforced from resident (non-reactive)
 builds via `stardag.build.RegistryConcurrencyLimiter` — both modes share

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -1727,16 +1727,41 @@ class StardagApp:
             # only the app recorded at trigger time may drive a build.
             # A foreign app's tick would schedule with ITS commit (its
             # workers, its selectors) and unpickle the owning app's task
-            # store (pickle skew across commits), so it must no-op.
-            # Explicit takeover = re-trigger from the new app (rewrites
-            # meta and re-persists the task objects under the new code).
+            # store (pickle skew across commits), so it must not run the
+            # tick loop itself. Instead it FORWARDS: best-effort spawn of
+            # the owner's tick, so wake-ups that land on the wrong app
+            # (e.g. a still-running worker of the previous owner after a
+            # takeover) are not dropped, and every app's watchdog sweep
+            # doubles as cross-app coverage. The owner-side single-flight
+            # lease collapses duplicate forwards. Explicit takeover =
+            # re-trigger from the new app (rewrites meta and re-persists
+            # the task objects under the new code).
             owner_app = (meta or {}).get("app_name")
             if owner_app is not None and owner_app != app_name:
+                forwarded = False
+                try:
+                    modal.Function.from_name(app_name=owner_app, name="tick").spawn(
+                        build_id=build_id
+                    )
+                    forwarded = True
+                except Exception as e:
+                    # Owner app deleted/renamed: the build is orphaned —
+                    # surfaced in logs; remedy is a re-trigger from a live
+                    # app (see the how-to's app-ownership section).
+                    logger.info(
+                        f"Tick for build {build_id}: could not forward to "
+                        f"owner app {owner_app!r} (deleted?): {e}"
+                    )
                 logger.info(
                     f"Tick for build {build_id}: owned by app "
-                    f"{owner_app!r}, not {app_name!r}; skipping."
+                    f"{owner_app!r}, not {app_name!r}; "
+                    f"{'forwarded to owner' if forwarded else 'skipping'}."
                 )
-                return {"outcome": "foreign_app", "owner_app": owner_app}
+                return {
+                    "outcome": "foreign_app",
+                    "owner_app": owner_app,
+                    "forwarded": forwarded,
+                }
             # Per-build tick configuration persisted at trigger time — every
             # tick (worker wake-ups and watchdog sweeps spawn with only the
             # build id) runs with the same settings. Explicit tick_kwargs

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -1721,14 +1721,28 @@ class StardagApp:
 
             build_uuid = _UUID(build_id)
             task_store = _BuildTaskStore(build_uuid)
+            meta = task_store.read_meta()
+            # App ownership: with multiple StardagApps in one environment,
+            # every app's watchdog sweeps ALL running reactive builds — but
+            # only the app recorded at trigger time may drive a build.
+            # A foreign app's tick would schedule with ITS commit (its
+            # workers, its selectors) and unpickle the owning app's task
+            # store (pickle skew across commits), so it must no-op.
+            # Explicit takeover = re-trigger from the new app (rewrites
+            # meta and re-persists the task objects under the new code).
+            owner_app = (meta or {}).get("app_name")
+            if owner_app is not None and owner_app != app_name:
+                logger.info(
+                    f"Tick for build {build_id}: owned by app "
+                    f"{owner_app!r}, not {app_name!r}; skipping."
+                )
+                return {"outcome": "foreign_app", "owner_app": owner_app}
             # Per-build tick configuration persisted at trigger time — every
             # tick (worker wake-ups and watchdog sweeps spawn with only the
             # build id) runs with the same settings. Explicit tick_kwargs
             # (tests/manual invocations) win over persisted ones; the limit
             # key selector is deployed-app configuration.
-            config = _build_tick_config(
-                task_store.read_meta(), tick_kwargs, limit_key_selector
-            )
+            config = _build_tick_config(meta, tick_kwargs, limit_key_selector)
 
             executor = ModalTaskExecutor(
                 modal_app_name=app_name,

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -824,6 +824,87 @@ class TestFinalizeRegistersTick:
         assert "tick_watchdog" in result.functions
 
 
+class TestTickAppOwnership:
+    """Only the app recorded in the build's meta may drive its ticks."""
+
+    def _capture_tick(self, app_name: str):
+        app = StardagApp(
+            app_name,
+            builder_settings=FunctionSettings(image=MagicMock()),
+            worker_settings={"default": FunctionSettings(image=MagicMock())},
+        )
+        captured: dict = {}
+
+        def capture_function(**kwargs):
+            def decorator(fn):
+                captured[kwargs.get("name", "unknown")] = fn
+                return fn
+
+            return decorator
+
+        app.modal_app.function = capture_function  # type: ignore[assignment]
+        with patch("stardag.integration.modal._app.get_target_roots_volumes") as mv:
+            mv.return_value = MagicMock(by_volume_name={}, by_root_key={})
+            app.finalize()
+        return captured["tick"]
+
+    def test_foreign_app_tick_noops(self, default_in_memory_fs_target):
+        """A tick from an app that doesn't own the build (per trigger-time
+        meta) must not drive it: a foreign app would schedule with its own
+        commit and unpickle the owner's task store (pickle skew)."""
+        from uuid import uuid4
+
+        from stardag.build import BuildTaskStore
+
+        tick = self._capture_tick("app-b")
+        build_id = uuid4()
+        BuildTaskStore(build_id).write_meta(
+            {"reactive": True, "app_name": "app-a", "root_task_ids": []}
+        )
+
+        result = tick(str(build_id))
+
+        assert result == {"outcome": "foreign_app", "owner_app": "app-a"}
+
+    def test_own_and_legacy_builds_proceed(self, default_in_memory_fs_target):
+        """The owning app ticks its build; meta without app_name (written by
+        an older SDK) is not treated as foreign."""
+        from uuid import uuid4
+
+        from stardag.build import BuildTaskStore, TickSummary
+
+        from stardag.registry import NoOpRegistry
+
+        ticked: list[str] = []
+
+        async def stub_tick_aio(build_uuid, **kwargs):
+            ticked.append(str(build_uuid))
+            return TickSummary(outcome="noop")
+
+        tick = self._capture_tick("app-a")
+        own = uuid4()
+        legacy = uuid4()
+        BuildTaskStore(own).write_meta(
+            {"reactive": True, "app_name": "app-a", "root_task_ids": []}
+        )
+        BuildTaskStore(legacy).write_meta({"reactive": True, "root_task_ids": []})
+
+        # Patch everything past the ownership guard: registry/lock-manager
+        # construction requires configured credentials (present on dev
+        # machines, absent in CI — the guard itself must not need them).
+        with (
+            patch("stardag.integration.modal._app.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch(
+                "stardag.integration.modal._app.RegistryGlobalConcurrencyLockManager"
+            ),
+        ):
+            rp.get.return_value = NoOpRegistry()
+            assert tick(str(own))["outcome"] == "noop"
+            assert tick(str(legacy))["outcome"] == "noop"
+        assert ticked == [str(own), str(legacy)]
+
+
 class TestReactiveRetrigger:
     """Re-triggering an existing reactive build: resume (un-terminal),
     append roots server-side, retry failed tasks, merge store meta."""

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -848,10 +848,15 @@ class TestTickAppOwnership:
             app.finalize()
         return captured["tick"]
 
-    def test_foreign_app_tick_noops(self, default_in_memory_fs_target):
+    def test_foreign_app_tick_forwards_to_owner(
+        self, default_in_memory_fs_target, modal_function_stub
+    ):
         """A tick from an app that doesn't own the build (per trigger-time
-        meta) must not drive it: a foreign app would schedule with its own
-        commit and unpickle the owner's task store (pickle skew)."""
+        meta) must not drive it — a foreign app would schedule with its own
+        commit and unpickle the owner's task store (pickle skew) — but it
+        forwards the wake-up to the owner's tick, so e.g. a still-running
+        worker of the previous owner completing after a takeover doesn't
+        drop the wake-up."""
         from uuid import uuid4
 
         from stardag.build import BuildTaskStore
@@ -872,7 +877,48 @@ class TestTickAppOwnership:
         ):
             result = tick(str(build_id))
 
-        assert result == {"outcome": "foreign_app", "owner_app": "app-a"}
+        assert result == {
+            "outcome": "foreign_app",
+            "owner_app": "app-a",
+            "forwarded": True,
+        }
+        assert modal_function_stub["from_name"] == {
+            "app_name": "app-a",
+            "name": "tick",
+        }
+        assert modal_function_stub["op"] == "spawn"
+        assert modal_function_stub["kwargs"] == {"build_id": str(build_id)}
+        rp.get.assert_not_called()
+        tick_aio.assert_not_called()
+
+    def test_foreign_app_forward_failure_tolerated(self, default_in_memory_fs_target):
+        """Owner app deleted (orphaned build): the forward fails, the tick
+        still no-ops cleanly — logged, never raised."""
+        from uuid import uuid4
+
+        from stardag.build import BuildTaskStore
+
+        tick = self._capture_tick("app-b")
+        build_id = uuid4()
+        BuildTaskStore(build_id).write_meta(
+            {"reactive": True, "app_name": "app-gone", "root_task_ids": []}
+        )
+
+        with (
+            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch("stardag.integration.modal._app.run_tick_aio") as tick_aio,
+            patch(
+                "modal.Function.from_name",
+                side_effect=Exception("app not found"),
+            ),
+        ):
+            result = tick(str(build_id))
+
+        assert result == {
+            "outcome": "foreign_app",
+            "owner_app": "app-gone",
+            "forwarded": False,
+        }
         rp.get.assert_not_called()
         tick_aio.assert_not_called()
 

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -862,9 +862,19 @@ class TestTickAppOwnership:
             {"reactive": True, "app_name": "app-a", "root_task_ids": []}
         )
 
-        result = tick(str(build_id))
+        # Patch the registry and the tick loop to assert they are never
+        # touched — otherwise the test is environment-dependent (on a dev
+        # machine with credentials configured an accidental registry call
+        # would succeed and go unnoticed).
+        with (
+            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch("stardag.integration.modal._app.run_tick_aio") as tick_aio,
+        ):
+            result = tick(str(build_id))
 
         assert result == {"outcome": "foreign_app", "owner_app": "app-a"}
+        rp.get.assert_not_called()
+        tick_aio.assert_not_called()
 
     def test_own_and_legacy_builds_proceed(self, default_in_memory_fs_target):
         """The owning app ticks its build; meta without app_name (written by


### PR DESCRIPTION
## Summary

Stacked on the resident-limiter PR. With multiple `StardagApp`s (different names/commits) deployed in **one environment**, every app's watchdog sweeps ALL running reactive builds — whichever app's tick won the per-build scheduler lease would drive the build with **its** commit: its workers, its selectors, and it would unpickle the *originating* app's task store (pickle skew across commits → tick failure, or worse, tasks running under the wrong code), with ownership ping-ponging between versions on subsequent lease races.

## Change

- The Modal `tick` no-ops with `outcome="foreign_app"` when the build's trigger-time meta records a different `app_name` — before touching the registry or the task store.
- **Unaffected:** same-name redeploys (the supported upgrade path), resident builds (existing meta gate), worker wake-ups (already app-targeted), and builds triggered by older SDKs (no recorded owner → ticked by any app, as before).
- **Explicit takeover** = re-trigger from the new app (`build_trigger(tasks, reactive=True, build_id=<existing>)`): the existing re-trigger path already rewrites the meta (new owner) and re-persists the task objects under the new app's code — now documented as the migration path.
- Server-side ownership (a column on the build row so `build_list_running` can filter per app) is deferred — it composes with the planned registry-side "reactive" marker.

## Docs

Concepts page (reactive scheduling section), Modal how-to (app-ownership paragraph incl. the takeover recipe), CHANGELOG.

## Testing

Two new unit tests: a foreign app's tick returns `foreign_app` without touching the registry; the owning app and legacy no-owner builds proceed to the tick loop. Full Modal integration suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)