### PR TITLE
CLI: concurrency-limit CRUD (list/set/delete/holders/evict)

### DIFF
--- a/.claude/skills/stardag/registry-and-platform.md
+++ b/.claude/skills/stardag/registry-and-platform.md
@@ -145,6 +145,19 @@ stardag environment target-roots add KEY URI # Add target root
 stardag environment target-roots list        # List target roots
 ```
 
+### Concurrency Limits
+
+```bash
+stardag concurrency-limits list              # List named limits (--holders adds counts)
+stardag concurrency-limits set KEY N         # Upsert a limit (max_concurrent = N)
+stardag concurrency-limits delete KEY        # Remove a limit (--yes to skip confirm)
+stardag concurrency-limits holders KEY       # List RUNNING slot holders
+stardag concurrency-limits evict KEY TASK_ID # Free a leaked slot (--yes to skip confirm)
+```
+
+All accept `-p/--stardag-profile` and `-e/--stardag-env` to target a
+non-active profile / environment.
+
 ### Modal Integration
 
 ```bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,13 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 - **CLI: `stardag concurrency-limits` command group for managing named
   concurrency limits.** Wraps the registry's concurrency-limit endpoints for
   the active profile / environment (override with `-p/--stardag-profile` and
-  `-e/--stardag-env`): `list` (with optional `--holders` counts), `set <key>
-<max_concurrent>` (upsert), `delete <key>` (`--yes` to skip confirmation),
-  `holders <key>` (RUNNING slot holders, oldest first), and `evict <key>
-<task_id>` to free leaked slots. Replaces the need for an ad-hoc script to
-  `PUT /api/v1/concurrency-limits/{key}`. Backed by new `APIRegistry`
-  `concurrency_limit_{list,set,delete,holders,evict}` methods.
+  `-e/--stardag-env`). Subcommands: `list` (with optional `--holders` counts);
+  `set` to upsert a limit (`stardag concurrency-limits set <key> <max_concurrent>`);
+  `delete <key>` (`--yes` to skip confirmation); `holders <key>` (RUNNING slot
+  holders, oldest first); and `evict` to free leaked slots
+  (`stardag concurrency-limits evict <key> <task_id>`). Replaces the need for an
+  ad-hoc script to `PUT /api/v1/concurrency-limits/{key}`. Backed by new
+  `APIRegistry` `concurrency_limit_{list,set,delete,holders,evict}` methods.
 
 ## [0.10.2] — 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to the Stardag project (SDK, Registry API, and UI).
 
 For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
+## [Unreleased]
+
+### SDK
+
+- **CLI: `stardag concurrency-limits` command group for managing named
+  concurrency limits.** Wraps the registry's concurrency-limit endpoints for
+  the active profile / environment (override with `-p/--stardag-profile` and
+  `-e/--stardag-env`): `list` (with optional `--holders` counts), `set <key>
+<max_concurrent>` (upsert), `delete <key>` (`--yes` to skip confirmation),
+  `holders <key>` (RUNNING slot holders, oldest first), and `evict <key>
+<task_id>` to free leaked slots. Replaces the need for an ad-hoc script to
+  `PUT /api/v1/concurrency-limits/{key}`. Backed by new `APIRegistry`
+  `concurrency_limit_{list,set,delete,holders,evict}` methods.
+
 ## [0.10.2] — 2026-07-14
 
 ### SDK

--- a/docs/docs/configuration/cli.md
+++ b/docs/docs/configuration/cli.md
@@ -340,6 +340,50 @@ Target roots are managed under `stardag environment target-roots`. Changes are a
 
 See `stardag environment target-roots --help` for full options (e.g. `--env` to target a specific environment).
 
+## Concurrency Limit Commands
+
+Named concurrency limits cap how many tasks tagged with a given key may run
+concurrently across all builds in an environment. The SDK tags tasks with keys;
+the cap lives server-side in the registry and is enforced atomically when a task
+starts. Manage them with `stardag concurrency-limits` (or in the registry UI:
+workspace admin → Concurrency Limits).
+
+=== "Active venv"
+
+    ```sh
+    stardag concurrency-limits list [--holders]
+    stardag concurrency-limits set <key> <max_concurrent>
+    stardag concurrency-limits delete <key> [--yes]
+    stardag concurrency-limits holders <key> [--limit N]
+    stardag concurrency-limits evict <key> <task_id> [--yes]
+    ```
+
+=== "uv run ..."
+
+    ```sh
+    uv run stardag concurrency-limits list [--holders]
+    uv run stardag concurrency-limits set <key> <max_concurrent>
+    uv run stardag concurrency-limits delete <key> [--yes]
+    uv run stardag concurrency-limits holders <key> [--limit N]
+    uv run stardag concurrency-limits evict <key> <task_id> [--yes]
+    ```
+
+All commands accept `-p/--stardag-profile` and `-e/--stardag-env` to target a
+profile / environment other than the active one.
+
+- `list` — show each key and its `max_concurrent` (`--holders` adds the current
+  holder count, one extra call per key).
+- `set` — create or update a limit (upsert; `max_concurrent` must be ≥ 1).
+- `delete` — remove a limit so the key becomes unlimited.
+- `holders` — list the RUNNING tasks currently holding slots of a key
+  (oldest-running first), with task id/name, running-since and executor.
+- `evict` — record `TASK_FAILED` for a RUNNING holder to free leaked slots.
+  Only evict holders whose process you know is dead: the server cannot verify
+  liveness, so evicting a live worker leaves the cap oversubscribed until it
+  finishes.
+
+See `stardag concurrency-limits --help` for full options.
+
 ## Environment Variables
 
 All CLI behavior can be overridden with environment variables:

