### PR TITLE
Modal reactive fixes (0.10.1): provider cloudpickle, secret propagation, write-once store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,16 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   also declares the same secret still gets it once). Previously workers
   `401`ed on their self-reported lifecycle events unless the secret was
   repeated on every worker.
+- **Fix: re-triggering a reactive build crashed on an immutable/no-overwrite
+  target root.** The per-build task store rewrote its `meta.json` on every
+  re-trigger (add-roots / retry), but a target root may refuse overwrites
+  (Modal volumes raise; an immutable/object-locked S3 root would too), so
+  the re-trigger crashed with `FileExistsError`. The store is now
+  write-once: the reactive marker is written only at the first trigger, and
+  task pickles are skipped if already present. Build roots are tracked
+  solely in the registry (the scheduler reads them from the frontier), so a
+  re-trigger no longer mutates the store. Note: `tick_kwargs` are fixed at
+  first trigger until reactive build metadata moves to the registry.
 
 ## [0.10.0] — 2026-07-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to the Stardag project (SDK, Registry API, and UI).
 
 For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
+## [Unreleased]
+
+### SDK
+
+- **Fix: reactive Modal scheduling crashed in fresh containers.** A
+  `resource_provider` (e.g. `registry_provider`) captured by a
+  `serialized=True` Modal function is cloudpickled by value; its unset
+  sentinel is a bare `object()` whose identity does not survive pickling,
+  so a deserialized provider returned that bare `object()` from `get()`.
+  In a deployed app this crashed the reactive scheduler `tick` and the
+  scheduled `tick_watchdog` (which runs cold, with no build) with
+  `AttributeError: 'object' object has no attribute 'build_list_running'`.
+  Providers now serialize without their live resource and re-initialize
+  lazily in the new process (`ResourceProvider.__getstate__`/`__setstate__`).
+- **`StardagApp` propagates the builder's secrets to workers and the
+  tick/watchdog.** Since worker-side lifecycle reporting, every deployed
+  function talks to the registry, so all of them need registry
+  credentials — but the secret is naturally declared only on the builder.
+  `finalize()` now applies the builder's declared secrets to the worker
+  functions and the tick/watchdog, de-duplicated by name (a function that
+  also declares the same secret still gets it once). Previously workers
+  `401`ed on their self-reported lifecycle events unless the secret was
+  repeated on every worker.
+
 ## [0.10.0] — 2026-07-13
 
 Modal as a first-class execution layer. A large, fully backward-compatible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Stardag project (SDK, Registry API, and UI).
 
 For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
-## [Unreleased]
+## [0.10.1] — 2026-07-14
 
 ### SDK
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,27 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.10.1 — Modal reactive scheduling bug fixes
+
+A bug-fix release for reactive Modal scheduling (shipped in 0.10.0).
+**SDK-only — no API change, no migration, no server upgrade.** Run
+`pip install -U stardag` and **redeploy your Modal app** so its image
+picks up the fixes.
+
+- **Reactive ticks / watchdog no longer crash in fresh containers.** A
+  resource provider captured by a serialized Modal function (e.g. the
+  scheduler `tick` / `tick_watchdog`) now re-initializes correctly in the
+  container instead of returning an uninitialized sentinel.
+- **Registry credentials propagate from the builder to the workers and
+  tick/watchdog.** Declare the `stardag-api-key` secret once on
+  `builder_settings`; workers no longer `401` on their self-reported
+  lifecycle events. (Add it per-worker only if you must stay on ≤ 0.10.0.)
+- **Re-triggering a reactive build (add-roots / retry) no longer fails on
+  a no-overwrite / immutable target root.** The per-build task store is
+  write-once; build roots are tracked solely in the registry.
+
+---
+
 ## v0.10.0 — Modal as a first-class execution layer
 
 A large feature release that makes Modal a first-class execution layer:

