### PR TITLE
Examples: full Modal integration walkthrough (detached, reactive, limits)

### DIFF
--- a/lib/stardag-examples/src/stardag_examples/modal/README.md
+++ b/lib/stardag-examples/src/stardag_examples/modal/README.md
@@ -5,6 +5,10 @@ Run Stardag tasks on Modal's serverless infrastructure with automatic scaling, G
 Includes examples for:
 
 - **basic/** - Minimal Modal app setup
+- **walkthrough/** - Full integration walkthrough: `build_trigger` (restart-safe
+  triggering and reactive scheduling), detached execution, dynamic deps, and
+  registry-backed named concurrency limits — see
+  [walkthrough/README.md](walkthrough/README.md)
 - **ml_pipeline/** - ML pipeline on Modal
 - **prefect/** - Modal + Prefect for observability
 

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/README.md
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/README.md
@@ -1,0 +1,172 @@
+# Modal Integration Walkthrough
+
+A ready-to-run tour of the full Stardag + Modal feature set: restart-safe
+triggering with `build_trigger`, detached task execution, reactive
+scheduling (no resident orchestrator), and registry-backed named
+concurrency limits.
+
+For the concepts behind everything shown here, see the how-to guide:
+[Integrate with Modal](https://docs.stardag.com/how-to/integrate-modal/).
+This example is the `stardag-examples` companion to that guide — the
+minimal counterpart is [`modal/basic`](../basic/) (`build_spawn`, no
+registry required).
+
+## The DAG
+
+`tasks.py` defines a small pipeline shaped to exercise the interesting
+execution paths (all "work" is sleep-based, durations are parameters):
+
+```
+Report
+├── Summarize            (dynamic deps: yields the shard fan-out)
+│   ├── PlanShards       (static dep: decides the fan-out)
+│   └── ProcessShard × N (medium tasks, named concurrency limit)
+└── LongScan             (long-running, routed to the "long" worker)
+```
+
+`app.py` configures the `StardagApp`:
+
+- **builder retries** — with `build_trigger`, a Modal-level restart of the
+  build function resumes the same registry build.
+- **two workers + `worker_selector`** — `LongScan` runs on a `long` worker
+  with a higher timeout.
+- **`watchdog_period_minutes=5`** — scheduled safety-net ticks for
+  reactive builds (lost wake-ups, UI cancellations, stale limit slots).
+- **`limit_key_selector`** — tags every `ProcessShard` with the
+  `walkthrough-shards` named limit. The cap itself is configured in the
+  registry (next section).
+
+## Prerequisites
+
+- A [Modal](https://modal.com/) account with credentials set up locally
+  (`modal token new`).
+- Stardag Registry credentials in the calling process — an active stardag
+  profile (`stardag auth login`, or an API key). `build_trigger` mints the
+  build id locally, unlike `build_spawn`.
+- A registry server version matching this SDK. Reactive scheduling fails
+  explicitly against an older server; concurrency-limit enforcement is
+  **silently ignored** by an older server — upgrade before relying on it.
+- An environment whose default target root the calling process can access
+  (reactive mode persists task objects there), e.g. a Modal volume:
+
+```sh
+cd lib/stardag-examples
+uv sync --extra modal
+
+# Create an isolated environment backed by a Modal volume, and a profile:
+uv run stardag environment create "Modal Walkthrough" \
+    --target-root "default=modalvol://stardag-examples/target-roots/walkthrough"
+uv run stardag config profile add walkthrough -e modal-walkthrough --default
+
+# Give the deployed Modal functions access to the registry:
+uv run stardag modal stardag-api-key create
+```
+
+## Deploy
+
+```sh
+uv run stardag modal deploy src/stardag_examples/modal/walkthrough/app.py
+```
+
+This creates the `build`, `worker_default`, `worker_long`, `tick` and
+`tick_watchdog` functions (the latter two power reactive scheduling).
+
+## Configure the named concurrency limit
+
+The limit cap lives in the registry, per environment:
+
+```sh
+uv run python -m stardag_examples.modal.walkthrough.configure_limits --max-concurrent 3
+```
+
+(Equivalently: `PUT /api/v1/concurrency-limits/walkthrough-shards` with
+`{"max_concurrent": 3}`, or the **Concurrency Limits** admin page in the
+registry UI, where you can also inspect current slot holders.)
+
+## Run
+
+### Default mode: resident build function, detached tasks
+
+```sh
+uv run python -m stardag_examples.modal.walkthrough.main
+```
+
+Prints the `build_id` minted at the trigger point. The build function
+orchestrates on Modal; every task runs as a _detached_ spawned function
+call that survives orchestrator restarts.
+
+Re-trigger the same build at any time — completed tasks are skipped,
+still-running tasks are **re-attached** instead of re-executed (try it
+while `LongScan` sleeps):
+
+```sh
+uv run python -m stardag_examples.modal.walkthrough.main --build-id <id>
+```
+
+### Reactive mode: no resident orchestrator (experimental)
+
+```sh
+uv run python -m stardag_examples.modal.walkthrough.main --reactive
+```
+
+Discovery happens at the trigger; the build is then driven purely by
+short-lived scheduler _ticks_ (spawned at the trigger, by workers
+finishing tasks, and by the watchdog). Between ticks nothing runs except
+your tasks — no orchestrator container time, no orchestrator to crash.
+Note in this mode the named limit is enforced registry-side **across
+builds**: trigger two reactive builds for different sources and watch
+their `ProcessShard` tasks share the 3 slots.
+
+### Add a root to a running build (add-roots / retry path)
+
+Re-triggering with the same build id and a _different_ source appends the
+new DAG as an extra root of the same build (and resets any
+failed/cancelled/skipped tasks to pending — the retry path):
+
+```sh
+uv run python -m stardag_examples.modal.walkthrough.main --reactive \
+    --build-id <id> --source other-dataset
+```
+
+## What to look for in the registry UI
+
+- **Builds page**: the build appears immediately at the trigger, before
+  any Modal container has started.
+- **Executor badges**: tasks executed on Modal carry an executor (⚡)
+  badge with **deep links to the Modal dashboard** (app, function call) —
+  from the recorded executor metadata (app name, workspace, environment,
+  function name).
+- **DAG view**: the `Summarize → ProcessShard` edges render as _dynamic_
+  deps (discovered at runtime), unlike the static `requires()` edges; the
+  task suspends while its yielded deps run.
+- **Concurrency Limits admin page**: the `walkthrough-shards` cap and its
+  live slot holders — watch `ProcessShard` tasks queue (stay pending) and
+  drain as slots free.
+- **Failure handling**: if a task fails, tasks transitively blocked by it
+  are marked **skipped** — and a later re-trigger of the same build id
+  retries them.
+
+## Contrast: the same named limits from resident builds
+
+Named limits are not reactive-only. A resident build — `sd.build(...)`
+running anywhere, even locally — can enforce the _same_ registry-backed
+limits (sharing slots with reactive builds) via
+`RegistryConcurrencyLimiter`:
+
+```python
+import stardag as sd
+from stardag.build import RegistryConcurrencyLimiter
+
+from stardag_examples.modal.walkthrough.app import limit_key_selector
+from stardag_examples.modal.walkthrough.tasks import report_dag
+
+sd.build(
+    report_dag("local-run"),
+    concurrency_limiter=RegistryConcurrencyLimiter(key_selector=limit_key_selector),
+)
+```
+
+Caveat when mixing modes: a crashed resident build has no automatic
+healer — its RUNNING task holds the slot until explicitly
+failed/cancelled via the API/UI. Prefer reactive scheduling for
+unattended limited runs.

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/app.py
@@ -1,0 +1,97 @@
+"""StardagApp definition for the Modal integration walkthrough.
+
+Compared to the minimal ``modal/basic`` example, this app configures the
+full (new) feature set:
+
+- ``builder_settings`` with ``retries``: Modal re-runs the build function
+  after infrastructure failures, and — combined with ``build_trigger`` —
+  each retry *resumes* the same registry build instead of starting a new
+  one.
+- Two workers: ``default`` for ordinary tasks and ``long`` with a higher
+  timeout for the long-running task; ``worker_selector`` routes by task
+  name. Configured on the app (not per trigger) so reactive scheduler
+  ticks apply the same routing.
+- ``watchdog_period_minutes``: a scheduled function that periodically
+  re-ticks running reactive builds — the safety net for lost wake-ups,
+  builds cancelled from the UI, and stale concurrency-limit slots.
+  Strongly recommended whenever reactive mode or named limits are used.
+- ``limit_key_selector``: tags every ``ProcessShard`` task with the
+  ``SHARD_LIMIT_KEY`` named concurrency limit. The cap itself lives in
+  the registry, per environment — see ``configure_limits.py``. Like the
+  worker selector this is deployed-app configuration, applied
+  consistently by every scheduler tick.
+
+Deploy with the active stardag profile (see the README):
+
+    stardag modal deploy src/stardag_examples/modal/walkthrough/app.py
+
+then trigger builds with ``main.py``.
+"""
+
+import sys
+
+import modal
+import stardag as sd
+import stardag.integration.modal as sd_modal
+
+# The named concurrency-limit key ProcessShard tasks run under. The cap is
+# configured per environment in the registry (see configure_limits.py and
+# the Concurrency Limits page in the UI).
+SHARD_LIMIT_KEY = "walkthrough-shards"
+
+# Must match local Python version for Modal serialization compatibility
+python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+# Define the Modal image
+image = (
+    modal.Image.debian_slim(python_version=python_version)
+    .uv_sync()
+    .add_local_python_source("stardag_examples")
+)
+
+# Optionally use this instead to use local source for stardag itself.
+# image = sd_modal.with_stardag_on_image(
+#     modal.Image.debian_slim(python_version=python_version).pip_install(
+#         # helper to pull in all dependencies of current package (stardag-examples)
+#         *sd_modal.get_package_deps(__file__),
+#     )
+# ).add_local_python_source("stardag_examples")
+
+
+# Both selectors match on task *name* (rather than importing the task
+# classes) so this module stays a pure deployment definition.
+def worker_selector(task: sd.BaseTask) -> str:
+    if task.get_name() == "LongScan":
+        return "long"
+    return "default"
+
+
+def limit_key_selector(task: sd.BaseTask) -> list[str]:
+    if task.get_name() == "ProcessShard":
+        return [SHARD_LIMIT_KEY]
+    return []
+
+
+app = sd_modal.StardagApp(
+    "stardag_examples-walkthrough",
+    builder_settings=sd_modal.FunctionSettings(
+        image=image,
+        secrets=[
+            # required for communication with registry
+            modal.Secret.from_name("stardag-api-key"),
+        ],
+        # Let Modal restart the build function after infrastructure
+        # failures; with build_trigger each restart resumes the same build.
+        retries=2,
+    ),
+    worker_settings={
+        "default": sd_modal.FunctionSettings(image=image, cpu=1),
+        # Long-running tasks get their own worker with a generous timeout.
+        "long": sd_modal.FunctionSettings(image=image, cpu=1, timeout=1800),
+    },
+    worker_selector=worker_selector,
+    # Reactive-mode safety net: periodically re-check running builds
+    # (lost wake-ups, UI cancellations, stale limit slots).
+    watchdog_period_minutes=5,
+    limit_key_selector=limit_key_selector,
+)

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/configure_limits.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/configure_limits.py
@@ -1,0 +1,75 @@
+"""Configure the named concurrency limit used by the walkthrough.
+
+Named concurrency limits are configured *per environment in the
+registry* — the SDK-side ``limit_key_selector`` (see ``app.py``) only
+tags tasks with keys; the cap lives server-side and is enforced
+atomically when a task starts, across all builds in the environment.
+
+The API is a single endpoint (see the Modal how-to guide):
+
+    PUT /api/v1/concurrency-limits/{key}   {"max_concurrent": N}
+
+Equivalent curl (with an environment-scoped API key):
+
+    curl -X PUT "$STARDAG_API_URL/api/v1/concurrency-limits/walkthrough-shards" \\
+        -H "X-API-Key: $STARDAG_API_KEY" \\
+        -H "Content-Type: application/json" \\
+        -d '{"max_concurrent": 3}'
+
+This script does the same through the SDK's configured registry client
+(so it works with your active stardag profile, API key or browser
+login). You can also manage limits in the registry UI: workspace admin
+-> Concurrency Limits.
+
+Usage:
+
+    python -m stardag_examples.modal.walkthrough.configure_limits            # cap = 3
+    python -m stardag_examples.modal.walkthrough.configure_limits --max-concurrent 5
+"""
+
+import argparse
+
+import stardag as sd
+from stardag.registry import APIRegistry
+
+from stardag_examples.modal.walkthrough.app import SHARD_LIMIT_KEY
+
+
+def set_limit(key: str, max_concurrent: int) -> None:
+    registry = sd.registry_provider.get()
+    if not isinstance(registry, APIRegistry):
+        raise SystemExit(
+            "No registry configured. Run 'stardag auth login' or set "
+            "STARDAG_API_KEY / STARDAG_API_URL."
+        )
+    response = registry.client.put(
+        f"{registry.api_url}/api/v1/concurrency-limits/{key}",
+        json={"max_concurrent": max_concurrent},
+        # Required for browser-login (JWT) auth; ignored with API keys.
+        params=(
+            {"environment_id": registry.environment_id}
+            if registry.environment_id
+            else None
+        ),
+    )
+    response.raise_for_status()
+    print(f"Configured limit: {response.json()}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Set the walkthrough's named concurrency limit."
+    )
+    parser.add_argument("--key", default=SHARD_LIMIT_KEY)
+    parser.add_argument(
+        "--max-concurrent",
+        type=int,
+        default=3,
+        help="Max ProcessShard tasks running at once (across builds).",
+    )
+    args = parser.parse_args()
+    set_limit(args.key, args.max_concurrent)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/main.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/main.py
@@ -1,0 +1,108 @@
+"""Trigger the walkthrough DAG on the deployed Modal app.
+
+Uses ``StardagApp.build_trigger`` — the recommended way to start builds
+when using the Stardag Registry: the build id is minted in the registry
+*from this process, before anything runs on Modal*, so any restart or
+re-trigger resumes the same build instead of starting a new one.
+
+Examples (after ``stardag modal deploy .../walkthrough/app.py``):
+
+    # Default mode: resident build function orchestrates; tasks run as
+    # detached Modal function calls.
+    python -m stardag_examples.modal.walkthrough.main
+
+    # Reactive mode (experimental): no resident orchestrator — the build
+    # is driven by short-lived scheduler ticks.
+    python -m stardag_examples.modal.walkthrough.main --reactive
+
+    # Re-trigger an existing build (resume after failure, wake a stalled
+    # reactive build) — completed tasks are skipped, running tasks are
+    # re-attached:
+    python -m stardag_examples.modal.walkthrough.main --build-id <id>
+
+    # Add another root to the same build (new fan-out for another
+    # source), sharing the build id and the registry DAG view:
+    python -m stardag_examples.modal.walkthrough.main \\
+        --build-id <id> --source other-dataset
+
+Requires registry credentials locally (the active stardag profile) in
+addition to Modal credentials — unlike ``build_spawn`` (see
+``modal/basic``), which needs only Modal credentials.
+"""
+
+import argparse
+from uuid import UUID
+
+from stardag_examples.modal.walkthrough.app import app
+from stardag_examples.modal.walkthrough.tasks import report_dag
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Trigger the walkthrough DAG on the deployed Modal app."
+    )
+    parser.add_argument(
+        "--source",
+        default="demo",
+        help="Source to process (each source yields a deterministic DAG).",
+    )
+    parser.add_argument(
+        "--reactive",
+        action="store_true",
+        help=(
+            "Schedule reactively (experimental): no resident build "
+            "function; scheduler ticks drive the build."
+        ),
+    )
+    parser.add_argument(
+        "--build-id",
+        default=None,
+        help=(
+            "Existing build id to re-attach to. Re-triggers resume the "
+            "build; passing a new --source adds its DAG as an extra root."
+        ),
+    )
+    parser.add_argument(
+        "--shard-sleep-seconds",
+        type=float,
+        default=20.0,
+        help="Duration of each ProcessShard task.",
+    )
+    parser.add_argument(
+        "--scan-sleep-seconds",
+        type=float,
+        default=240.0,
+        help="Duration of the LongScan task.",
+    )
+    parser.add_argument(
+        "--wait",
+        action="store_true",
+        help="Block until the spawned Modal function call finishes.",
+    )
+    args = parser.parse_args()
+
+    root = report_dag(
+        args.source,
+        shard_sleep_seconds=args.shard_sleep_seconds,
+        scan_sleep_seconds=args.scan_sleep_seconds,
+    )
+
+    result = app.build_trigger(
+        root,
+        build_id=UUID(args.build_id) if args.build_id else None,
+        description=f"Modal walkthrough ({args.source})",
+        # NOTE: in reactive mode a re-trigger must also pass reactive=True.
+        reactive=args.reactive,
+    )
+    print(f"build_id:      {result.build_id}")
+    print(f"function call: {result.function_call.object_id}")
+    print(f"root task:     {root.id}")
+    print("Follow the build in the registry UI (Builds page).")
+    if args.wait:
+        print("Waiting for the spawned function call to finish...")
+        result.function_call.get()
+        print(f"Done. Report: {root.load()!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/main.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/main.py
@@ -31,6 +31,7 @@ addition to Modal credentials — unlike ``build_spawn`` (see
 """
 
 import argparse
+import time
 from uuid import UUID
 
 from stardag_examples.modal.walkthrough.app import app
@@ -77,7 +78,12 @@ def main() -> None:
     parser.add_argument(
         "--wait",
         action="store_true",
-        help="Block until the spawned Modal function call finishes.",
+        help=(
+            "Block until the build's root task is complete. (In default "
+            "mode the spawned call IS the whole build; in reactive mode "
+            "it is only the first scheduler tick, so completion is "
+            "polled via the root task's target.)"
+        ),
     )
     args = parser.parse_args()
 
@@ -99,8 +105,16 @@ def main() -> None:
     print(f"root task:     {root.id}")
     print("Follow the build in the registry UI (Builds page).")
     if args.wait:
-        print("Waiting for the spawned function call to finish...")
-        result.function_call.get()
+        if args.reactive:
+            # The spawned call is just the FIRST tick — it exits while
+            # workers run detached. The build is done when the root task's
+            # target exists (targets are ground truth).
+            print("Waiting for the root task to complete (reactive mode)...")
+            while not root.complete():
+                time.sleep(5.0)
+        else:
+            print("Waiting for the build function to finish...")
+            result.function_call.get()
         print(f"Done. Report: {root.load()!r}")
 
 

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/tasks.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/tasks.py
@@ -1,0 +1,167 @@
+"""Task definitions for the Modal integration walkthrough.
+
+A small but non-trivial DAG, shaped to exercise the interesting parts of
+detached/reactive Modal execution:
+
+- ``ProcessShard``: a *fan-out* of medium-length tasks (sleep-based). The
+  app tags them with a named concurrency-limit key (see ``app.py``), so
+  with a configured cap you can watch them queue and drain in the
+  registry UI.
+- ``LongScan``: one longer-running task, routed to a dedicated worker
+  with a higher timeout — long enough to observe detached execution
+  (e.g. re-trigger the build while it runs and see it *re-attach*
+  instead of re-executing).
+- ``Summarize``: a task with *dynamic dependencies*: it first requires
+  ``PlanShards`` (static dep), then yields one ``ProcessShard`` per
+  discovered shard from its ``run()`` generator. Between the yield and
+  the resume the task is *suspended* — with no orchestrator holding it
+  in memory in reactive mode.
+
+All sleeps are parameters so tests (and impatient users) can build the
+same DAG with ``*_sleep_seconds=0``.
+"""
+
+import hashlib
+import time
+
+import stardag as sd
+from pydantic import BaseModel
+
+sd.auto_namespace(__name__)
+
+# Cap the fan-out to something easy to eyeball in the UI.
+MIN_SHARDS = 4
+MAX_SHARDS = 8
+
+
+class ShardSpec(BaseModel):
+    shard_id: int
+    size: int
+
+
+class PlanShards(sd.Task[list[ShardSpec]]):
+    """Pretends to inspect ``source`` and decide which shards to process.
+
+    Uses a deterministic hash of ``source`` so the same source always
+    yields the same DAG, while different sources yield different fan-outs
+    (handy for re-triggering a build with an extra root).
+    """
+
+    source: str
+
+    def run(self) -> None:
+        digest = hashlib.sha256(self.source.encode()).digest()
+        num_shards = MIN_SHARDS + digest[0] % (MAX_SHARDS - MIN_SHARDS + 1)
+        self._save(
+            [
+                # digest is 32 bytes; byte[i+1] is in range for i < MAX_SHARDS < 32
+                ShardSpec(shard_id=i, size=1 + digest[i + 1] % 100)
+                for i in range(num_shards)
+            ]
+        )
+
+
+class ProcessShard(sd.Task[dict[str, float]]):
+    """A medium-length unit of work — the fan-out under the concurrency limit.
+
+    The app's ``limit_key_selector`` tags every ``ProcessShard`` with the
+    ``SHARD_LIMIT_KEY`` named limit (see ``app.py``), so at most
+    ``max_concurrent`` of them run at once — across builds, enforced by
+    the registry.
+    """
+
+    source: str
+    spec: ShardSpec
+    sleep_seconds: float = 20.0
+
+    def run(self) -> None:
+        time.sleep(self.sleep_seconds)
+        self._save(
+            {"shard_id": float(self.spec.shard_id), "value": float(self.spec.size)}
+        )
+
+
+class Summarize(sd.Task[dict[str, float]]):
+    """Aggregates the shard results — via *dynamic dependencies*.
+
+    The shard fan-out isn't known until ``PlanShards`` has run, so it
+    can't be declared in ``requires()``. Instead ``run()`` is a generator:
+    it yields the ``ProcessShard`` batch, the build suspends the task
+    until all shards are complete, then resumes the generator to
+    aggregate. In the UI the yielded edges render as *dynamic* deps.
+    """
+
+    source: str
+    shard_sleep_seconds: float = 20.0
+
+    def requires(self):
+        return PlanShards(source=self.source)
+
+    def run(self):
+        specs = self.requires().load()
+        shards = [
+            ProcessShard(
+                source=self.source,
+                spec=spec,
+                sleep_seconds=self.shard_sleep_seconds,
+            )
+            for spec in specs
+        ]
+        yield shards  # suspend until every shard is complete
+        values = [shard.load()["value"] for shard in shards]
+        self._save(
+            {
+                "num_shards": float(len(shards)),
+                "total": float(sum(values)),
+                "max": float(max(values)),
+            }
+        )
+
+
+class LongScan(sd.Task[dict[str, float]]):
+    """One long-running task (sleep-based stand-in for a slow scan/training).
+
+    Routed to the ``long`` worker (higher timeout) by the app's
+    ``worker_selector``. While it sleeps, try re-triggering the build —
+    the running function call is re-attached, not re-executed.
+    """
+
+    source: str
+    sleep_seconds: float = 240.0
+
+    def run(self) -> None:
+        time.sleep(self.sleep_seconds)
+        digest = hashlib.sha256(self.source.encode()).digest()
+        self._save({"checksum": float(int.from_bytes(digest[:4], "big"))})
+
+
+class Report(sd.Task[str]):
+    """Root task: joins the shard summary and the long scan."""
+
+    summary: sd.TaskLoads[dict[str, float]]
+    scan: sd.TaskLoads[dict[str, float]]
+
+    def requires(self):
+        return [self.summary, self.scan]
+
+    def run(self) -> None:
+        summary = self.summary.load()
+        scan = self.scan.load()
+        self._save(
+            f"Processed {summary['num_shards']:.0f} shards "
+            f"(total={summary['total']:.0f}, max={summary['max']:.0f}); "
+            f"scan checksum {scan['checksum']:.0f}."
+        )
+
+
+def report_dag(
+    source: str = "demo",
+    *,
+    shard_sleep_seconds: float = 20.0,
+    scan_sleep_seconds: float = 240.0,
+) -> Report:
+    """The walkthrough DAG for one ``source``."""
+    return Report(
+        summary=Summarize(source=source, shard_sleep_seconds=shard_sleep_seconds),
+        scan=LongScan(source=source, sleep_seconds=scan_sleep_seconds),
+    )

--- a/lib/stardag-examples/tests/test_modal/test_walkthrough.py
+++ b/lib/stardag-examples/tests/test_modal/test_walkthrough.py
@@ -5,7 +5,25 @@ zero-duration sleeps. The app module (selectors) only needs the ``modal``
 package importable, not any Modal credentials.
 """
 
+import importlib.util
+
 import pytest
+
+# The walkthrough uses APIs introduced together with reactive scheduling
+# (StardagApp watchdog/limit-selector kwargs, build_trigger,
+# RegistryConcurrencyLimiter). Skip the whole module when the installed
+# stardag predates them (the examples lockfile pins the published
+# release) — anything else (including bugs in the example modules) must
+# surface, not skip. Module-existence sentinel: needs neither the modal
+# extra nor an import (stardag.build the *attribute* is the build()
+# function, so hasattr checks won't do).
+if importlib.util.find_spec("stardag.build._registry_limiter") is None:
+    pytest.skip(
+        "installed stardag predates the walkthrough APIs (bump the "
+        "examples lockfile after the release)",
+        allow_module_level=True,
+    )
+
 from stardag.build import build_sequential
 from stardag.testing import test_harness as _test_harness
 
@@ -20,9 +38,11 @@ from stardag_examples.modal.walkthrough.tasks import (
     report_dag,
 )
 
-try:
+# Explicit availability check instead of try/except ImportError, which
+# would also swallow real import-time bugs in the example modules.
+if importlib.util.find_spec("modal") is not None:
     from stardag_examples.modal.walkthrough import app as walkthrough_app
-except ImportError:  # modal extra not installed
+else:  # modal extra not installed
     walkthrough_app = None
 
 

--- a/lib/stardag-examples/tests/test_modal/test_walkthrough.py
+++ b/lib/stardag-examples/tests/test_modal/test_walkthrough.py
@@ -1,0 +1,86 @@
+"""Tests for the Modal walkthrough example that don't need Modal (or a registry).
+
+The DAG in ``tasks.py`` is plain stardag — buildable locally with
+zero-duration sleeps. The app module (selectors) only needs the ``modal``
+package importable, not any Modal credentials.
+"""
+
+import pytest
+from stardag.build import build_sequential
+from stardag.testing import test_harness as _test_harness
+
+from stardag_examples.modal.walkthrough.tasks import (
+    MAX_SHARDS,
+    MIN_SHARDS,
+    LongScan,
+    PlanShards,
+    ProcessShard,
+    ShardSpec,
+    Summarize,
+    report_dag,
+)
+
+try:
+    from stardag_examples.modal.walkthrough import app as walkthrough_app
+except ImportError:  # modal extra not installed
+    walkthrough_app = None
+
+
+def _fast_dag(source: str = "test-source"):
+    return report_dag(source, shard_sleep_seconds=0.0, scan_sleep_seconds=0.0)
+
+
+def test_dag_structure():
+    root = _fast_dag()
+    summary, scan = root.requires()
+    assert isinstance(summary, Summarize)
+    assert isinstance(scan, LongScan)
+    assert isinstance(summary.requires(), PlanShards)
+    # Same source everywhere -> deterministic task ids
+    assert root.id == _fast_dag().id
+    assert root.id != _fast_dag("other-source").id
+
+
+def test_build_and_dynamic_fan_out():
+    # Isolated target roots + no-op registry — no config or API access.
+    with _test_harness():
+        root = _fast_dag()
+        build_sequential([root])
+        assert root.complete()
+
+        plan = PlanShards(source="test-source")
+        specs = plan.load()
+        assert MIN_SHARDS <= len(specs) <= MAX_SHARDS
+        # Every dynamically yielded shard was built
+        for spec in specs:
+            shard = ProcessShard(source="test-source", spec=spec, sleep_seconds=0.0)
+            assert shard.complete()
+            assert shard.load()["value"] == float(spec.size)
+
+        summary = root.summary.load()
+        assert summary["num_shards"] == float(len(specs))
+        assert summary["total"] == float(sum(spec.size for spec in specs))
+        assert f"{len(specs)}" in root.load()
+
+
+@pytest.mark.skipif(walkthrough_app is None, reason="modal is not installed")
+def test_worker_and_limit_key_selectors():
+    assert walkthrough_app is not None
+    root = _fast_dag()
+    summary, scan = root.requires()
+    shard = ProcessShard(
+        source="test-source", spec=ShardSpec(shard_id=0, size=1), sleep_seconds=0.0
+    )
+
+    assert walkthrough_app.worker_selector(scan) == "long"
+    assert walkthrough_app.worker_selector(shard) == "default"
+    assert walkthrough_app.worker_selector(root) == "default"
+
+    assert walkthrough_app.limit_key_selector(shard) == [
+        walkthrough_app.SHARD_LIMIT_KEY
+    ]
+    assert walkthrough_app.limit_key_selector(scan) == []
+    assert walkthrough_app.limit_key_selector(summary) == []
+
+    # The app enables the reactive-mode safety-net watchdog.
+    assert walkthrough_app.app.watchdog_period_minutes == 5

--- a/lib/stardag-examples/uv.lock
+++ b/lib/stardag-examples/uv.lock
@@ -3886,7 +3886,7 @@ wheels = [
 
 [[package]]
 name = "stardag"
-version = "0.6.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3899,9 +3899,9 @@ dependencies = [
     { name = "typer" },
     { name = "uuid6" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/68/cc4f9f1186326fb6c4d37258a0ef73b3bb5452183958a3c63d045b6a2012/stardag-0.6.0.tar.gz", hash = "sha256:1dc2885b8447f59aea9f20fdd65a324d6d63a2c8be04030da881f5ec15e85336", size = 480086, upload-time = "2026-04-30T11:37:50.526Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/1a/fdd26e977716f54e7f423bbfd78ffe0d05fff4ce44392fd90db562f5cb40/stardag-0.10.0.tar.gz", hash = "sha256:7e311c6de47dd296e8114d7c3dea8932ea237446821e38d638be2ae092d34df4", size = 588573, upload-time = "2026-07-13T19:15:23.75Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/b8/17dd604b6aec545a0437cc070c26ce04063286ea533c4d0c85c07d726cbf/stardag-0.6.0-py3-none-any.whl", hash = "sha256:4bdf110eeba49c55282104f2f1b0c4e5d45763b4c322cb0e7dc78b256aea8ac0", size = 178167, upload-time = "2026-04-30T11:37:48.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/75/bbbaf9b98938f0f42b29adec820f8238b26ba428b79638aa8d1abf6de705/stardag-0.10.0-py3-none-any.whl", hash = "sha256:483e5a2127fd8d54ac3a62208c1168e4b2d1be3a8d88db0e382800fc4303ca37", size = 234618, upload-time = "2026-07-13T19:15:22.266Z" },
 ]
 
 [[package]]

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,11 @@ commands =
 #       uv pip install -e ../stardag
 #   commands =
 #       uv run --active --no-sync pytest {posargs:tests}
+# TEMPORARY (editable stardag): the modal/walkthrough example uses v0.10.0
+# APIs not yet on PyPI, so the examples package is built against the local
+# ../stardag source until v0.10.0 is published. AFTER PUBLISHING v0.10.0:
+# revert both envs below to plain `uv sync` + `uv run --active`, then
+# `cd lib/stardag-examples && uv lock --upgrade-package stardag`.
 [testenv:stardag-examples-py{311,312,313,314}]
 description = Run tests for stardag-examples package
 skip_install = true
@@ -52,8 +57,9 @@ allowlist_externals = uv
 change_dir = lib/stardag-examples
 commands_pre =
     uv sync --active --all-extras
+    uv pip install -e ../stardag
 commands =
-    uv run --active pytest {posargs:tests}
+    uv run --active --no-sync pytest {posargs:tests}
 
 [testenv:stardag-examples-pyright]
 description = Type check stardag-examples package
@@ -62,8 +68,9 @@ allowlist_externals = uv
 change_dir = lib/stardag-examples
 commands_pre =
     uv sync --active --all-extras
+    uv pip install -e ../stardag
 commands =
-    uv run --active pyright src tests
+    uv run --active --no-sync pyright src tests
 
 # ============================================================================
 # app/stardag-api - API service

--- a/tox.ini
+++ b/tox.ini
@@ -45,11 +45,6 @@ commands =
 #       uv pip install -e ../stardag
 #   commands =
 #       uv run --active --no-sync pytest {posargs:tests}
-# TEMPORARY (editable stardag): the modal/walkthrough example uses v0.10.0
-# APIs not yet on PyPI, so the examples package is built against the local
-# ../stardag source until v0.10.0 is published. AFTER PUBLISHING v0.10.0:
-# revert both envs below to plain `uv sync` + `uv run --active`, then
-# `cd lib/stardag-examples && uv lock --upgrade-package stardag`.
 [testenv:stardag-examples-py{311,312,313,314}]
 description = Run tests for stardag-examples package
 skip_install = true
@@ -57,9 +52,8 @@ allowlist_externals = uv
 change_dir = lib/stardag-examples
 commands_pre =
     uv sync --active --all-extras
-    uv pip install -e ../stardag
 commands =
-    uv run --active --no-sync pytest {posargs:tests}
+    uv run --active pytest {posargs:tests}
 
 [testenv:stardag-examples-pyright]
 description = Type check stardag-examples package
@@ -68,9 +62,8 @@ allowlist_externals = uv
 change_dir = lib/stardag-examples
 commands_pre =
     uv sync --active --all-extras
-    uv pip install -e ../stardag
 commands =
-    uv run --active --no-sync pyright src tests
+    uv run --active pyright src tests
 
 # ============================================================================
 # app/stardag-api - API service


### PR DESCRIPTION
## What

Adds `stardag_examples/modal/walkthrough/` — a runnable `stardag-examples` companion to the [Integrate with Modal](https://docs.stardag.com/how-to/integrate-modal/) how-to that demonstrates the full new Modal feature set end to end, following the guide's patterns exactly. The minimal `modal/basic` example is left as-is (it remains the correct minimal `build_spawn` intro); this is a sibling module with its own teaching narrative.

### What the example demonstrates

- **`app.py`** — `StardagApp` with the full configuration surface:
  - two workers (`default`, `long`) + a `worker_selector` routing the long-running task to the higher-timeout worker (configured on the app so reactive ticks apply the same routing),
  - `builder_settings` with `retries` (Modal restarts resume the same build under `build_trigger`),
  - `watchdog_period_minutes=5` (reactive safety-net ticks),
  - `limit_key_selector` tagging every `ProcessShard` with the `walkthrough-shards` named concurrency-limit key.
- **`tasks.py`** — a small DAG shaped for the interesting execution paths: a fan-out of medium (sleep-based) `ProcessShard` tasks under the named limit, one long-running `LongScan` (observe detached re-attach while it runs), and `Summarize` with dynamic deps (generator `run()` yield → suspension). All durations are parameters so tests build the same DAG with zero sleeps.
- **`main.py`** — `build_trigger` in both modes with a small CLI: default (resident build function, detached task execution), `--reactive` (tick-scheduled, no resident orchestrator — marked experimental like the docs), `--build-id` for restart-safe re-trigger, and `--build-id` + a new `--source` for the add-roots/retry path.
- **`configure_limits.py`** — configures the named limit cap against the registry (`PUT /api/v1/concurrency-limits/{key}`, as the how-to documents) through the SDK's configured registry client; the README also shows the equivalent curl and points at the Concurrency Limits admin page in the UI.
- **`README.md`** — narrates prerequisites (deployed app, registry credentials, matching server version), deploy/run steps, what to look for in the registry UI (executor ⚡ badges + Modal deep links, dynamic-dep edges, the Concurrency Limits page with live slot holders, skipped tasks on failure), and a short contrast snippet enforcing the same limits from resident builds via `stardag.build.RegistryConcurrencyLimiter`.
- **`tests/test_modal/test_walkthrough.py`** — DAG construction/determinism, a local sequential build exercising the dynamic fan-out (isolated via `stardag.testing.test_harness`), and selector wiring. No Modal credentials or registry needed.

## ⚠️ Merge-order dependency — do not merge yet

`lib/stardag-examples` installs stardag from **PyPI**, which does not yet include these APIs (`build_trigger` reactive kwargs, `watchdog_period_minutes`, `limit_key_selector`, `RegistryConcurrencyLimiter`). Consequently **CI's `pyright-stardag-examples` will fail on this PR — expected.** Merge only after:

1. the next stardag release containing these APIs is published to PyPI, and
2. the examples lockfile is bumped: `cd lib/stardag-examples && uv lock --upgrade-package stardag`.

## Verification

- `pytest tests` in `lib/stardag-examples` with an editable install of `lib/stardag`: all pass (including the 3 new tests).
- `pyright src tests` with the editable install: 0 errors (the `.pre-commit-config.yaml`/`tox.ini` editable-install switches were used only locally and are **not** committed).
- `pre-commit` hooks: all pass except `pyright-stardag-examples` against the published package (the failure above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update (CI):** the `stardag-examples` tox envs are temporarily built against the local `../stardag` source (editable install) so `stardag-examples-pyright` passes against the unreleased v0.10.0 APIs. **At merge time, after v0.10.0 is published to PyPI:** revert the `tox.ini` editable switch and run `cd lib/stardag-examples && uv lock --upgrade-package stardag` (per CLAUDE.md "After publishing"). Until then this branch is green but pinned to local source.