--- a/lib/stardag/src/stardag/_cli/__init__.py
+++ b/lib/stardag/src/stardag/_cli/__init__.py
@@ -25,6 +25,12 @@ Usage:
     stardag environment target-roots remove <name> [--env <env>]
     stardag environment target-roots set <name=uri ...> [--json <json>] [--env <env>]
 
+    stardag concurrency-limits list [--holders] [-p profile] [-e env]
+    stardag concurrency-limits set <key> <max_concurrent> [-p profile] [-e env]
+    stardag concurrency-limits delete <key> [--yes] [-p profile] [-e env]
+    stardag concurrency-limits holders <key> [--limit N] [-p profile] [-e env]
+    stardag concurrency-limits evict <key> <task_id> [--yes] [-p profile] [-e env]
+
     stardag modal deploy <app_ref> [--name name] [-e env] [--stream-logs] [--tag tag] [-m]
     stardag modal stardag-api-key create [--modal-env env] [-w workspace] [-e env] [-p profile]
 
@@ -37,7 +43,7 @@ Configuration:
 
 import typer
 
-from stardag._cli import auth, config, environment
+from stardag._cli import auth, config, environment, limits
 
 # Main CLI app
 app = typer.Typer(
@@ -50,6 +56,7 @@ app = typer.Typer(
 app.add_typer(auth.app, name="auth")
 app.add_typer(config.app, name="config")
 app.add_typer(environment.app, name="environment")
+app.add_typer(limits.app, name="concurrency-limits")
 
 # Add modal subcommand only if modal is installed
 try:

--- a/lib/stardag/src/stardag/_cli/limits.py
+++ b/lib/stardag/src/stardag/_cli/limits.py
@@ -78,27 +78,35 @@ def _resolve_registry(profile: str | None, env_override: str | None) -> APIRegis
 
         environment_id = reg.environment_id or None
         if env_override:
-            from stardag._cli.credentials import resolve_environment_slug_to_id
+            from stardag.config.cache import _looks_like_uuid
 
-            registry_name = config.context.registry_name
-            workspace_id = reg.workspace_id or None
-            user = reg.auth.user_email
-            if not registry_name or not workspace_id:
-                error_console.print(
-                    "[bold red]Cannot resolve --stardag-env without a configured "
-                    "registry and workspace.[/bold red] Pass an environment ID, or "
-                    "activate a profile."
+            if _looks_like_uuid(env_override):
+                # A raw environment ID needs no registry/workspace context to
+                # resolve — use it directly (documented alongside slugs).
+                environment_id = env_override
+            else:
+                from stardag._cli.credentials import resolve_environment_slug_to_id
+
+                registry_name = config.context.registry_name
+                workspace_id = reg.workspace_id or None
+                user = reg.auth.user_email
+                if not registry_name or not workspace_id:
+                    error_console.print(
+                        "[bold red]Cannot resolve an environment slug without a "
+                        "configured registry and workspace.[/bold red] Pass an "
+                        "environment ID, or activate a profile."
+                    )
+                    raise typer.Exit(1)
+                resolved = resolve_environment_slug_to_id(
+                    registry_name, workspace_id, env_override, user
                 )
-                raise typer.Exit(1)
-            resolved = resolve_environment_slug_to_id(
-                registry_name, workspace_id, env_override, user
-            )
-            if not resolved:
-                error_console.print(
-                    f"[bold red]Could not resolve environment: {env_override}[/bold red]"
-                )
-                raise typer.Exit(1)
-            environment_id = resolved
+                if not resolved:
+                    error_console.print(
+                        f"[bold red]Could not resolve environment: "
+                        f"{env_override}[/bold red]"
+                    )
+                    raise typer.Exit(1)
+                environment_id = resolved
 
         return APIRegistry(environment_id=environment_id)
     finally:

--- a/lib/stardag/src/stardag/_cli/limits.py
+++ b/lib/stardag/src/stardag/_cli/limits.py
@@ -1,0 +1,303 @@
+"""Named concurrency-limit management commands for the Stardag CLI.
+
+Named concurrency limits are configured *per environment in the
+registry*. The SDK only tags tasks with limit keys (see the Modal how-to
+guide); the cap itself lives server-side and is enforced atomically when a
+task starts, across all builds in the environment.
+
+These commands wrap the registry's ``/api/v1/concurrency-limits`` endpoints
+for the active stardag profile / environment (override with
+``-p/--stardag-profile`` and ``-e/--stardag-env``). They can also be
+managed in the registry UI: workspace admin -> Concurrency Limits.
+
+    stardag concurrency-limits list [--holders]
+    stardag concurrency-limits set <key> <max_concurrent>
+    stardag concurrency-limits delete <key> [--yes]
+    stardag concurrency-limits holders <key> [--limit N]
+    stardag concurrency-limits evict <key> <task_id> [--yes]
+"""
+
+import os
+from typing import NoReturn, Optional
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from stardag.config.loader import clear_config_cache, get_config
+from stardag.exceptions import StardagError
+from stardag.registry import APIRegistry
+
+app = typer.Typer(
+    help="Manage named concurrency limits for an environment",
+    no_args_is_help=True,
+)
+
+console = Console()
+error_console = Console(stderr=True)
+
+
+_PROFILE_OPTION = typer.Option(
+    None,
+    "-p",
+    "--stardag-profile",
+    help="Stardag profile to use. Defaults to the active profile.",
+)
+_ENV_OPTION = typer.Option(
+    None,
+    "-e",
+    "--stardag-env",
+    help="Stardag environment slug or ID. Defaults to the active profile's env.",
+)
+
+
+def _resolve_registry(profile: str | None, env_override: str | None) -> APIRegistry:
+    """Build an APIRegistry for the (optionally overridden) profile/env.
+
+    Mirrors ``configure_limits.py``'s guard: exits with a clear error when
+    no registry is configured. When ``profile`` is given it is applied via
+    STARDAG_PROFILE (with a config-cache clear) for the duration of
+    construction; the built registry captures its URL/auth/env eagerly, so
+    the environment override is restored before returning.
+    """
+    old_profile = os.environ.get("STARDAG_PROFILE")
+    try:
+        if profile:
+            os.environ["STARDAG_PROFILE"] = profile
+            clear_config_cache()
+
+        config = get_config()
+        reg = config.registry
+        if reg is None or not reg.url:
+            error_console.print(
+                "[bold red]No registry configured.[/bold red]\n"
+                "Run 'stardag auth login', activate a profile with "
+                "STARDAG_PROFILE, or set STARDAG_API_URL / STARDAG_API_KEY."
+            )
+            raise typer.Exit(1)
+
+        environment_id = reg.environment_id or None
+        if env_override:
+            from stardag._cli.credentials import resolve_environment_slug_to_id
+
+            registry_name = config.context.registry_name
+            workspace_id = reg.workspace_id or None
+            user = reg.auth.user_email
+            if not registry_name or not workspace_id:
+                error_console.print(
+                    "[bold red]Cannot resolve --stardag-env without a configured "
+                    "registry and workspace.[/bold red] Pass an environment ID, or "
+                    "activate a profile."
+                )
+                raise typer.Exit(1)
+            resolved = resolve_environment_slug_to_id(
+                registry_name, workspace_id, env_override, user
+            )
+            if not resolved:
+                error_console.print(
+                    f"[bold red]Could not resolve environment: {env_override}[/bold red]"
+                )
+                raise typer.Exit(1)
+            environment_id = resolved
+
+        return APIRegistry(environment_id=environment_id)
+    finally:
+        if old_profile is not None:
+            os.environ["STARDAG_PROFILE"] = old_profile
+        else:
+            os.environ.pop("STARDAG_PROFILE", None)
+        if profile:
+            clear_config_cache()
+
+
+def _fail(exc: Exception) -> NoReturn:
+    """Print a friendly error for a registry/API failure and exit."""
+    error_console.print(f"[bold red]Error:[/bold red] {exc}")
+    raise typer.Exit(1)
+
+
+@app.command("list")
+def limits_list(
+    stardag_profile: Optional[str] = _PROFILE_OPTION,
+    stardag_env: Optional[str] = _ENV_OPTION,
+    holders: bool = typer.Option(
+        False,
+        "--holders/--no-holders",
+        help="Also fetch each key's current holder count (one extra call per key).",
+    ),
+) -> None:
+    """List the environment's named concurrency limits."""
+    registry = _resolve_registry(stardag_profile, stardag_env)
+    try:
+        limits = registry.concurrency_limit_list()
+        holder_counts: dict[str, int] = {}
+        if holders:
+            for limit in limits:
+                data = registry.concurrency_limit_holders(limit["key"], limit=1)
+                holder_counts[limit["key"]] = data.get("total", 0)
+    except StardagError as e:
+        _fail(e)
+    finally:
+        registry.close()
+
+    if not limits:
+        console.print("No concurrency limits configured for this environment.")
+        console.print(
+            "\n[dim]Add one with: "
+            "stardag concurrency-limits set <key> <max_concurrent>[/dim]"
+        )
+        return
+
+    table = Table(title="Concurrency Limits")
+    table.add_column("Key")
+    table.add_column("Max concurrent", justify="right")
+    if holders:
+        table.add_column("Holders", justify="right")
+    for limit in limits:
+        row = [limit["key"], str(limit["max_concurrent"])]
+        if holders:
+            row.append(str(holder_counts.get(limit["key"], 0)))
+        table.add_row(*row)
+    console.print(table)
+
+
+@app.command("set")
+def limits_set(
+    key: str = typer.Argument(..., help="Concurrency-limit key"),
+    max_concurrent: int = typer.Argument(
+        ..., help="Maximum tasks that may run concurrently for this key (>= 1)"
+    ),
+    stardag_profile: Optional[str] = _PROFILE_OPTION,
+    stardag_env: Optional[str] = _ENV_OPTION,
+) -> None:
+    """Create or update a named concurrency limit (upsert)."""
+    if max_concurrent < 1:
+        error_console.print("[bold red]Error:[/bold red] max_concurrent must be >= 1")
+        raise typer.Exit(1)
+
+    registry = _resolve_registry(stardag_profile, stardag_env)
+    try:
+        result = registry.concurrency_limit_set(key, max_concurrent)
+    except StardagError as e:
+        _fail(e)
+    finally:
+        registry.close()
+
+    console.print(
+        f"[green]Set concurrency limit[/green] "
+        f"{result['key']} -> max_concurrent={result['max_concurrent']}"
+    )
+
+
+@app.command("delete")
+def limits_delete(
+    key: str = typer.Argument(..., help="Concurrency-limit key to delete"),
+    stardag_profile: Optional[str] = _PROFILE_OPTION,
+    stardag_env: Optional[str] = _ENV_OPTION,
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip the confirmation prompt."
+    ),
+) -> None:
+    """Delete a named concurrency limit (the key becomes unlimited)."""
+    if not yes:
+        typer.confirm(
+            f"Delete concurrency limit '{key}'? The key will become unlimited.",
+            abort=True,
+        )
+
+    registry = _resolve_registry(stardag_profile, stardag_env)
+    try:
+        registry.concurrency_limit_delete(key)
+    except StardagError as e:
+        _fail(e)
+    finally:
+        registry.close()
+
+    console.print(f"[green]Deleted concurrency limit '{key}'.[/green]")
+
+
+@app.command("holders")
+def limits_holders(
+    key: str = typer.Argument(..., help="Concurrency-limit key"),
+    stardag_profile: Optional[str] = _PROFILE_OPTION,
+    stardag_env: Optional[str] = _ENV_OPTION,
+    limit: int = typer.Option(
+        100, "--limit", "-n", min=1, max=1000, help="Max holders to display."
+    ),
+) -> None:
+    """List the RUNNING tasks currently holding slots of a key.
+
+    Holders are shown oldest-running first (eviction candidates on top).
+    """
+    registry = _resolve_registry(stardag_profile, stardag_env)
+    try:
+        data = registry.concurrency_limit_holders(key, limit=limit)
+    except StardagError as e:
+        _fail(e)
+    finally:
+        registry.close()
+
+    holders = data.get("holders", [])
+    total = data.get("total", len(holders))
+    if not holders:
+        console.print(f"No current holders for concurrency limit '{key}'.")
+        return
+
+    table = Table(title=f"Holders of '{key}' (total: {total})")
+    table.add_column("Task ID")
+    table.add_column("Task")
+    table.add_column("Running since")
+    table.add_column("Executor")
+    for h in holders:
+        name = h.get("task_name") or ""
+        namespace = h.get("task_namespace") or ""
+        qualified = f"{namespace}.{name}" if namespace else name
+        table.add_row(
+            h.get("task_id", ""),
+            qualified,
+            h.get("latest_status_at") or "-",
+            h.get("latest_executor") or "-",
+        )
+    console.print(table)
+    if total > len(holders):
+        console.print(
+            f"[dim]Showing {len(holders)} of {total} holders "
+            f"(raise --limit to see more).[/dim]"
+        )
+
+
+@app.command("evict")
+def limits_evict(
+    key: str = typer.Argument(..., help="Concurrency-limit key"),
+    task_id: str = typer.Argument(..., help="Task ID of the holder to evict"),
+    stardag_profile: Optional[str] = _PROFILE_OPTION,
+    stardag_env: Optional[str] = _ENV_OPTION,
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Skip the confirmation prompt."
+    ),
+) -> None:
+    """Evict a RUNNING slot holder (records TASK_FAILED, freeing its slots).
+
+    Only evict holders whose process you know is dead: the server cannot
+    verify liveness, so evicting a task whose worker is still running leaves
+    the cap oversubscribed until that worker finishes.
+    """
+    if not yes:
+        typer.confirm(
+            f"Evict task '{task_id}' from concurrency limit '{key}'? "
+            "This records TASK_FAILED for it.",
+            abort=True,
+        )
+
+    registry = _resolve_registry(stardag_profile, stardag_env)
+    try:
+        result = registry.concurrency_limit_evict(key, task_id)
+    except StardagError as e:
+        _fail(e)
+    finally:
+        registry.close()
+
+    console.print(
+        f"[green]Evicted[/green] {result.get('task_id', task_id)} "
+        f"(status: {result.get('status', 'unknown')})"
+    )

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -7,6 +7,7 @@ import logging
 import time
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 from uuid import UUID
 
 import httpx
@@ -848,7 +849,7 @@ class APIRegistry(RegistryABC):
         """
         response = self._request(
             "PUT",
-            f"{self.api_url}/api/v1/concurrency-limits/{key}",
+            f"{self.api_url}/api/v1/concurrency-limits/{quote(key, safe='')}",
             json={"max_concurrent": max_concurrent},
             params=self._get_params(),
             operation=f"Set concurrency limit {key!r}",
@@ -859,7 +860,7 @@ class APIRegistry(RegistryABC):
         """Delete a named concurrency limit (the key becomes unlimited)."""
         self._request(
             "DELETE",
-            f"{self.api_url}/api/v1/concurrency-limits/{key}",
+            f"{self.api_url}/api/v1/concurrency-limits/{quote(key, safe='')}",
             params=self._get_params(),
             operation=f"Delete concurrency limit {key!r}",
         )
@@ -874,7 +875,7 @@ class APIRegistry(RegistryABC):
         """
         response = self._request(
             "GET",
-            f"{self.api_url}/api/v1/concurrency-limits/{key}/holders",
+            f"{self.api_url}/api/v1/concurrency-limits/{quote(key, safe='')}/holders",
             params={**self._get_params(), "limit": str(limit)},
             operation=f"List holders of concurrency limit {key!r}",
         )
@@ -888,7 +889,8 @@ class APIRegistry(RegistryABC):
         """
         response = self._request(
             "POST",
-            f"{self.api_url}/api/v1/concurrency-limits/{key}/holders/{task_id}/evict",
+            f"{self.api_url}/api/v1/concurrency-limits/{quote(key, safe='')}"
+            f"/holders/{quote(task_id, safe='')}/evict",
             params=self._get_params(),
             operation=f"Evict {task_id} from concurrency limit {key!r}",
         )

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -823,6 +823,77 @@ class APIRegistry(RegistryABC):
         )
         logger.debug(f"Uploaded {len(artifacts)} artifacts for task {task.id}")
 
+    # -------------------------------------------------------------------------
+    # Named concurrency limits (per-environment)
+    # -------------------------------------------------------------------------
+
+    def concurrency_limit_list(self) -> list[dict[str, Any]]:
+        """List the environment's named concurrency limits.
+
+        Returns a list of ``{"key": str, "max_concurrent": int}`` dicts,
+        ordered by key.
+        """
+        response = self._request(
+            "GET",
+            f"{self.api_url}/api/v1/concurrency-limits",
+            params=self._get_params(),
+            operation="List concurrency limits",
+        )
+        return list(response.json().get("limits", []))
+
+    def concurrency_limit_set(self, key: str, max_concurrent: int) -> dict[str, Any]:
+        """Create or update a named concurrency limit (PUT upsert).
+
+        Returns the resulting ``{"key", "max_concurrent"}`` dict.
+        """
+        response = self._request(
+            "PUT",
+            f"{self.api_url}/api/v1/concurrency-limits/{key}",
+            json={"max_concurrent": max_concurrent},
+            params=self._get_params(),
+            operation=f"Set concurrency limit {key!r}",
+        )
+        return response.json()
+
+    def concurrency_limit_delete(self, key: str) -> None:
+        """Delete a named concurrency limit (the key becomes unlimited)."""
+        self._request(
+            "DELETE",
+            f"{self.api_url}/api/v1/concurrency-limits/{key}",
+            params=self._get_params(),
+            operation=f"Delete concurrency limit {key!r}",
+        )
+
+    def concurrency_limit_holders(self, key: str, limit: int = 100) -> dict[str, Any]:
+        """List the RUNNING tasks currently holding slots of ``key``.
+
+        Returns ``{"key", "holders": [...], "total": int}`` where each
+        holder carries task id/name, ``latest_status_at`` (running since)
+        and executor info. ``total`` is the full holder count (``holders``
+        is capped by ``limit``, oldest-running first).
+        """
+        response = self._request(
+            "GET",
+            f"{self.api_url}/api/v1/concurrency-limits/{key}/holders",
+            params={**self._get_params(), "limit": str(limit)},
+            operation=f"List holders of concurrency limit {key!r}",
+        )
+        return response.json()
+
+    def concurrency_limit_evict(self, key: str, task_id: str) -> dict[str, Any]:
+        """Evict a RUNNING slot holder of ``key`` (records TASK_FAILED).
+
+        Recovery path for slots leaked by a dead build process. Returns the
+        ``{"task_id", "status"}`` event response.
+        """
+        response = self._request(
+            "POST",
+            f"{self.api_url}/api/v1/concurrency-limits/{key}/holders/{task_id}/evict",
+            params=self._get_params(),
+            operation=f"Evict {task_id} from concurrency limit {key!r}",
+        )
+        return response.json()
+
     def task_get_metadata(self, task_id: UUID) -> TaskMetadata:
         """Get metadata for a registered task.
 

--- a/lib/stardag/tests/test__cli/test_limits.py
+++ b/lib/stardag/tests/test__cli/test_limits.py
@@ -6,12 +6,30 @@ registry client, so no network / real registry is required.
 
 from unittest import mock
 
+import pytest
+import typer
 from typer.testing import CliRunner
 
-from stardag._cli.limits import app
+from stardag._cli.limits import app, _resolve_registry
 from stardag.exceptions import APIError
 
 runner = CliRunner()
+
+
+def _fake_config(
+    *,
+    registry_name: str | None = "reg",
+    workspace_id: str | None = "ws-1",
+    env_id: str | None = None,
+):
+    """Build a config mock with a configured registry, as _resolve_registry reads it."""
+    config = mock.MagicMock()
+    config.registry.url = "http://test.invalid"
+    config.registry.environment_id = env_id
+    config.registry.workspace_id = workspace_id
+    config.registry.auth.user_email = "user@example.com"
+    config.context.registry_name = registry_name
+    return config
 
 
 def _mock_registry(**methods):
@@ -178,3 +196,66 @@ class TestErrorHandling:
                 result = runner.invoke(app, ["list"])
         assert result.exit_code == 1
         assert "No registry configured" in result.output
+
+
+_ENV_UUID = "12345678-1234-1234-1234-1234567890ab"
+
+
+class TestResolveEnv:
+    """``-e/--stardag-env`` accepts either a raw environment UUID or a slug."""
+
+    def test_raw_uuid_used_directly(self):
+        """A UUID is used as-is, without registry/workspace context or slug lookup."""
+        config = _fake_config()
+        with (
+            mock.patch("stardag._cli.limits.get_config", return_value=config),
+            mock.patch("stardag._cli.limits.clear_config_cache"),
+            mock.patch("stardag._cli.limits.APIRegistry") as api_registry,
+            mock.patch(
+                "stardag._cli.credentials.resolve_environment_slug_to_id"
+            ) as resolve,
+        ):
+            _resolve_registry(None, _ENV_UUID)
+        # No slug resolution attempted for a UUID value.
+        resolve.assert_not_called()
+        api_registry.assert_called_once_with(environment_id=_ENV_UUID)
+
+    def test_raw_uuid_works_without_registry_workspace_context(self):
+        """A UUID resolves even when registry_name / workspace_id are absent."""
+        config = _fake_config(registry_name=None, workspace_id=None)
+        with (
+            mock.patch("stardag._cli.limits.get_config", return_value=config),
+            mock.patch("stardag._cli.limits.clear_config_cache"),
+            mock.patch("stardag._cli.limits.APIRegistry") as api_registry,
+        ):
+            _resolve_registry(None, _ENV_UUID)
+        api_registry.assert_called_once_with(environment_id=_ENV_UUID)
+
+    def test_slug_resolved_via_lookup(self):
+        """A non-UUID value is resolved slug->id using registry/workspace context."""
+        config = _fake_config()
+        with (
+            mock.patch("stardag._cli.limits.get_config", return_value=config),
+            mock.patch("stardag._cli.limits.clear_config_cache"),
+            mock.patch("stardag._cli.limits.APIRegistry") as api_registry,
+            mock.patch(
+                "stardag._cli.credentials.resolve_environment_slug_to_id",
+                return_value=_ENV_UUID,
+            ) as resolve,
+        ):
+            _resolve_registry(None, "my-env-slug")
+        resolve.assert_called_once_with(
+            "reg", "ws-1", "my-env-slug", "user@example.com"
+        )
+        api_registry.assert_called_once_with(environment_id=_ENV_UUID)
+
+    def test_slug_requires_registry_and_workspace(self):
+        """A slug (non-UUID) still errors without registry/workspace context."""
+        config = _fake_config(registry_name=None, workspace_id=None)
+        with (
+            mock.patch("stardag._cli.limits.get_config", return_value=config),
+            mock.patch("stardag._cli.limits.clear_config_cache"),
+            mock.patch("stardag._cli.limits.APIRegistry"),
+        ):
+            with pytest.raises(typer.Exit):
+                _resolve_registry(None, "my-env-slug")

--- a/lib/stardag/tests/test__cli/test_limits.py
+++ b/lib/stardag/tests/test__cli/test_limits.py
@@ -1,0 +1,180 @@
+"""Tests for the `stardag concurrency-limits` CLI.
+
+Commands are exercised with typer's ``CliRunner`` against a mocked
+registry client, so no network / real registry is required.
+"""
+
+from unittest import mock
+
+from typer.testing import CliRunner
+
+from stardag._cli.limits import app
+from stardag.exceptions import APIError
+
+runner = CliRunner()
+
+
+def _mock_registry(**methods):
+    """Build a MagicMock APIRegistry with the given method return values."""
+    registry = mock.MagicMock()
+    for name, value in methods.items():
+        getattr(registry, name).return_value = value
+    return registry
+
+
+def _patch_resolve(registry):
+    """Patch ``_resolve_registry`` to return the given mock registry."""
+    return mock.patch("stardag._cli.limits._resolve_registry", return_value=registry)
+
+
+class TestList:
+    def test_list_happy_path(self):
+        registry = _mock_registry(
+            concurrency_limit_list=[
+                {"key": "shards", "max_concurrent": 3},
+                {"key": "gpu", "max_concurrent": 1},
+            ]
+        )
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0, result.output
+        assert "shards" in result.output
+        assert "gpu" in result.output
+        registry.concurrency_limit_list.assert_called_once_with()
+        registry.close.assert_called_once()
+
+    def test_list_empty(self):
+        registry = _mock_registry(concurrency_limit_list=[])
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["list"])
+        assert result.exit_code == 0, result.output
+        assert "No concurrency limits" in result.output
+
+    def test_list_with_holders(self):
+        registry = _mock_registry(
+            concurrency_limit_list=[{"key": "shards", "max_concurrent": 3}],
+            concurrency_limit_holders={"key": "shards", "holders": [], "total": 2},
+        )
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["list", "--holders"])
+        assert result.exit_code == 0, result.output
+        assert "Holders" in result.output
+        # holder count fetched per key
+        registry.concurrency_limit_holders.assert_called_once_with("shards", limit=1)
+        assert "2" in result.output
+
+
+class TestSet:
+    def test_set_happy_path(self):
+        registry = _mock_registry(
+            concurrency_limit_set={"key": "shards", "max_concurrent": 5}
+        )
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["set", "shards", "5"])
+        assert result.exit_code == 0, result.output
+        assert "max_concurrent=5" in result.output
+        registry.concurrency_limit_set.assert_called_once_with("shards", 5)
+
+    def test_set_rejects_below_one(self):
+        registry = _mock_registry()
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["set", "shards", "0"])
+        assert result.exit_code == 1
+        assert "must be >= 1" in result.output
+        registry.concurrency_limit_set.assert_not_called()
+
+
+class TestDelete:
+    def test_delete_with_yes(self):
+        registry = _mock_registry(concurrency_limit_delete=None)
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["delete", "shards", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert "Deleted concurrency limit 'shards'" in result.output
+        registry.concurrency_limit_delete.assert_called_once_with("shards")
+
+    def test_delete_aborts_without_confirm(self):
+        registry = _mock_registry(concurrency_limit_delete=None)
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["delete", "shards"], input="n\n")
+        assert result.exit_code != 0
+        registry.concurrency_limit_delete.assert_not_called()
+
+
+class TestHolders:
+    def test_holders_happy_path(self):
+        registry = _mock_registry(
+            concurrency_limit_holders={
+                "key": "shards",
+                "holders": [
+                    {
+                        "task_id": "task-abc",
+                        "task_namespace": "walkthrough",
+                        "task_name": "ProcessShard",
+                        "latest_status_at": "2026-07-14T10:00:00Z",
+                        "latest_executor": "modal",
+                    }
+                ],
+                "total": 1,
+            }
+        )
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["holders", "shards"])
+        assert result.exit_code == 0, result.output
+        assert "task-abc" in result.output
+        assert "walkthrough.ProcessShard" in result.output
+        assert "modal" in result.output
+        registry.concurrency_limit_holders.assert_called_once_with("shards", limit=100)
+
+    def test_holders_empty(self):
+        registry = _mock_registry(
+            concurrency_limit_holders={"key": "shards", "holders": [], "total": 0}
+        )
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["holders", "shards"])
+        assert result.exit_code == 0, result.output
+        assert "No current holders" in result.output
+
+
+class TestEvict:
+    def test_evict_with_yes(self):
+        registry = _mock_registry(
+            concurrency_limit_evict={"task_id": "task-abc", "status": "failed"}
+        )
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["evict", "shards", "task-abc", "--yes"])
+        assert result.exit_code == 0, result.output
+        assert "Evicted" in result.output
+        assert "task-abc" in result.output
+        registry.concurrency_limit_evict.assert_called_once_with("shards", "task-abc")
+
+    def test_evict_aborts_without_confirm(self):
+        registry = _mock_registry()
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["evict", "shards", "task-abc"], input="n\n")
+        assert result.exit_code != 0
+        registry.concurrency_limit_evict.assert_not_called()
+
+
+class TestErrorHandling:
+    def test_api_error_reported(self):
+        registry = mock.MagicMock()
+        registry.concurrency_limit_list.side_effect = APIError(
+            "List concurrency limits failed", status_code=403, detail="denied"
+        )
+        with _patch_resolve(registry):
+            result = runner.invoke(app, ["list"])
+        assert result.exit_code == 1
+        assert "Error:" in result.output
+        # client still closed on failure
+        registry.close.assert_called_once()
+
+    def test_no_registry_configured(self):
+        """Without a configured registry the command exits with a clear error."""
+        fake_config = mock.MagicMock()
+        fake_config.registry = None
+        with mock.patch("stardag._cli.limits.get_config", return_value=fake_config):
+            with mock.patch("stardag._cli.limits.clear_config_cache"):
+                result = runner.invoke(app, ["list"])
+        assert result.exit_code == 1
+        assert "No registry configured" in result.output

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -526,3 +526,71 @@ class TestBuildResume404Swallow:
             await registry.build_resume_aio(
                 UUID("00000000-0000-0000-0000-000000000001")
             )