--- a/lib/stardag/src/stardag/build/_task_store.py
+++ b/lib/stardag/src/stardag/build/_task_store.py
@@ -71,7 +71,16 @@ class BuildTaskStore:
     # --- task pickles ---
 
     def save_task(self, task: BaseTask) -> None:
-        with self._target(f"tasks/{task.id}.pkl").open("wb") as handle:
+        # Write-once: a task id maps to one immutable object, so an existing
+        # pickle is already correct — skip it. This keeps the store
+        # compatible with immutable/append-only target roots and lets
+        # re-triggers re-persist a DAG without overwriting (a stale pickle
+        # from a redeployed app is handled by the registry-rehydration
+        # fallback, not by overwriting here).
+        target = self._target(f"tasks/{task.id}.pkl")
+        if target.exists():
+            return
+        with target.open("wb") as handle:
             handle.write(pickle.dumps(task))
 
     def save_tasks(self, tasks: typing.Iterable[BaseTask]) -> None:

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -264,6 +264,25 @@ class FinalizeResult(typing.NamedTuple):
 # --- Function settings ---
 
 
+def _dedupe_secrets(secrets: list[modal.Secret]) -> list[modal.Secret]:
+    """De-duplicate Modal secrets by name, preserving order.
+
+    Named secrets (``Secret.from_name``) dedupe by name so a secret
+    propagated from the builder to a worker that also declares it is applied
+    once. Secrets without a usable name (e.g. ``Secret.from_dict``) fall back
+    to object identity.
+    """
+    seen: set = set()
+    result: list[modal.Secret] = []
+    for secret in secrets:
+        key = getattr(secret, "name", None) or id(secret)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(secret)
+    return result
+
+
 def _run_watchdog_sweep(
     registry: typing.Any,
     tick: typing.Callable[..., typing.Any],
@@ -1778,12 +1797,14 @@ class StardagApp:
 
         Auto-mounted volumes are merged with user volumes, where user-specified
         volumes at the same mount path take precedence over auto-mounted ones.
+        Secrets are de-duplicated by name (a named secret propagated from the
+        builder plus one the function already declares should apply once).
         """
         result: dict[str, typing.Any] = dict(settings)
 
-        # Merge secrets: existing + extra
+        # Merge secrets: existing + extra, de-duplicated by name.
         existing_secrets: list[modal.Secret] = list(result.get("secrets") or [])
-        result["secrets"] = existing_secrets + extra_secrets
+        result["secrets"] = _dedupe_secrets(existing_secrets + extra_secrets)
 
         # Merge volumes: auto-mounted (lower priority) + user (higher priority)
         user_volumes = dict(result.get("volumes") or {})
@@ -1892,11 +1913,21 @@ class StardagApp:
 
         function_names = ["build"]
 
+        # Registry credentials (and any other secrets) declared on the
+        # builder are propagated to the workers and the tick/watchdog:
+        # since worker-side lifecycle reporting, every function talks to the
+        # registry, so declaring the secret once on the builder is enough.
+        # De-duplication (by name, in _prepare_function_settings) means a
+        # function that also declares the same secret still gets it once.
+        builder_secrets: list[modal.Secret] = list(
+            self._builder_settings.get("secrets") or []
+        )
+
         # Create worker functions
         for worker_name, settings in self._worker_settings.items():
             worker_settings = self._prepare_function_settings(
                 settings,
-                extra_secrets=extra_secrets,
+                extra_secrets=extra_secrets + builder_secrets,
                 auto_volumes=auto_volumes,
             )
 
@@ -2005,7 +2036,11 @@ class StardagApp:
 
         tick_settings = self._prepare_function_settings(
             self._tick_settings or self._builder_settings,
-            extra_secrets=extra_secrets,
+            # Propagate the builder's secrets here too, so custom
+            # tick_settings (which would otherwise not inherit them) still
+            # get registry credentials. Deduped when tick falls back to
+            # builder_settings.
+            extra_secrets=extra_secrets + builder_secrets,
             auto_volumes=auto_volumes,
         )
         self.modal_app.function(

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -272,10 +272,10 @@ def _dedupe_secrets(secrets: list[modal.Secret]) -> list[modal.Secret]:
     once. Secrets without a usable name (e.g. ``Secret.from_dict``) fall back
     to object identity.
     """
-    seen: set = set()
+    seen: set[str | int] = set()
     result: list[modal.Secret] = []
     for secret in secrets:
-        key = getattr(secret, "name", None) or id(secret)
+        key: str | int = getattr(secret, "name", None) or id(secret)
         if key in seen:
             continue
         seen.add(key)

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -2330,22 +2330,22 @@ class StardagApp:
         )
         store = BuildTaskStore(build_id)
         store.save_tasks(discovery.incomplete.values())
