### PR TITLE
UI: hierarchical breadcrumb for the task Execution section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to the Stardag project (SDK, Registry API, and UI).
 
 For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
+## [Unreleased]
+
+### UI
+
+- **Task detail "Execution" section is now a hierarchical breadcrumb.** The
+  previous flat label/value rows (App, Function, Call ref, Workspace / env)
+  are replaced by a single `workspace / environment / app_name /
+function_name / <call-ref>` trail (workspace and environment collapse into
+  one linked segment). Each present level is a best-effort deep link into the
+  corresponding Modal dashboard page (opening in a new tab), falling back to
+  plain text when the ids needed to build that level's URL are absent; absent
+  levels are omitted so the trail starts at the first level actually
+  recorded. The call-ref segment keeps its click-to-copy button. The
+  collapsible "More details" block now renders the captured identifiers as a
+  2-column table (human-readable names, then a divider, then the raw ids),
+  each value click-to-copy.
+
 ## [0.11.0] — 2026-07-15
 
 ### SDK

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,16 +10,15 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 - **Task detail "Execution" section is now a hierarchical breadcrumb.** The
   previous flat label/value rows (App, Function, Call ref, Workspace / env)
-  are replaced by a single `workspace / environment / app_name /
-function_name / <call-ref>` trail (workspace and environment collapse into
-  one linked segment). Each present level is a best-effort deep link into the
-  corresponding Modal dashboard page (opening in a new tab), falling back to
-  plain text when the ids needed to build that level's URL are absent; absent
-  levels are omitted so the trail starts at the first level actually
-  recorded. The call-ref segment keeps its click-to-copy button. The
-  collapsible "More details" block now renders the captured identifiers as a
-  2-column table (human-readable names, then a divider, then the raw ids),
-  each value click-to-copy.
+  are replaced by a breadcrumb trail: `workspace / environment` (one link to
+  the environment) then `app_name`, `function_name`, and the call ref. Each
+  present level is a best-effort deep link into the corresponding Modal
+  dashboard page (opening in a new tab), falling back to plain text when the
+  ids for that level are absent; absent levels are omitted so the trail
+  starts at the first level actually recorded. The call ref keeps its
+  click-to-copy button. The collapsible "More details" block is now a
+  2-column table — human-readable names, a divider, then the raw ids — each
+  value click-to-copy.
 
 ## [0.11.0] — 2026-07-15
 

