### PR TITLE
UI: Modal execution surfacing + concurrency-limits admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### UI
+
+- **Modal execution surfacing.** Tasks executed on Modal now show a
+  "⚡ Modal" badge (tooltip shows the function call ref; click to copy)
+  in the build task table, the Task Explorer, and DAG node hover. The
+  task detail panel gains an **Execution** section — executor kind, app
+  name, function name, call ref, and workspace/environment — with deep
+  links into the Modal dashboard (app page and function call). The
+  build view shows a "Modal: app-name" chip linking to the app page
+  plus a "reactive" badge for tick-scheduled builds. All Modal URL
+  patterns are centralized in `src/utils/modalLinks.ts`; links render
+  only when the recorded metadata has the required fields (older
+  servers / missing metadata degrade to plain text, never dead links).
+- **Concurrency limits admin view.** New env-scoped "Concurrency
+  Limits" sidebar page: list the environment's named limits with
+  current holder counts, create/edit/delete keys, and drill into a
+  key's holders (task detail link, running-since, executor badge,
+  Modal deep link) with an **Evict** action that fails a stuck RUNNING
+  holder to free its slots — the recovery path for slots leaked by a
+  crashed resident build process.
+
 ### SDK
 
 - **Executor metadata for Modal executions.** Task starts and triggered

--- a/app/stardag-ui/src/App.tsx
+++ b/app/stardag-ui/src/App.tsx
@@ -15,6 +15,7 @@ import { PendingInvites } from "./components/PendingInvites";
 import type { NavItem } from "./components/Sidebar";
 import { Sidebar } from "./components/Sidebar";
 import { TaskExplorer } from "./components/TaskExplorer";
+import { ConcurrencyLimits } from "./components/ConcurrencyLimits";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { UserMenu } from "./components/UserMenu";
 import { AuthProvider, useAuth } from "./context/AuthContext";
@@ -184,6 +185,28 @@ function TaskExplorerPage({
       onToggleSidebar={onToggleSidebar}
     >
       <TaskExplorer onNavigateToBuild={onNavigateToBuild} />
+    </MainLayout>
+  );
+}
+
+// Concurrency limits admin page
+type ConcurrencyLimitsPageProps = SidebarStateProps & {
+  onNavigate: (item: NavItem) => void;
+};
+
+function ConcurrencyLimitsPage({
+  onNavigate,
+  sidebarCollapsed,
+  onToggleSidebar,
+}: ConcurrencyLimitsPageProps) {
+  return (
+    <MainLayout
+      activeNav="limits"
+      onNavigate={onNavigate}
+      sidebarCollapsed={sidebarCollapsed}
+      onToggleSidebar={onToggleSidebar}
+    >
+      <ConcurrencyLimits />
     </MainLayout>
   );
 }
@@ -570,6 +593,9 @@ function Router() {
     // Check for tasks path: /tasks, /:org/tasks, or /:org/:environment/tasks
     if (path === "/tasks" || path.endsWith("/tasks")) return "tasks";
 
+    // Concurrency limits admin: /limits (same env-scoped forms as /tasks)
+    if (path === "/limits" || path.endsWith("/limits")) return "limits";
+
     // Check for build ID in path: /builds/:id or /:org/:environment/builds/:id
     const buildMatch = path.match(/\/builds\/([^/]+)/);
     if (buildMatch) {
@@ -589,6 +615,9 @@ function Router() {
           break;
         case "tasks":
           navigateTo(`${basePath}/tasks`);
+          break;
+        case "limits":
+          navigateTo(`${basePath}/limits`);
           break;
         case "settings":
           navigateTo("/settings");
@@ -656,6 +685,15 @@ function Router() {
           <TaskExplorerPage
             onNavigate={handleNavigation}
             onNavigateToBuild={handleSelectBuild}
+            sidebarCollapsed={sidebarCollapsed}
+            onToggleSidebar={handleToggleSidebar}
+          />
+        );
+
+      case "limits":
+        return (
+          <ConcurrencyLimitsPage
+            onNavigate={handleNavigation}
             sidebarCollapsed={sidebarCollapsed}
             onToggleSidebar={handleToggleSidebar}
           />

--- a/app/stardag-ui/src/api/concurrencyLimits.test.ts
+++ b/app/stardag-ui/src/api/concurrencyLimits.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setAccessTokenGetter, setCurrentWorkspaceId } from "./client";
+import {
+  deleteConcurrencyLimit,
+  evictConcurrencyLimitHolder,
+  fetchConcurrencyLimitHolders,
+  fetchConcurrencyLimits,
+  upsertConcurrencyLimit,
+} from "./concurrencyLimits";
+
+describe("concurrency limits API client", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    setAccessTokenGetter(async () => "token");
+    setCurrentWorkspaceId("ws-1");
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    setAccessTokenGetter(async () => null);
+    setCurrentWorkspaceId(null);
+  });
+
+  function requestedUrl(): string {
+    return fetchMock.mock.calls[0][0] as string;
+  }
+
+  it("fetches and unwraps the limits list", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ limits: [{ key: "gpu", max_concurrent: 2 }] }), {
+        status: 200,
+      }),
+    );
+
+    const limits = await fetchConcurrencyLimits("env-1");
+    expect(limits).toEqual([{ key: "gpu", max_concurrent: 2 }]);
+    expect(requestedUrl()).toContain("/api/v1/concurrency-limits?");
+    expect(requestedUrl()).toContain("environment_id=env-1");
+  });
+
+  it("upserts a limit via PUT with a JSON body", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ key: "gpu", max_concurrent: 3 }), {
+        status: 200,
+      }),
+    );
+
+    const result = await upsertConcurrencyLimit("gpu", 3, "env-1");
+    expect(result).toEqual({ key: "gpu", max_concurrent: 3 });
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/api/v1/concurrency-limits/gpu?");
+    expect(options.method).toBe("PUT");
+    expect(JSON.parse(options.body as string)).toEqual({ max_concurrent: 3 });
+  });
+
+  it("URL-encodes the limit key", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    await deleteConcurrencyLimit("db/write slots", "env-1");
+    expect(requestedUrl()).toContain("/concurrency-limits/db%2Fwrite%20slots?");
+    expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe("DELETE");
+  });
+
+  it("fetches holders with a limit param", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ key: "gpu", holders: [], total: 0 }), {
+        status: 200,
+      }),
+    );
+
+    const result = await fetchConcurrencyLimitHolders("gpu", "env-1", 5);
+    expect(result.total).toBe(0);
+    expect(requestedUrl()).toContain("/concurrency-limits/gpu/holders?");
+    expect(requestedUrl()).toContain("limit=5");
+    expect(requestedUrl()).toContain("environment_id=env-1");
+  });
+
+  it("evicts a holder via POST", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ task_id: "t-1", status: "failed" }), {
+        status: 200,
+      }),
+    );
+
+    const result = await evictConcurrencyLimitHolder("gpu", "t-1", "env-1");
+    expect(result).toEqual({ task_id: "t-1", status: "failed" });
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toContain("/concurrency-limits/gpu/holders/t-1/evict?");
+    expect(options.method).toBe("POST");
+  });
+
+  it("throws on non-OK responses", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("nope", { status: 404, statusText: "Not Found" }),
+    );
+    await expect(evictConcurrencyLimitHolder("gpu", "t-1", "env-1")).rejects.toThrow(
+      "Failed to evict holder: Not Found",
+    );
+  });
+});

