### PR TITLE
UI: stable Modal deep links + execution details + sidebar nav label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to the Stardag project (SDK, Registry API, and UI).
 
 For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
+## [Unreleased]
+
+### UI
+
+- **Stable, stop/redeploy-proof Modal function-call deep links.** The task
+  detail and concurrency-holder "View on Modal" links previously used a
+  query-param form that didn't resolve. They now build the app-id URL
+  (`.../apps/{workspace}/{env}/{app_id}?activeTab=functions&functionId=…&functionSection=calls&fcId=…`)
+  when the newly captured `app_id`/`function_id` metadata is present,
+  falling back to the deployed-app-name form and then the plain app-page
+  link. Reads the new metadata defensively, so older data without the ids
+  still gets a working, non-dead link. Pairs with the SDK change that
+  records `app_id`/`function_id` in the executor metadata.
+- **Task detail: "more details" block for Modal identifiers.** The
+  Execution section now has a collapsible list of every captured Modal
+  identifier (kind, app/function names, workspace, environment, app id,
+  function id, and the function-call ref), each click-to-copy, so a
+  reference can be reconstructed by hand if the dashboard URL format
+  drifts. Only present fields render.
+- **Sidebar: shortened the "Concurrency Limits" nav item to "Concurrency"
+  and made every nav label left-aligned and single-line (truncating with
+  an ellipsis instead of wrapping and centering).**
+
 ## [0.10.2] — 2026-07-14
 
 ### SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,18 +14,26 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   (`.../apps/{workspace}/{env}/{app_id}?activeTab=functions&functionId=…&functionSection=calls&fcId=…`)
   when the newly captured `app_id`/`function_id` metadata is present,
   falling back to the deployed-app-name form and then the plain app-page
-  link. Reads the new metadata defensively, so older data without the ids
-  still gets a working, non-dead link. Pairs with the SDK change that
-  records `app_id`/`function_id` in the executor metadata.
+  link. The app-page fallback itself prefers the stable app-id form
+  (`.../apps/{workspace}/{env}/{app_id}`) whenever `app_id` is available —
+  so metadata with an `app_id` but no `function_id` still degrades to a
+  stop/redeploy-proof link rather than the deployed-name page. Reads the
+  new metadata defensively, so older data without the ids still gets a
+  working, non-dead link. Pairs with the SDK change that records
+  `app_id`/`function_id` in the executor metadata.
 - **Task detail: "more details" block for Modal identifiers.** The
   Execution section now has a collapsible list of every captured Modal
   identifier (kind, app/function names, workspace, environment, app id,
   function id, and the function-call ref), each click-to-copy, so a
   reference can be reconstructed by hand if the dashboard URL format
-  drifts. Only present fields render.
+  drifts. Only present fields render, and the block is gated to Modal
+  executions — it never surfaces its Modal-labeled fields for an
+  explicitly non-modal executor kind.
 - **Sidebar: shortened the "Concurrency Limits" nav item to "Concurrency"
   and made every nav label left-aligned and single-line (truncating with
-  an ellipsis instead of wrapping and centering).**
+  an ellipsis instead of wrapping and centering).** Each item also carries
+  a `title` tooltip with its full label, so a truncated label stays
+  readable on hover.
 
 ## [0.10.2] — 2026-07-14
 

--- a/app/stardag-ui/src/components/ConcurrencyLimits.test.tsx
+++ b/app/stardag-ui/src/components/ConcurrencyLimits.test.tsx
@@ -50,6 +50,8 @@ const holder = {
     kind: "modal",
     app_name: "my-app",
     workspace: "my-workspace",
+    app_id: "ap-123",
+    function_id: "fu-456",
   },
 };
 