+
+
+class TestConcurrencyLimitPathEncoding:
+    """Concurrency-limit keys / task ids are URL-encoded per path segment.
+
+    A key created from the UI may contain ``/`` or other reserved
+    characters; interpolating it raw into the URL path would break routing
+    (a ``/`` splits into extra path segments) or hit the wrong endpoint.
+    Each embedded segment must be percent-encoded with ``safe=""`` so even
+    ``/`` is escaped.
+    """
+
+    def _make_registry_and_capture(self):
+        import httpx
+
+        from stardag.registry._api_registry import APIRegistry
+
+        captured: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            return httpx.Response(200, json={"ok": True, "holders": [], "total": 0})
+
+        registry = APIRegistry(api_url="http://test.invalid", api_key="test-key")
+        registry._client = httpx.Client(
+            transport=httpx.MockTransport(handler),
+            auth=registry._auth,
+        )
+        return registry, captured
+
+    @staticmethod
+    def _encoded_path(request) -> str:
+        # ``url.path`` percent-decodes for display; ``raw_path`` preserves the
+        # bytes actually put on the wire (and appends the query string, which
+        # we strip here). This is what proves the segment was encoded.
+        return request.url.raw_path.decode().split("?", 1)[0]
+
+    def test_set_encodes_key_segment(self):
+        registry, captured = self._make_registry_and_capture()
+        registry.concurrency_limit_set("a/b c#d", 3)
+        assert len(captured) == 1
+        # The raw key never appears verbatim; ``/`` and other reserved chars
+        # are percent-encoded so the whole key stays a single path segment.
+        assert (
+            self._encoded_path(captured[0])
+            == "/api/v1/concurrency-limits/a%2Fb%20c%23d"
+        )
+
+    def test_delete_encodes_key_segment(self):
+        registry, captured = self._make_registry_and_capture()
+        registry.concurrency_limit_delete("a/b")
+        assert self._encoded_path(captured[0]) == "/api/v1/concurrency-limits/a%2Fb"
+
+    def test_holders_encodes_key_segment(self):
+        registry, captured = self._make_registry_and_capture()
+        registry.concurrency_limit_holders("a/b")
+        assert (
+            self._encoded_path(captured[0])
+            == "/api/v1/concurrency-limits/a%2Fb/holders"
+        )
+
+    def test_evict_encodes_both_segments(self):
+        registry, captured = self._make_registry_and_capture()
+        registry.concurrency_limit_evict("a/b", "id/1")
+        assert (
+            self._encoded_path(captured[0])
+            == "/api/v1/concurrency-limits/a%2Fb/holders/id%2F1/evict"
+        )