-        existing_meta = (store.read_meta() or {}) if is_retrigger else {}
-        merged_root_ids = list(
-            dict.fromkeys([*existing_meta.get("root_task_ids", []), *root_ids])
-        )
-        store.write_meta(
-            {
-                "reactive": True,
-                "app_name": self.name,
-                "root_task_ids": merged_root_ids,
-                "tick_kwargs": (
-                    tick_kwargs
-                    if tick_kwargs is not None
-                    else existing_meta.get("tick_kwargs") or {}
-                ),
-            }
-        )
+        # Write the reactive marker/config exactly once, at the first
+        # trigger. The store lives on a target root that may be immutable,
+        # so we never rewrite it: build roots are tracked in the registry
+        # (build_add_roots above — the scheduler reads them from the
+        # frontier, never from the store), so a re-trigger needs no store
+        # mutation. NOTE: this means tick_kwargs are fixed at first
+        # trigger; changing scheduling config on re-trigger is not
+        # supported until build metadata moves to the registry.
+        if store.read_meta() is None:
+            store.write_meta(
+                {
+                    "reactive": True,
+                    "app_name": self.name,
+                    "tick_kwargs": tick_kwargs or {},
+                }
+            )
         tick_function = modal.Function.from_name(app_name=self.name, name="tick")
         function_call = tick_function.spawn(build_id=str(build_id))
         return BuildTriggerResult(build_id=build_id, function_call=function_call)

--- a/lib/stardag/src/stardag/utils/resource_provider.py
+++ b/lib/stardag/src/stardag/utils/resource_provider.py
@@ -38,6 +38,27 @@ class ResourceProvider(Generic[_ResourceType]):
     def clear(self):
         self._resource = _ResourceUnset  # type: ignore
 