--- a/app/stardag-ui/src/api/concurrencyLimits.ts
+++ b/app/stardag-ui/src/api/concurrencyLimits.ts
@@ -1,0 +1,123 @@
+// API client for named environment concurrency limits (admin surface).
+
+import type { ExecutorMetadata, TaskStatus } from "../types/task";
+import { fetchWithAuth } from "./client";
+import { API_V1 } from "./config";
+
+export interface ConcurrencyLimit {
+  key: string;
+  max_concurrent: number;
+}
+
+// A RUNNING task currently occupying one slot of a limit key.
+export interface ConcurrencyLimitHolder {
+  task_id: string;
+  task_namespace: string;
+  task_name: string;
+  // When the task's RUNNING status was recorded ("running since").
+  latest_status_at: string | null;
+  latest_executor: string | null;
+  latest_executor_ref: string | null;
+  latest_executor_metadata: ExecutorMetadata | null;
+}
+
+export interface ConcurrencyLimitHoldersResponse {
+  key: string;
+  // Capped by the `limit` param, oldest running first; `total` carries
+  // the full holder count.
+  holders: ConcurrencyLimitHolder[];
+  total: number;
+}
+
+export interface EvictHolderResponse {
+  task_id: string;
+  status: TaskStatus;
+}
+
+function limitsUrl(environmentId: string, path = "", extra?: URLSearchParams): string {
+  const params = extra ?? new URLSearchParams();
+  params.set("environment_id", environmentId);
+  return `${API_V1}/concurrency-limits${path}?${params.toString()}`;
+}
+
+export async function fetchConcurrencyLimits(
+  environmentId: string,
+): Promise<ConcurrencyLimit[]> {
+  const response = await fetchWithAuth(limitsUrl(environmentId));
+  if (!response.ok) {
+    throw new Error(`Failed to fetch concurrency limits: ${response.statusText}`);
+  }
+  const data: { limits: ConcurrencyLimit[] } = await response.json();
+  return data.limits;
+}
+
+export async function upsertConcurrencyLimit(
+  key: string,
+  maxConcurrent: number,
+  environmentId: string,
+): Promise<ConcurrencyLimit> {
+  const response = await fetchWithAuth(
+    limitsUrl(environmentId, `/${encodeURIComponent(key)}`),
+    {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ max_concurrent: maxConcurrent }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to save concurrency limit: ${response.statusText}`);
+  }
+  return response.json();
+}
+
+export async function deleteConcurrencyLimit(
+  key: string,
+  environmentId: string,
+): Promise<void> {
+  const response = await fetchWithAuth(
+    limitsUrl(environmentId, `/${encodeURIComponent(key)}`),
+    { method: "DELETE" },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to delete concurrency limit: ${response.statusText}`);
+  }
+}
+
+export async function fetchConcurrencyLimitHolders(
+  key: string,
+  environmentId: string,
+  limit = 100,
+): Promise<ConcurrencyLimitHoldersResponse> {
+  const params = new URLSearchParams();
+  params.set("limit", String(limit));
+  const response = await fetchWithAuth(
+    limitsUrl(environmentId, `/${encodeURIComponent(key)}/holders`, params),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch concurrency limit holders: ${response.statusText}`,
+    );
+  }
+  return response.json();
+}
+
+// Evict a slot holder: records TASK_FAILED for a task currently RUNNING
+// and holding `key`, freeing all its slots. 404s when the task is not a
+// current holder.
+export async function evictConcurrencyLimitHolder(
+  key: string,
+  taskId: string,
+  environmentId: string,
+): Promise<EvictHolderResponse> {
+  const response = await fetchWithAuth(
+    limitsUrl(
+      environmentId,
+      `/${encodeURIComponent(key)}/holders/${encodeURIComponent(taskId)}/evict`,
+    ),
+    { method: "POST" },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to evict holder: ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -26,6 +26,7 @@ import type {
 } from "../types/task";
 import { isExtendedResponse } from "../types/task";
 import { BuildStatusBadge } from "./BuildStatusBadge";
+import { BuildExecutorChips } from "./ExecutorBadge";
 import { DagControls, type DagControlsState } from "./DagControls";
 import { DagGraph } from "./DagGraph";
 import {
@@ -279,7 +280,10 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
       {
         label: build?.name ?? buildId.slice(0, 8),
         detail: build ? (
-          <BuildStatusBadge status={build.status} isResumed={build.is_resumed} />
+          <span className="flex items-center gap-1.5">
+            <BuildStatusBadge status={build.status} isResumed={build.is_resumed} />
+            <BuildExecutorChips metadata={build.executor_metadata} />
+          </span>
         ) : undefined,
       },
     ];
@@ -346,6 +350,10 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
         // Cross-build status fields
         waiting_for_lock: fullTask?.waiting_for_lock,
         status_build_id: fullTask?.status_build_id,
+        // Executor identity (DAG node hover + detail panel)
+        latest_executor: fullTask?.latest_executor,
+        latest_executor_ref: fullTask?.latest_executor_ref,
+        latest_executor_metadata: fullTask?.latest_executor_metadata,
       };
     });
   }, [graph, allTasks, filteredTasks, nameFilter, statusFilter, build]);

--- a/app/stardag-ui/src/components/ConcurrencyLimits.test.tsx
+++ b/app/stardag-ui/src/components/ConcurrencyLimits.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BreadcrumbProvider } from "../context/BreadcrumbContext";
+import { ConcurrencyLimits } from "./ConcurrencyLimits";
+
+vi.mock("../context/EnvironmentContext", () => ({
+  useEnvironment: () => ({
+    activeEnvironment: { id: "env-1", slug: "default", name: "default" },
+  }),
+}));
+
+vi.mock("../api/concurrencyLimits", () => ({
+  fetchConcurrencyLimits: vi.fn(),
+  fetchConcurrencyLimitHolders: vi.fn(),
+  upsertConcurrencyLimit: vi.fn(),
+  deleteConcurrencyLimit: vi.fn(),
+  evictConcurrencyLimitHolder: vi.fn(),
+}));
+
+vi.mock("../api/tasks", () => ({
+  fetchTask: vi.fn(),
+  fetchTaskArtifacts: vi.fn().mockResolvedValue({ artifacts: [] }),
+  fetchTaskEvents: vi.fn().mockResolvedValue([]),
+  cancelTask: vi.fn(),
+}));
+
+import {
+  evictConcurrencyLimitHolder,
+  fetchConcurrencyLimitHolders,
+  fetchConcurrencyLimits,
+  upsertConcurrencyLimit,
+} from "../api/concurrencyLimits";
+
+const holder = {
+  task_id: "task-abc-123456",
+  task_namespace: "",
+  task_name: "TrainModel",
+  latest_status_at: "2026-01-01T10:00:00Z",
+  latest_executor: "modal",
+  latest_executor_ref: "fc-123",
+  latest_executor_metadata: {
+    kind: "modal",
+    app_name: "my-app",
+    workspace: "my-workspace",
+  },
+};
+
+function renderPage() {
+  return render(
+    <BreadcrumbProvider>
+      <ConcurrencyLimits />
+    </BreadcrumbProvider>,
+  );
+}
+
+describe("ConcurrencyLimits", () => {
+  beforeEach(() => {
+    vi.mocked(fetchConcurrencyLimits).mockResolvedValue([
+      { key: "gpu", max_concurrent: 2 },
+    ]);
+    vi.mocked(fetchConcurrencyLimitHolders).mockResolvedValue({
+      key: "gpu",
+      holders: [holder],
+      total: 1,
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists limits with holder counts", async () => {
+    renderPage();
+
+    expect(await screen.findByText("gpu")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+    // Holder count fetched with limit=1
+    await waitFor(() =>
+      expect(fetchConcurrencyLimitHolders).toHaveBeenCalledWith("gpu", "env-1", 1),
+    );
+    expect(await screen.findByText("1")).toBeInTheDocument();
+  });
+
+  it("creates a limit via the form", async () => {
+    vi.mocked(upsertConcurrencyLimit).mockResolvedValue({
+      key: "db",
+      max_concurrent: 5,
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText("gpu");
+
+    await user.type(screen.getByPlaceholderText("e.g. gpu"), "db");
+    const maxInput = screen.getByLabelText("Max concurrent");
+    await user.clear(maxInput);
+    await user.type(maxInput, "5");
+    await user.click(screen.getByRole("button", { name: "Add limit" }));
+
+    await waitFor(() =>
+      expect(upsertConcurrencyLimit).toHaveBeenCalledWith("db", 5, "env-1"),
+    );
+  });
+
+  it("drills into holders and evicts one after confirmation", async () => {
+    vi.mocked(evictConcurrencyLimitHolder).mockResolvedValue({
+      task_id: holder.task_id,
+      status: "failed",
+    });
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText("gpu");
+
+    // Expand the holders drill-down
+    await user.click(await screen.findByTitle("Show current slot holders"));
+    expect(await screen.findByText("TrainModel")).toBeInTheDocument();
+    // Executor badge + Modal deep link render for the holder
+    expect(screen.getByText("⚡ Modal")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "View on Modal" })).toHaveAttribute(
+      "href",
+      "https://modal.com/apps/my-workspace/main/deployed/my-app?functionCallId=fc-123",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Evict" }));
+    expect(confirmSpy).toHaveBeenCalled();
+    await waitFor(() =>
+      expect(evictConcurrencyLimitHolder).toHaveBeenCalledWith(
+        "gpu",
+        holder.task_id,
+        "env-1",
+      ),
+    );
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/app/stardag-ui/src/components/ConcurrencyLimits.test.tsx
+++ b/app/stardag-ui/src/components/ConcurrencyLimits.test.tsx
@@ -4,9 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { BreadcrumbProvider } from "../context/BreadcrumbContext";
 import { ConcurrencyLimits } from "./ConcurrencyLimits";
 
+let mockEnvironmentId = "env-1";
 vi.mock("../context/EnvironmentContext", () => ({
   useEnvironment: () => ({
-    activeEnvironment: { id: "env-1", slug: "default", name: "default" },
+    activeEnvironment: {
+      id: mockEnvironmentId,
+      slug: "default",
+      name: "default",
+    },
   }),
 }));
 
@@ -56,6 +61,7 @@ function renderPage() {
 
 describe("ConcurrencyLimits", () => {
   beforeEach(() => {
+    mockEnvironmentId = "env-1";
     vi.mocked(fetchConcurrencyLimits).mockResolvedValue([
       { key: "gpu", max_concurrent: 2 },
     ]);
@@ -80,6 +86,37 @@ describe("ConcurrencyLimits", () => {
       expect(fetchConcurrencyLimitHolders).toHaveBeenCalledWith("gpu", "env-1", 1),
     );
     expect(await screen.findByText("1")).toBeInTheDocument();
+  });
+
+  it("drops stale responses from a previous environment", async () => {
+    // env-1's limits fetch resolves LATE — after the user has switched to
+    // env-2 — and must not overwrite env-2's state.
+    let resolveEnv1: (limits: { key: string; max_concurrent: number }[]) => void;
+    vi.mocked(fetchConcurrencyLimits).mockImplementation((envId: string) => {
+      if (envId === "env-1") {
+        return new Promise((resolve) => {
+          resolveEnv1 = resolve;
+        });
+      }
+      return Promise.resolve([{ key: "env2-key", max_concurrent: 3 }]);
+    });
+
+    const { rerender } = renderPage();
+    // env-1 load in flight; switch environments and re-render.
+    mockEnvironmentId = "env-2";
+    rerender(
+      <BreadcrumbProvider>
+        <ConcurrencyLimits />
+      </BreadcrumbProvider>,
+    );
+    expect(await screen.findByText("env2-key")).toBeInTheDocument();
+
+    // The slow env-1 response lands now: it must be dropped.
+    resolveEnv1!([{ key: "stale-env1-key", max_concurrent: 9 }]);
+    await waitFor(() =>
+      expect(screen.queryByText("stale-env1-key")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("env2-key")).toBeInTheDocument();
   });
 
   it("creates a limit via the form", async () => {

--- a/app/stardag-ui/src/components/ConcurrencyLimits.test.tsx
+++ b/app/stardag-ui/src/components/ConcurrencyLimits.test.tsx
@@ -5,6 +5,7 @@ import { BreadcrumbProvider } from "../context/BreadcrumbContext";
 import { ConcurrencyLimits } from "./ConcurrencyLimits";
 
 let mockEnvironmentId = "env-1";
+let mockWorkspaceRole: "owner" | "admin" | "member" | null = "admin";
 vi.mock("../context/EnvironmentContext", () => ({
   useEnvironment: () => ({
     activeEnvironment: {
@@ -12,6 +13,7 @@ vi.mock("../context/EnvironmentContext", () => ({
       slug: "default",
       name: "default",
     },
+    activeWorkspaceRole: mockWorkspaceRole,
   }),
 }));
 
@@ -62,6 +64,7 @@ function renderPage() {
 describe("ConcurrencyLimits", () => {
   beforeEach(() => {
     mockEnvironmentId = "env-1";
+    mockWorkspaceRole = "admin";
     vi.mocked(fetchConcurrencyLimits).mockResolvedValue([
       { key: "gpu", max_concurrent: 2 },
     ]);
@@ -171,5 +174,94 @@ describe("ConcurrencyLimits", () => {
     );
 
     confirmSpy.mockRestore();
+  });
+
+  it("does not evict when the confirm dialog is declined", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText("gpu");
+    await user.click(await screen.findByTitle("Show current slot holders"));
+    await screen.findByText("TrainModel");
+
+    await user.click(screen.getByRole("button", { name: "Evict" }));
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(evictConcurrencyLimitHolder).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  it("surfaces an evict failure as an action error", async () => {
+    vi.mocked(evictConcurrencyLimitHolder).mockRejectedValue(
+      new Error("Failed to evict holder: Not Found"),
+    );
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+
+    const user = userEvent.setup();
+    renderPage();
+    await screen.findByText("gpu");
+    await user.click(await screen.findByTitle("Show current slot holders"));
+    await screen.findByText("TrainModel");
+
+    await user.click(screen.getByRole("button", { name: "Evict" }));
+    expect(
+      await screen.findByText("Failed to evict holder: Not Found"),
+    ).toBeInTheDocument();
+    // The holder row is still rendered and actionable after the failure.
+    expect(screen.getByRole("button", { name: "Evict" })).toBeEnabled();
+
+    confirmSpy.mockRestore();
+  });
+
+  it("does not show a previous environment's holder count for a same-named key", async () => {
+    // env-1's "gpu" has 5 holders; env-2 also has a "gpu" key but its
+    // count fetch fails — env-2's row must show the unknown marker, not 5.
+    vi.mocked(fetchConcurrencyLimitHolders).mockImplementation(
+      (_key: string, envId: string) => {
+        if (envId === "env-1") {
+          return Promise.resolve({ key: "gpu", holders: [], total: 5 });
+        }
+        return Promise.reject(new Error("count fetch failed"));
+      },
+    );
+
+    const { rerender } = renderPage();
+    expect(await screen.findByText("5")).toBeInTheDocument();
+
+    mockEnvironmentId = "env-2";
+    rerender(
+      <BreadcrumbProvider>
+        <ConcurrencyLimits />
+      </BreadcrumbProvider>,
+    );
+    // env-2's limits load (same "gpu" key) with the count fetch failing:
+    // the row must show the unknown marker, never env-1's count.
+    await waitFor(() => {
+      expect(screen.getByTitle("Show current slot holders")).toHaveTextContent("—");
+    });
+    expect(screen.queryByText("5")).not.toBeInTheDocument();
+  });
+
+  it("hides limit and holder mutations from non-admin members", async () => {
+    mockWorkspaceRole = "member";
+    const user = userEvent.setup();
+    renderPage();
+
+    // Limits and holder counts are still viewable...
+    expect(await screen.findByText("gpu")).toBeInTheDocument();
+    expect(await screen.findByText("1")).toBeInTheDocument();
+    expect(screen.getByText("2")).toBeInTheDocument();
+
+    // ...but create/edit/delete are not.
+    expect(screen.queryByRole("button", { name: "Add limit" })).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("e.g. gpu")).not.toBeInTheDocument();
+    expect(screen.queryByTitle("Edit max concurrency")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
+
+    // The holders drill-down still works, without the Evict action.
+    await user.click(await screen.findByTitle("Show current slot holders"));
+    expect(await screen.findByText("TrainModel")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Evict" })).not.toBeInTheDocument();
   });
 });

--- a/app/stardag-ui/src/components/ConcurrencyLimits.tsx
+++ b/app/stardag-ui/src/components/ConcurrencyLimits.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   deleteConcurrencyLimit,
   evictConcurrencyLimitHolder,
@@ -49,12 +49,21 @@ export function ConcurrencyLimits() {
   // Holder task detail panel
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
 
+  // Stale-response guards: each async load captures an epoch at start and
+  // drops its results if a newer load (or an environment switch) has
+  // bumped it since — a slow response from a previous environment must
+  // not overwrite the current one's state.
+  const limitsEpochRef = useRef(0);
+  const holdersEpochRef = useRef(0);
+
   useEffect(() => {
     setBreadcrumb([{ label: "Concurrency Limits" }]);
     return () => setBreadcrumb([]);
   }, [setBreadcrumb]);
 
   const loadLimits = useCallback(async () => {
+    const epoch = ++limitsEpochRef.current;
+    const fresh = () => limitsEpochRef.current === epoch;
     if (!activeEnvironment?.id) {
       setLimits([]);
       setLoading(false);
@@ -63,6 +72,7 @@ export function ConcurrencyLimits() {
     setError(null);
     try {
       const fetched = await fetchConcurrencyLimits(activeEnvironment.id);
+      if (!fresh()) return;
       setLimits(fetched);
       // Holder counts per key: a holders fetch with limit=1 returns the
       // full count in `total`. Limit lists are small (admin-configured),
@@ -81,19 +91,26 @@ export function ConcurrencyLimits() {
           }
         }),
       );
+      if (!fresh()) return;
       setHolderCounts(
         Object.fromEntries(counts.filter((c): c is [string, number] => c !== null)),
       );
     } catch (err) {
+      if (!fresh()) return;
       setError(
         err instanceof Error ? err.message : "Failed to load concurrency limits",
       );
     } finally {
-      setLoading(false);
+      if (fresh()) {
+        setLoading(false);
+      }
     }
   }, [activeEnvironment?.id]);
 
   useEffect(() => {
+    // Invalidate any in-flight holders load from the previous environment
+    // (loadLimits bumps its own epoch on each call).
+    holdersEpochRef.current++;
     setLoading(true);
     setExpandedKey(null);
     setSelectedTask(null);
@@ -103,15 +120,21 @@ export function ConcurrencyLimits() {
   const loadHolders = useCallback(
     async (key: string) => {
       if (!activeEnvironment?.id) return;
+      const epoch = ++holdersEpochRef.current;
+      const fresh = () => holdersEpochRef.current === epoch;
       setHoldersLoading(true);
       try {
         const response = await fetchConcurrencyLimitHolders(key, activeEnvironment.id);
+        if (!fresh()) return;
         setHolders(response.holders);
         setHoldersTotal(response.total);
       } catch (err) {
+        if (!fresh()) return;
         setActionError(err instanceof Error ? err.message : "Failed to load holders");
       } finally {
-        setHoldersLoading(false);
+        if (fresh()) {
+          setHoldersLoading(false);
+        }
       }
     },
     [activeEnvironment?.id],

--- a/app/stardag-ui/src/components/ConcurrencyLimits.tsx
+++ b/app/stardag-ui/src/components/ConcurrencyLimits.tsx
@@ -1,0 +1,591 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  deleteConcurrencyLimit,
+  evictConcurrencyLimitHolder,
+  fetchConcurrencyLimitHolders,
+  fetchConcurrencyLimits,
+  upsertConcurrencyLimit,
+  type ConcurrencyLimit,
+  type ConcurrencyLimitHolder,
+} from "../api/concurrencyLimits";
+import { fetchTask } from "../api/tasks";
+import { useBreadcrumb } from "../context/BreadcrumbContext";
+import { useEnvironment } from "../context/EnvironmentContext";
+import type { Task } from "../types/task";
+import { modalFunctionCallUrl } from "../utils/modalLinks";
+import { ExecutorBadge } from "./ExecutorBadge";
+import { TaskDetail } from "./TaskDetail";
+
+// Env-scoped admin view for named concurrency limits: list/create/edit/
+// delete limit keys and drill into a key's current slot holders (RUNNING
+// tasks), with an evict action to recover leaked slots.
+export function ConcurrencyLimits() {
+  const { activeEnvironment } = useEnvironment();
+  const { setItems: setBreadcrumb } = useBreadcrumb();
+
+  const [limits, setLimits] = useState<ConcurrencyLimit[]>([]);
+  const [holderCounts, setHolderCounts] = useState<Record<string, number>>({});
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  // Create form
+  const [newKey, setNewKey] = useState("");
+  const [newMax, setNewMax] = useState("1");
+  const [creating, setCreating] = useState(false);
+
+  // Inline edit
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  // Per-key holder drill-down
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
+  const [holders, setHolders] = useState<ConcurrencyLimitHolder[]>([]);
+  const [holdersTotal, setHoldersTotal] = useState(0);
+  const [holdersLoading, setHoldersLoading] = useState(false);
+  const [evictingTaskId, setEvictingTaskId] = useState<string | null>(null);
+
+  // Holder task detail panel
+  const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+
+  useEffect(() => {
+    setBreadcrumb([{ label: "Concurrency Limits" }]);
+    return () => setBreadcrumb([]);
+  }, [setBreadcrumb]);
+
+  const loadLimits = useCallback(async () => {
+    if (!activeEnvironment?.id) {
+      setLimits([]);
+      setLoading(false);
+      return;
+    }
+    setError(null);
+    try {
+      const fetched = await fetchConcurrencyLimits(activeEnvironment.id);
+      setLimits(fetched);
+      // Holder counts per key: a holders fetch with limit=1 returns the
+      // full count in `total`. Limit lists are small (admin-configured),
+      // so a request per key is fine. Count failures degrade to "—".
+      const counts = await Promise.all(
+        fetched.map(async (limit) => {
+          try {
+            const response = await fetchConcurrencyLimitHolders(
+              limit.key,
+              activeEnvironment.id,
+              1,
+            );
+            return [limit.key, response.total] as const;
+          } catch {
+            return null;
+          }
+        }),
+      );
+      setHolderCounts(
+        Object.fromEntries(counts.filter((c): c is [string, number] => c !== null)),
+      );
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load concurrency limits",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [activeEnvironment?.id]);
+
+  useEffect(() => {
+    setLoading(true);
+    setExpandedKey(null);
+    setSelectedTask(null);
+    loadLimits();
+  }, [loadLimits]);
+
+  const loadHolders = useCallback(
+    async (key: string) => {
+      if (!activeEnvironment?.id) return;
+      setHoldersLoading(true);
+      try {
+        const response = await fetchConcurrencyLimitHolders(key, activeEnvironment.id);
+        setHolders(response.holders);
+        setHoldersTotal(response.total);
+      } catch (err) {
+        setActionError(err instanceof Error ? err.message : "Failed to load holders");
+      } finally {
+        setHoldersLoading(false);
+      }
+    },
+    [activeEnvironment?.id],
+  );
+
+  const handleToggleHolders = useCallback(
+    (key: string) => {
+      setActionError(null);
+      if (expandedKey === key) {
+        setExpandedKey(null);
+        return;
+      }
+      setExpandedKey(key);
+      setHolders([]);
+      setHoldersTotal(0);
+      loadHolders(key);
+    },
+    [expandedKey, loadHolders],
+  );
+
+  const handleCreate = async () => {
+    if (!activeEnvironment?.id) return;
+    const key = newKey.trim();
+    const max = Number(newMax);
+    if (!key || !Number.isInteger(max) || max < 1) {
+      setActionError("Enter a key and a max concurrency of at least 1");
+      return;
+    }
+    setCreating(true);
+    setActionError(null);
+    try {
+      await upsertConcurrencyLimit(key, max, activeEnvironment.id);
+      setNewKey("");
+      setNewMax("1");
+      await loadLimits();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to create limit");
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleStartEdit = (limit: ConcurrencyLimit) => {
+    setActionError(null);
+    setEditingKey(limit.key);
+    setEditValue(String(limit.max_concurrent));
+  };
+
+  const handleSaveEdit = async (key: string) => {
+    if (!activeEnvironment?.id) return;
+    const max = Number(editValue);
+    if (!Number.isInteger(max) || max < 1) {
+      setActionError("Max concurrency must be an integer of at least 1");
+      return;
+    }
+    setSaving(true);
+    setActionError(null);
+    try {
+      await upsertConcurrencyLimit(key, max, activeEnvironment.id);
+      setEditingKey(null);
+      await loadLimits();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to update limit");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleDelete = async (key: string) => {
+    if (!activeEnvironment?.id) return;
+    const confirmed = window.confirm(
+      `Delete the concurrency limit "${key}"? The key becomes unlimited.`,
+    );
+    if (!confirmed) return;
+    setActionError(null);
+    try {
+      await deleteConcurrencyLimit(key, activeEnvironment.id);
+      if (expandedKey === key) setExpandedKey(null);
+      await loadLimits();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to delete limit");
+    }
+  };
+
+  const handleEvict = async (key: string, holder: ConcurrencyLimitHolder) => {
+    if (!activeEnvironment?.id) return;
+    const confirmed = window.confirm(
+      `Evict task "${holder.task_name}" (${holder.task_id.slice(0, 12)}...) from ` +
+        `"${key}"? The task is marked FAILED and all its slots are freed.`,
+    );
+    if (!confirmed) return;
+    setEvictingTaskId(holder.task_id);
+    setActionError(null);
+    try {
+      await evictConcurrencyLimitHolder(key, holder.task_id, activeEnvironment.id);
+      await Promise.all([loadHolders(key), loadLimits()]);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to evict holder");
+    } finally {
+      setEvictingTaskId(null);
+    }
+  };
+
+  const handleSelectHolderTask = async (holder: ConcurrencyLimitHolder) => {
+    if (!activeEnvironment?.id) return;
+    setActionError(null);
+    try {
+      const task = await fetchTask(holder.task_id, activeEnvironment.id);
+      setSelectedTask(task);
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Failed to load task");
+    }
+  };
+
+  if (!activeEnvironment) {
+    return (
+      <div className="flex h-full items-center justify-center text-gray-500 dark:text-gray-400">
+        Select an environment to manage its concurrency limits.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full overflow-hidden">
+      <div className="flex-1 overflow-auto p-4">
+        <div className="mx-auto max-w-4xl space-y-4">
+          <div>
+            <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              Concurrency Limits
+            </h1>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Named per-environment caps on concurrently running tasks. Tasks started
+              with a key count against its limit until they leave the running state.
+            </p>
+          </div>
+
+          {error && (
+            <div className="rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+              {error}
+            </div>
+          )}
+          {actionError && (
+            <div className="rounded-md bg-red-50 p-4 text-sm text-red-700 dark:bg-red-900/20 dark:text-red-400">
+              {actionError}
+            </div>
+          )}
+
+          {/* Create form */}
+          <div className="flex items-end gap-2 rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+            <div className="flex-1">
+              <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
+                Key
+              </label>
+              <input
+                type="text"
+                value={newKey}
+                onChange={(e) => setNewKey(e.target.value)}
+                placeholder="e.g. gpu"
+                className="mt-1 w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+              />
+            </div>
+            <div className="w-32">
+              <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
+                Max concurrent
+              </label>
+              <input
+                type="number"
+                min={1}
+                value={newMax}
+                onChange={(e) => setNewMax(e.target.value)}
+                aria-label="Max concurrent"
+                className="mt-1 w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+              />
+            </div>
+            <button
+              onClick={handleCreate}
+              disabled={creating || !newKey.trim()}
+              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+            >
+              {creating ? "Adding..." : "Add limit"}
+            </button>
+          </div>
+
+          {/* Limits table */}
+          {loading ? (
+            <div className="flex items-center justify-center py-8">
+              <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+            </div>
+          ) : limits.length === 0 ? (
+            <div className="py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+              No concurrency limits configured for this environment.
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700">
+              <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                <thead className="bg-gray-50 dark:bg-gray-800">
+                  <tr>
+                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      Key
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      Max Concurrent
+                    </th>
+                    <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      Current Holders
+                    </th>
+                    <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
+                  {limits.map((limit) => (
+                    <LimitRow
+                      key={limit.key}
+                      limit={limit}
+                      holderCount={holderCounts[limit.key]}
+                      expanded={expandedKey === limit.key}
+                      editing={editingKey === limit.key}
+                      editValue={editValue}
+                      saving={saving}
+                      holders={holders}
+                      holdersTotal={holdersTotal}
+                      holdersLoading={holdersLoading}
+                      evictingTaskId={evictingTaskId}
+                      onToggleHolders={() => handleToggleHolders(limit.key)}
+                      onStartEdit={() => handleStartEdit(limit)}
+                      onEditValueChange={setEditValue}
+                      onSaveEdit={() => handleSaveEdit(limit.key)}
+                      onCancelEdit={() => setEditingKey(null)}
+                      onDelete={() => handleDelete(limit.key)}
+                      onEvict={(holder) => handleEvict(limit.key, holder)}
+                      onSelectTask={handleSelectHolderTask}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Holder task detail panel */}
+      {selectedTask && (
+        <div className="w-96 flex-shrink-0 border-l border-gray-200 dark:border-gray-700">
+          <TaskDetail task={selectedTask} onClose={() => setSelectedTask(null)} />
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface LimitRowProps {
+  limit: ConcurrencyLimit;
+  holderCount: number | undefined;
+  expanded: boolean;
+  editing: boolean;
+  editValue: string;
+  saving: boolean;
+  holders: ConcurrencyLimitHolder[];
+  holdersTotal: number;
+  holdersLoading: boolean;
+  evictingTaskId: string | null;
+  onToggleHolders: () => void;
+  onStartEdit: () => void;
+  onEditValueChange: (value: string) => void;
+  onSaveEdit: () => void;
+  onCancelEdit: () => void;
+  onDelete: () => void;
+  onEvict: (holder: ConcurrencyLimitHolder) => void;
+  onSelectTask: (holder: ConcurrencyLimitHolder) => void;
+}
+
+function LimitRow({
+  limit,
+  holderCount,
+  expanded,
+  editing,
+  editValue,
+  saving,
+  holders,
+  holdersTotal,
+  holdersLoading,
+  evictingTaskId,
+  onToggleHolders,
+  onStartEdit,
+  onEditValueChange,
+  onSaveEdit,
+  onCancelEdit,
+  onDelete,
+  onEvict,
+  onSelectTask,
+}: LimitRowProps) {
+  return (
+    <>
+      <tr className="hover:bg-gray-50 dark:hover:bg-gray-800">
+        <td className="px-4 py-2 font-mono text-sm text-gray-900 dark:text-gray-100">
+          {limit.key}
+        </td>
+        <td className="px-4 py-2 text-sm text-gray-900 dark:text-gray-100">
+          {editing ? (
+            <div className="flex items-center gap-2">
+              <input
+                type="number"
+                min={1}
+                value={editValue}
+                onChange={(e) => onEditValueChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") onSaveEdit();
+                  if (e.key === "Escape") onCancelEdit();
+                }}
+                autoFocus
+                className="w-20 rounded-md border border-gray-300 bg-white px-2 py-0.5 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                aria-label={`Max concurrent for ${limit.key}`}
+              />
+              <button
+                onClick={onSaveEdit}
+                disabled={saving}
+                className="text-xs font-medium text-blue-600 hover:text-blue-700 disabled:opacity-50 dark:text-blue-400"
+              >
+                {saving ? "Saving..." : "Save"}
+              </button>
+              <button
+                onClick={onCancelEdit}
+                className="text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+              >
+                Cancel
+              </button>
+            </div>
+          ) : (
+            <button
+              onClick={onStartEdit}
+              className="rounded px-1 hover:bg-gray-100 dark:hover:bg-gray-700"
+              title="Edit max concurrency"
+            >
+              {limit.max_concurrent}
+              <span className="ml-1.5 text-xs text-gray-400">✎</span>
+            </button>
+          )}
+        </td>
+        <td className="px-4 py-2 text-sm">
+          <button
+            onClick={onToggleHolders}
+            className="flex items-center gap-1 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300"
+            title="Show current slot holders"
+          >
+            <svg
+              className={`h-3 w-3 transition-transform ${expanded ? "rotate-90" : ""}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+            {holderCount ?? "—"}
+          </button>
+        </td>
+        <td className="px-4 py-2 text-right">
+          <button
+            onClick={onDelete}
+            className="rounded-md px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+            title="Delete this limit (the key becomes unlimited)"
+          >
+            Delete
+          </button>
+        </td>
+      </tr>
+      {expanded && (
+        <tr>
+          <td colSpan={4} className="bg-gray-50 px-4 py-3 dark:bg-gray-800/50">
+            {holdersLoading ? (
+              <div className="flex items-center justify-center py-4">
+                <div className="h-5 w-5 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+              </div>
+            ) : holders.length === 0 ? (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                No tasks currently hold a slot of this key.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {holdersTotal > holders.length && (
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    Showing {holders.length} of {holdersTotal} holders (oldest running
+                    first).
+                  </p>
+                )}
+                <table className="min-w-full">
+                  <thead>
+                    <tr>
+                      <th className="py-1 pr-4 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                        Task
+                      </th>
+                      <th className="py-1 pr-4 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                        Running Since
+                      </th>
+                      <th className="py-1 pr-4 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                        Executor
+                      </th>
+                      <th className="py-1 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                        Actions
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
+                    {holders.map((holder) => {
+                      const callUrl = modalFunctionCallUrl(
+                        holder.latest_executor_metadata,
+                        holder.latest_executor_ref,
+                      );
+                      return (
+                        <tr key={holder.task_id}>
+                          <td className="py-1.5 pr-4">
+                            <button
+                              onClick={() => onSelectTask(holder)}
+                              className="text-left text-sm text-blue-600 hover:text-blue-700 hover:underline dark:text-blue-400 dark:hover:text-blue-300"
+                              title="View task details"
+                            >
+                              {holder.task_name}
+                            </button>
+                            <span className="ml-2 font-mono text-xs text-gray-500 dark:text-gray-400">
+                              {holder.task_id.slice(0, 12)}...
+                            </span>
+                          </td>
+                          <td className="py-1.5 pr-4 text-sm text-gray-900 dark:text-gray-100">
+                            {holder.latest_status_at
+                              ? new Date(holder.latest_status_at).toLocaleString()
+                              : "—"}
+                          </td>
+                          <td className="py-1.5 pr-4">
+                            <span className="flex items-center gap-1.5">
+                              <ExecutorBadge
+                                executor={holder.latest_executor}
+                                executorRef={holder.latest_executor_ref}
+                              />
+                              {callUrl && (
+                                <a
+                                  href={callUrl}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="text-xs text-blue-600 hover:underline dark:text-blue-400"
+                                  title="Open the function call in the Modal dashboard"
+                                >
+                                  View on Modal
+                                </a>
+                              )}
+                            </span>
+                          </td>
+                          <td className="py-1.5 text-right">
+                            <button
+                              onClick={() => onEvict(holder)}
+                              disabled={evictingTaskId === holder.task_id}
+                              className="rounded-md bg-red-100 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-200 disabled:opacity-50 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"
+                              title="Mark the task failed and free all its slots"
+                            >
+                              {evictingTaskId === holder.task_id
+                                ? "Evicting..."
+                                : "Evict"}
+                            </button>
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/app/stardag-ui/src/components/ConcurrencyLimits.tsx
+++ b/app/stardag-ui/src/components/ConcurrencyLimits.tsx
@@ -18,10 +18,14 @@ import { TaskDetail } from "./TaskDetail";
 
 // Env-scoped admin view for named concurrency limits: list/create/edit/
 // delete limit keys and drill into a key's current slot holders (RUNNING
-// tasks), with an evict action to recover leaked slots.
+// tasks), with an evict action to recover leaked slots. Limits and
+// holders are viewable by all workspace members; mutations (create/
+// edit/delete/evict) are workspace-admin-only, matching the server-side
+// role gate and the WorkspaceSettings gating pattern.
 export function ConcurrencyLimits() {
-  const { activeEnvironment } = useEnvironment();
+  const { activeEnvironment, activeWorkspaceRole } = useEnvironment();
   const { setItems: setBreadcrumb } = useBreadcrumb();
+  const isAdmin = activeWorkspaceRole === "owner" || activeWorkspaceRole === "admin";
 
   const [limits, setLimits] = useState<ConcurrencyLimit[]>([]);
   const [holderCounts, setHolderCounts] = useState<Record<string, number>>({});
@@ -66,6 +70,7 @@ export function ConcurrencyLimits() {
     const fresh = () => limitsEpochRef.current === epoch;
     if (!activeEnvironment?.id) {
       setLimits([]);
+      setHolderCounts({});
       setLoading(false);
       return;
     }
@@ -114,6 +119,11 @@ export function ConcurrencyLimits() {
     setLoading(true);
     setExpandedKey(null);
     setSelectedTask(null);
+    // Clear counts eagerly: environments can share key names, so a stale
+    // count from the previous environment must not show on the new
+    // environment's row while its own count fetch is in flight (or after
+    // it failed).
+    setHolderCounts({});
     loadLimits();
   }, [loadLimits]);
 
@@ -223,7 +233,11 @@ export function ConcurrencyLimits() {
     if (!activeEnvironment?.id) return;
     const confirmed = window.confirm(
       `Evict task "${holder.task_name}" (${holder.task_id.slice(0, 12)}...) from ` +
-        `"${key}"? The task is marked FAILED and all its slots are freed.`,
+        `"${key}"?\n\nThe task is marked FAILED and all its slots are freed — but ` +
+        `the underlying process is NOT stopped. Only evict holders whose process ` +
+        `you know is dead: evicting a live worker oversubscribes the cap, and in ` +
+        `a fail-fast reactive build the evicted-but-alive execution is the one ` +
+        `that never gets cancelled (it can still complete after the build failed).`,
     );
     if (!confirmed) return;
     setEvictingTaskId(holder.task_id);
@@ -282,41 +296,43 @@ export function ConcurrencyLimits() {
             </div>
           )}
 
-          {/* Create form */}
-          <div className="flex items-end gap-2 rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
-            <div className="flex-1">
-              <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
-                Key
-              </label>
-              <input
-                type="text"
-                value={newKey}
-                onChange={(e) => setNewKey(e.target.value)}
-                placeholder="e.g. gpu"
-                className="mt-1 w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
-              />
+          {/* Create form (workspace admins only) */}
+          {isAdmin && (
+            <div className="flex items-end gap-2 rounded-lg border border-gray-200 bg-white p-3 dark:border-gray-700 dark:bg-gray-800">
+              <div className="flex-1">
+                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
+                  Key
+                </label>
+                <input
+                  type="text"
+                  value={newKey}
+                  onChange={(e) => setNewKey(e.target.value)}
+                  placeholder="e.g. gpu"
+                  className="mt-1 w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                />
+              </div>
+              <div className="w-32">
+                <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
+                  Max concurrent
+                </label>
+                <input
+                  type="number"
+                  min={1}
+                  value={newMax}
+                  onChange={(e) => setNewMax(e.target.value)}
+                  aria-label="Max concurrent"
+                  className="mt-1 w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+                />
+              </div>
+              <button
+                onClick={handleCreate}
+                disabled={creating || !newKey.trim()}
+                className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+              >
+                {creating ? "Adding..." : "Add limit"}
+              </button>
             </div>
-            <div className="w-32">
-              <label className="block text-xs font-medium text-gray-500 dark:text-gray-400">
-                Max concurrent
-              </label>
-              <input
-                type="number"
-                min={1}
-                value={newMax}
-                onChange={(e) => setNewMax(e.target.value)}
-                aria-label="Max concurrent"
-                className="mt-1 w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
-              />
-            </div>
-            <button
-              onClick={handleCreate}
-              disabled={creating || !newKey.trim()}
-              className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
-            >
-              {creating ? "Adding..." : "Add limit"}
-            </button>
-          </div>
+          )}
 
           {/* Limits table */}
           {loading ? (
@@ -341,9 +357,11 @@ export function ConcurrencyLimits() {
                     <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
                       Current Holders
                     </th>
-                    <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                      Actions
-                    </th>
+                    {isAdmin && (
+                      <th className="px-4 py-2 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                        Actions
+                      </th>
+                    )}
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
@@ -351,6 +369,7 @@ export function ConcurrencyLimits() {
                     <LimitRow
                       key={limit.key}
                       limit={limit}
+                      isAdmin={isAdmin}
                       holderCount={holderCounts[limit.key]}
                       expanded={expandedKey === limit.key}
                       editing={editingKey === limit.key}
@@ -389,6 +408,8 @@ export function ConcurrencyLimits() {
 
 interface LimitRowProps {
   limit: ConcurrencyLimit;
+  // Workspace-admin mutations (edit/delete/evict) are hidden otherwise.
+  isAdmin: boolean;
   holderCount: number | undefined;
   expanded: boolean;
   editing: boolean;
@@ -410,6 +431,7 @@ interface LimitRowProps {
 
 function LimitRow({
   limit,
+  isAdmin,
   holderCount,
   expanded,
   editing,
@@ -464,7 +486,7 @@ function LimitRow({
                 Cancel
               </button>
             </div>
-          ) : (
+          ) : isAdmin ? (
             <button
               onClick={onStartEdit}
               className="rounded px-1 hover:bg-gray-100 dark:hover:bg-gray-700"
@@ -473,6 +495,8 @@ function LimitRow({
               {limit.max_concurrent}
               <span className="ml-1.5 text-xs text-gray-400">✎</span>
             </button>
+          ) : (
+            <span className="px-1">{limit.max_concurrent}</span>
           )}
         </td>
         <td className="px-4 py-2 text-sm">
@@ -497,19 +521,24 @@ function LimitRow({
             {holderCount ?? "—"}
           </button>
         </td>
-        <td className="px-4 py-2 text-right">
-          <button
-            onClick={onDelete}
-            className="rounded-md px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
-            title="Delete this limit (the key becomes unlimited)"
-          >
-            Delete
-          </button>
-        </td>
+        {isAdmin && (
+          <td className="px-4 py-2 text-right">
+            <button
+              onClick={onDelete}
+              className="rounded-md px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
+              title="Delete this limit (the key becomes unlimited)"
+            >
+              Delete
+            </button>
+          </td>
+        )}
       </tr>
       {expanded && (
         <tr>
-          <td colSpan={4} className="bg-gray-50 px-4 py-3 dark:bg-gray-800/50">
+          <td
+            colSpan={isAdmin ? 4 : 3}
+            className="bg-gray-50 px-4 py-3 dark:bg-gray-800/50"
+          >
             {holdersLoading ? (
               <div className="flex items-center justify-center py-4">
                 <div className="h-5 w-5 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
@@ -538,9 +567,11 @@ function LimitRow({
                       <th className="py-1 pr-4 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
                         Executor
                       </th>
-                      <th className="py-1 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
-                        Actions
-                      </th>
+                      {isAdmin && (
+                        <th className="py-1 text-right text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400">
+                          Actions
+                        </th>
+                      )}
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
@@ -587,18 +618,20 @@ function LimitRow({
                               )}
                             </span>
                           </td>
-                          <td className="py-1.5 text-right">
-                            <button
-                              onClick={() => onEvict(holder)}
-                              disabled={evictingTaskId === holder.task_id}
-                              className="rounded-md bg-red-100 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-200 disabled:opacity-50 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"
-                              title="Mark the task failed and free all its slots"
-                            >
-                              {evictingTaskId === holder.task_id
-                                ? "Evicting..."
-                                : "Evict"}
-                            </button>
-                          </td>
+                          {isAdmin && (
+                            <td className="py-1.5 text-right">
+                              <button
+                                onClick={() => onEvict(holder)}
+                                disabled={evictingTaskId === holder.task_id}
+                                className="rounded-md bg-red-100 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-200 disabled:opacity-50 dark:bg-red-900/30 dark:text-red-400 dark:hover:bg-red-900/50"
+                                title="Mark the task failed and free all its slots"
+                              >
+                                {evictingTaskId === holder.task_id
+                                  ? "Evicting..."
+                                  : "Evict"}
+                              </button>
+                            </td>
+                          )}
                         </tr>
                       );
                     })}

--- a/app/stardag-ui/src/components/DagGraph.tsx
+++ b/app/stardag-ui/src/components/DagGraph.tsx
@@ -305,6 +305,8 @@ export function DagGraph({
           statusBuildId: task?.status_build_id,
           currentBuildId: buildId,
           onStatusBuildClick,
+          latestExecutor: task?.latest_executor,
+          latestExecutorRef: task?.latest_executor_ref,
         },
       } satisfies TaskNodeType;
     });

--- a/app/stardag-ui/src/components/ExecutorBadge.test.tsx
+++ b/app/stardag-ui/src/components/ExecutorBadge.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { BuildExecutorChips, ExecutorBadge } from "./ExecutorBadge";
+
+describe("ExecutorBadge", () => {
+  it("renders the Modal chip for the modal executor", () => {
+    render(<ExecutorBadge executor="modal" />);
+    expect(screen.getByText("⚡ Modal")).toBeInTheDocument();
+  });
+
+  it("renders the raw executor name for unknown executor kinds", () => {
+    render(<ExecutorBadge executor="k8s" />);
+    expect(screen.getByText("k8s")).toBeInTheDocument();
+  });
+
+  it("renders nothing without an executor", () => {
+    const { container } = render(<ExecutorBadge executor={null} />);
+    expect(container).toBeEmptyDOMElement();
+    const { container: undefinedContainer } = render(<ExecutorBadge />);
+    expect(undefinedContainer).toBeEmptyDOMElement();
+  });
+
+  it("shows the call ref in the tooltip and copies it on click", async () => {
+    // userEvent.setup() installs a working clipboard stub in jsdom.
+    const user = userEvent.setup();
+    render(<ExecutorBadge executor="modal" executorRef="fc-abc123" />);
+
+    const badge = screen.getByRole("button");
+    expect(badge).toHaveAttribute("title", "Call ref: fc-abc123 (click to copy)");
+    await user.click(badge);
+    expect(await window.navigator.clipboard.readText()).toBe("fc-abc123");
+    expect(badge).toHaveAttribute("title", "Copied!");
+  });
+
+  it("is not clickable without a call ref", () => {
+    render(<ExecutorBadge executor="modal" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+});
+
+describe("BuildExecutorChips", () => {
+  const metadata = {
+    kind: "modal",
+    app_name: "my-app",
+    workspace: "my-workspace",
+    environment: "staging",
+    reactive: true,
+  };
+
+  it("renders a Modal app chip linking to the app page and a reactive badge", () => {
+    render(<BuildExecutorChips metadata={metadata} />);
+    const link = screen.getByRole("link", { name: "Modal: my-app" });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+    );
+    expect(screen.getByText("reactive")).toBeInTheDocument();
+  });
+
+  it("renders a plain chip (no dead link) when the app URL cannot be built", () => {
+    render(<BuildExecutorChips metadata={{ kind: "modal", app_name: "my-app" }} />);
+    expect(screen.getByText("Modal: my-app")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("omits the reactive badge when reactive is false", () => {
+    render(<BuildExecutorChips metadata={{ ...metadata, reactive: false }} />);
+    expect(screen.queryByText("reactive")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing without metadata", () => {
+    const { container } = render(<BuildExecutorChips metadata={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/app/stardag-ui/src/components/ExecutorBadge.tsx
+++ b/app/stardag-ui/src/components/ExecutorBadge.tsx
@@ -75,14 +75,20 @@ export function BuildExecutorChips({ metadata }: BuildExecutorChipsProps) {
   if (!metadata) return null;
 
   const isModal = metadata.kind === "modal" || metadata.kind === undefined;
-  const appName = typeof metadata.app_name === "string" ? metadata.app_name : null;
+  const appName =
+    typeof metadata.app_name === "string" && metadata.app_name.length > 0
+      ? metadata.app_name
+      : null;
+  // Non-null appUrl implies a non-empty app_name (modalAppUrl requires it),
+  // so the label needs no fallback.
   const appUrl = modalAppUrl(metadata);
 
-  const modalChipLabel =
-    isModal && (appName || appUrl) ? `Modal: ${appName ?? "app"}` : null;
+  const modalChipLabel = isModal && appName ? `Modal: ${appName}` : null;
 
+  // max-w + truncate: app_name is unvalidated server-side, so an oversized
+  // value must not blow up the breadcrumb row (full label in the tooltip).
   const chipClasses =
-    "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium " +
+    "inline-flex max-w-64 items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium " +
     "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300";
 
   if (!modalChipLabel && metadata.reactive !== true) return null;
@@ -97,12 +103,14 @@ export function BuildExecutorChips({ metadata }: BuildExecutorChipsProps) {
             rel="noopener noreferrer"
             onClick={(e) => e.stopPropagation()}
             className={`${chipClasses} hover:ring-1 hover:ring-emerald-400`}
-            title="Open the Modal app dashboard"
+            title={`${modalChipLabel} — open the Modal app dashboard`}
           >
-            {modalChipLabel}
+            <span className="truncate">{modalChipLabel}</span>
           </a>
         ) : (
-          <span className={chipClasses}>{modalChipLabel}</span>
+          <span className={chipClasses} title={modalChipLabel}>
+            <span className="truncate">{modalChipLabel}</span>
+          </span>
         ))}
       {metadata.reactive === true && (
         <span

--- a/app/stardag-ui/src/components/ExecutorBadge.tsx
+++ b/app/stardag-ui/src/components/ExecutorBadge.tsx
@@ -1,0 +1,117 @@
+import { useState } from "react";
+import type { ExecutorMetadata } from "../types/task";
+import { modalAppUrl } from "../utils/modalLinks";
+
+interface ExecutorBadgeProps {
+  executor?: string | null;
+  executorRef?: string | null;
+}
+
+// Small chip identifying the executor backend a task last ran on
+// ("⚡ Modal" for modal; the raw executor name otherwise). Renders
+// nothing when no executor was recorded. When a call ref is present the
+// tooltip shows it and clicking copies it to the clipboard.
+export function ExecutorBadge({ executor, executorRef }: ExecutorBadgeProps) {
+  const [copied, setCopied] = useState(false);
+
+  if (!executor) return null;
+
+  const label = executor === "modal" ? "⚡ Modal" : executor;
+  const hasRef = Boolean(executorRef);
+
+  const tooltip = copied
+    ? "Copied!"
+    : hasRef
+      ? `Call ref: ${executorRef} (click to copy)`
+      : `Executor: ${executor}`;
+
+  const handleCopy = async (e: React.MouseEvent) => {
+    // Badges render inside clickable rows/nodes — don't trigger those.
+    e.stopPropagation();
+    if (!executorRef) return;
+    try {
+      await navigator.clipboard.writeText(executorRef);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy:", err);
+    }
+  };
+
+  const baseClasses =
+    "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium " +
+    "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300";
+
+  if (!hasRef) {
+    return (
+      <span className={baseClasses} title={tooltip}>
+        {label}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className={`${baseClasses} cursor-pointer hover:ring-1 hover:ring-emerald-400`}
+      title={tooltip}
+    >
+      {label}
+      {copied && <span aria-hidden="true">✓</span>}
+    </button>
+  );
+}
+
+interface BuildExecutorChipsProps {
+  metadata?: ExecutorMetadata | null;
+}
+
+// Build-level executor chips: "Modal: {app_name}" linking to the app's
+// dashboard page (plain chip when the link can't be built) plus a
+// "reactive" badge for tick-scheduled builds. Renders nothing without
+// recorded metadata.
+export function BuildExecutorChips({ metadata }: BuildExecutorChipsProps) {
+  if (!metadata) return null;
+
+  const isModal = metadata.kind === "modal" || metadata.kind === undefined;
+  const appName = typeof metadata.app_name === "string" ? metadata.app_name : null;
+  const appUrl = modalAppUrl(metadata);
+
+  const modalChipLabel =
+    isModal && (appName || appUrl) ? `Modal: ${appName ?? "app"}` : null;
+
+  const chipClasses =
+    "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium " +
+    "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300";
+
+  if (!modalChipLabel && metadata.reactive !== true) return null;
+
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      {modalChipLabel &&
+        (appUrl ? (
+          <a
+            href={appUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            onClick={(e) => e.stopPropagation()}
+            className={`${chipClasses} hover:ring-1 hover:ring-emerald-400`}
+            title="Open the Modal app dashboard"
+          >
+            {modalChipLabel}
+          </a>
+        ) : (
+          <span className={chipClasses}>{modalChipLabel}</span>
+        ))}
+      {metadata.reactive === true && (
+        <span
+          className="inline-flex items-center rounded-full bg-sky-100 px-2 py-0.5 text-xs font-medium text-sky-800 dark:bg-sky-900/30 dark:text-sky-300"
+          title="Reactive build: scheduled by tick functions, no resident orchestrator"
+        >
+          reactive
+        </span>
+      )}
+    </span>
+  );
+}

--- a/app/stardag-ui/src/components/Sidebar.tsx
+++ b/app/stardag-ui/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Logo } from "./Logo";
 
-export type NavItem = "home" | "builds" | "tasks" | "settings";
+export type NavItem = "home" | "builds" | "tasks" | "limits" | "settings";
 
 interface SidebarProps {
   activeItem: NavItem;
@@ -40,6 +40,20 @@ export function Sidebar({
             strokeLinejoin="round"
             strokeWidth={2}
             d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+      ),
+    },
+    {
+      id: "limits",
+      label: "Concurrency Limits",
+      icon: (
+        <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"
           />
         </svg>
       ),

--- a/app/stardag-ui/src/components/TaskDetail.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { cancelTask, fetchTaskArtifacts, fetchTaskEvents } from "../api/tasks";
 import type { Task, TaskArtifact, TaskEvent, EventType } from "../types/task";
+import { modalAppUrl, modalFunctionCallUrl } from "../utils/modalLinks";
 import { ArtifactList, ExpandButton } from "./ArtifactViewer";
+import { ExecutorBadge } from "./ExecutorBadge";
 import { FullscreenModal } from "./FullscreenModal";
 import { StatusBadge } from "./StatusBadge";
 
@@ -291,6 +293,97 @@ export function TaskDetail({
                 {task.commit_hash}
               </code>
               <CopyButton text={task.commit_hash} className="flex-shrink-0" />
+            </div>
+          </div>
+        )}
+
+        {/* Execution - only when executor identity/metadata was recorded */}
+        {(task.latest_executor ||
+          task.latest_executor_ref ||
+          task.latest_executor_metadata) && (
+          <div>
+            <label className="block text-sm font-medium text-gray-500 dark:text-gray-400">
+              Execution
+            </label>
+            <div className="mt-1 space-y-1 text-sm text-gray-900 dark:text-gray-100">
+              {task.latest_executor && (
+                <div className="flex items-center gap-2">
+                  <ExecutorBadge executor={task.latest_executor} />
+                </div>
+              )}
+              {task.latest_executor_metadata?.app_name && (
+                <div className="flex items-center gap-1">
+                  <span className="text-gray-500 dark:text-gray-400">App:</span>
+                  {(() => {
+                    const appUrl = modalAppUrl(task.latest_executor_metadata);
+                    const appName = task.latest_executor_metadata?.app_name;
+                    return appUrl ? (
+                      <a
+                        href={appUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-blue-600 hover:underline dark:text-blue-400"
+                        title="Open the Modal app dashboard"
+                      >
+                        {appName}
+                      </a>
+                    ) : (
+                      <span>{appName}</span>
+                    );
+                  })()}
+                </div>
+              )}
+              {task.latest_executor_metadata?.function_name && (
+                <div className="flex items-center gap-1">
+                  <span className="text-gray-500 dark:text-gray-400">Function:</span>
+                  <span className="font-mono">
+                    {task.latest_executor_metadata.function_name}
+                  </span>
+                </div>
+              )}
+              {task.latest_executor_ref && (
+                <div className="flex items-center gap-1">
+                  <span className="text-gray-500 dark:text-gray-400">Call ref:</span>
+                  {(() => {
+                    const callUrl = modalFunctionCallUrl(
+                      task.latest_executor_metadata,
+                      task.latest_executor_ref,
+                    );
+                    return callUrl ? (
+                      <a
+                        href={callUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="truncate font-mono text-blue-600 hover:underline dark:text-blue-400"
+                        title="Open the function call in the Modal dashboard"
+                      >
+                        {task.latest_executor_ref}
+                      </a>
+                    ) : (
+                      <span className="truncate font-mono">
+                        {task.latest_executor_ref}
+                      </span>
+                    );
+                  })()}
+                  <CopyButton
+                    text={task.latest_executor_ref}
+                    className="flex-shrink-0"
+                  />
+                </div>
+              )}
+              {(task.latest_executor_metadata?.workspace ||
+                task.latest_executor_metadata?.environment) && (
+                <div className="flex items-center gap-1">
+                  <span className="text-gray-500 dark:text-gray-400">
+                    Workspace / env:
+                  </span>
+                  <span>
+                    {task.latest_executor_metadata?.workspace ?? "—"}
+                    {" / "}
+                    {task.latest_executor_metadata?.environment ?? "—"}
+                  </span>
+                </div>
+              )}
             </div>
           </div>
         )}

--- a/app/stardag-ui/src/components/TaskExplorer.tsx
+++ b/app/stardag-ui/src/components/TaskExplorer.tsx
@@ -561,6 +561,10 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
         error_message: searchTask?.error_message ?? null,
         artifact_count: node.artifact_count,
         isFilterMatch: isPrimary && searchTaskIds.has(node.task_id),
+        // Executor identity (DAG node hover + detail panel)
+        latest_executor: searchTask?.latest_executor,
+        latest_executor_ref: searchTask?.latest_executor_ref,
+        latest_executor_metadata: searchTask?.latest_executor_metadata,
       };
     });
   }, [dagGraph, tasks, activeEnvironment?.id]);

--- a/app/stardag-ui/src/components/TaskExplorerTable.tsx
+++ b/app/stardag-ui/src/components/TaskExplorerTable.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import type { Task, TaskStatus } from "../types/task";
 import { truncateNestedKeyToWidth } from "../utils/truncateKey";
 import type { ColumnConfig } from "./ColumnManagerModal";
+import { ExecutorBadge } from "./ExecutorBadge";
 
 export interface TaskSearchResult extends Task {
   build_id?: string;
@@ -214,12 +215,18 @@ function renderCell(
 
   if (key === "status" && typeof value === "string") {
     return (
-      <span
-        className={`rounded-full px-2 py-0.5 text-xs font-medium ${getStatusColor(
-          value as TaskStatus,
-        )}`}
-      >
-        {value}
+      <span className="inline-flex items-center gap-1.5">
+        <span
+          className={`rounded-full px-2 py-0.5 text-xs font-medium ${getStatusColor(
+            value as TaskStatus,
+          )}`}
+        >
+          {value}
+        </span>
+        <ExecutorBadge
+          executor={task.latest_executor}
+          executorRef={task.latest_executor_ref}
+        />
       </span>
     );
   }

--- a/app/stardag-ui/src/components/TaskNode.tsx
+++ b/app/stardag-ui/src/components/TaskNode.tsx
@@ -16,6 +16,10 @@ export interface TaskNodeData extends Record<string, unknown> {
   statusBuildId?: string;
   currentBuildId?: string;
   onStatusBuildClick?: (buildId: string) => void;
+  // Executor identity, surfaced via the node's hover tooltip only to
+  // keep DAG nodes uncluttered.
+  latestExecutor?: string | null;
+  latestExecutorRef?: string | null;
 }
 
 const statusBorderColors: Record<TaskStatus, string> = {
@@ -106,7 +110,13 @@ export function TaskNode({ data }: TaskNodeProps) {
               ? "text-gray-500 dark:text-gray-400"
               : "text-gray-900 dark:text-gray-100"
           }`}
-          title={data.label}
+          title={
+            data.latestExecutor
+              ? `${data.label}\nExecutor: ${data.latestExecutor}${
+                  data.latestExecutorRef ? ` (${data.latestExecutorRef})` : ""
+                }`
+              : data.label
+          }
         >
           {truncateLabel(data.label)}
         </span>

--- a/app/stardag-ui/src/components/TaskTable.tsx
+++ b/app/stardag-ui/src/components/TaskTable.tsx
@@ -1,4 +1,5 @@
 import type { Task } from "../types/task";
+import { ExecutorBadge } from "./ExecutorBadge";
 import { StatusBadge } from "./StatusBadge";
 
 interface TaskTableProps {
@@ -115,13 +116,19 @@ export function TaskTable({
                     {task.task_id.slice(0, 12)}...
                   </td>
                   <td className="px-3 py-1.5">
-                    <StatusBadge
-                      status={task.status}
-                      waitingForLock={task.waiting_for_lock}
-                      statusBuildId={task.status_build_id}
-                      currentBuildId={buildId}
-                      onStatusBuildClick={onStatusBuildClick}
-                    />
+                    <span className="inline-flex items-center gap-1.5">
+                      <StatusBadge
+                        status={task.status}
+                        waitingForLock={task.waiting_for_lock}
+                        statusBuildId={task.status_build_id}
+                        currentBuildId={buildId}
+                        onStatusBuildClick={onStatusBuildClick}
+                      />
+                      <ExecutorBadge
+                        executor={task.latest_executor}
+                        executorRef={task.latest_executor_ref}
+                      />
+                    </span>
                   </td>
                   <td className="px-3 py-1.5 text-xs text-gray-500 dark:text-gray-400">
                     {new Date(task.created_at).toLocaleString()}

--- a/app/stardag-ui/src/types/task.ts
+++ b/app/stardag-ui/src/types/task.ts
@@ -15,6 +15,22 @@ export type BuildStatus =
   | "cancelled"
   | "exit_early";
 
+// Descriptive metadata about the executor backend that ran a task or
+// triggered a build (recorded on TASK_STARTED / build creation events).
+// For Modal executions: {kind: "modal", app_name, workspace, environment,
+// function_name} — every key is optional (older SDKs may record a subset),
+// so consumers must handle missing fields (see utils/modalLinks.ts).
+export interface ExecutorMetadata {
+  kind?: string;
+  app_name?: string;
+  workspace?: string;
+  environment?: string;
+  function_name?: string;
+  // Build-level only: true when triggered in reactive (tick-scheduled) mode
+  reactive?: boolean;
+  [key: string]: unknown;
+}
+
 // User info for manual status triggers
 export interface StatusTriggeredByUser {
   id: string;
@@ -43,6 +59,11 @@ export interface Build {
   // Optional in the type so older API responses (without the field)
   // deserialize without runtime errors.
   is_resumed?: boolean;
+  // Executor-descriptive metadata of the trigger that created the build
+  // (e.g. the Modal app of a build_trigger call). Optional: absent on
+  // older API responses and null for builds without a recorded trigger
+  // executor.
+  executor_metadata?: ExecutorMetadata | null;
 }
 
 export interface BuildListResponse {
@@ -81,6 +102,12 @@ export interface Task {
   // a not-yet-registered task (legacy/safety-hatch path; with the SDK's
   // post-order discover this is rare). UI hides phantoms from list views.
   is_phantom?: boolean;
+  // Executor identity of the most recent TASK_STARTED event. Optional:
+  // absent on older API responses, null for tasks never started via an
+  // executor that records it.
+  latest_executor?: string | null;
+  latest_executor_ref?: string | null;
+  latest_executor_metadata?: ExecutorMetadata | null;
 }
 
 export interface TaskListResponse {

--- a/app/stardag-ui/src/utils/modalLinks.test.ts
+++ b/app/stardag-ui/src/utils/modalLinks.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { modalAppUrl, modalFunctionCallUrl } from "./modalLinks";
+
+const fullMetadata = {
+  kind: "modal",
+  app_name: "my-app",
+  workspace: "my-workspace",
+  environment: "staging",
+  function_name: "worker_default",
+};
+
+function withoutKey(key: keyof typeof fullMetadata): Record<string, unknown> {
+  const copy: Record<string, unknown> = { ...fullMetadata };
+  delete copy[key];
+  return copy;
+}
+
+describe("modalAppUrl", () => {
+  it("builds the deployed-app URL from full metadata", () => {
+    expect(modalAppUrl(fullMetadata)).toBe(
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+    );
+  });
+
+  it("falls back to the 'main' environment when absent", () => {
+    expect(modalAppUrl(withoutKey("environment"))).toBe(
+      "https://modal.com/apps/my-workspace/main/deployed/my-app",
+    );
+  });
+
+  it("accepts metadata without an explicit kind", () => {
+    expect(modalAppUrl(withoutKey("kind"))).toBe(
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+    );
+  });
+
+  it("returns null for a non-modal kind", () => {
+    expect(modalAppUrl({ ...fullMetadata, kind: "k8s" })).toBeNull();
+  });
+
+  it("returns null when workspace is missing or empty", () => {
+    expect(modalAppUrl(withoutKey("workspace"))).toBeNull();
+    expect(modalAppUrl({ ...fullMetadata, workspace: "" })).toBeNull();
+  });
+
+  it("returns null when app_name is missing", () => {
+    expect(modalAppUrl(withoutKey("app_name"))).toBeNull();
+  });
+
+  it("returns null for null/undefined metadata", () => {
+    expect(modalAppUrl(null)).toBeNull();
+    expect(modalAppUrl(undefined)).toBeNull();
+  });
+
+  it("URL-encodes path segments", () => {
+    expect(
+      modalAppUrl({
+        kind: "modal",
+        app_name: "my app/x",
+        workspace: "ws#1",
+        environment: "env 2",
+      }),
+    ).toBe("https://modal.com/apps/ws%231/env%202/deployed/my%20app%2Fx");
+  });
+});
+
+describe("modalFunctionCallUrl", () => {
+  it("appends the functionCallId query param to the app URL", () => {
+    expect(modalFunctionCallUrl(fullMetadata, "fc-abc123")).toBe(
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app?functionCallId=fc-abc123",
+    );
+  });
+
+  it("returns null without a call ref", () => {
+    expect(modalFunctionCallUrl(fullMetadata, null)).toBeNull();
+    expect(modalFunctionCallUrl(fullMetadata, undefined)).toBeNull();
+    expect(modalFunctionCallUrl(fullMetadata, "")).toBeNull();
+  });
+
+  it("returns null when the app URL cannot be built", () => {
+    expect(modalFunctionCallUrl(null, "fc-abc123")).toBeNull();
+    expect(modalFunctionCallUrl({ kind: "modal" }, "fc-abc123")).toBeNull();
+  });
+
+  it("URL-encodes the call ref", () => {
+    expect(modalFunctionCallUrl(fullMetadata, "fc a&b")).toBe(
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app?functionCallId=fc%20a%26b",
+    );
+  });
+});

--- a/app/stardag-ui/src/utils/modalLinks.ts
+++ b/app/stardag-ui/src/utils/modalLinks.ts
@@ -1,0 +1,50 @@
+import type { ExecutorMetadata } from "../types/task";
+
+// Modal dashboard deep links.
+//
+// ALL Modal URL patterns are centralized in THIS file — if Modal ever
+// changes its dashboard URL format, this is the only place to update.
+//
+// Patterns (matching the "View Deployment" URL the Modal CLI prints on
+// `modal deploy`):
+//   app page:      https://modal.com/apps/{workspace}/{environment}/deployed/{app_name}
+//   function call: app page + ?functionCallId={function_call_id}
+//
+// The environment segment falls back to Modal's default environment name
+// ("main") when the metadata doesn't record one. Both builders return
+// null when a required field is missing so callers never render dead
+// links (graceful degradation for old servers / partial metadata).
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+// URL of the deployed Modal app's dashboard page, or null if the
+// metadata doesn't identify a Modal app (missing workspace/app_name, or
+// an explicitly non-modal kind).
+export function modalAppUrl(
+  metadata: ExecutorMetadata | null | undefined,
+): string | null {
+  if (!metadata) return null;
+  // `kind` may be absent (older SDKs); only bail when it's explicitly
+  // something other than "modal".
+  if (metadata.kind !== undefined && metadata.kind !== "modal") return null;
+  const workspace = nonEmptyString(metadata.workspace);
+  const appName = nonEmptyString(metadata.app_name);
+  if (!workspace || !appName) return null;
+  const environment = nonEmptyString(metadata.environment) ?? "main";
+  return `https://modal.com/apps/${encodeURIComponent(workspace)}/${encodeURIComponent(
+    environment,
+  )}/deployed/${encodeURIComponent(appName)}`;
+}
+
+// URL of a specific function call on the app's dashboard page, or null
+// when either the app page can't be built or the call ref is missing.
+export function modalFunctionCallUrl(
+  metadata: ExecutorMetadata | null | undefined,
+  functionCallId: string | null | undefined,
+): string | null {
+  const appUrl = modalAppUrl(metadata);
+  if (!appUrl || !functionCallId) return null;
+  return `${appUrl}?functionCallId=${encodeURIComponent(functionCallId)}`;
+}


### PR DESCRIPTION
Stacked on #165 (executor metadata + limits admin API). Frontend for the new surface: make Modal executions visible in the UI and add an admin view for named environment concurrency limits.

## Execution surfacing

- **`src/utils/modalLinks.ts`** — the single place Modal dashboard URL patterns live (a dashboard format change is a one-file fix):
  - app page: `https://modal.com/apps/{workspace}/{environment|"main"}/deployed/{app_name}` (matches the "View Deployment" URL the Modal CLI prints on `modal deploy`)
  - function call: app page + `?functionCallId={ref}`
  - Both builders return `null` when a required metadata field is missing — the UI never renders a dead link.
- **`ExecutorBadge`** — small "⚡ Modal" chip (raw executor name for unknown kinds, nothing when no executor recorded), tooltip shows the function call ref, click copies it. Rendered in the build task table, Task Explorer status cells, and DAG node hover (tooltip only, to keep nodes uncluttered).
- **Task detail** — new *Execution* section when executor fields exist: kind, app name (→ app page), function name, call ref (→ function-call deep link, copyable), workspace/environment.
- **Build view** — when `build.executor_metadata` is present: a "Modal: app-name" chip linking to the app page, plus a "reactive" badge when the build was triggered in reactive mode.

## Concurrency-limits admin

New env-scoped **Concurrency Limits** sidebar page:

- Table of key / max concurrent / current holder count (holder counts via `GET …/holders?limit=1` → `total`).
- Create, inline edit (`PUT`), and delete (`DELETE`, confirm-guarded).
- Per-key drill-down of current slot holders: task link opening the task detail panel, running-since, executor badge + "View on Modal" deep link, and a confirm-guarded **Evict** button (`POST …/holders/{task_id}/evict`) that fails the holder and frees its slots — the recovery path for slots leaked by a crashed resident build process.
- `src/api/concurrencyLimits.ts` client in the style of the existing `src/api/*` modules; `Task`/`Build` types extended with the new optional executor fields.

## Graceful degradation

Every new surface tolerates old servers / non-Modal executors / partial metadata: optional fields throughout, badges and sections render only when data exists, links render only when all required URL parts are present (plain text otherwise). No behavior change anywhere when the new fields are absent.

## Testing

- `modalLinks.test.ts` — exact URLs, env fallback, null-safety per missing field, URL-encoding (12 tests)
- `ExecutorBadge.test.tsx` — modal/unknown/absent rendering, ref tooltip + click-to-copy, build chips incl. no-dead-link case (9 tests)
- `concurrencyLimits.test.ts` — API client methods, key encoding, error propagation (6 tests)
- `ConcurrencyLimits.test.tsx` — page happy path: list + holder counts, create, drill-down with badge/deep-link, confirm-guarded evict (3 tests)

Full UI suite: 40/40 green. `eslint`, `tsc`, and `prettier` pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)