@@ -160,7 +162,8 @@ describe("ConcurrencyLimits", () => {
     expect(screen.getByText("⚡ Modal")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View on Modal" })).toHaveAttribute(
       "href",
-      "https://modal.com/apps/my-workspace/main/deployed/my-app?functionCallId=fc-123",
+      "https://modal.com/apps/my-workspace/main/ap-123" +
+        "?activeTab=functions&functionId=fu-456&functionSection=calls&fcId=fc-123",
     );
 
     await user.click(screen.getByRole("button", { name: "Evict" }));

--- a/app/stardag-ui/src/components/Sidebar.test.tsx
+++ b/app/stardag-ui/src/components/Sidebar.test.tsx
@@ -19,6 +19,16 @@ describe("Sidebar", () => {
     }
   });
 
+  it("gives each nav item a title tooltip carrying the full label", () => {
+    // With single-line `truncate`, an ellipsized label must still be
+    // readable on hover — so every item carries `title={label}` (see #174).
+    render(<Sidebar activeItem="home" onNavigate={vi.fn()} />);
+    for (const label of ["Home", "Task Explorer", "Concurrency", "Settings"]) {
+      const button = screen.getByRole("button", { name: label });
+      expect(button).toHaveAttribute("title", label);
+    }
+  });
+
   it("hides labels when collapsed", () => {
     render(<Sidebar activeItem="home" onNavigate={vi.fn()} collapsed />);
     expect(screen.queryByText("Concurrency")).not.toBeInTheDocument();

--- a/app/stardag-ui/src/components/Sidebar.test.tsx
+++ b/app/stardag-ui/src/components/Sidebar.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { Sidebar } from "./Sidebar";
+
+describe("Sidebar", () => {
+  it("labels the concurrency nav item 'Concurrency' (single-line, see #174)", () => {
+    render(<Sidebar activeItem="home" onNavigate={vi.fn()} />);
+    expect(screen.getByText("Concurrency")).toBeInTheDocument();
+    // The old two-word label wrapped and center-aligned; it must be gone.
+    expect(screen.queryByText("Concurrency Limits")).not.toBeInTheDocument();
+  });
+
+  it("renders each nav label left-aligned with no-wrap truncation", () => {
+    render(<Sidebar activeItem="home" onNavigate={vi.fn()} />);
+    for (const label of ["Home", "Task Explorer", "Concurrency", "Settings"]) {
+      const span = screen.getByText(label);
+      expect(span.className).toContain("truncate");
+      expect(span.className).toContain("text-left");
+    }
+  });
+
+  it("hides labels when collapsed", () => {
+    render(<Sidebar activeItem="home" onNavigate={vi.fn()} collapsed />);
+    expect(screen.queryByText("Concurrency")).not.toBeInTheDocument();
+  });
+});

--- a/app/stardag-ui/src/components/Sidebar.tsx
+++ b/app/stardag-ui/src/components/Sidebar.tsx
@@ -138,7 +138,10 @@ export function Sidebar({
                   ? "bg-blue-50 text-blue-700 dark:bg-blue-900/50 dark:text-blue-300"
                   : "text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
               } ${collapsed ? "justify-center" : ""}`}
-              title={collapsed ? item.label : undefined}
+              // Always carry the full label: it's the only affordance for a
+              // collapsed item, and in the expanded sidebar it keeps a label
+              // that ellipsizes under `truncate` readable on hover (see #174).
+              title={item.label}
             >
               <span
                 className={`flex-shrink-0 ${

--- a/app/stardag-ui/src/components/Sidebar.tsx
+++ b/app/stardag-ui/src/components/Sidebar.tsx
@@ -46,7 +46,7 @@ export function Sidebar({
     },
     {
       id: "limits",
-      label: "Concurrency Limits",
+      label: "Concurrency",
       icon: (
         <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
@@ -140,10 +140,19 @@ export function Sidebar({
               } ${collapsed ? "justify-center" : ""}`}
               title={collapsed ? item.label : undefined}
             >
-              <span className={isActive ? "text-blue-600 dark:text-blue-400" : ""}>
+              <span
+                className={`flex-shrink-0 ${
+                  isActive ? "text-blue-600 dark:text-blue-400" : ""
+                }`}
+              >
                 {item.icon}
               </span>
-              {!collapsed && <span>{item.label}</span>}
+              {!collapsed && (
+                // min-w-0 + truncate + text-left keep every label on a single
+                // left-aligned line (ellipsis if it can't fit), so a long
+                // label never wraps and centers like the others (see #174).
+                <span className="min-w-0 flex-1 truncate text-left">{item.label}</span>
+              )}
             </button>
           );
         })}

--- a/app/stardag-ui/src/components/TaskDetail.test.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { ModalExecutionDetails } from "./TaskDetail";
+
+describe("ModalExecutionDetails", () => {
+  const fullMetadata = {
+    kind: "modal",
+    app_name: "my-app",
+    workspace: "my-workspace",
+    environment: "staging",
+    function_name: "worker_default",
+    app_id: "ap-123",
+    function_id: "fu-456",
+  };
+
+  it("lists every captured identifier verbatim once expanded", async () => {
+    const user = userEvent.setup();
+    render(<ModalExecutionDetails metadata={fullMetadata} executorRef="fc-789" />);
+
+    // Collapsed by default.
+    expect(screen.queryByText("ap-123")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /more details/i }));
+
+    for (const value of [
+      "modal",
+      "my-app",
+      "my-workspace",
+      "staging",
+      "worker_default",
+      "ap-123",
+      "fu-456",
+      "fc-789", // function-call ref
+    ]) {
+      expect(screen.getByText(value)).toBeInTheDocument();
+    }
+  });
+
+  it("renders only the fields that are present", async () => {
+    const user = userEvent.setup();
+    render(
+      <ModalExecutionDetails
+        metadata={{ kind: "modal", app_name: "my-app" }}
+        executorRef={null}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /more details/i }));
+
+    expect(screen.getByText("my-app")).toBeInTheDocument();
+    // Absent metadata fields and the missing call ref must not render.
+    expect(screen.queryByText("Workspace:")).not.toBeInTheDocument();
+    expect(screen.queryByText("App ID:")).not.toBeInTheDocument();
+    expect(screen.queryByText("Function call ID:")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when no identifiers are present", () => {
+    const { container } = render(
+      <ModalExecutionDetails metadata={null} executorRef={null} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the function call id even without any metadata", async () => {
+    const user = userEvent.setup();
+    render(<ModalExecutionDetails metadata={null} executorRef="fc-789" />);
+    await user.click(screen.getByRole("button", { name: /more details/i }));
+    expect(screen.getByText("fc-789")).toBeInTheDocument();
+  });
+
+  it("copies an identifier to the clipboard", async () => {
+    const user = userEvent.setup();
+    render(<ModalExecutionDetails metadata={fullMetadata} executorRef="fc-789" />);
+    await user.click(screen.getByRole("button", { name: /more details/i }));
+
+    // Copy the Function call ID (last copy button in the disclosure list).
+    const copyButtons = screen.getAllByRole("button", {
+      name: /copy to clipboard/i,
+    });
+    await user.click(copyButtons[copyButtons.length - 1]);
+    expect(await window.navigator.clipboard.readText()).toBe("fc-789");
+  });
+});

--- a/app/stardag-ui/src/components/TaskDetail.test.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.test.tsx
@@ -61,6 +61,28 @@ describe("ModalExecutionDetails", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("renders nothing for an explicitly non-modal kind", () => {
+    // The block's labels ("App name", "Function ID", …) are Modal-specific,
+    // so it must not surface identifiers from a non-modal executor as Modal
+    // fields.
+    const { container } = render(
+      <ModalExecutionDetails
+        metadata={{ kind: "k8s", app_name: "some-pod", function_id: "fu-x" }}
+        executorRef="ref-1"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders for kind-less metadata (legacy, treated as modal)", async () => {
+    const user = userEvent.setup();
+    render(
+      <ModalExecutionDetails metadata={{ app_name: "my-app" }} executorRef={null} />,
+    );
+    await user.click(screen.getByRole("button", { name: /more details/i }));
+    expect(screen.getByText("my-app")).toBeInTheDocument();
+  });
+
   it("renders the function call id even without any metadata", async () => {
     const user = userEvent.setup();
     render(<ModalExecutionDetails metadata={null} executorRef="fc-789" />);

--- a/app/stardag-ui/src/components/TaskDetail.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useState } from "react";
 import { cancelTask, fetchTaskArtifacts, fetchTaskEvents } from "../api/tasks";
-import type { Task, TaskArtifact, TaskEvent, EventType } from "../types/task";
+import type {
+  Task,
+  TaskArtifact,
+  TaskEvent,
+  EventType,
+  ExecutorMetadata,
+} from "../types/task";
 import { modalAppUrl, modalFunctionCallUrl } from "../utils/modalLinks";
 import { ArtifactList, ExpandButton } from "./ArtifactViewer";
 import { ExecutorBadge } from "./ExecutorBadge";
@@ -52,6 +58,77 @@ function CopyButton({ text, className = "" }: { text: string; className?: string
         </svg>
       )}
     </button>
+  );
+}
+
+// Collapsible "more details" block listing every captured Modal identifier
+// verbatim, each click-to-copy. Modal gives no URL-format guarantee (see
+// utils/modalLinks.ts), so surfacing the raw ids lets a user reconstruct or
+// paste a reference by hand even if the dashboard URL format drifts. Only
+// fields that are present are rendered; renders nothing when none are.
+export function ModalExecutionDetails({
+  metadata,
+  executorRef,
+}: {
+  metadata?: ExecutorMetadata | null;
+  executorRef?: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+
+  const fields: { label: string; value: string }[] = [];
+  const push = (label: string, value: unknown) => {
+    if (typeof value === "string" && value.length > 0) {
+      fields.push({ label, value });
+    }
+  };
+  push("Kind", metadata?.kind);
+  push("App name", metadata?.app_name);
+  push("Workspace", metadata?.workspace);
+  push("Environment", metadata?.environment);
+  push("Function name", metadata?.function_name);
+  push("App ID", metadata?.app_id);
+  push("Function ID", metadata?.function_id);
+  push("Function call ID", executorRef);
+
+  if (fields.length === 0) return null;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+      >
+        <svg
+          className={`h-3 w-3 transition-transform ${open ? "rotate-90" : ""}`}
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 5l7 7-7 7"
+          />
+        </svg>
+        {open ? "Hide details" : "More details"}
+      </button>
+      {open && (
+        <dl className="mt-1 space-y-1">
+          {fields.map((field) => (
+            <div key={field.label} className="flex items-center gap-1">
+              <dt className="text-gray-500 dark:text-gray-400">{field.label}:</dt>
+              <dd className="truncate font-mono" title={field.value}>
+                {field.value}
+              </dd>
+              <CopyButton text={field.value} className="flex-shrink-0" />
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
   );
 }
 
@@ -384,6 +461,10 @@ export function TaskDetail({
                   </span>
                 </div>
               )}
+              <ModalExecutionDetails
+                metadata={task.latest_executor_metadata}
+                executorRef={task.latest_executor_ref}
+              />
             </div>
           </div>
         )}

--- a/app/stardag-ui/src/components/TaskDetail.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.tsx
@@ -7,7 +7,11 @@ import type {
   EventType,
   ExecutorMetadata,
 } from "../types/task";
-import { modalAppUrl, modalFunctionCallUrl } from "../utils/modalLinks";
+import {
+  isModalMetadata,
+  modalAppUrl,
+  modalFunctionCallUrl,
+} from "../utils/modalLinks";
 import { ArtifactList, ExpandButton } from "./ArtifactViewer";
 import { ExecutorBadge } from "./ExecutorBadge";
 import { FullscreenModal } from "./FullscreenModal";
@@ -66,6 +70,12 @@ function CopyButton({ text, className = "" }: { text: string; className?: string
 // utils/modalLinks.ts), so surfacing the raw ids lets a user reconstruct or
 // paste a reference by hand even if the dashboard URL format drifts. Only
 // fields that are present are rendered; renders nothing when none are.
+//
+// Gated to Modal executions: this block's labels ("App name", "Function ID",
+// …) are Modal-specific, so it renders only for modal metadata, for the
+// legacy kind-less case (treated as modal for back-compat), and for the
+// executorRef-only case (no metadata at all). It never renders Modal-labeled
+// fields for an explicitly non-modal kind (e.g. "k8s").
 export function ModalExecutionDetails({
   metadata,
   executorRef,
@@ -74,6 +84,8 @@ export function ModalExecutionDetails({
   executorRef?: string | null;
 }) {
   const [open, setOpen] = useState(false);
+
+  const isModal = !metadata || isModalMetadata(metadata);
 
   const fields: { label: string; value: string }[] = [];
   const push = (label: string, value: unknown) => {
@@ -90,7 +102,7 @@ export function ModalExecutionDetails({
   push("Function ID", metadata?.function_id);
   push("Function call ID", executorRef);
 
-  if (fields.length === 0) return null;
+  if (!isModal || fields.length === 0) return null;
 
   return (
     <div>

--- a/app/stardag-ui/src/types/task.ts
+++ b/app/stardag-ui/src/types/task.ts
@@ -18,14 +18,22 @@ export type BuildStatus =
 // Descriptive metadata about the executor backend that ran a task or
 // triggered a build (recorded on TASK_STARTED / build creation events).
 // For Modal executions: {kind: "modal", app_name, workspace, environment,
-// function_name} — every key is optional (older SDKs may record a subset),
-// so consumers must handle missing fields (see utils/modalLinks.ts).
+// function_name, app_id, function_id} — every key is optional (older SDKs
+// may record a subset), so consumers must handle missing fields (see
+// utils/modalLinks.ts).
 export interface ExecutorMetadata {
   kind?: string;
   app_name?: string;
   workspace?: string;
   environment?: string;
   function_name?: string;
+  // Modal object ids captured at execution time (best-effort; absent on
+  // data recorded before the SDK started capturing them). Used to build
+  // stop/redeploy-proof dashboard deep links — see utils/modalLinks.ts.
+  //   app_id      — Modal App object id, "ap-…"
+  //   function_id — Modal Function object id, "fu-…"
+  app_id?: string;
+  function_id?: string;
   // Build-level only: true when triggered in reactive (tick-scheduled) mode
   reactive?: boolean;
   [key: string]: unknown;

--- a/app/stardag-ui/src/utils/modalLinks.test.ts
+++ b/app/stardag-ui/src/utils/modalLinks.test.ts
@@ -7,6 +7,8 @@ const fullMetadata = {
   workspace: "my-workspace",
   environment: "staging",
   function_name: "worker_default",
+  app_id: "ap-123",
+  function_id: "fu-456",
 };
 
 function withoutKey(key: keyof typeof fullMetadata): Record<string, unknown> {
@@ -65,26 +67,76 @@ describe("modalAppUrl", () => {
 });
 
 describe("modalFunctionCallUrl", () => {
-  it("appends the functionCallId query param to the app URL", () => {
-    expect(modalFunctionCallUrl(fullMetadata, "fc-abc123")).toBe(
-      "https://modal.com/apps/my-workspace/staging/deployed/my-app?functionCallId=fc-abc123",
+  it("builds the stable app-id URL when all ids are present", () => {
+    // app-id path form → survives an app stop/redeploy.
+    expect(modalFunctionCallUrl(fullMetadata, "fc-789")).toBe(
+      "https://modal.com/apps/my-workspace/staging/ap-123" +
+        "?activeTab=functions&functionId=fu-456&functionSection=calls&fcId=fc-789",
     );
   });
 
-  it("returns null without a call ref", () => {
-    expect(modalFunctionCallUrl(fullMetadata, null)).toBeNull();
-    expect(modalFunctionCallUrl(fullMetadata, undefined)).toBeNull();
-    expect(modalFunctionCallUrl(fullMetadata, "")).toBeNull();
+  it("falls back to the 'main' environment in the stable URL", () => {
+    expect(modalFunctionCallUrl(withoutKey("environment"), "fc-789")).toBe(
+      "https://modal.com/apps/my-workspace/main/ap-123" +
+        "?activeTab=functions&functionId=fu-456&functionSection=calls&fcId=fc-789",
+    );
   });
 
-  it("returns null when the app URL cannot be built", () => {
-    expect(modalFunctionCallUrl(null, "fc-abc123")).toBeNull();
-    expect(modalFunctionCallUrl({ kind: "modal" }, "fc-abc123")).toBeNull();
+  it("falls back to the deployed-name form when app_id is missing", () => {
+    // Resolves only while the app version is live, but survives without app_id.
+    expect(modalFunctionCallUrl(withoutKey("app_id"), "fc-789")).toBe(
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app" +
+        "?activeTab=functions&functionId=fu-456&functionSection=calls&fcId=fc-789",
+    );
   });
 
-  it("URL-encodes the call ref", () => {
-    expect(modalFunctionCallUrl(fullMetadata, "fc a&b")).toBe(
-      "https://modal.com/apps/my-workspace/staging/deployed/my-app?functionCallId=fc%20a%26b",
+  it("falls back to the plain app page when function_id is missing", () => {
+    expect(modalFunctionCallUrl(withoutKey("function_id"), "fc-789")).toBe(
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+    );
+  });
+
+  it("falls back to the plain app page when the call ref is missing", () => {
+    expect(modalFunctionCallUrl(fullMetadata, null)).toBe(
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+    );
+    expect(modalFunctionCallUrl(fullMetadata, "")).toBe(
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+    );
+  });
+
+  it("returns null when nothing usable can be built", () => {
+    expect(modalFunctionCallUrl(null, "fc-789")).toBeNull();
+    expect(modalFunctionCallUrl(undefined, "fc-789")).toBeNull();
+    // Only ids, no workspace/app_name → neither the call URL nor the app
+    // page can be built.
+    expect(
+      modalFunctionCallUrl(
+        { kind: "modal", app_id: "ap-123", function_id: "fu-456" },
+        "fc-789",
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for a non-modal kind", () => {
+    expect(modalFunctionCallUrl({ ...fullMetadata, kind: "k8s" }, "fc-789")).toBeNull();
+  });
+
+  it("URL-encodes ids and the call ref", () => {
+    expect(
+      modalFunctionCallUrl(
+        {
+          kind: "modal",
+          workspace: "ws#1",
+          environment: "env 2",
+          app_id: "ap 1/2",
+          function_id: "fu 3&4",
+        },
+        "fc a&b",
+      ),
+    ).toBe(
+      "https://modal.com/apps/ws%231/env%202/ap%201%2F2" +
+        "?activeTab=functions&functionId=fu%203%264&functionSection=calls&fcId=fc%20a%26b",
     );
   });
 });

--- a/app/stardag-ui/src/utils/modalLinks.test.ts
+++ b/app/stardag-ui/src/utils/modalLinks.test.ts
@@ -18,21 +18,36 @@ function withoutKey(key: keyof typeof fullMetadata): Record<string, unknown> {
 }
 
 describe("modalAppUrl", () => {
-  it("builds the deployed-app URL from full metadata", () => {
+  it("prefers the stable app-id URL when app_id is present", () => {
+    // app-id path form → survives an app stop/redeploy.
     expect(modalAppUrl(fullMetadata)).toBe(
+      "https://modal.com/apps/my-workspace/staging/ap-123",
+    );
+  });
+
+  it("falls back to the deployed-name URL when app_id is missing", () => {
+    // Resolves only while the app version is live, but survives without app_id.
+    expect(modalAppUrl(withoutKey("app_id"))).toBe(
       "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+    );
+  });
+
+  it("still builds the stable URL when app_name is missing", () => {
+    // app_id alone is enough to address the app page.
+    expect(modalAppUrl(withoutKey("app_name"))).toBe(
+      "https://modal.com/apps/my-workspace/staging/ap-123",
     );
   });
 
   it("falls back to the 'main' environment when absent", () => {
     expect(modalAppUrl(withoutKey("environment"))).toBe(
-      "https://modal.com/apps/my-workspace/main/deployed/my-app",
+      "https://modal.com/apps/my-workspace/main/ap-123",
     );
   });
 
   it("accepts metadata without an explicit kind", () => {
     expect(modalAppUrl(withoutKey("kind"))).toBe(
-      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+      "https://modal.com/apps/my-workspace/staging/ap-123",
     );
   });
 
@@ -45,8 +60,8 @@ describe("modalAppUrl", () => {
     expect(modalAppUrl({ ...fullMetadata, workspace: "" })).toBeNull();
   });
 
-  it("returns null when app_name is missing", () => {
-    expect(modalAppUrl(withoutKey("app_name"))).toBeNull();
+  it("returns null when neither app_id nor app_name is present", () => {
+    expect(modalAppUrl({ kind: "modal", workspace: "my-workspace" })).toBeNull();
   });
 
   it("returns null for null/undefined metadata", () => {
@@ -54,7 +69,18 @@ describe("modalAppUrl", () => {
     expect(modalAppUrl(undefined)).toBeNull();
   });
 
-  it("URL-encodes path segments", () => {
+  it("URL-encodes the app-id path segment", () => {
+    expect(
+      modalAppUrl({
+        kind: "modal",
+        app_id: "ap 1/2",
+        workspace: "ws#1",
+        environment: "env 2",
+      }),
+    ).toBe("https://modal.com/apps/ws%231/env%202/ap%201%2F2");
+  });
+
+  it("URL-encodes the deployed-name path segments", () => {
     expect(
       modalAppUrl({
         kind: "modal",
@@ -90,18 +116,34 @@ describe("modalFunctionCallUrl", () => {
     );
   });
 
-  it("falls back to the plain app page when function_id is missing", () => {
+  it("falls back to the stable app-id page when function_id is missing", () => {
+    // No function_id → can't address the call, but app_id still yields the
+    // stop/redeploy-proof app page rather than the deployed-name form.
     expect(modalFunctionCallUrl(withoutKey("function_id"), "fc-789")).toBe(
-      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+      "https://modal.com/apps/my-workspace/staging/ap-123",
     );
   });
 
-  it("falls back to the plain app page when the call ref is missing", () => {
+  it("falls back to the deployed-name page when neither function_id nor app_id is present", () => {
+    expect(
+      modalFunctionCallUrl(
+        {
+          kind: "modal",
+          app_name: "my-app",
+          workspace: "my-workspace",
+          environment: "staging",
+        },
+        "fc-789",
+      ),
+    ).toBe("https://modal.com/apps/my-workspace/staging/deployed/my-app");
+  });
+
+  it("falls back to the stable app-id page when the call ref is missing", () => {
     expect(modalFunctionCallUrl(fullMetadata, null)).toBe(
-      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+      "https://modal.com/apps/my-workspace/staging/ap-123",
     );
     expect(modalFunctionCallUrl(fullMetadata, "")).toBe(
-      "https://modal.com/apps/my-workspace/staging/deployed/my-app",
+      "https://modal.com/apps/my-workspace/staging/ap-123",
     );
   });
 

--- a/app/stardag-ui/src/utils/modalLinks.ts
+++ b/app/stardag-ui/src/utils/modalLinks.ts
@@ -8,7 +8,10 @@ import type { ExecutorMetadata } from "../types/task";
 // deep link here is best-effort resilience, not a contract.
 //
 // Patterns:
-//   app page (plain):
+//   app page (stable / stop+redeploy-proof — addresses the app by its id):
+//     https://modal.com/apps/{workspace}/{environment}/{app_id}
+//   app page (deployed-name form — only resolves while that app version is
+//   live, but survives when we lack the app id):
 //     https://modal.com/apps/{workspace}/{environment}/deployed/{app_name}
 //   function call (stable / stop+redeploy-proof — addresses the app by its
 //   id, so it keeps resolving after the app version is stopped/redeployed):
@@ -30,25 +33,37 @@ function nonEmptyString(value: unknown): string | null {
 // True unless the metadata explicitly records a non-modal executor kind.
 // `kind` may be absent on older SDKs, so we only bail when it's present and
 // something other than "modal".
-function isModalMetadata(metadata: ExecutorMetadata): boolean {
+export function isModalMetadata(metadata: ExecutorMetadata): boolean {
   return metadata.kind === undefined || metadata.kind === "modal";
 }
 
-// URL of the deployed Modal app's dashboard page, or null if the
-// metadata doesn't identify a Modal app (missing workspace/app_name, or
-// an explicitly non-modal kind).
+// URL of the Modal app's dashboard page, or null if the metadata doesn't
+// identify a Modal app (missing workspace + app id/name, or an explicitly
+// non-modal kind).
+//
+// Prefers the stable app-id form (survives an app stop/redeploy) when
+// `app_id` is present, and degrades to the deployed-name form (resolves
+// only while that app version is live) for older data that lacks it.
 export function modalAppUrl(
   metadata: ExecutorMetadata | null | undefined,
 ): string | null {
   if (!metadata) return null;
   if (!isModalMetadata(metadata)) return null;
   const workspace = nonEmptyString(metadata.workspace);
-  const appName = nonEmptyString(metadata.app_name);
-  if (!workspace || !appName) return null;
+  if (!workspace) return null;
   const environment = nonEmptyString(metadata.environment) ?? "main";
-  return `https://modal.com/apps/${encodeURIComponent(workspace)}/${encodeURIComponent(
-    environment,
-  )}/deployed/${encodeURIComponent(appName)}`;
+  const appId = nonEmptyString(metadata.app_id);
+  const appName = nonEmptyString(metadata.app_name);
+  const base = `https://modal.com/apps/${encodeURIComponent(
+    workspace,
+  )}/${encodeURIComponent(environment)}`;
+  if (appId) {
+    return `${base}/${encodeURIComponent(appId)}`;
+  }
+  if (appName) {
+    return `${base}/deployed/${encodeURIComponent(appName)}`;
+  }
+  return null;
 }
 
 // Shared query string for the function-call deep links (both the app-id and
@@ -68,9 +83,10 @@ function functionCallQuery(functionId: string, fcId: string): string {
 //      (survives an app stop/redeploy).
 //   2. workspace + app_name + function_id + fcId → deployed-name URL
 //      (resolves only while that app version is live).
-//   3. otherwise → the plain app-page link (or null if even that can't be
-//      built), so old data without the new ids still gets a working,
-//      non-dead link.
+//   3. otherwise → the plain app-page link (stable app-id form when we
+//      have app_id but no function_id, else the deployed-name form, else
+//      null), so old/partial data still gets the most resilient link the
+//      identifiers allow rather than a dead one.
 export function modalFunctionCallUrl(
   metadata: ExecutorMetadata | null | undefined,
   functionCallId: string | null | undefined,

--- a/app/stardag-ui/src/utils/modalLinks.ts
+++ b/app/stardag-ui/src/utils/modalLinks.ts
@@ -4,19 +4,34 @@ import type { ExecutorMetadata } from "../types/task";
 //
 // ALL Modal URL patterns are centralized in THIS file — if Modal ever
 // changes its dashboard URL format, this is the only place to update.
+// Modal gives NO forward-compatibility guarantee for these URLs, so every
+// deep link here is best-effort resilience, not a contract.
 //
-// Patterns (matching the "View Deployment" URL the Modal CLI prints on
-// `modal deploy`):
-//   app page:      https://modal.com/apps/{workspace}/{environment}/deployed/{app_name}
-//   function call: app page + ?functionCallId={function_call_id}
+// Patterns:
+//   app page (plain):
+//     https://modal.com/apps/{workspace}/{environment}/deployed/{app_name}
+//   function call (stable / stop+redeploy-proof — addresses the app by its
+//   id, so it keeps resolving after the app version is stopped/redeployed):
+//     https://modal.com/apps/{workspace}/{environment}/{app_id}?activeTab=functions&functionId={function_id}&functionSection=calls&fcId={fc}
+//   function call (deployed-name form — only resolves while that app
+//   version is live, but survives when we lack the app id):
+//     https://modal.com/apps/{workspace}/{environment}/deployed/{app_name}?activeTab=functions&functionId={function_id}&functionSection=calls&fcId={fc}
 //
 // The environment segment falls back to Modal's default environment name
-// ("main") when the metadata doesn't record one. Both builders return
-// null when a required field is missing so callers never render dead
-// links (graceful degradation for old servers / partial metadata).
+// ("main") when the metadata doesn't record one. Builders return null when
+// a required field is missing so callers never render dead links (graceful
+// degradation for old servers / partial metadata — `app_id`/`function_id`
+// are absent on data recorded before the SDK started capturing them).
 
 function nonEmptyString(value: unknown): string | null {
   return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+// True unless the metadata explicitly records a non-modal executor kind.
+// `kind` may be absent on older SDKs, so we only bail when it's present and
+// something other than "modal".
+function isModalMetadata(metadata: ExecutorMetadata): boolean {
+  return metadata.kind === undefined || metadata.kind === "modal";
 }
 
 // URL of the deployed Modal app's dashboard page, or null if the
@@ -26,9 +41,7 @@ export function modalAppUrl(
   metadata: ExecutorMetadata | null | undefined,
 ): string | null {
   if (!metadata) return null;
-  // `kind` may be absent (older SDKs); only bail when it's explicitly
-  // something other than "modal".
-  if (metadata.kind !== undefined && metadata.kind !== "modal") return null;
+  if (!isModalMetadata(metadata)) return null;
   const workspace = nonEmptyString(metadata.workspace);
   const appName = nonEmptyString(metadata.app_name);
   if (!workspace || !appName) return null;
@@ -38,13 +51,59 @@ export function modalAppUrl(
   )}/deployed/${encodeURIComponent(appName)}`;
 }
 
-// URL of a specific function call on the app's dashboard page, or null
-// when either the app page can't be built or the call ref is missing.
+// Shared query string for the function-call deep links (both the app-id and
+// the deployed-name forms use the same params).
+function functionCallQuery(functionId: string, fcId: string): string {
+  return (
+    `?activeTab=functions&functionId=${encodeURIComponent(functionId)}` +
+    `&functionSection=calls&fcId=${encodeURIComponent(fcId)}`
+  );
+}
+
+// URL pointing at a specific function call in the Modal dashboard, or null
+// when nothing usable can be built.
+//
+// Prefers the most resilient form we have enough identifiers for:
+//   1. workspace + app_id + function_id + fcId → stable app-id URL
+//      (survives an app stop/redeploy).
+//   2. workspace + app_name + function_id + fcId → deployed-name URL
+//      (resolves only while that app version is live).
+//   3. otherwise → the plain app-page link (or null if even that can't be
+//      built), so old data without the new ids still gets a working,
+//      non-dead link.
 export function modalFunctionCallUrl(
   metadata: ExecutorMetadata | null | undefined,
   functionCallId: string | null | undefined,
 ): string | null {
-  const appUrl = modalAppUrl(metadata);
-  if (!appUrl || !functionCallId) return null;
-  return `${appUrl}?functionCallId=${encodeURIComponent(functionCallId)}`;
+  if (!metadata || !isModalMetadata(metadata)) return null;
+
+  const workspace = nonEmptyString(metadata.workspace);
+  const environment = nonEmptyString(metadata.environment) ?? "main";
+  const appId = nonEmptyString(metadata.app_id);
+  const appName = nonEmptyString(metadata.app_name);
+  const functionId = nonEmptyString(metadata.function_id);
+  const fcId = nonEmptyString(functionCallId);
+
+  if (workspace && functionId && fcId) {
+    const base = `https://modal.com/apps/${encodeURIComponent(
+      workspace,
+    )}/${encodeURIComponent(environment)}`;
+    if (appId) {
+      return `${base}/${encodeURIComponent(appId)}${functionCallQuery(
+        functionId,
+        fcId,
+      )}`;
+    }
+    if (appName) {
+      return `${base}/deployed/${encodeURIComponent(appName)}${functionCallQuery(
+        functionId,
+        fcId,
+      )}`;
+    }
+  }
+
+  // Not enough to address the call itself — fall back to the app page (or
+  // null). Never append the old `?functionCallId=` param: that URL doesn't
+  // resolve in the Modal dashboard.
+  return modalAppUrl(metadata);
 }

--- a/integration-tests/tests/test_browser.py
+++ b/integration-tests/tests/test_browser.py
@@ -226,9 +226,11 @@ class TestUISidebarNavigation:
         """Test that Task Explorer navigation works."""
         self._go_to_home(logged_in_page, docker_services)
 
-        task_explorer_btn = logged_in_page.get_by_text("Task Explorer").or_(
-            logged_in_page.get_by_title("Task Explorer")
-        )
+        # The nav button carries both its label text and a matching `title`
+        # tooltip, so a text/title union would double-match; the button role
+        # (accessible name from label or title) resolves it in either the
+        # expanded or collapsed sidebar.
+        task_explorer_btn = logged_in_page.get_by_role("button", name="Task Explorer")
 
         if task_explorer_btn.is_visible():
             task_explorer_btn.click()
@@ -253,9 +255,10 @@ class TestUITaskExplorer:
             state="visible", timeout=10000
         )
 
-        task_explorer_btn = page.get_by_text("Task Explorer").or_(
-            page.get_by_title("Task Explorer")
-        )
+        # Button role (accessible name from label or title) resolves cleanly;
+        # a text/title union double-matches now that the nav label also has a
+        # matching `title` tooltip.
+        task_explorer_btn = page.get_by_role("button", name="Task Explorer")
         task_explorer_btn.click()
         page.wait_for_load_state("networkidle")
 
@@ -388,9 +391,10 @@ class TestUIDAGPanel:
             state="visible", timeout=10000
         )
 
-        task_explorer_btn = page.get_by_text("Task Explorer").or_(
-            page.get_by_title("Task Explorer")
-        )
+        # Button role (accessible name from label or title) resolves cleanly;
+        # a text/title union double-matches now that the nav label also has a
+        # matching `title` tooltip.
+        task_explorer_btn = page.get_by_role("button", name="Task Explorer")
         task_explorer_btn.click()
         page.wait_for_load_state("networkidle")
         # "Task Explorer" appears in breadcrumb nav (header span, not h1)


### PR DESCRIPTION
Fixes two UI issues in `app/stardag-ui`. UI-only; needs a production UI deploy.

## 1. Stable Modal function-call deep links (#173)

The task-detail and concurrency-holder "View on Modal" links used a query-param form (`?functionCallId=…`) that doesn't resolve in the Modal dashboard, and even the working `deployed/{app_name}` form only resolves while that app version is live — a stopped/redeployed app is addressed by its **app id** instead.

`modalFunctionCallUrl` now picks the most resilient form it has enough identifiers for:

1. `workspace + app_id + function_id + fcId` → **stable, stop/redeploy-proof** app-id URL:
   `https://modal.com/apps/{workspace}/{environment}/{app_id}?activeTab=functions&functionId={function_id}&functionSection=calls&fcId={fc}`
2. else `workspace + app_name + function_id + fcId` → the `deployed/{app_name}?activeTab=functions&functionId=…&functionSection=calls&fcId=…` form (works while the app is live).
3. else → the plain app-page link (or `null` if even that can't be built).

Every segment/param is `encodeURIComponent`-escaped, and all Modal URL patterns stay centralized in `modalLinks.ts` (Modal gives no URL-format guarantee). New optional `app_id` (`ap-…`) / `function_id` (`fu-…`) keys were added to the `ExecutorMetadata` type and are read **defensively** — absent on older data, which still degrades to a working, non-dead link.

> Pairs with the SDK metadata PR (`feat/modal-id-metadata`), which starts recording `app_id`/`function_id` in the Modal executor metadata. This UI reads them if present and works fine without them.

## 2. "More details" block in TaskDetail (#173)

The Execution section gains a collapsible **"more details"** block listing every captured Modal identifier verbatim (kind, app/function names, workspace, environment, app id, function id, and the function-call ref), each click-to-copy — so a user can reconstruct a reference by hand even if the dashboard URL format drifts. Only present fields render.

## 3. Sidebar nav label (#174)

Shortened "Concurrency Limits" to **"Concurrency"** and made every nav label robustly left-aligned and single-line (`truncate` with ellipsis) so a long label never wraps and center-aligns like the others.

## Tests / quality

- `modalLinks`: stable URL with all ids, deployed-name fallback, plain-app fallback, null-safety, non-modal kind, URL-encoding.
- `ModalExecutionDetails`: present/absent fields, empty render, click-to-copy.
- `Sidebar`: label rendering + left-align/no-wrap classes.
- Full UI suite green (57 tests). prettier / eslint / tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)