+    def __getstate__(self) -> dict:
+        # A provider is a process-local handle: its resource (a registry
+        # client, config, target factory, ...) must not travel across a
+        # process/pickle boundary. This matters most when a provider is
+        # captured by a cloudpickled function — e.g. a ``serialized=True``
+        # Modal function that references ``registry_provider`` — and
+        # deserialized in a fresh container. Serialize *without* the live
+        # resource so it re-initializes lazily from the new process's own
+        # environment/config.
+        state = self.__dict__.copy()
+        state.pop("_resource", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        # Bind to THIS process's sentinel so ``get()``'s identity check
+        # treats the resource as unset. (A pickled ``object()`` sentinel
+        # deserializes to a *distinct* object, so carrying it across would
+        # make ``get()`` return the bare sentinel instead of the resource.)
+        self._resource = _ResourceUnset  # type: ignore
+
     def default_factory(self, **kwargs) -> _ResourceType:
         """Needs to be implemented by subclasses.
 

--- a/lib/stardag/tests/test_build/test_task_store.py
+++ b/lib/stardag/tests/test_build/test_task_store.py
@@ -1,0 +1,49 @@
+"""Tests for BuildTaskStore write-once semantics.
+
+The store lives on a target root that may be immutable/append-only, so its
+writes must never require overwriting an existing object (this is what
+broke re-triggering a reactive build on a Modal volume).
+"""
+
+from __future__ import annotations
+
+import typing
+from uuid import uuid4
+
+from stardag.build import BuildTaskStore
+from stardag.target import InMemoryFileTarget
+from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+
+def test_save_task_is_idempotent(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+):
+    store = BuildTaskStore(uuid4())
+    task = SyncOnlyTask(name="ws")
+    store.save_task(task)
+    # Saving the same task id again must be a no-op, not an overwrite/error.
+    store.save_task(task)
+    loaded = store.load_task(task.id)
+    assert loaded is not None
+    assert loaded.id == task.id
+
+
+def test_save_tasks_skips_already_persisted(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+):
+    store = BuildTaskStore(uuid4())
+    a, b = SyncOnlyTask(name="a"), SyncOnlyTask(name="b")
+    store.save_tasks([a])
+    # A re-trigger re-persisting a DAG that overlaps the first must not fail.
+    store.save_tasks([a, b])
+    assert store.load_task(a.id) is not None
+    assert store.load_task(b.id) is not None
+
+
+def test_meta_roundtrip(
+    default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+):
+    store = BuildTaskStore(uuid4())
+    assert store.read_meta() is None
+    store.write_meta({"reactive": True, "app_name": "x", "tick_kwargs": {}})
+    assert store.read_meta() == {"reactive": True, "app_name": "x", "tick_kwargs": {}}

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1052,7 +1052,7 @@ class TestReactiveRetrigger:
             worker_settings={"default": FunctionSettings(image=_make_image())},
         )
 
-    def test_retrigger_resumes_appends_roots_and_merges_meta(
+    def test_retrigger_resumes_and_appends_roots_via_registry(
         self, modal_function_stub, default_in_memory_fs_target
     ):
         from stardag.build import BuildTaskStore
@@ -1095,12 +1095,19 @@ class TestReactiveRetrigger:
 
         assert registry.build_resume.call_count == 1
         assert registry.build_resume.call_args.args == (build_id,)
+        # The new root is appended in the REGISTRY (source of truth for the
+        # scheduler frontier) — not by rewriting the store.
         registry.build_add_roots.assert_called_once_with(build_id, [str(new_root.id)])
+        # The store marker is written once, at the first trigger, and NOT
+        # rewritten on re-trigger (target roots may be immutable). It carries
+        # the reactive flag + owning app + the first trigger's tick_kwargs;
+        # roots are deliberately not stored (they live in the registry).
         meta = BuildTaskStore(build_id).read_meta()
         assert meta is not None
-        # Roots unioned; tick_kwargs preserved from the original trigger.
-        assert meta["root_task_ids"] == [str(original_root.id), str(new_root.id)]
+        assert meta["reactive"] is True
+        assert meta["app_name"] == app.name
         assert meta["tick_kwargs"] == {"fail_mode": "continue"}
+        assert "root_task_ids" not in meta
 
 
 class TestWatchdogSweep:

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -793,6 +793,73 @@ class TestStardagAppReactiveTrigger:
                 )
 
 
+class TestBuilderSecretPropagation:
+    """The builder's declared secrets (e.g. registry credentials) must
+    reach the workers and the tick/watchdog — every function talks to the
+    registry since worker-side lifecycle reporting."""
+
+    def _finalize_capturing(self, builder_secrets, worker_secrets=None, **app_kwargs):
+        builder = FunctionSettings(image=_make_image(), secrets=builder_secrets)
+        worker = FunctionSettings(image=_make_image())
+        if worker_secrets is not None:
+            worker = FunctionSettings(image=_make_image(), secrets=worker_secrets)
+        app = StardagApp(
+            "test-secret-propagation",
+            builder_settings=builder,
+            worker_settings={"default": worker},
+            **app_kwargs,
+        )
+        registered: dict = {}
+
+        def capture_function(**kwargs):
+            def decorator(fn):
+                registered[kwargs.get("name", "unknown")] = kwargs
+                return fn
+
+            return decorator
+
+        app.modal_app.function = capture_function  # type: ignore[assignment]
+        with patch(
+            "stardag.integration.modal._app.get_target_roots_volumes"
+        ) as mock_volumes:
+            mock_volumes.return_value = MagicMock(by_volume_name={}, by_root_key={})
+            app.finalize()
+        return registered
+
+    @staticmethod
+    def _secret_names(kwargs) -> list[str | None]:
+        return [getattr(s, "name", None) for s in (kwargs.get("secrets") or [])]
+
+    def test_builder_secret_reaches_workers_and_tick(self):
+        import modal
+
+        reg = modal.Secret.from_name("stardag-api-key")
+        registered = self._finalize_capturing([reg], watchdog_period_minutes=5)
+        for fn in ("build", "worker_default", "tick", "tick_watchdog"):
+            assert "stardag-api-key" in self._secret_names(registered[fn]), fn
+
+    def test_propagated_secret_deduped_when_worker_also_declares_it(self):
+        import modal
+
+        registered = self._finalize_capturing(
+            [modal.Secret.from_name("stardag-api-key")],
+            worker_secrets=[modal.Secret.from_name("stardag-api-key")],
+        )
+        names = self._secret_names(registered["worker_default"])
+        assert names.count("stardag-api-key") == 1
+
+    def test_worker_keeps_its_own_extra_secret(self):
+        import modal
+
+        registered = self._finalize_capturing(
+            [modal.Secret.from_name("stardag-api-key")],
+            worker_secrets=[modal.Secret.from_name("gpu-creds")],
+        )
+        names = self._secret_names(registered["worker_default"])
+        assert "stardag-api-key" in names  # propagated
+        assert "gpu-creds" in names  # own
+
+
 class TestFinalizeRegistersTick:
     def _capture_app(self, **app_kwargs):
         app = StardagApp(

--- a/lib/stardag/tests/test_resource_provider.py
+++ b/lib/stardag/tests/test_resource_provider.py
@@ -1,0 +1,74 @@
+"""Tests for ResourceProvider, incl. cloudpickle survival.
+
+Regression coverage for the Modal reactive-scheduling crash: a
+``serialized=True`` Modal function (e.g. the scheduler ``tick`` /
+``tick_watchdog``) captures ``registry_provider`` by value — the
+``FunctionalResourceProvider`` class is created inside ``resource_provider``
+and is not importable, so cloudpickle serializes the instance by value.
+The unset sentinel is a bare ``object()`` whose identity does not survive
+pickling, so a deserialized provider used to report itself as "already
+set" to a stale sentinel and ``get()`` returned that bare ``object()``
+(``AttributeError: 'object' object has no attribute ...`` in the
+container). Providers must instead re-initialize their resource lazily in
+the new process.
+"""
+
+import cloudpickle
+
+from stardag.registry import RegistryABC, registry_provider
+from stardag.utils.resource_provider import resource_provider
+
+
+def test_unset_provider_reinitializes_after_cloudpickle():
+    """An *unset* provider (the common case at Modal deploy time: the
+    provider hasn't been .get()'d yet) must re-initialize in the new
+    process. This is the exact failure: the unset sentinel is a bare
+    ``object()`` whose identity is lost through pickling, so without the
+    fix ``get()`` returns that stale ``object()`` instead of running the
+    factory."""
+    provider = resource_provider(str, default_factory=lambda: "from-factory")
+    assert not provider.is_initialized()
+
+    copy = cloudpickle.loads(cloudpickle.dumps(provider))
+    assert copy is not provider
+    result = copy.get()
+    assert result == "from-factory", f"expected re-init, got {result!r}"
+
+
+def test_initialized_provider_does_not_carry_resource_across_cloudpickle():
+    calls = {"n": 0}
+
+    def factory() -> str:
+        calls["n"] += 1
+        return f"resource-{calls['n']}"
+
+    provider = resource_provider(str, default_factory=factory)
+    assert provider.get() == "resource-1"  # live resource in this process
+
+    # The copy must re-run its factory in the new process, not carry the
+    # original's live resource.
+    copy = cloudpickle.loads(cloudpickle.dumps(provider))
+    assert not copy.is_initialized()
+    assert isinstance(copy.get(), str)
+
+
+def test_registry_provider_resolves_after_cloudpickle():
+    """The exact shape of the Modal watchdog crash: a cloudpickled
+    ``registry_provider`` must resolve to a real registry, not a bare
+    ``object()``."""
+    copy = cloudpickle.loads(cloudpickle.dumps(registry_provider))
+    resource = copy.get()
+    assert isinstance(resource, RegistryABC)
+
+
+def test_getstate_omits_live_resource():
+    provider = resource_provider(str, default_factory=lambda: "x")
+    provider.get()  # initialize
+    assert "_resource" not in provider.__getstate__()
+
+
+def test_set_default_factory_survives_cloudpickle():
+    provider = resource_provider(str, default_factory=lambda: "default")
+    provider.set_default_factory(lambda: "overridden")
+    copy = cloudpickle.loads(cloudpickle.dumps(provider))
+    assert copy.get() == "overridden"

--- a/lib/stardag/tests/test_resource_provider.py
+++ b/lib/stardag/tests/test_resource_provider.py
@@ -13,10 +13,16 @@ container). Providers must instead re-initialize their resource lazily in
 the new process.
 """
 
-import cloudpickle
+import pytest
 
 from stardag.registry import RegistryABC, registry_provider
 from stardag.utils.resource_provider import resource_provider
+
+# cloudpickle isn't a core/dev dependency (it comes with the `modal`
+# extra); it's what Modal uses to serialize functions, and the bug under
+# test is specifically about surviving that. Skip cleanly when it's absent
+# rather than failing collection of the base suite.
+cloudpickle = pytest.importorskip("cloudpickle")
 
 
 def test_unset_provider_reinitializes_after_cloudpickle():


### PR DESCRIPTION
Three client-side SDK fixes for reactive Modal scheduling as shipped in 0.10.0, all surfaced deploying the `modal/walkthrough` example and **verified end-to-end on live Modal** (fresh resident + reactive builds, and re-trigger/add-roots). **stardag-api needs no change.** This is the 0.10.1 batch.

### 1. ResourceProvider survives cloudpickle
A `resource_provider` (`registry_provider`, …) captured by a `serialized=True` Modal function is cloudpickled by value; its unset sentinel is a bare `object()` whose identity is lost through pickling, so a deserialized provider returned that bare `object()` from `get()`. Crashed the reactive `tick` and the scheduled `tick_watchdog` (cold container, no build) with `AttributeError: 'object' object has no attribute 'build_list_running'`. Fix: `__getstate__`/`__setstate__` re-initialize the resource lazily in the new process.

### 2. StardagApp propagates the builder's secrets to workers + tick/watchdog
Since worker-side lifecycle reporting, workers POST their own lifecycle to the registry, so they need registry credentials — but the secret is naturally declared only on the builder, so workers `401`ed. `finalize()` now applies the builder's declared secrets to workers and the tick/watchdog, deduped by name.

### 3. Write-once reactive build store (re-trigger / add-roots fix)
Re-triggering rewrote `meta.json`, which crashes on a target root that refuses overwrites (Modal volumes; immutable/object-locked S3). The store is now write-once: the reactive marker is written once at first trigger, task pickles are skipped if present, and build roots live solely in the registry (the scheduler reads them from the frontier). Dropped the dead `meta["root_task_ids"]`. (Follow-up: move reactive build metadata off the target root and into the registry — separate PR.)

### Testing
`test_resource_provider.py` (5), `TestBuilderSecretPropagation` (3), `test_task_store.py` (3) + updated re-trigger test. Full stardag unit + Modal suites green. CHANGELOG updated for all three.

## ⚠️ Do not merge until the walkthrough is confirmed end-to-end
Confirmed working via the `verify/modal-walkthrough-local-stardag` branch (local stardag baked into the image). This is the 0.10.1 content; the example PR (#169) depends on the release + a lockfile bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)