### PR TITLE
Reject bare abstract polymorphic fields at definition; enforce exact-type on bare concrete ones (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Stardag project (SDK, Registry API, and UI).
 
 For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
-## [Unreleased]
+## [0.12.0] — 2026-07-15
 
 ### SDK
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+- **Bare abstract task-typed fields are now rejected at class-definition time.**
+  A field annotated directly with an abstract polymorphic base (e.g.
+  `child: BaseTask`, `deps: list[Task[int]]`) rather than wrapping it in
+  `SubClass[...]` / `TaskLoads[...]` used to serialize by silently dropping
+  every subclass-specific parameter and then crash on load (the payload tried
+  to instantiate the abstract base directly). Such annotations now raise
+  `NakedPolymorphicFieldError` as soon as the class is defined, with a message
+  pointing at the correct polymorphic form. Concrete (non-abstract)
+  `PolymorphicRoot`/`Task` subclasses used as strict fields are unaffected.
+
 ### UI
 
 - **Task detail "Execution" section is now a hierarchical breadcrumb.** The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,17 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   every subclass-specific parameter and then crash on load (the payload tried
   to instantiate the abstract base directly). Such annotations now raise
   `NakedPolymorphicFieldError` as soon as the class is defined, with a message
-  pointing at the correct polymorphic form. Concrete (non-abstract)
-  `PolymorphicRoot`/`Task` subclasses used as strict fields are unaffected.
+  pointing at the correct polymorphic form.
+
+- **Bare _concrete_ task-typed fields are now strict (exact-type) at
+  validation time.** A field like `child: MyTask` (a concrete base, without
+  `SubClass[...]`) means exactly `MyTask`. Passing a _subclass_ instance
+  (`child=ChildOfMyTask(...)`) previously succeeded but silently dropped the
+  subclass's extra parameters on serialization — and, because task identity is
+  derived from the serialized form, distinct subclass values collapsed to the
+  same task id. This now raises `StrictPolymorphicTypeError` at construction,
+  directing you to `SubClass[MyTask]` if you intend to accept subclasses.
+  Passing an exact-type instance is unaffected.
 
 ### UI
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,61 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.12.0 — Stricter polymorphic field validation
+
+Task fields that hold other tasks (or any `PolymorphicRoot`) must use a
+polymorphic wrapper — `sd.SubClass[...]` or `sd.TaskLoads[...]` — so that the
+concrete subclass and all of its parameters round-trip through serialization.
+This release turns two long-standing silent-data-loss traps around bare
+task-typed annotations into explicit, up-front errors. Pure bug fix — but
+because it replaces silent corruption with a raised error, code that was
+already (silently) corrupting will now fail loudly. Run `pip install -U stardag`.
+
+> **⚠️ May surface latent bugs as errors.** If your task defines a field with
+> a _bare_ task/polymorphic annotation, you will now get an error instead of
+> silently losing data. The fix is to wrap the annotation. Both cases below
+> were already broken before this release (dropped parameters, colliding task
+> ids, load failures) — the error just makes that visible.
+
+**1. Bare _abstract_ base annotations are rejected at class-definition time.**
+A field annotated with an abstract base — `dep: BaseTask`, `deps: list[Task[int]]`,
+`dep: TargetTask`, etc. — now raises `NakedPolymorphicFieldError` when the class
+is defined:
+
+```python
+# Before (silently dropped subclass params, crashed on load):
+class MyTask(sd.Task[int]):
+    dep: sd.Task[int]
+
+# After — wrap it:
+class MyTask(sd.Task[int]):
+    dep: sd.SubClass[sd.Task[int]]     # keeps the concrete subclass
+    # or, if you consume the dependency's loaded output:
+    dep_value: sd.TaskLoads[int]
+```
+
+**2. Bare _concrete_ base annotations are now strict (exact-type).**
+A bare concrete annotation (`dep: MyTask`, without `SubClass[...]`) is a
+_strict_ field meaning exactly `MyTask`. Passing a **subclass instance** now
+raises `StrictPolymorphicTypeError` at construction, instead of silently
+dropping the subclass's extra parameters (which also collapsed distinct values
+to the same task id):
+
+```python
+class Parent(sd.Task[int]):
+    dep: MyTask                        # strict: exactly MyTask
+
+Parent(dep=MyTask(...))                # OK
+Parent(dep=ChildOfMyTask(...))         # StrictPolymorphicTypeError
+
+# To accept subclasses, wrap it:
+class Parent(sd.Task[int]):
+    dep: sd.SubClass[MyTask]
+```
+
+Passing an exact-type instance, and any field already using `sd.SubClass[...]`
+or `sd.TaskLoads[...]`, are unaffected.
+
 ## v0.11.0 — Reactive build metadata in the registry
 
 Reactive scheduling now keeps its marker/owner/tick-config in the registry

--- a/docs/docs/how-to/define-tasks.md
+++ b/docs/docs/how-to/define-tasks.md
@@ -190,4 +190,24 @@ The same task in all three APIs:
 4. **Make tasks pure** - Avoid side effects; same inputs = same outputs
 5. **Use versioning** - Bump version when logic changes significantly
 
+!!! warning "Wrap task-typed fields in `SubClass[...]` / `TaskLoads[...]`"
+
+    A field that holds another task must be annotated with a polymorphic
+    wrapper so the concrete subclass (and all its parameters) round-trips
+    through serialization:
+
+    ```python
+    class MyTask(sd.Task[int]):
+        dep: sd.SubClass[sd.Task[int]]        # ✅ keeps the concrete subclass
+        loaded: sd.TaskLoads[list[int]]       # ✅ loads the dependency's output
+    ```
+
+    Annotating a field with a *bare abstract* task base instead —
+    `dep: sd.Task[int]`, `deps: list[BaseTask]` — is rejected at
+    class-definition time with `NakedPolymorphicFieldError`. Without the
+    wrapper, serialization would silently drop every subclass-specific
+    parameter and loading the task back would fail. A bare *concrete* task
+    subclass is still allowed as a "strict" field (it always holds exactly
+    that type).
+
 <!-- TODO: Add more examples and patterns -->

