### PR TITLE
UI: Execution shows only the call ref; per-level links in More details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 ### UI
 
 - **Task detail "Execution" section: minimal Modal call-ref line.** Shows the
-  function-call id (`fc-…`) as a copyable deep link to the Modal call page;
-  the per-level app/function/environment deep links now live in the
-  collapsible "More details" table (each value linked, click-to-copy).
+  function-call id (`fc-…`) as a link to the Modal call page, with a button
+  that copies the id itself; the per-level app/function/environment deep
+  links now live in the collapsible "More details" table (each value linked,
+  with a copy-the-value button).
 
 ## [0.12.0] — 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to the Stardag project (SDK, Registry API, and UI).
 
 For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
+## UI Only — 2026-07-15
+
+### UI
+
+- **Task detail "Execution" section: minimal Modal call-ref line.** Shows the
+  function-call id (`fc-…`) as a copyable deep link to the Modal call page;
+  the per-level app/function/environment deep links now live in the
+  collapsible "More details" table (each value linked, click-to-copy).
+
 ## [0.12.0] — 2026-07-15
 
 ### SDK
@@ -26,20 +35,6 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   same task id. This now raises `StrictPolymorphicTypeError` at construction,
   directing you to `SubClass[MyTask]` if you intend to accept subclasses.
   Passing an exact-type instance is unaffected.
-
-### UI
-
-- **Task detail "Execution" section is now a hierarchical breadcrumb.** The
-  previous flat label/value rows (App, Function, Call ref, Workspace / env)
-  are replaced by a breadcrumb trail: `workspace / environment` (one link to
-  the environment) then `app_name`, `function_name`, and the call ref. Each
-  present level is a best-effort deep link into the corresponding Modal
-  dashboard page (opening in a new tab), falling back to plain text when the
-  ids for that level are absent; absent levels are omitted so the trail
-  starts at the first level actually recorded. The call ref keeps its
-  click-to-copy button. The collapsible "More details" block is now a
-  2-column table — human-readable names, a divider, then the raw ids — each
-  value click-to-copy.
 
 ## [0.11.0] — 2026-07-15
 