### PR DESCRIPTION
Adds a `stardag concurrency-limits` command group so users can manage named
concurrency limits from the CLI instead of an ad-hoc script.

## Commands

All accept `-p/--stardag-profile` and `-e/--stardag-env` to target a
non-active profile / environment.

- `stardag concurrency-limits list [--holders]` — table of key /
  max_concurrent; `--holders` adds each key's current holder count (one extra
  call per key).
- `stardag concurrency-limits set <key> <max_concurrent>` — upsert
  (`PUT /api/v1/concurrency-limits/{key}`); `max_concurrent` must be >= 1.
- `stardag concurrency-limits delete <key> [--yes]` — DELETE (confirm unless
  `--yes`).
- `stardag concurrency-limits holders <key> [--limit N]` — list RUNNING slot
  holders (task id/name, running-since, executor), oldest-running first.
- `stardag concurrency-limits evict <key> <task_id> [--yes]` — POST evict to
  free a leaked slot (confirm unless `--yes`).

## Implementation

- New `APIRegistry.concurrency_limit_{list,set,delete,holders,evict}` methods
  wrap the endpoints and reuse the client's rate-limit retry + error handling
  (preferred over calling httpx directly for testability).
- New `_cli/limits.py` command group, registered as `concurrency-limits` in
  the CLI; resolves the active/overridden profile + environment and builds an
  `APIRegistry` (with the same "no registry configured" guard the ad-hoc
  script used).
- Tests: typer `CliRunner` against a mocked registry — list/set/delete/holders/
  evict happy paths, confirmation-abort, validation, API-error reporting, and
  the no-registry guard.
- Docs: a Concurrency Limits section in the CLI reference, an entry in the SDK
  skill bundle, and a CHANGELOG `[Unreleased]` note.

This replaces the walkthrough example's ad-hoc `configure_limits.py`, which
can be retired once this ships (its migration to the CLI is left as a separate
follow-up and is not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)