--- a/app/stardag-ui/src/components/TaskDetail.test.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.test.tsx
@@ -1,19 +1,132 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import { ModalExecutionDetails } from "./TaskDetail";
+import { ModalExecutionBreadcrumb, ModalExecutionDetails } from "./TaskDetail";
+
+const fullMetadata = {
+  kind: "modal",
+  app_name: "my-app",
+  workspace: "my-workspace",
+  environment: "staging",
+  function_name: "worker_default",
+  app_id: "ap-123",
+  function_id: "fu-456",
+};
+
+describe("ModalExecutionBreadcrumb", () => {
+  it("renders four top-level segments in hierarchy order, each a Modal link", () => {
+    render(<ModalExecutionBreadcrumb metadata={fullMetadata} executorRef="fc-789" />);
+
+    // workspace + environment collapse into ONE link (to the environment
+    // page); then app, function, call ref.
+    const links = screen.getAllByRole("link");
+    expect(links.map((a) => a.textContent)).toEqual([
+      "my-workspace / staging",
+      "my-app",
+      "worker_default",
+      "fc-789",
+    ]);
+    expect(links.map((a) => a.getAttribute("href"))).toEqual([
+      "https://modal.com/apps/my-workspace/staging",
+      "https://modal.com/apps/my-workspace/staging/ap-123",
+      "https://modal.com/apps/my-workspace/staging/ap-123?activeTab=functions&functionId=fu-456",
+      "https://modal.com/apps/my-workspace/staging/ap-123?activeTab=functions&functionId=fu-456&functionSection=calls&fcId=fc-789",
+    ]);
+    // Every link opens in a new tab safely.
+    for (const a of links) {
+      expect(a).toHaveAttribute("target", "_blank");
+      expect(a).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+
+  it("renders just the environment (plain text) when workspace is missing", () => {
+    render(
+      <ModalExecutionBreadcrumb
+        metadata={{ kind: "modal", environment: "staging", app_id: "ap-123" }}
+        executorRef={null}
+      />,
+    );
+    // Without a workspace neither the env URL nor the app URL can be built,
+    // so the env segment is plain text (not a link) and shows only the
+    // environment half (no phantom workspace).
+    expect(screen.getByText("staging")).toBeInTheDocument();
+    expect(screen.queryByText("my-workspace")).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders just the workspace (plain text, no link) when environment is missing", () => {
+    render(
+      <ModalExecutionBreadcrumb
+        metadata={{ kind: "modal", workspace: "my-workspace" }}
+        executorRef={null}
+      />,
+    );
+    // A workspace-only URL is misleading, so it is never emitted.
+    expect(screen.getByText("my-workspace")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("omits absent segments (trail starts at the first level present)", () => {
+    render(
+      <ModalExecutionBreadcrumb
+        metadata={{ kind: "modal", workspace: "my-workspace", app_name: "my-app" }}
+        executorRef={null}
+      />,
+    );
+    // workspace present but no environment → workspace is plain text (no
+    // link); only the app segment links.
+    const links = screen.getAllByRole("link");
+    expect(links.map((a) => a.textContent)).toEqual(["my-app"]);
+    expect(screen.getByText("my-workspace")).toBeInTheDocument();
+    // Absent environment / function / call-ref must not appear.
+    expect(screen.queryByText("staging")).not.toBeInTheDocument();
+    expect(screen.queryByText("worker_default")).not.toBeInTheDocument();
+  });
+
+  it("renders a segment as plain text when its URL can't be built", () => {
+    // function_name present but no function_id/app → modalFunctionUrl is null.
+    render(
+      <ModalExecutionBreadcrumb
+        metadata={{ kind: "modal", function_name: "worker_default" }}
+        executorRef={null}
+      />,
+    );
+    expect(screen.getByText("worker_default")).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("gives the last (call-ref) segment a copy button that copies the fc id", async () => {
+    const user = userEvent.setup();
+    render(<ModalExecutionBreadcrumb metadata={fullMetadata} executorRef="fc-789" />);
+
+    // Only the call-ref segment carries a copy control.
+    const copyButtons = screen.getAllByRole("button", {
+      name: /copy to clipboard/i,
+    });
+    expect(copyButtons).toHaveLength(1);
+    await user.click(copyButtons[0]);
+    expect(await window.navigator.clipboard.readText()).toBe("fc-789");
+  });
+
+  it("renders nothing for an explicitly non-modal kind", () => {
+    const { container } = render(
+      <ModalExecutionBreadcrumb
+        metadata={{ kind: "k8s", workspace: "my-workspace", app_name: "my-app" }}
+        executorRef="ref-1"
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when there is nothing to show", () => {
+    const { container } = render(
+      <ModalExecutionBreadcrumb metadata={null} executorRef={null} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});
 
 describe("ModalExecutionDetails", () => {
-  const fullMetadata = {
-    kind: "modal",
-    app_name: "my-app",
-    workspace: "my-workspace",
-    environment: "staging",
-    function_name: "worker_default",
-    app_id: "ap-123",
-    function_id: "fu-456",
-  };
-
   it("lists every captured identifier verbatim once expanded", async () => {
     const user = userEvent.setup();
     render(<ModalExecutionDetails metadata={fullMetadata} executorRef="fc-789" />);
@@ -23,8 +136,8 @@ describe("ModalExecutionDetails", () => {
 
     await user.click(screen.getByRole("button", { name: /more details/i }));
 
+    // Every captured value appears; the redundant `kind` is not shown.
     for (const value of [
-      "modal",
       "my-app",
       "my-workspace",
       "staging",
@@ -35,11 +148,36 @@ describe("ModalExecutionDetails", () => {
     ]) {
       expect(screen.getByText(value)).toBeInTheDocument();
     }
+    expect(screen.queryByText("modal")).not.toBeInTheDocument();
+    expect(screen.queryByText("Kind")).not.toBeInTheDocument();
   });
 
-  it("renders only the fields that are present", async () => {
+  it("groups names then ids with a divider only when both groups are present", async () => {
     const user = userEvent.setup();
-    render(
+    const { container } = render(
+      <ModalExecutionDetails metadata={fullMetadata} executorRef="fc-789" />,
+    );
+    await user.click(screen.getByRole("button", { name: /more details/i }));
+
+    // Row labels reflect the name/id split.
+    for (const label of [
+      "Workspace",
+      "Environment",
+      "App",
+      "Function",
+      "App ID",
+      "Function ID",
+      "Call ref",
+    ]) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    // Divider between the two groups.
+    expect(container.querySelector("hr")).toBeInTheDocument();
+  });
+
+  it("renders only the fields that are present, without a divider for one group", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
       <ModalExecutionDetails
         metadata={{ kind: "modal", app_name: "my-app" }}
         executorRef={null}
@@ -48,10 +186,14 @@ describe("ModalExecutionDetails", () => {
     await user.click(screen.getByRole("button", { name: /more details/i }));
 
     expect(screen.getByText("my-app")).toBeInTheDocument();
+    // The one present field renders with its row label.
+    expect(screen.getByText("App")).toBeInTheDocument();
     // Absent metadata fields and the missing call ref must not render.
-    expect(screen.queryByText("Workspace:")).not.toBeInTheDocument();
-    expect(screen.queryByText("App ID:")).not.toBeInTheDocument();
-    expect(screen.queryByText("Function call ID:")).not.toBeInTheDocument();
+    expect(screen.queryByText("Workspace")).not.toBeInTheDocument();
+    expect(screen.queryByText("App ID")).not.toBeInTheDocument();
+    expect(screen.queryByText("Call ref")).not.toBeInTheDocument();
+    // Only the names group is present → no divider.
+    expect(container.querySelector("hr")).not.toBeInTheDocument();
   });
 
   it("renders nothing when no identifiers are present", () => {

--- a/app/stardag-ui/src/components/TaskDetail.test.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.test.tsx
@@ -108,6 +108,45 @@ describe("ModalExecutionBreadcrumb", () => {
     expect(await window.navigator.clipboard.readText()).toBe("fc-789");
   });
 
+  it("links the call ref only to a genuine call-level URL", () => {
+    // function_id present → the call ref is a real deep link to the call.
+    render(<ModalExecutionBreadcrumb metadata={fullMetadata} executorRef="fc-789" />);
+    expect(screen.getByRole("link", { name: "fc-789" })).toHaveAttribute(
+      "href",
+      "https://modal.com/apps/my-workspace/staging/ap-123" +
+        "?activeTab=functions&functionId=fu-456&functionSection=calls&fcId=fc-789",
+    );
+  });
+
+  it("renders the call ref as plain text (never linking to the app page) when function_id is missing", async () => {
+    const user = userEvent.setup();
+    // app_name/app_id resolvable but NO function_id: modalFunctionCallUrl
+    // would fall back to the app page, which must not become a clickable call
+    // ref. It renders as plain text but keeps its copy button.
+    render(
+      <ModalExecutionBreadcrumb
+        metadata={{
+          kind: "modal",
+          workspace: "my-workspace",
+          environment: "staging",
+          app_name: "my-app",
+          app_id: "ap-123",
+        }}
+        executorRef="fc-789"
+      />,
+    );
+    // The call ref is not a link (only the ws/env and app segments are).
+    expect(screen.queryByRole("link", { name: "fc-789" })).not.toBeInTheDocument();
+    expect(screen.getByText("fc-789")).toBeInTheDocument();
+    // Copy button still present and copies the raw fc id.
+    const copyButtons = screen.getAllByRole("button", {
+      name: /copy to clipboard/i,
+    });
+    expect(copyButtons).toHaveLength(1);
+    await user.click(copyButtons[0]);
+    expect(await window.navigator.clipboard.readText()).toBe("fc-789");
+  });
+
   it("renders nothing for an explicitly non-modal kind", () => {
     const { container } = render(
       <ModalExecutionBreadcrumb

--- a/app/stardag-ui/src/components/TaskDetail.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { Fragment, useCallback, useEffect, useState } from "react";
 import { cancelTask, fetchTaskArtifacts, fetchTaskEvents } from "../api/tasks";
 import type {
   Task,
@@ -10,7 +10,9 @@ import type {
 import {
   isModalMetadata,
   modalAppUrl,
+  modalEnvironmentUrl,
   modalFunctionCallUrl,
+  modalFunctionUrl,
 } from "../utils/modalLinks";
 import { ArtifactList, ExpandButton } from "./ArtifactViewer";
 import { ExecutorBadge } from "./ExecutorBadge";
@@ -65,15 +67,130 @@ function CopyButton({ text, className = "" }: { text: string; className?: string
   );
 }
 
-// Collapsible "more details" block listing every captured Modal identifier
-// verbatim, each click-to-copy. Modal gives no URL-format guarantee (see
-// utils/modalLinks.ts), so surfacing the raw ids lets a user reconstruct or
-// paste a reference by hand even if the dashboard URL format drifts. Only
-// fields that are present are rendered; renders nothing when none are.
+// Hierarchical breadcrumb for a Modal execution. Four top-level segments:
+//   [workspace / environment] / app_name / function_name / <call-ref>
+// The first segment combines workspace + environment (a bare workspace URL
+// is misleading — see modalEnvironmentUrl), rendered as one link to the
+// environment page. Absent levels are omitted (the trail starts at the first
+// level actually recorded). Every segment is a best-effort deep link into the
+// corresponding Modal dashboard level; when the URL for a level can't be
+// built (missing id — see utils/modalLinks.ts) the segment renders as plain
+// text instead, but the label still shows. The last segment (the fc-… call
+// ref) also gets a click-to-copy button.
 //
-// Gated to Modal executions: this block's labels ("App name", "Function ID",
-// …) are Modal-specific, so it renders only for modal metadata, for the
-// legacy kind-less case (treated as modal for back-compat), and for the
+// Wrapping: each top-level segment plus its trailing " /" separator is one
+// `whitespace-nowrap` unit, and the only breakable whitespace sits *between*
+// units — so a line can wrap only right after a top-level slash, never
+// mid-segment and never before the slash (the workspace/environment pair
+// stays glued as one unit). The container uses `pl-4 -indent-4` for a hanging
+// indent (first line flush, wrapped continuation lines indented ~1rem). The
+// anchors/segments stay `display:inline` so the block's text-indent applies
+// to them; only the trailing copy button (on the last line) is inline-block.
+//
+// Gated to Modal executions (reuses isModalMetadata): renders for modal
+// metadata, the legacy kind-less case (treated as modal), and the
+// executorRef-only case (no metadata). Renders nothing for an explicitly
+// non-modal kind, or when there is genuinely nothing to show.
+export function ModalExecutionBreadcrumb({
+  metadata,
+  executorRef,
+}: {
+  metadata?: ExecutorMetadata | null;
+  executorRef?: string | null;
+}) {
+  const isModal = !metadata || isModalMetadata(metadata);
+  if (!isModal) return null;
+
+  // A segment's label is one or more parts joined by a muted " / " (only the
+  // workspace/environment segment has two parts); the whole label links to
+  // `url` when present, else renders as plain text.
+  type Segment = { key: string; parts: string[]; url: string | null; copy?: boolean };
+  const segments: Segment[] = [];
+
+  const nonEmpty = (value: unknown): string | null =>
+    typeof value === "string" && value.length > 0 ? value : null;
+
+  // Combined workspace / environment segment. Links to the environment page
+  // only when both are present; with just one, that half is plain text (a
+  // workspace-only URL would be misleading).
+  const workspace = nonEmpty(metadata?.workspace);
+  const environment = nonEmpty(metadata?.environment);
+  if (workspace && environment) {
+    segments.push({
+      key: "workspace_env",
+      parts: [workspace, environment],
+      url: modalEnvironmentUrl(metadata),
+    });
+  } else if (environment) {
+    segments.push({ key: "workspace_env", parts: [environment], url: null });
+  } else if (workspace) {
+    segments.push({ key: "workspace_env", parts: [workspace], url: null });
+  }
+
+  const push = (key: string, label: unknown, url: string | null, copy = false) => {
+    const value = nonEmpty(label);
+    if (value) segments.push({ key, parts: [value], url, copy });
+  };
+  push("app_name", metadata?.app_name, modalAppUrl(metadata));
+  push("function_name", metadata?.function_name, modalFunctionUrl(metadata));
+  push("call_ref", executorRef, modalFunctionCallUrl(metadata, executorRef), true);
+
+  if (segments.length === 0) return null;
+
+  const sep = <span className="text-gray-400 dark:text-gray-500"> / </span>;
+
+  return (
+    <div className="pl-4 -indent-4 font-mono leading-relaxed">
+      {segments.map((seg, i) => {
+        const isLast = i === segments.length - 1;
+        const label = seg.parts.map((part, j) => (
+          <Fragment key={j}>
+            {j > 0 && sep}
+            {part}
+          </Fragment>
+        ));
+        return (
+          <Fragment key={seg.key}>
+            {/* Segment + its trailing " /" are one non-breaking unit. */}
+            <span className="whitespace-nowrap">
+              {seg.url ? (
+                <a
+                  href={seg.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-blue-600 hover:underline dark:text-blue-400"
+                >
+                  {label}
+                </a>
+              ) : (
+                <span>{label}</span>
+              )}
+              {seg.copy && (
+                <CopyButton text={seg.parts[0]} className="ml-0.5 align-middle" />
+              )}
+              {!isLast && <span className="text-gray-400 dark:text-gray-500"> /</span>}
+            </span>
+            {/* The only breakable whitespace: sits between units. */}
+            {!isLast && " "}
+          </Fragment>
+        );
+      })}
+    </div>
+  );
+}
+
+// Collapsible "more details" block: a 2-column table of the captured Modal
+// identifiers verbatim, each value click-to-copy. Rows are grouped top-down —
+// human-readable names first (Workspace, Environment, App, Function), then a
+// hairline divider, then the raw ids (App ID, Function ID, Call ref). Modal
+// gives no URL-format guarantee (see utils/modalLinks.ts), so surfacing the
+// raw ids lets a user reconstruct or paste a reference by hand even if the
+// dashboard URL format drifts. Only present fields render; the divider shows
+// only when both groups are non-empty; renders nothing when none are.
+//
+// Gated to Modal executions: this block's labels ("App", "Function ID", …)
+// are Modal-specific, so it renders only for modal metadata, for the legacy
+// kind-less case (treated as modal for back-compat), and for the
 // executorRef-only case (no metadata at all). It never renders Modal-labeled
 // fields for an explicitly non-modal kind (e.g. "k8s").
 export function ModalExecutionDetails({
@@ -87,22 +204,46 @@ export function ModalExecutionDetails({
 
   const isModal = !metadata || isModalMetadata(metadata);
 
-  const fields: { label: string; value: string }[] = [];
-  const push = (label: string, value: unknown) => {
-    if (typeof value === "string" && value.length > 0) {
-      fields.push({ label, value });
+  const collect = (entries: [string, unknown][]) => {
+    const rows: { label: string; value: string }[] = [];
+    for (const [label, value] of entries) {
+      if (typeof value === "string" && value.length > 0) {
+        rows.push({ label, value });
+      }
     }
+    return rows;
   };
-  push("Kind", metadata?.kind);
-  push("App name", metadata?.app_name);
-  push("Workspace", metadata?.workspace);
-  push("Environment", metadata?.environment);
-  push("Function name", metadata?.function_name);
-  push("App ID", metadata?.app_id);
-  push("Function ID", metadata?.function_id);
-  push("Function call ID", executorRef);
+  // Human-readable names first, then the raw object ids.
+  const names = collect([
+    ["Workspace", metadata?.workspace],
+    ["Environment", metadata?.environment],
+    ["App", metadata?.app_name],
+    ["Function", metadata?.function_name],
+  ]);
+  const ids = collect([
+    ["App ID", metadata?.app_id],
+    ["Function ID", metadata?.function_id],
+    ["Call ref", executorRef],
+  ]);
 
-  if (!isModal || fields.length === 0) return null;
+  if (!isModal || (names.length === 0 && ids.length === 0)) return null;
+
+  const renderRow = (field: { label: string; value: string }) => (
+    <tr key={field.label}>
+      <th
+        scope="row"
+        className="whitespace-nowrap py-0.5 pr-3 align-top font-normal text-gray-500 dark:text-gray-400"
+      >
+        {field.label}
+      </th>
+      <td className="py-0.5 align-top">
+        <span className="flex items-start gap-1">
+          <span className="break-all font-mono">{field.value}</span>
+          <CopyButton text={field.value} className="flex-shrink-0" />
+        </span>
+      </td>
+    </tr>
+  );
 
   return (
     <div>
@@ -128,17 +269,19 @@ export function ModalExecutionDetails({
         {open ? "Hide details" : "More details"}
       </button>
       {open && (
-        <dl className="mt-1 space-y-1">
-          {fields.map((field) => (
-            <div key={field.label} className="flex items-center gap-1">
-              <dt className="text-gray-500 dark:text-gray-400">{field.label}:</dt>
-              <dd className="truncate font-mono" title={field.value}>
-                {field.value}
-              </dd>
-              <CopyButton text={field.value} className="flex-shrink-0" />
-            </div>
-          ))}
-        </dl>
+        <table className="mt-1 w-full text-left align-top">
+          <tbody>
+            {names.map(renderRow)}
+            {names.length > 0 && ids.length > 0 && (
+              <tr aria-hidden="true">
+                <td colSpan={2} className="py-1">
+                  <hr className="border-gray-200 dark:border-gray-700" />
+                </td>
+              </tr>
+            )}
+            {ids.map(renderRow)}
+          </tbody>
+        </table>
       )}
     </div>
   );
@@ -394,85 +537,16 @@ export function TaskDetail({
             <label className="block text-sm font-medium text-gray-500 dark:text-gray-400">
               Execution
             </label>
-            <div className="mt-1 space-y-1 text-sm text-gray-900 dark:text-gray-100">
+            <div className="mt-1 space-y-2 text-sm text-gray-900 dark:text-gray-100">
               {task.latest_executor && (
                 <div className="flex items-center gap-2">
                   <ExecutorBadge executor={task.latest_executor} />
                 </div>
               )}
-              {task.latest_executor_metadata?.app_name && (
-                <div className="flex items-center gap-1">
-                  <span className="text-gray-500 dark:text-gray-400">App:</span>
-                  {(() => {
-                    const appUrl = modalAppUrl(task.latest_executor_metadata);
-                    const appName = task.latest_executor_metadata?.app_name;
-                    return appUrl ? (
-                      <a
-                        href={appUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-blue-600 hover:underline dark:text-blue-400"
-                        title="Open the Modal app dashboard"
-                      >
-                        {appName}
-                      </a>
-                    ) : (
-                      <span>{appName}</span>
-                    );
-                  })()}
-                </div>
-              )}
-              {task.latest_executor_metadata?.function_name && (
-                <div className="flex items-center gap-1">
-                  <span className="text-gray-500 dark:text-gray-400">Function:</span>
-                  <span className="font-mono">
-                    {task.latest_executor_metadata.function_name}
-                  </span>
-                </div>
-              )}
-              {task.latest_executor_ref && (
-                <div className="flex items-center gap-1">
-                  <span className="text-gray-500 dark:text-gray-400">Call ref:</span>
-                  {(() => {
-                    const callUrl = modalFunctionCallUrl(
-                      task.latest_executor_metadata,
-                      task.latest_executor_ref,
-                    );
-                    return callUrl ? (
-                      <a
-                        href={callUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="truncate font-mono text-blue-600 hover:underline dark:text-blue-400"
-                        title="Open the function call in the Modal dashboard"
-                      >
-                        {task.latest_executor_ref}
-                      </a>
-                    ) : (
-                      <span className="truncate font-mono">
-                        {task.latest_executor_ref}
-                      </span>
-                    );
-                  })()}
-                  <CopyButton
-                    text={task.latest_executor_ref}
-                    className="flex-shrink-0"
-                  />
-                </div>
-              )}
-              {(task.latest_executor_metadata?.workspace ||
-                task.latest_executor_metadata?.environment) && (
-                <div className="flex items-center gap-1">
-                  <span className="text-gray-500 dark:text-gray-400">
-                    Workspace / env:
-                  </span>
-                  <span>
-                    {task.latest_executor_metadata?.workspace ?? "—"}
-                    {" / "}
-                    {task.latest_executor_metadata?.environment ?? "—"}
-                  </span>
-                </div>
-              )}
+              <ModalExecutionBreadcrumb
+                metadata={task.latest_executor_metadata}
+                executorRef={task.latest_executor_ref}
+              />
               <ModalExecutionDetails
                 metadata={task.latest_executor_metadata}
                 executorRef={task.latest_executor_ref}

--- a/app/stardag-ui/src/components/TaskDetail.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.tsx
@@ -133,7 +133,16 @@ export function ModalExecutionBreadcrumb({
   };
   push("app_name", metadata?.app_name, modalAppUrl(metadata));
   push("function_name", metadata?.function_name, modalFunctionUrl(metadata));
-  push("call_ref", executorRef, modalFunctionCallUrl(metadata, executorRef), true);
+  // Link the call ref ONLY to a genuine call-level URL. modalFunctionCallUrl
+  // falls back to the app page when function_id is missing (other callers,
+  // e.g. the "View on Modal" links, rely on that), but here a clickable call
+  // ref must never navigate to a coarser level — so we gate on
+  // modalFunctionUrl (function_id + resolvable app URL) being non-null and
+  // otherwise render the ref as plain text (the copy button stays either way).
+  const callUrl = modalFunctionUrl(metadata)
+    ? modalFunctionCallUrl(metadata, executorRef)
+    : null;
+  push("call_ref", executorRef, callUrl, true);
 
   if (segments.length === 0) return null;
 

--- a/app/stardag-ui/src/utils/modalLinks.test.ts
+++ b/app/stardag-ui/src/utils/modalLinks.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { modalAppUrl, modalFunctionCallUrl } from "./modalLinks";
+import {
+  modalAppUrl,
+  modalEnvironmentUrl,
+  modalFunctionCallUrl,
+  modalFunctionUrl,
+} from "./modalLinks";
 
 const fullMetadata = {
   kind: "modal",
@@ -89,6 +94,82 @@ describe("modalAppUrl", () => {
         environment: "env 2",
       }),
     ).toBe("https://modal.com/apps/ws%231/env%202/deployed/my%20app%2Fx");
+  });
+});
+
+describe("modalEnvironmentUrl", () => {
+  it("builds the workspace+environment apps URL", () => {
+    expect(modalEnvironmentUrl(fullMetadata)).toBe(
+      "https://modal.com/apps/my-workspace/staging",
+    );
+  });
+
+  it("returns null when workspace is missing", () => {
+    expect(modalEnvironmentUrl(withoutKey("workspace"))).toBeNull();
+  });
+
+  it("returns null when environment is missing (no 'main' fallback here)", () => {
+    // Unlike modalAppUrl, the breadcrumb env segment only links when an
+    // environment was actually recorded.
+    expect(modalEnvironmentUrl(withoutKey("environment"))).toBeNull();
+  });
+
+  it("returns null for a non-modal kind", () => {
+    expect(modalEnvironmentUrl({ ...fullMetadata, kind: "k8s" })).toBeNull();
+  });
+
+  it("URL-encodes both segments", () => {
+    expect(
+      modalEnvironmentUrl({
+        kind: "modal",
+        workspace: "ws#1",
+        environment: "env 2/a",
+      }),
+    ).toBe("https://modal.com/apps/ws%231/env%202%2Fa");
+  });
+});
+
+describe("modalFunctionUrl", () => {
+  it("builds the stable app-id URL scoped to the function", () => {
+    expect(modalFunctionUrl(fullMetadata)).toBe(
+      "https://modal.com/apps/my-workspace/staging/ap-123" +
+        "?activeTab=functions&functionId=fu-456",
+    );
+  });
+
+  it("falls back to the deployed-name app URL when app_id is missing", () => {
+    expect(modalFunctionUrl(withoutKey("app_id"))).toBe(
+      "https://modal.com/apps/my-workspace/staging/deployed/my-app" +
+        "?activeTab=functions&functionId=fu-456",
+    );
+  });
+
+  it("returns null when function_id is missing", () => {
+    expect(modalFunctionUrl(withoutKey("function_id"))).toBeNull();
+  });
+
+  it("returns null when no app URL can be built (no workspace)", () => {
+    expect(modalFunctionUrl(withoutKey("workspace"))).toBeNull();
+  });
+
+  it("returns null for a non-modal kind", () => {
+    // modalAppUrl bails on non-modal kinds, so no app URL → null.
+    expect(modalFunctionUrl({ ...fullMetadata, kind: "k8s" })).toBeNull();
+  });
+
+  it("URL-encodes the function id query param", () => {
+    expect(
+      modalFunctionUrl({
+        kind: "modal",
+        workspace: "ws#1",
+        environment: "env 2",
+        app_id: "ap-1",
+        function_id: "fu 3&4",
+      }),
+    ).toBe(
+      "https://modal.com/apps/ws%231/env%202/ap-1" +
+        "?activeTab=functions&functionId=fu%203%264",
+    );
   });
 });
 

--- a/app/stardag-ui/src/utils/modalLinks.ts
+++ b/app/stardag-ui/src/utils/modalLinks.ts
@@ -66,6 +66,42 @@ export function modalAppUrl(
   return null;
 }
 
+// URL of the Modal workspace+environment apps page, or null when either the
+// workspace or the environment is missing (or the executor is non-modal).
+// Unlike modalAppUrl this does NOT fall back to the "main" environment: the
+// breadcrumb segment only links when an environment was actually recorded.
+//
+// There is deliberately no workspace-only builder: a bare
+// `modal.com/apps/{workspace}` resolves to whichever environment was "latest
+// active", which is misleading — the coarsest addressable level is the
+// workspace+environment pair.
+export function modalEnvironmentUrl(
+  metadata: ExecutorMetadata | null | undefined,
+): string | null {
+  if (!metadata || !isModalMetadata(metadata)) return null;
+  const workspace = nonEmptyString(metadata.workspace);
+  const environment = nonEmptyString(metadata.environment);
+  if (!workspace || !environment) return null;
+  return `https://modal.com/apps/${encodeURIComponent(workspace)}/${encodeURIComponent(
+    environment,
+  )}`;
+}
+
+// URL scoped to a specific Modal function within its app dashboard, or null
+// when there's no function_id or no resolvable app URL. Reuses modalAppUrl
+// for the app-addressing part (stable app-id form when available, else the
+// deployed-name form), then narrows to the function via query params.
+export function modalFunctionUrl(
+  metadata: ExecutorMetadata | null | undefined,
+): string | null {
+  if (!metadata) return null;
+  const functionId = nonEmptyString(metadata.function_id);
+  if (!functionId) return null;
+  const appUrl = modalAppUrl(metadata);
+  if (!appUrl) return null;
+  return `${appUrl}?activeTab=functions&functionId=${encodeURIComponent(functionId)}`;
+}
+
 // Shared query string for the function-call deep links (both the app-id and
 // the deployed-name forms use the same params).
 function functionCallQuery(functionId: string, fcId: string): string {


### PR DESCRIPTION
## What

Redesigns the **Execution** section of the task detail panel (`app/stardag-ui`). The previous flat label/value rows are replaced with a hierarchical breadcrumb, and the collapsible "More details" block becomes a grouped 2-column table.

### Before / after (Execution section)

**Before** — a stack of label/value rows:

```
⚡ Modal
App:              my-app
Function:         worker_default
Call ref:         fc-…            [copy]
Workspace / env:  my-workspace / staging
▸ More details
```

**After** — one hierarchical breadcrumb:

```
⚡ Modal
my-workspace / staging / my-app / worker_default / fc-…   [copy]
▸ More details
```

## Breadcrumb behavior

- Four top-level segments: `[workspace / environment] / app_name / function_name / <call-ref>`.
  - Workspace and environment **collapse into one linked segment** — a bare `modal.com/apps/{workspace}` URL is misleading (it resolves to whichever environment was "latest active"), so the coarsest addressable level is the workspace+environment pair.
- Each segment is a **best-effort Modal dashboard deep link** (`target="_blank" rel="noopener noreferrer"`); when the ids needed to build that level's URL are missing, the segment renders as **plain text** but still shows the label.
- **Absent segments are omitted** — the trail starts at the first level actually recorded. Renders nothing for an explicitly non-modal `kind`, or when there's nothing to show.
- The call-ref segment keeps its **click-to-copy** button.

### Wrapping / hanging indent

Each top-level segment plus its trailing ` /` is one `whitespace-nowrap` unit; the only breakable whitespace sits *between* units. So a line can wrap **only right after a slash** — never mid-segment, never before the slash (the workspace/environment pair stays glued). The block uses `pl-4 -indent-4` for a hanging indent: the first line is flush, wrapped continuation lines are indented ~1rem. Separators are muted.

## URL builders (`utils/modalLinks.ts`)

New, matching the existing style (all `encodeURIComponent`-safe, `string | null`, graceful fallback):

- `modalEnvironmentUrl(m)` → `…/apps/{workspace}/{environment}` (null if either missing; no "main" fallback here).
- `modalFunctionUrl(m)` → the app URL + `?activeTab=functions&functionId={function_id}` (null without `function_id` or a resolvable app URL).

Reused alongside the existing `modalAppUrl` / `modalFunctionCallUrl`.

## "More details" table

Grouped top-down: human-readable names (Workspace, Environment, App, Function), a hairline divider, then raw ids (App ID, Function ID, Call ref). The redundant `kind` row is dropped; the divider shows only when both groups have fields; only present fields render; each value keeps click-to-copy.

## Tests

Full UI suite green: **84 tests** across 8 files. New/updated coverage for the URL builders (happy path, null-on-missing-field, reserved-char encoding) and the breadcrumb (order, omitted/plain-text segments, combined ws/env edge cases, call-ref copy, non-modal gating) plus the grouped table.