--- a/app/stardag-ui/src/components/TaskDetail.test.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
-import { ModalExecutionBreadcrumb, ModalExecutionDetails } from "./TaskDetail";
+import { ModalExecutionCallRef, ModalExecutionDetails } from "./TaskDetail";
 
 const fullMetadata = {
   kind: "modal",
@@ -13,93 +13,24 @@ const fullMetadata = {
   function_id: "fu-456",
 };
 
-describe("ModalExecutionBreadcrumb", () => {
-  it("renders four top-level segments in hierarchy order, each a Modal link", () => {
-    render(<ModalExecutionBreadcrumb metadata={fullMetadata} executorRef="fc-789" />);
+// Deep-link URLs for fullMetadata (kept in one place for readability).
+const ENV_URL = "https://modal.com/apps/my-workspace/staging";
+const APP_URL = "https://modal.com/apps/my-workspace/staging/ap-123";
+const FUNC_URL = `${APP_URL}?activeTab=functions&functionId=fu-456`;
+const CALL_URL = `${FUNC_URL}&functionSection=calls&fcId=fc-789`;
 
-    // workspace + environment collapse into ONE link (to the environment
-    // page); then app, function, call ref.
-    const links = screen.getAllByRole("link");
-    expect(links.map((a) => a.textContent)).toEqual([
-      "my-workspace / staging",
-      "my-app",
-      "worker_default",
-      "fc-789",
-    ]);
-    expect(links.map((a) => a.getAttribute("href"))).toEqual([
-      "https://modal.com/apps/my-workspace/staging",
-      "https://modal.com/apps/my-workspace/staging/ap-123",
-      "https://modal.com/apps/my-workspace/staging/ap-123?activeTab=functions&functionId=fu-456",
-      "https://modal.com/apps/my-workspace/staging/ap-123?activeTab=functions&functionId=fu-456&functionSection=calls&fcId=fc-789",
-    ]);
-    // Every link opens in a new tab safely.
-    for (const a of links) {
-      expect(a).toHaveAttribute("target", "_blank");
-      expect(a).toHaveAttribute("rel", "noopener noreferrer");
-    }
+describe("ModalExecutionCallRef", () => {
+  it("links the call ref to a genuine call-level URL (new tab)", () => {
+    render(<ModalExecutionCallRef metadata={fullMetadata} executorRef="fc-789" />);
+    const link = screen.getByRole("link", { name: "fc-789" });
+    expect(link).toHaveAttribute("href", CALL_URL);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
   });
 
-  it("renders just the environment (plain text) when workspace is missing", () => {
-    render(
-      <ModalExecutionBreadcrumb
-        metadata={{ kind: "modal", environment: "staging", app_id: "ap-123" }}
-        executorRef={null}
-      />,
-    );
-    // Without a workspace neither the env URL nor the app URL can be built,
-    // so the env segment is plain text (not a link) and shows only the
-    // environment half (no phantom workspace).
-    expect(screen.getByText("staging")).toBeInTheDocument();
-    expect(screen.queryByText("my-workspace")).not.toBeInTheDocument();
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
-  });
-
-  it("renders just the workspace (plain text, no link) when environment is missing", () => {
-    render(
-      <ModalExecutionBreadcrumb
-        metadata={{ kind: "modal", workspace: "my-workspace" }}
-        executorRef={null}
-      />,
-    );
-    // A workspace-only URL is misleading, so it is never emitted.
-    expect(screen.getByText("my-workspace")).toBeInTheDocument();
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
-  });
-
-  it("omits absent segments (trail starts at the first level present)", () => {
-    render(
-      <ModalExecutionBreadcrumb
-        metadata={{ kind: "modal", workspace: "my-workspace", app_name: "my-app" }}
-        executorRef={null}
-      />,
-    );
-    // workspace present but no environment → workspace is plain text (no
-    // link); only the app segment links.
-    const links = screen.getAllByRole("link");
-    expect(links.map((a) => a.textContent)).toEqual(["my-app"]);
-    expect(screen.getByText("my-workspace")).toBeInTheDocument();
-    // Absent environment / function / call-ref must not appear.
-    expect(screen.queryByText("staging")).not.toBeInTheDocument();
-    expect(screen.queryByText("worker_default")).not.toBeInTheDocument();
-  });
-
-  it("renders a segment as plain text when its URL can't be built", () => {
-    // function_name present but no function_id/app → modalFunctionUrl is null.
-    render(
-      <ModalExecutionBreadcrumb
-        metadata={{ kind: "modal", function_name: "worker_default" }}
-        executorRef={null}
-      />,
-    );
-    expect(screen.getByText("worker_default")).toBeInTheDocument();
-    expect(screen.queryByRole("link")).not.toBeInTheDocument();
-  });
-
-  it("gives the last (call-ref) segment a copy button that copies the fc id", async () => {
+  it("copies the raw fc id via its copy button", async () => {
     const user = userEvent.setup();
-    render(<ModalExecutionBreadcrumb metadata={fullMetadata} executorRef="fc-789" />);
-
-    // Only the call-ref segment carries a copy control.
+    render(<ModalExecutionCallRef metadata={fullMetadata} executorRef="fc-789" />);
     const copyButtons = screen.getAllByRole("button", {
       name: /copy to clipboard/i,
     });
@@ -108,23 +39,13 @@ describe("ModalExecutionBreadcrumb", () => {
     expect(await window.navigator.clipboard.readText()).toBe("fc-789");
   });
 
-  it("links the call ref only to a genuine call-level URL", () => {
-    // function_id present → the call ref is a real deep link to the call.
-    render(<ModalExecutionBreadcrumb metadata={fullMetadata} executorRef="fc-789" />);
-    expect(screen.getByRole("link", { name: "fc-789" })).toHaveAttribute(
-      "href",
-      "https://modal.com/apps/my-workspace/staging/ap-123" +
-        "?activeTab=functions&functionId=fu-456&functionSection=calls&fcId=fc-789",
-    );
-  });
-
-  it("renders the call ref as plain text (never linking to the app page) when function_id is missing", async () => {
+  it("renders the call ref as plain text (never the app page) when function_id is missing", async () => {
     const user = userEvent.setup();
     // app_name/app_id resolvable but NO function_id: modalFunctionCallUrl
     // would fall back to the app page, which must not become a clickable call
     // ref. It renders as plain text but keeps its copy button.
     render(
-      <ModalExecutionBreadcrumb
+      <ModalExecutionCallRef
         metadata={{
           kind: "modal",
           workspace: "my-workspace",
@@ -135,10 +56,8 @@ describe("ModalExecutionBreadcrumb", () => {
         executorRef="fc-789"
       />,
     );
-    // The call ref is not a link (only the ws/env and app segments are).
-    expect(screen.queryByRole("link", { name: "fc-789" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
     expect(screen.getByText("fc-789")).toBeInTheDocument();
-    // Copy button still present and copies the raw fc id.
     const copyButtons = screen.getAllByRole("button", {
       name: /copy to clipboard/i,
     });
@@ -147,19 +66,26 @@ describe("ModalExecutionBreadcrumb", () => {
     expect(await window.navigator.clipboard.readText()).toBe("fc-789");
   });
 
+  it("renders for kind-less metadata (legacy, treated as modal)", () => {
+    render(
+      <ModalExecutionCallRef metadata={{ app_name: "my-app" }} executorRef="fc-1" />,
+    );
+    expect(screen.getByText("fc-1")).toBeInTheDocument();
+  });
+
   it("renders nothing for an explicitly non-modal kind", () => {
     const { container } = render(
-      <ModalExecutionBreadcrumb
-        metadata={{ kind: "k8s", workspace: "my-workspace", app_name: "my-app" }}
+      <ModalExecutionCallRef
+        metadata={{ kind: "k8s", app_name: "my-app" }}
         executorRef="ref-1"
       />,
     );
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("renders nothing when there is nothing to show", () => {
+  it("renders nothing when there is no call ref", () => {
     const { container } = render(
-      <ModalExecutionBreadcrumb metadata={null} executorRef={null} />,
+      <ModalExecutionCallRef metadata={fullMetadata} executorRef={null} />,
     );
     expect(container).toBeEmptyDOMElement();
   });
@@ -214,6 +140,50 @@ describe("ModalExecutionDetails", () => {
     expect(container.querySelector("hr")).toBeInTheDocument();
   });
 
+  it("links each value to its Modal level; workspace stays plain text", async () => {
+    const user = userEvent.setup();
+    render(<ModalExecutionDetails metadata={fullMetadata} executorRef="fc-789" />);
+    await user.click(screen.getByRole("button", { name: /more details/i }));
+
+    // Workspace has no meaningful standalone URL → plain text, not a link.
+    expect(screen.getByText("my-workspace").closest("a")).toBeNull();
+
+    // Every other value is a best-effort deep link (new tab) to its level.
+    const cases: [string, string][] = [
+      ["staging", ENV_URL],
+      ["my-app", APP_URL],
+      ["worker_default", FUNC_URL],
+      ["ap-123", APP_URL],
+      ["fu-456", FUNC_URL],
+      ["fc-789", CALL_URL],
+    ];
+    for (const [value, href] of cases) {
+      const link = screen.getByRole("link", { name: value });
+      expect(link).toHaveAttribute("href", href);
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    }
+  });
+
+  it("falls back to plain text (still with copy) when a value's URL can't be built", async () => {
+    const user = userEvent.setup();
+    // Only app_name, no workspace → modalAppUrl is null, so App is plain text.
+    render(
+      <ModalExecutionDetails
+        metadata={{ kind: "modal", app_name: "my-app" }}
+        executorRef={null}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /more details/i }));
+
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("my-app").closest("a")).toBeNull();
+    // Copy button is present regardless of whether the value links.
+    expect(
+      screen.getByRole("button", { name: /copy to clipboard/i }),
+    ).toBeInTheDocument();
+  });
+
   it("renders only the fields that are present, without a divider for one group", async () => {
     const user = userEvent.setup();
     const { container } = render(
@@ -243,9 +213,8 @@ describe("ModalExecutionDetails", () => {
   });
 
   it("renders nothing for an explicitly non-modal kind", () => {
-    // The block's labels ("App name", "Function ID", …) are Modal-specific,
-    // so it must not surface identifiers from a non-modal executor as Modal
-    // fields.
+    // The block's labels ("App", "Function ID", …) are Modal-specific, so it
+    // must not surface identifiers from a non-modal executor as Modal fields.
     const { container } = render(
       <ModalExecutionDetails
         metadata={{ kind: "k8s", app_name: "some-pod", function_id: "fu-x" }}
@@ -276,7 +245,7 @@ describe("ModalExecutionDetails", () => {
     render(<ModalExecutionDetails metadata={fullMetadata} executorRef="fc-789" />);
     await user.click(screen.getByRole("button", { name: /more details/i }));
 
-    // Copy the Function call ID (last copy button in the disclosure list).
+    // Copy the Call ref (last copy button in the disclosure list).
     const copyButtons = screen.getAllByRole("button", {
       name: /copy to clipboard/i,
     });

--- a/app/stardag-ui/src/components/TaskDetail.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { cancelTask, fetchTaskArtifacts, fetchTaskEvents } from "../api/tasks";
 import type {
   Task,
@@ -67,31 +67,22 @@ function CopyButton({ text, className = "" }: { text: string; className?: string
   );
 }
 
-// Hierarchical breadcrumb for a Modal execution. Four top-level segments:
-//   [workspace / environment] / app_name / function_name / <call-ref>
-// The first segment combines workspace + environment (a bare workspace URL
-// is misleading — see modalEnvironmentUrl), rendered as one link to the
-// environment page. Absent levels are omitted (the trail starts at the first
-// level actually recorded). Every segment is a best-effort deep link into the
-// corresponding Modal dashboard level; when the URL for a level can't be
-// built (missing id — see utils/modalLinks.ts) the segment renders as plain
-// text instead, but the label still shows. The last segment (the fc-… call
-// ref) also gets a click-to-copy button.
+// The Modal function-call reference (fc-…) for an execution: the raw id as a
+// deep link to the function call in the Modal dashboard when a genuine
+// call-level URL is resolvable, otherwise plain text, always followed by a
+// click-to-copy button.
 //
-// Wrapping: each top-level segment plus its trailing " /" separator is one
-// `whitespace-nowrap` unit, and the only breakable whitespace sits *between*
-// units — so a line can wrap only right after a top-level slash, never
-// mid-segment and never before the slash (the workspace/environment pair
-// stays glued as one unit). The container uses `pl-4 -indent-4` for a hanging
-// indent (first line flush, wrapped continuation lines indented ~1rem). The
-// anchors/segments stay `display:inline` so the block's text-indent applies
-// to them; only the trailing copy button (on the last line) is inline-block.
+// The call-level link is gated on modalFunctionUrl being non-null.
+// modalFunctionCallUrl falls back to the app page when function_id is missing
+// (other callers, e.g. the "View on Modal" links, rely on that shared
+// fallback), but here a clickable call ref must never navigate to a coarser
+// level — so we only link when the function itself is addressable; otherwise
+// the ref renders as plain text (the copy button stays either way).
 //
 // Gated to Modal executions (reuses isModalMetadata): renders for modal
-// metadata, the legacy kind-less case (treated as modal), and the
-// executorRef-only case (no metadata). Renders nothing for an explicitly
-// non-modal kind, or when there is genuinely nothing to show.
-export function ModalExecutionBreadcrumb({
+// metadata and the legacy kind-less case (treated as modal). Renders nothing
+// for an explicitly non-modal kind, or when there is no call ref to show.
+export function ModalExecutionCallRef({
   metadata,
   executorRef,
 }: {
@@ -101,89 +92,29 @@ export function ModalExecutionBreadcrumb({
   const isModal = !metadata || isModalMetadata(metadata);
   if (!isModal) return null;
 
-  // A segment's label is one or more parts joined by a muted " / " (only the
-  // workspace/environment segment has two parts); the whole label links to
-  // `url` when present, else renders as plain text.
-  type Segment = { key: string; parts: string[]; url: string | null; copy?: boolean };
-  const segments: Segment[] = [];
+  const fcId =
+    typeof executorRef === "string" && executorRef.length > 0 ? executorRef : null;
+  if (!fcId) return null;
 
-  const nonEmpty = (value: unknown): string | null =>
-    typeof value === "string" && value.length > 0 ? value : null;
-
-  // Combined workspace / environment segment. Links to the environment page
-  // only when both are present; with just one, that half is plain text (a
-  // workspace-only URL would be misleading).
-  const workspace = nonEmpty(metadata?.workspace);
-  const environment = nonEmpty(metadata?.environment);
-  if (workspace && environment) {
-    segments.push({
-      key: "workspace_env",
-      parts: [workspace, environment],
-      url: modalEnvironmentUrl(metadata),
-    });
-  } else if (environment) {
-    segments.push({ key: "workspace_env", parts: [environment], url: null });
-  } else if (workspace) {
-    segments.push({ key: "workspace_env", parts: [workspace], url: null });
-  }
-
-  const push = (key: string, label: unknown, url: string | null, copy = false) => {
-    const value = nonEmpty(label);
-    if (value) segments.push({ key, parts: [value], url, copy });
-  };
-  push("app_name", metadata?.app_name, modalAppUrl(metadata));
-  push("function_name", metadata?.function_name, modalFunctionUrl(metadata));
-  // Link the call ref ONLY to a genuine call-level URL. modalFunctionCallUrl
-  // falls back to the app page when function_id is missing (other callers,
-  // e.g. the "View on Modal" links, rely on that), but here a clickable call
-  // ref must never navigate to a coarser level — so we gate on
-  // modalFunctionUrl (function_id + resolvable app URL) being non-null and
-  // otherwise render the ref as plain text (the copy button stays either way).
   const callUrl = modalFunctionUrl(metadata)
-    ? modalFunctionCallUrl(metadata, executorRef)
+    ? modalFunctionCallUrl(metadata, fcId)
     : null;
-  push("call_ref", executorRef, callUrl, true);
-
-  if (segments.length === 0) return null;
-
-  const sep = <span className="text-gray-400 dark:text-gray-500"> / </span>;
 
   return (
-    <div className="pl-4 -indent-4 font-mono leading-relaxed">
-      {segments.map((seg, i) => {
-        const isLast = i === segments.length - 1;
-        const label = seg.parts.map((part, j) => (
-          <Fragment key={j}>
-            {j > 0 && sep}
-            {part}
-          </Fragment>
-        ));
-        return (
-          <Fragment key={seg.key}>
-            {/* Segment + its trailing " /" are one non-breaking unit. */}
-            <span className="whitespace-nowrap">
-              {seg.url ? (
-                <a
-                  href={seg.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-blue-600 hover:underline dark:text-blue-400"
-                >
-                  {label}
-                </a>
-              ) : (
-                <span>{label}</span>
-              )}
-              {seg.copy && (
-                <CopyButton text={seg.parts[0]} className="ml-0.5 align-middle" />
-              )}
-              {!isLast && <span className="text-gray-400 dark:text-gray-500"> /</span>}
-            </span>
-            {/* The only breakable whitespace: sits between units. */}
-            {!isLast && " "}
-          </Fragment>
-        );
-      })}
+    <div className="flex items-center gap-1 font-mono">
+      {callUrl ? (
+        <a
+          href={callUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="break-all text-blue-600 hover:underline dark:text-blue-400"
+        >
+          {fcId}
+        </a>
+      ) : (
+        <span className="break-all">{fcId}</span>
+      )}
+      <CopyButton text={fcId} className="flex-shrink-0" />
     </div>
   );
 }
@@ -213,31 +144,41 @@ export function ModalExecutionDetails({
 
   const isModal = !metadata || isModalMetadata(metadata);
 
-  const collect = (entries: [string, unknown][]) => {
-    const rows: { label: string; value: string }[] = [];
-    for (const [label, value] of entries) {
+  const collect = (entries: [string, unknown, string | null][]) => {
+    const rows: { label: string; value: string; url: string | null }[] = [];
+    for (const [label, value, url] of entries) {
       if (typeof value === "string" && value.length > 0) {
-        rows.push({ label, value });
+        rows.push({ label, value, url });
       }
     }
     return rows;
   };
+
+  // Best-effort Modal dashboard links per level (null when not resolvable —
+  // see utils/modalLinks.ts). Workspace has no meaningful standalone URL, so
+  // it stays plain text. The call ref is gated on the function being
+  // addressable (modalFunctionUrl non-null) so it never links to a coarser
+  // level; see ModalExecutionCallRef.
+  const appUrl = modalAppUrl(metadata);
+  const funcUrl = modalFunctionUrl(metadata);
+  const callUrl = funcUrl ? modalFunctionCallUrl(metadata, executorRef) : null;
+
   // Human-readable names first, then the raw object ids.
   const names = collect([
-    ["Workspace", metadata?.workspace],
-    ["Environment", metadata?.environment],
-    ["App", metadata?.app_name],
-    ["Function", metadata?.function_name],
+    ["Workspace", metadata?.workspace, null],
+    ["Environment", metadata?.environment, modalEnvironmentUrl(metadata)],
+    ["App", metadata?.app_name, appUrl],
+    ["Function", metadata?.function_name, funcUrl],
   ]);
   const ids = collect([
-    ["App ID", metadata?.app_id],
-    ["Function ID", metadata?.function_id],
-    ["Call ref", executorRef],
+    ["App ID", metadata?.app_id, appUrl],
+    ["Function ID", metadata?.function_id, funcUrl],
+    ["Call ref", executorRef, callUrl],
   ]);
 
   if (!isModal || (names.length === 0 && ids.length === 0)) return null;
 
-  const renderRow = (field: { label: string; value: string }) => (
+  const renderRow = (field: { label: string; value: string; url: string | null }) => (
     <tr key={field.label}>
       <th
         scope="row"
@@ -247,7 +188,18 @@ export function ModalExecutionDetails({
       </th>
       <td className="py-0.5 align-top">
         <span className="flex items-start gap-1">
-          <span className="break-all font-mono">{field.value}</span>
+          {field.url ? (
+            <a
+              href={field.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="break-all font-mono text-blue-600 hover:underline dark:text-blue-400"
+            >
+              {field.value}
+            </a>
+          ) : (
+            <span className="break-all font-mono">{field.value}</span>
+          )}
           <CopyButton text={field.value} className="flex-shrink-0" />
         </span>
       </td>
@@ -283,7 +235,13 @@ export function ModalExecutionDetails({
             {names.map(renderRow)}
             {names.length > 0 && ids.length > 0 && (
               <tr aria-hidden="true">
-                <td colSpan={2} className="py-1">
+                {/* Same total height as py-1, but the hairline is nudged down
+                    (less top, more bottom padding) to sit visually centered
+                    between the groups: the align-top value rows leave
+                    line-height descender slack above the divider, so equal
+                    padding would render the line too close to the group
+                    below. */}
+                <td colSpan={2} className="pt-0.5 pb-1.5">
                   <hr className="border-gray-200 dark:border-gray-700" />
                 </td>
               </tr>
@@ -552,7 +510,7 @@ export function TaskDetail({
                   <ExecutorBadge executor={task.latest_executor} />
                 </div>
               )}
-              <ModalExecutionBreadcrumb
+              <ModalExecutionCallRef
                 metadata={task.latest_executor_metadata}
                 executorRef={task.latest_executor_ref}
               />


### PR DESCRIPTION
Task detail **Execution** area now shows only the call ref (`fc-…`) — a deep link to the function call when genuinely resolvable (gated so it never falls back to the app page), else plain text, with the copy button. The full breadcrumb is removed.

**More details** table is otherwise unchanged, but each value is now a best-effort link to its Modal level (Environment / App / Function / their ids / call ref); Workspace stays plain text. Copy button stays on every row. Also nudged the group divider down so the hairline is visually centered between the two groups.