--- a/docs/docs/how-to/define-tasks.md
+++ b/docs/docs/how-to/define-tasks.md
@@ -206,8 +206,12 @@ The same task in all three APIs:
     `dep: sd.Task[int]`, `deps: list[BaseTask]` — is rejected at
     class-definition time with `NakedPolymorphicFieldError`. Without the
     wrapper, serialization would silently drop every subclass-specific
-    parameter and loading the task back would fail. A bare *concrete* task
-    subclass is still allowed as a "strict" field (it always holds exactly
-    that type).
+    parameter and loading the task back would fail.
+
+    A bare *concrete* task class (`dep: MyTask`) is allowed, but it is a
+    **strict** field — it accepts *exactly* `MyTask`. Passing a subclass
+    instance raises `StrictPolymorphicTypeError` (it would otherwise drop the
+    subclass's extra parameters and collide task identities). Use
+    `SubClass[MyTask]` if you want the field to accept subclasses.
 
 <!-- TODO: Add more examples and patterns -->

--- a/lib/stardag/src/stardag/__init__.py
+++ b/lib/stardag/src/stardag/__init__.py
@@ -62,7 +62,12 @@ from stardag.exceptions import (
     StardagError,
     TokenExpiredError,
 )
-from stardag.polymorphic import NakedPolymorphicFieldError, Polymorphic, SubClass
+from stardag.polymorphic import (
+    NakedPolymorphicFieldError,
+    Polymorphic,
+    StrictPolymorphicTypeError,
+    SubClass,
+)
 from stardag.registry import registry_provider
 from stardag.target import (
     DirectoryTarget,
@@ -115,6 +120,7 @@ __all__ = [
     "StardagError",
     "StardagBaseModel",
     "StardagField",
+    "StrictPolymorphicTypeError",
     "SubClass",
     "Task",
     "TaskRehydrationError",

--- a/lib/stardag/src/stardag/__init__.py
+++ b/lib/stardag/src/stardag/__init__.py
@@ -62,7 +62,7 @@ from stardag.exceptions import (
     StardagError,
     TokenExpiredError,
 )
-from stardag.polymorphic import Polymorphic, SubClass
+from stardag.polymorphic import NakedPolymorphicFieldError, Polymorphic, SubClass
 from stardag.registry import registry_provider
 from stardag.target import (
     DirectoryTarget,
@@ -108,6 +108,7 @@ __all__ = [
     "LoadableTask",
     "LoadValidator",
     "LocalFileTarget",
+    "NakedPolymorphicFieldError",
     "namespace",
     "Polymorphic",
     "registry_provider",

--- a/lib/stardag/src/stardag/polymorphic.py
+++ b/lib/stardag/src/stardag/polymorphic.py
@@ -1,3 +1,5 @@
+import abc
+import inspect
 import logging
 import os
 import types
@@ -22,6 +24,7 @@ from pydantic import BaseModel, GetCoreSchemaHandler, SerializationInfo, Validat
 from pydantic_core import core_schema
 
 from stardag.base_model import StardagBaseModel
+from stardag.exceptions import StardagError
 
 logger = logging.getLogger(__name__)
 
@@ -329,6 +332,40 @@ def _is_stardag_abstract(cls: type) -> bool:
     return cls.__dict__.get("__stardag_abstract__", False) is True
 
 
+class NakedPolymorphicFieldError(StardagError):
+    """Raised at class-construction time for an unsafe polymorphic field annotation.
+
+    A field annotated directly with an *abstract* ``PolymorphicRoot`` subclass
+    (e.g. ``child: BaseTask``) rather than wrapping it in ``SubClass[...]`` /
+    ``Annotated[..., Polymorphic()]`` is a silent data-loss trap: serialization
+    keeps only the abstract base's fields (dropping every subclass-specific
+    parameter) and deserialization then fails trying to instantiate the abstract
+    base directly. This error rejects such annotations up front rather than
+    letting them corrupt persisted data.
+    """
+
+
+def _is_abstract_polymorphic(cls: type) -> bool:
+    """True if ``cls`` is a ``PolymorphicRoot`` subclass that cannot be safely
+    used as a *bare* field annotation because it is an abstract base.
+
+    Any value assigned to such a field is necessarily a concrete subclass whose
+    extra parameters would be silently dropped on serialization; on load the
+    framework would try to instantiate the abstract base and crash. Concrete
+    ``PolymorphicRoot`` subclasses are intentionally *allowed* as bare ("strict")
+    annotations and are therefore not considered abstract here.
+    """
+    # Resolve a parameterized generic alias (e.g. ``Task[int]``) to its origin
+    # (``Task``); the abstractness markers live on the origin class.
+    meta = getattr(cls, "__pydantic_generic_metadata__", None)
+    origin = (meta.get("origin") if meta else None) or cls
+    return (
+        inspect.isabstract(origin)
+        or _is_stardag_abstract(origin)
+        or abc.ABC in getattr(origin, "__bases__", ())
+    )
+
+
 _TPolymorphicRoot = TypeVar("_TPolymorphicRoot", bound="PolymorphicRoot")
 _TBaseModel = TypeVar("_TBaseModel", bound=StardagBaseModel)
 
@@ -422,6 +459,13 @@ class PolymorphicRoot(StardagBaseModel):
                     name_override=name_override,
                     namespace_override=namespace_override,
                 )
+
+        # Reject unsafe bare abstract-polymorphic field annotations at class
+        # construction time (see NakedPolymorphicFieldError). Skip parameterized
+        # generic aliases (e.g. ``Task[int]``) — they mirror the origin class's
+        # fields, which are validated when the origin itself is defined.
+        if not _is_parameterized_generic_alias(cls):
+            _validate_no_naked_polymorphic_fields(cls)
 
     def __class_getitem__(
         cls: Type[BaseModel],
@@ -630,6 +674,73 @@ class Polymorphic:
                 return_schema=core_schema.any_schema(),
             ),
         )
+
+
+def _find_naked_polymorphic(annotation: Any, guarded: bool) -> type | None:
+    """Return the first abstract ``PolymorphicRoot`` subclass reachable from
+    ``annotation`` that is *not* wrapped in ``Polymorphic()`` / ``SubClass[...]``,
+    or ``None`` if the annotation is safe.
+
+    ``guarded`` is True when the current position is directly wrapped by a
+    ``Polymorphic()`` annotation. The guard does not propagate through containers
+    (``list``, ``dict``, unions, ...): a ``Polymorphic()`` only applies to the
+    type it directly annotates, so recursing into container args resets it.
+    """
+    if get_origin(annotation) is Annotated:
+        args = get_args(annotation)
+        inner, extras = args[0], args[1:]
+        guarded_here = guarded or any(isinstance(e, Polymorphic) for e in extras)
+        return _find_naked_polymorphic(inner, guarded_here)
+
+    if isinstance(annotation, type) and issubclass(annotation, PolymorphicRoot):
+        if not guarded and _is_abstract_polymorphic(annotation):
+            return annotation
+        # Guarded, or a concrete "strict" annotation — both fine. Don't recurse
+        # into the model's own fields; those are validated on their own class.
+        return None
+
+    # Container / union / other generic: recurse into type args with the guard
+    # reset (a Polymorphic() cannot legally wrap a container).
+    for arg in get_args(annotation):
+        found = _find_naked_polymorphic(arg, False)
+        if found is not None:
+            return found
+    return None
+
+
+def _naked_polymorphic_field_message(
+    cls: type, field_name: str, offending: type
+) -> str:
+    offending_name = getattr(offending, "__name__", str(offending))
+    return (
+        f"Field '{field_name}' on '{cls.__name__}' is annotated with the abstract "
+        f"polymorphic type '{offending_name}' without polymorphic handling.\n\n"
+        f"A bare abstract-base annotation silently drops subclass-specific "
+        f"parameters when the model is serialized, and then fails to deserialize "
+        f"(it would try to instantiate the abstract base directly). Wrap the type "
+        f"with SubClass[...] (or Annotated[..., Polymorphic()]):\n\n"
+        f"    from stardag import SubClass\n\n"
+        f"    {field_name}: SubClass[{offending_name}]\n\n"
+        f"For a container field, wrap the inner type, e.g. "
+        f"'list[SubClass[{offending_name}]]' or "
+        f"'dict[str, SubClass[{offending_name}]]'."
+    )
+
+
+def _validate_no_naked_polymorphic_fields(cls: type["PolymorphicRoot"]) -> None:
+    """Raise ``NakedPolymorphicFieldError`` if any field of ``cls`` uses an
+    abstract ``PolymorphicRoot`` subclass as a bare (non-polymorphic) annotation.
+    """
+    for name, field in cls.model_fields.items():
+        # A top-level ``SubClass[X]`` lands here as annotation ``X`` plus a
+        # ``Polymorphic()`` in ``field.metadata``; treat that as guarding the
+        # field's annotation.
+        guarded = any(isinstance(m, Polymorphic) for m in field.metadata)
+        offending = _find_naked_polymorphic(field.annotation, guarded)
+        if offending is not None:
+            raise NakedPolymorphicFieldError(
+                _naked_polymorphic_field_message(cls, name, offending)
+            )
 
 
 class _SubClass:

--- a/lib/stardag/src/stardag/polymorphic.py
+++ b/lib/stardag/src/stardag/polymorphic.py
@@ -5,6 +5,7 @@ import os
 import types
 import typing
 import warnings
+from collections import abc as collections_abc
 from dataclasses import dataclass
 from typing import (
     TYPE_CHECKING,
@@ -20,7 +21,13 @@ from typing import (
     get_origin,
 )
 
-from pydantic import BaseModel, GetCoreSchemaHandler, SerializationInfo, ValidationInfo
+from pydantic import (
+    BaseModel,
+    GetCoreSchemaHandler,
+    SerializationInfo,
+    ValidationInfo,
+    model_validator,
+)
 from pydantic_core import core_schema
 
 from stardag.base_model import StardagBaseModel
@@ -345,6 +352,20 @@ class NakedPolymorphicFieldError(StardagError):
     """
 
 
+class StrictPolymorphicTypeError(StardagError):
+    """Raised when a *subclass* instance is assigned to a bare, concrete
+    ``PolymorphicRoot`` field.
+
+    A bare concrete annotation (e.g. ``child: MyTask``, without
+    ``SubClass[...]``) is a *strict* field: it means exactly ``MyTask``. If a
+    subclass instance is passed, serialization would silently drop the
+    subclass's extra parameters — and because task identity is derived from the
+    serialized form, two distinct subclass values would collapse to the same id.
+    Enforcing exact type at validation time turns that silent corruption into an
+    explicit error; use ``SubClass[MyTask]`` to accept subclasses instead.
+    """
+
+
 def _is_abstract_polymorphic(cls: type) -> bool:
     """True if ``cls`` is a ``PolymorphicRoot`` subclass that cannot be safely
     used as a *bare* field annotation because it is an abstract base.
@@ -395,6 +416,12 @@ class PolymorphicRoot(StardagBaseModel):
     # IMPORTANT: per-family registry lives on the base class
     __registry__: ClassVar[_TypeRegistry] = _TypeRegistry()
 
+    # Names of fields whose annotation contains a bare, *concrete* PolymorphicRoot
+    # (a "strict" field: exactly that type, no subclasses). Populated per class at
+    # construction time; enforced at validation time by
+    # ``_enforce_strict_polymorphic_exact_type``.
+    __stardag_strict_polymorphic_fields__: ClassVar[tuple[str, ...]] = ()
+
     if TYPE_CHECKING:
         # Optionally set on subclasses to override default namespace resolution
         __namespace__: ClassVar[str]
@@ -405,6 +432,29 @@ class PolymorphicRoot(StardagBaseModel):
         # If you ever want a deep hierarchy, you can ensure the registry is owned by the root
         # but in many cases, "cls" itself is the desired owner.
         return cls.__registry__
+
+    @model_validator(mode="after")
+    def _enforce_strict_polymorphic_exact_type(self) -> "PolymorphicRoot":
+        """Reject subclass instances assigned to bare, concrete polymorphic fields.
+
+        A bare concrete annotation is *strict* (exactly that type). Passing a
+        subclass instance would silently drop its extra parameters on
+        serialization and collide task identities, so it is rejected here — see
+        ``StrictPolymorphicTypeError``. Fields with no strict-polymorphic
+        annotation (the common case) short-circuit immediately.
+        """
+        for name in type(self).__stardag_strict_polymorphic_fields__:
+            field = type(self).model_fields[name]
+            guarded = any(isinstance(m, Polymorphic) for m in field.metadata)
+            violation = _find_strict_polymorphic_violation(
+                field.annotation, getattr(self, name), guarded
+            )
+            if violation is not None:
+                expected, actual = violation
+                raise StrictPolymorphicTypeError(
+                    _strict_polymorphic_message(type(self), name, expected, actual)
+                )
+        return self
 
     @classmethod
     def resolve(
@@ -460,12 +510,13 @@ class PolymorphicRoot(StardagBaseModel):
                     namespace_override=namespace_override,
                 )
 
-        # Reject unsafe bare abstract-polymorphic field annotations at class
-        # construction time (see NakedPolymorphicFieldError). Skip parameterized
-        # generic aliases (e.g. ``Task[int]``) — they mirror the origin class's
-        # fields, which are validated when the origin itself is defined.
+        # Validate polymorphic field annotations at class construction: reject
+        # bare *abstract* bases (NakedPolymorphicFieldError) and index bare
+        # *concrete* ("strict") fields for exact-type enforcement at validation
+        # time. Skip parameterized generic aliases (e.g. ``Task[int]``) — they
+        # mirror the origin class's fields, validated when the origin is defined.
         if not _is_parameterized_generic_alias(cls):
-            _validate_no_naked_polymorphic_fields(cls)
+            _validate_and_index_polymorphic_fields(cls)
 
     def __class_getitem__(
         cls: Type[BaseModel],
@@ -676,10 +727,9 @@ class Polymorphic:
         )
 
 
-def _find_naked_polymorphic(annotation: Any, guarded: bool) -> type | None:
-    """Return the first abstract ``PolymorphicRoot`` subclass reachable from
-    ``annotation`` that is *not* wrapped in ``Polymorphic()`` / ``SubClass[...]``,
-    or ``None`` if the annotation is safe.
+def _iter_bare_polymorphic(annotation: Any, guarded: bool) -> "typing.Iterator[type]":
+    """Yield every ``PolymorphicRoot`` subclass that appears *bare* (not wrapped
+    in ``Polymorphic()`` / ``SubClass[...]``) anywhere in ``annotation``.
 
     ``guarded`` is True when the current position is directly wrapped by a
     ``Polymorphic()`` annotation. The guard does not propagate through containers
@@ -690,22 +740,20 @@ def _find_naked_polymorphic(annotation: Any, guarded: bool) -> type | None:
         args = get_args(annotation)
         inner, extras = args[0], args[1:]
         guarded_here = guarded or any(isinstance(e, Polymorphic) for e in extras)
-        return _find_naked_polymorphic(inner, guarded_here)
+        yield from _iter_bare_polymorphic(inner, guarded_here)
+        return
 
     if isinstance(annotation, type) and issubclass(annotation, PolymorphicRoot):
-        if not guarded and _is_abstract_polymorphic(annotation):
-            return annotation
-        # Guarded, or a concrete "strict" annotation — both fine. Don't recurse
-        # into the model's own fields; those are validated on their own class.
-        return None
+        if not guarded:
+            yield annotation
+        # Don't recurse into the model's own fields; those are validated on
+        # their own class.
+        return
 
     # Container / union / other generic: recurse into type args with the guard
     # reset (a Polymorphic() cannot legally wrap a container).
     for arg in get_args(annotation):
-        found = _find_naked_polymorphic(arg, False)
-        if found is not None:
-            return found
-    return None
+        yield from _iter_bare_polymorphic(arg, False)
 
 
 def _naked_polymorphic_field_message(
@@ -727,20 +775,125 @@ def _naked_polymorphic_field_message(
     )
 
 
-def _validate_no_naked_polymorphic_fields(cls: type["PolymorphicRoot"]) -> None:
-    """Raise ``NakedPolymorphicFieldError`` if any field of ``cls`` uses an
-    abstract ``PolymorphicRoot`` subclass as a bare (non-polymorphic) annotation.
+def _validate_and_index_polymorphic_fields(cls: type["PolymorphicRoot"]) -> None:
+    """Inspect ``cls``'s fields for bare polymorphic annotations.
+
+    - Any bare *abstract* ``PolymorphicRoot`` base raises
+      ``NakedPolymorphicFieldError`` (unsafe — see the class docstring).
+    - Any bare *concrete* base marks the field as *strict*; it is recorded in
+      ``cls.__stardag_strict_polymorphic_fields__`` so that
+      ``_enforce_strict_polymorphic_exact_type`` can reject subclass instances
+      for it at validation time.
     """
+    strict_fields: list[str] = []
     for name, field in cls.model_fields.items():
         # A top-level ``SubClass[X]`` lands here as annotation ``X`` plus a
         # ``Polymorphic()`` in ``field.metadata``; treat that as guarding the
         # field's annotation.
         guarded = any(isinstance(m, Polymorphic) for m in field.metadata)
-        offending = _find_naked_polymorphic(field.annotation, guarded)
-        if offending is not None:
-            raise NakedPolymorphicFieldError(
-                _naked_polymorphic_field_message(cls, name, offending)
-            )
+        bare = list(_iter_bare_polymorphic(field.annotation, guarded))
+        if not bare:
+            continue
+        for offending in bare:
+            if _is_abstract_polymorphic(offending):
+                raise NakedPolymorphicFieldError(
+                    _naked_polymorphic_field_message(cls, name, offending)
+                )
+        # All bare occurrences are concrete -> strict field.
+        strict_fields.append(name)
+    cls.__stardag_strict_polymorphic_fields__ = tuple(strict_fields)
+
+
+def _strict_polymorphic_message(
+    cls: type, field_name: str, expected: type, actual: Any
+) -> str:
+    expected_name = getattr(expected, "__name__", str(expected))
+    actual_name = type(actual).__name__
+    return (
+        f"Field '{field_name}' on '{cls.__name__}' is a strict (non-polymorphic) "
+        f"field annotated with '{expected_name}', but got an instance of subclass "
+        f"'{actual_name}'.\n\n"
+        f"A bare concrete annotation means exactly '{expected_name}': the extra "
+        f"parameters of '{actual_name}' would be silently dropped on "
+        f"serialization, and task identity (derived from the serialized form) "
+        f"would collide with the base type. Either pass an exact '{expected_name}' "
+        f"instance, or annotate the field polymorphically to accept subclasses:\n\n"
+        f"    from stardag import SubClass\n\n"
+        f"    {field_name}: SubClass[{expected_name}]"
+    )
+
+
+def _find_strict_polymorphic_violation(
+    annotation: Any, value: Any, guarded: bool
+) -> "tuple[type, Any] | None":
+    """Return ``(expected_type, offending_value)`` if ``value`` contains a
+    subclass instance at a position where ``annotation`` declares a bare,
+    concrete ``PolymorphicRoot`` type; otherwise ``None``.
+
+    Mirrors the structure of :func:`_iter_bare_polymorphic` but walks the runtime
+    ``value`` alongside the annotation. It is best-effort for container shapes it
+    doesn't recognise (returns ``None`` rather than risking a false positive).
+    """
+    origin = get_origin(annotation)
+
+    if origin is Annotated:
+        args = get_args(annotation)
+        inner, extras = args[0], args[1:]
+        guarded_here = guarded or any(isinstance(e, Polymorphic) for e in extras)
+        return _find_strict_polymorphic_violation(inner, value, guarded_here)
+
+    if isinstance(annotation, type) and issubclass(annotation, PolymorphicRoot):
+        # ``isinstance`` (not ``==``) so a value belonging to a *different* union
+        # arm is skipped; ``type(...) is not`` flags any strict subclass.
+        if (
+            not guarded
+            and isinstance(value, annotation)
+            and type(value) is not annotation
+        ):
+            return (annotation, value)
+        return None
+
+    args = get_args(annotation)
+    if not args:
+        return None
+
+    if origin in (Union, types.UnionType):
+        for arg in args:
+            found = _find_strict_polymorphic_violation(arg, value, False)
+            if found is not None:
+                return found
+        return None
+
+    # Mapping: check keys against the first arg and values against the last.
+    if isinstance(value, collections_abc.Mapping):
+        key_ann, val_ann = args[0], args[-1]
+        for key, val in value.items():
+            found = _find_strict_polymorphic_violation(key_ann, key, False)
+            if found is not None:
+                return found
+            found = _find_strict_polymorphic_violation(val_ann, val, False)
+            if found is not None:
+                return found
+        return None
+
+    # Sequence / set-like (but not str/bytes): recurse each element.
+    if isinstance(value, collections_abc.Collection) and not isinstance(
+        value, (str, bytes)
+    ):
+        items = list(value)
+        # Fixed-length tuple (``tuple[A, B]``) -> positional; everything else
+        # (``list[X]``, ``set[X]``, ``tuple[X, ...]``) uses a single element type.
+        if origin is tuple and Ellipsis not in args and len(args) == len(items):
+            pairs = zip(args, items)
+        else:
+            pairs = ((args[0], item) for item in items)
+        for elem_ann, item in pairs:
+            found = _find_strict_polymorphic_violation(elem_ann, item, False)
+            if found is not None:
+                return found
+        return None
+
+    return None
 
 
 class _SubClass:

--- a/lib/stardag/src/stardag/utils/testing/helper_tasks.py
+++ b/lib/stardag/src/stardag/utils/testing/helper_tasks.py
@@ -6,7 +6,7 @@ import asyncio
 import time
 from typing import Any
 
-from stardag import Task, auto_namespace
+from stardag import SubClass, Task, auto_namespace
 
 auto_namespace(__name__)
 
@@ -20,7 +20,7 @@ class SyncOnlyTask(Task[dict[str, Any]]):
     """Task with only sync run()."""
 
     name: str
-    deps: tuple[Task, ...] = ()
+    deps: tuple[SubClass[Task], ...] = ()
 
     def requires(self):
         return self.deps
@@ -33,7 +33,7 @@ class AsyncOnlyTask(Task[dict[str, Any]]):
     """Task with only async run_aio()."""
 
     name: str
-    deps: tuple[Task, ...] = ()
+    deps: tuple[SubClass[Task], ...] = ()
 
     def requires(self):
         return self.deps
@@ -48,7 +48,7 @@ class DualTask(Task[dict[str, Any]]):
 
     name: str
     prefer_async: bool = True
-    deps: tuple[Task, ...] = ()
+    deps: tuple[SubClass[Task], ...] = ()
 
     def requires(self):
         return self.deps
@@ -85,7 +85,7 @@ class SlowTask(Task[dict[str, Any]]):
 
     name: str
     delay: float = 0.1
-    deps: tuple[Task, ...] = ()
+    deps: tuple[SubClass[Task], ...] = ()
 
     def requires(self):
         return self.deps
@@ -122,7 +122,7 @@ class DiamondTask(Task[str]):
 
     name: str
     test_id: str  # Unique per test to isolate task IDs
-    deps: tuple[Task, ...] = ()
+    deps: tuple[SubClass[Task], ...] = ()
 
     def requires(self):
         return self.deps

--- a/lib/stardag/tests/test__core/test_rehydrate.py
+++ b/lib/stardag/tests/test__core/test_rehydrate.py
@@ -151,18 +151,17 @@ class TestErrors:
         with pytest.raises(TaskRehydrationError, match="aliased"):
             task_from_registry_data(data)
 
-    def test_plain_task_annotation_fails_clearly(
-        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
-    ):
-        """Nested task fields with plain (non-polymorphic) annotations can't
-        reconstruct — the identity check surfaces it with a pointer to
-        TaskLoads/SubClass instead of an opaque serialization error."""
-        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+    def test_plain_task_annotation_rejected_at_definition(self):
+        """A nested task field with a plain (non-polymorphic) annotation used to
+        only fail at rehydration; it is now rejected at class-construction time,
+        so the un-reconstructable payload can never be produced in the first
+        place (see NakedPolymorphicFieldError)."""
+        from stardag import NakedPolymorphicFieldError
 
-        dep = SyncOnlyTask(name="plain-dep")
-        root = SyncOnlyTask(name="plain-root", deps=(dep,))
+        with pytest.raises(NakedPolymorphicFieldError, match="SubClass"):
 
-        with pytest.raises(TaskRehydrationError, match="TaskLoads"):
-            task_from_registry_data(
-                root.model_dump(mode="json"), expected_task_id=root.id
-            )
+            class PlainDepTask(sd.Task[int]):
+                deps: tuple[sd.Task[int], ...] = ()
+
+                def run(self):
+                    self._save(1)

--- a/lib/stardag/tests/test_polymorphic.py
+++ b/lib/stardag/tests/test_polymorphic.py
@@ -1,11 +1,15 @@
-from abc import abstractmethod
-from typing import Generic, TypeVar
+from abc import ABC, abstractmethod
+from typing import Annotated, ClassVar, Generic, Optional, TypeVar
 
+import pytest
 from pydantic import BaseModel, TypeAdapter
 
+from stardag.exceptions import StardagError
 from stardag.polymorphic import (
     NAME_KEY,
     NAMESPACE_KEY,
+    NakedPolymorphicFieldError,
+    Polymorphic,
     PolymorphicRoot,
     SubClass,
     TypeId,
@@ -230,3 +234,107 @@ def test_name_handling():
 
     assert ChildA.get_name() == "ChildA"
     assert ChildB.get_name() == "CustomNameB"
+
+
+class TestNakedPolymorphicFieldRejection:
+    """A field annotated with a *bare* abstract PolymorphicRoot subclass is a
+    silent data-loss trap: serialization drops subclass-specific parameters and
+    deserialization crashes trying to instantiate the abstract base. Such
+    annotations are rejected at class-construction time.
+    """
+
+    def test_bare_abstract_base_rejected(self):
+        class Shape(PolymorphicRoot):
+            @abstractmethod
+            def area(self) -> float: ...
+
+        with pytest.raises(NakedPolymorphicFieldError, match="SubClass"):
+
+            class Canvas(PolymorphicRoot):
+                shape: Shape  # type: ignore[valid-type]  # naked abstract
+
+    def test_bare_abstract_base_in_list_rejected(self):
+        class Shape(PolymorphicRoot):
+            @abstractmethod
+            def area(self) -> float: ...
+
+        with pytest.raises(NakedPolymorphicFieldError):
+
+            class Canvas(PolymorphicRoot):
+                shapes: list[Shape]  # type: ignore[valid-type]
+
+    def test_bare_abstract_base_in_dict_value_rejected(self):
+        class Shape(PolymorphicRoot):
+            @abstractmethod
+            def area(self) -> float: ...
+
+        with pytest.raises(NakedPolymorphicFieldError):
+
+            class Canvas(PolymorphicRoot):
+                shapes: dict[str, Shape]  # type: ignore[valid-type]
+
+    def test_bare_abstract_base_in_optional_rejected(self):
+        class Shape(PolymorphicRoot):
+            @abstractmethod
+            def area(self) -> float: ...
+
+        with pytest.raises(NakedPolymorphicFieldError):
+
+            class Canvas(PolymorphicRoot):
+                shape: Optional[Shape] = None  # type: ignore[valid-type]
+
+    def test_stardag_abstract_marker_rejected(self):
+        """Abstract bases marked only via ``__stardag_abstract__`` are caught."""
+
+        class Node(PolymorphicRoot):
+            __stardag_abstract__: ClassVar[bool] = True
+
+        with pytest.raises(NakedPolymorphicFieldError):
+
+            class Graph(PolymorphicRoot):
+                node: Node  # type: ignore[valid-type]
+
+    def test_abc_base_marker_rejected(self):
+        """Abstract bases marked via ``abc.ABC`` in bases are caught."""
+
+        class Node(PolymorphicRoot, ABC):
+            pass
+
+        with pytest.raises(NakedPolymorphicFieldError):
+
+            class Graph(PolymorphicRoot):
+                node: Node  # type: ignore[valid-type]
+
+    def test_error_is_stardag_error(self):
+        assert issubclass(NakedPolymorphicFieldError, StardagError)
+
+    # --- accepted forms (no false positives) -------------------------------
+
+    def test_subclass_annotation_accepted(self):
+        class Shape(PolymorphicRoot):
+            @abstractmethod
+            def area(self) -> float: ...
+
+        class Canvas(PolymorphicRoot):
+            shape: SubClass[Shape]
+            shapes: list[SubClass[Shape]]
+            annotated: Annotated[Shape, Polymorphic()]
+
+    def test_concrete_strict_annotation_accepted(self):
+        """A bare *concrete* subclass is an intentional 'strict' field (only ever
+        holds exactly that type) and must keep working."""
+
+        class Animal(PolymorphicRoot):
+            pass
+
+        class Dog(Animal):
+            bark_volume: int = 3
+
+        class Kennel(PolymorphicRoot):
+            resident: Dog  # concrete -> allowed
+
+    def test_plain_scalar_fields_accepted(self):
+        class Plain(PolymorphicRoot):
+            a: int
+            b: str = "x"
+            c: list[int] = []

--- a/lib/stardag/tests/test_polymorphic.py
+++ b/lib/stardag/tests/test_polymorphic.py
@@ -11,6 +11,7 @@ from stardag.polymorphic import (
     NakedPolymorphicFieldError,
     Polymorphic,
     PolymorphicRoot,
+    StrictPolymorphicTypeError,
     SubClass,
     TypeId,
 )
@@ -251,7 +252,7 @@ class TestNakedPolymorphicFieldRejection:
         with pytest.raises(NakedPolymorphicFieldError, match="SubClass"):
 
             class Canvas(PolymorphicRoot):
-                shape: Shape  # type: ignore[valid-type]  # naked abstract
+                shape: Shape  # naked abstract
 
     def test_bare_abstract_base_in_list_rejected(self):
         class Shape(PolymorphicRoot):
@@ -261,7 +262,7 @@ class TestNakedPolymorphicFieldRejection:
         with pytest.raises(NakedPolymorphicFieldError):
 
             class Canvas(PolymorphicRoot):
-                shapes: list[Shape]  # type: ignore[valid-type]
+                shapes: list[Shape]
 
     def test_bare_abstract_base_in_dict_value_rejected(self):
         class Shape(PolymorphicRoot):
@@ -271,7 +272,7 @@ class TestNakedPolymorphicFieldRejection:
         with pytest.raises(NakedPolymorphicFieldError):
 
             class Canvas(PolymorphicRoot):
-                shapes: dict[str, Shape]  # type: ignore[valid-type]
+                shapes: dict[str, Shape]
 
     def test_bare_abstract_base_in_optional_rejected(self):
         class Shape(PolymorphicRoot):
@@ -281,7 +282,7 @@ class TestNakedPolymorphicFieldRejection:
         with pytest.raises(NakedPolymorphicFieldError):
 
             class Canvas(PolymorphicRoot):
-                shape: Optional[Shape] = None  # type: ignore[valid-type]
+                shape: Optional[Shape] = None
 
     def test_stardag_abstract_marker_rejected(self):
         """Abstract bases marked only via ``__stardag_abstract__`` are caught."""
@@ -292,7 +293,7 @@ class TestNakedPolymorphicFieldRejection:
         with pytest.raises(NakedPolymorphicFieldError):
 
             class Graph(PolymorphicRoot):
-                node: Node  # type: ignore[valid-type]
+                node: Node
 
     def test_abc_base_marker_rejected(self):
         """Abstract bases marked via ``abc.ABC`` in bases are caught."""
@@ -303,7 +304,7 @@ class TestNakedPolymorphicFieldRejection:
         with pytest.raises(NakedPolymorphicFieldError):
 
             class Graph(PolymorphicRoot):
-                node: Node  # type: ignore[valid-type]
+                node: Node
 
     def test_error_is_stardag_error(self):
         assert issubclass(NakedPolymorphicFieldError, StardagError)
@@ -338,3 +339,89 @@ class TestNakedPolymorphicFieldRejection:
             a: int
             b: str = "x"
             c: list[int] = []
+
+
+# Module-level so they are proper static types usable in annotations below
+# (a concrete family: ``_Animal`` is the concrete root, ``_Dog`` a subclass).
+class _Animal(PolymorphicRoot):
+    legs: int = 4
+
+
+class _Dog(_Animal):
+    bark_volume: int = 3
+
+
+class TestStrictConcretePolymorphicField:
+    """A bare *concrete* PolymorphicRoot field is a "strict" field: it means
+    exactly that type. Passing a subclass instance would silently drop the
+    subclass's extra params on serialization (and collide identities), so it is
+    rejected at validation time — use SubClass[...] to accept subclasses.
+    """
+
+    def test_exact_type_accepted(self):
+        class Zoo(PolymorphicRoot):
+            star: _Animal  # bare concrete = strict
+
+        assert Zoo.__stardag_strict_polymorphic_fields__ == ("star",)
+        zoo = Zoo(star=_Animal(legs=4))
+        assert type(zoo.star) is _Animal
+
+    def test_subclass_instance_rejected(self):
+        class Zoo(PolymorphicRoot):
+            star: _Animal
+
+        with pytest.raises(StrictPolymorphicTypeError, match="SubClass"):
+            Zoo(star=_Dog(legs=4, bark_volume=9))
+
+    def test_subclass_in_list_rejected(self):
+        class Zoo(PolymorphicRoot):
+            animals: list[_Animal]
+
+        Zoo(animals=[_Animal(), _Animal()])  # exact types OK
+        with pytest.raises(StrictPolymorphicTypeError):
+            Zoo(animals=[_Animal(), _Dog()])
+
+    def test_subclass_in_tuple_rejected(self):
+        class Zoo(PolymorphicRoot):
+            animals: tuple[_Animal, ...] = ()
+
+        Zoo(animals=(_Animal(), _Animal()))
+        with pytest.raises(StrictPolymorphicTypeError):
+            Zoo(animals=(_Animal(), _Dog()))
+
+    def test_subclass_in_dict_value_rejected(self):
+        class Zoo(PolymorphicRoot):
+            animals: dict[str, _Animal]
+
+        Zoo(animals={"a": _Animal()})
+        with pytest.raises(StrictPolymorphicTypeError):
+            Zoo(animals={"a": _Dog()})
+
+    def test_optional_strict_none_and_exact_ok_subclass_rejected(self):
+        class Zoo(PolymorphicRoot):
+            star: Optional[_Animal] = None
+
+        Zoo(star=None)
+        Zoo(star=_Animal())
+        with pytest.raises(StrictPolymorphicTypeError):
+            Zoo(star=_Dog())
+
+    def test_subclass_annotation_accepts_subclasses(self):
+        # Container is a *registered* subclass (a family root has no __type_id__
+        # and can't be serialized directly), mirroring real usage.
+        class ZooBase(PolymorphicRoot):
+            pass
+
+        class Zoo(ZooBase):
+            star: SubClass[_Animal]
+
+        # SubClass[...] is not a strict field, so subclasses round-trip fully.
+        assert Zoo.__stardag_strict_polymorphic_fields__ == ()
+        zoo = Zoo(star=_Dog(bark_volume=7))
+        assert type(zoo.star) is _Dog
+        reloaded = Zoo.model_validate(zoo.model_dump())
+        assert type(reloaded.star) is _Dog
+        assert reloaded.star.bark_volume == 7
+
+    def test_error_is_stardag_error(self):
+        assert issubclass(StrictPolymorphicTypeError, StardagError)


### PR DESCRIPTION
Closes #153.

## Problem

A task/model field annotated directly with a `PolymorphicRoot` base instead of
wrapping it in `SubClass[...]` / `TaskLoads[...]` is a silent data-loss trap:

1. **Silent corruption on serialize.** `model_dump()` keeps only the declared
   base's own fields, dropping every subclass-specific parameter.
2. **Identity corruption / crash.** Task identity is derived from the serialized
   form, so truncated subclass values collide; abstract bases additionally crash
   on load (they can't be instantiated directly).

## Fix (two layers)

### 1. Bare **abstract** base → rejected at class-definition time

`PolymorphicRoot.__pydantic_init_subclass__` walks each field's annotation
(recursing through containers, unions, and `Annotated`) and raises
`NakedPolymorphicFieldError` when it finds an abstract `PolymorphicRoot`
subclass (`BaseTask`, `Task[int]`, `LoadableTask`, `TargetTask`, or any user
`abc.ABC` / `__stardag_abstract__` base) that isn't guarded by `Polymorphic()`.
An abstract base as a bare annotation is *always* wrong (every value is a
subclass), so failing at definition time is safe and maximally early.

### 2. Bare **concrete** base → strict (exact-type) at validation time

A bare concrete field (`child: MyTask`) is a legitimate "strict" field meaning
*exactly* `MyTask` — but passing a **subclass instance** silently truncated it
and collided task ids (same bug, conditional on the value). Bare concrete fields
are now indexed at class construction (`__stardag_strict_polymorphic_fields__`)
and a `PolymorphicRoot` after-validator raises `StrictPolymorphicTypeError` if a
subclass instance is assigned, pointing at `SubClass[...]`. Exact-type instances
and `SubClass[...]` fields are unaffected; fields with no polymorphic annotation
short-circuit immediately.

```python
class Parent(sd.Task[int]):
    child: MyTask                 # strict = exactly MyTask

Parent(child=MyTask(...))         # OK
Parent(child=ChildOfMyTask(...))  # StrictPolymorphicTypeError -> use SubClass[MyTask]

class Parent(sd.Task[int]):
    child: sd.SubClass[MyTask]     # accepts subclasses, full-fidelity round-trip
```

## Notable

The abstract check immediately caught a real latent instance of this bug in the
shared build-test helpers (bare `tuple[Task, ...]` deps); fixed to
`tuple[SubClass[Task], ...]`.

The rehydrate-time safety net for the abstract case is now defense-in-depth (the
offending class can no longer be defined), so its test was updated to assert the
definition-time rejection.

## Changes

- `polymorphic.py` — annotation walk (`_iter_bare_polymorphic`), abstract
  rejection (`NakedPolymorphicFieldError`), strict-field indexing + after-validator
  (`StrictPolymorphicTypeError`)
- `__init__.py` — export both new errors
- `utils/testing/helper_tasks.py` — fix bare `tuple[Task, ...]` deps
- `tests/` — rejection + strict-enforcement tests, updated rehydrate test
- `CHANGELOG.md` (Unreleased) + `docs/how-to/define-tasks.md` note

## Verification

- `ruff`, `ruff-format`, `pyright`, `prettier` clean on changed files.
- Full test suite green (the only failures are a pre-existing, environment-local
  target-root config issue, identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)