### PR TITLE
Make the unit test suite hermetic w.r.t. ambient config

### DIFF
--- a/lib/stardag/tests/conftest.py
+++ b/lib/stardag/tests/conftest.py
@@ -4,6 +4,12 @@ from pathlib import Path
 
 import pytest
 
+from stardag.config import (
+    DEFAULT_TARGET_ROOT_KEY,
+    StardagConfig,
+    TargetConfig,
+    config_provider,
+)
 from stardag.target import (
     InMemoryFileTarget,
     target_factory_provider,
@@ -81,3 +87,38 @@ def cleared_stardag_env_vars() -> typing.Generator[None, None, None]:
     stardag_env_vars = [var for var in os.environ if var.startswith("STARDAG_")]
     with temp_env_vars({var: None for var in stardag_env_vars}):
         yield
+
+
+@pytest.fixture(scope="function", autouse=True)
+def hermetic_config(
+    cleared_stardag_env_vars: None,
+    tmp_path_factory: pytest.TempPathFactory,
+) -> typing.Generator[None, None, None]:
+    """Isolate every test from the developer's ambient stardag configuration.
+
+    Config is resolved not only from ``STARDAG_*`` env vars (which
+    ``cleared_stardag_env_vars`` already clears) but also from user/project
+    ``config.toml`` files and the active profile. Without this, a machine-local
+    default target root (e.g. a remote ``s3://`` / cloud-volume root) or registry
+    would leak into unit tests — most visibly into tests that build
+    ``task.target()`` without their own target-isolation fixture.
+
+    This overrides ``config_provider`` with a hermetic default — offline (no
+    registry) and a local temp target root — and rebuilds
+    ``target_factory_provider`` from it. Tests that set up their own factory
+    (``default_in_memory_fs_target``) or roots (``default_local_target_tmp_path``)
+    override on top and restore back to this hermetic baseline. Config-loader
+    tests that call ``clear_config_cache()`` and load from their own
+    monkeypatched sources are unaffected (the clear drops this override, and it
+    is re-established for the next test).
+    """
+    default_root = tmp_path_factory.mktemp("hermetic-target-root")
+    hermetic = StardagConfig(
+        registry=None,
+        target=TargetConfig(roots={DEFAULT_TARGET_ROOT_KEY: str(default_root)}),
+    )
+    with config_provider.override(hermetic):
+        # Build the factory inside the config override so it reads the hermetic
+        # roots, not a factory lazily built from ambient config earlier.
+        with target_factory_provider.override(TargetFactory()):
+            yield

--- a/lib/stardag/tests/test_hermetic_config.py
+++ b/lib/stardag/tests/test_hermetic_config.py
@@ -1,0 +1,42 @@
+"""Regression tests for hermetic test configuration.
+
+The unit suite must never read the developer's ambient stardag configuration
+(user/project ``config.toml``, active profile, or ``STARDAG_*`` env vars). A
+machine-local *remote* default target root (e.g. an ``s3://`` / cloud-volume
+root) used to leak into any test that built ``task.target()`` without its own
+target-isolation fixture, failing it with a "URI ... does not match any of the
+configured prefixes" error. The autouse ``hermetic_config`` fixture in
+``conftest.py`` guarantees a local, offline baseline instead.
+"""
+
+import stardag as sd
+from stardag import LocalFileTarget
+from stardag.config import config_provider
+from stardag.target.serialize import FileSerializable
+
+
+class _HermeticIntTask(sd.Task[int]):
+    value: int = 0
+
+    def run(self):
+        self._save(self.value)
+
+
+def test_config_is_offline_by_default():
+    """No ambient registry leaks into the suite."""
+    assert config_provider.get().registry is None
+
+
+def test_default_target_root_is_local():
+    """The default target root is a local filesystem path, not a remote scheme
+    inherited from the developer's config."""
+    default_root = config_provider.get().target.roots["default"]
+    assert "://" not in default_root
+
+
+def test_target_builds_local_regardless_of_ambient_config():
+    """Building a task target succeeds and yields a local file target — the
+    exact path that broke when ambient config supplied a remote root."""
+    target = _HermeticIntTask(value=1).target()
+    assert isinstance(target, FileSerializable)
+    assert isinstance(target.wrapped, LocalFileTarget)


### PR DESCRIPTION
Closes #180.

## Problem

Some unit tests read the developer's **ambient** stardag configuration instead
of a hermetic setup. Config is resolved from user/project `config.toml` and the
active profile — not just `STARDAG_*` env vars. The existing autouse
`cleared_stardag_env_vars` fixture only clears env vars, so a machine-local
**remote** default target root (any non-filesystem scheme) leaked into any test
that built `task.target()` without its own target-isolation fixture, e.g.:

```
ValueError: URI s3://my-bucket/... does not match any of the configured prefixes: ['/'].
```

Concretely this failed `TestTarget` / `TestDirectoryTarget` in
`test__core/test_task.py` (they build `.target()` and assert its type/uri, with
no isolation fixture — unlike `TestRunAndSave`, which takes
`default_in_memory_fs_target`).

## Fix

Add an autouse `hermetic_config` fixture (`tests/conftest.py`) that overrides
`config_provider` with a hermetic default — **offline (no registry) + a local
temp target root** — and rebuilds `target_factory_provider` from it. This makes
the whole suite independent of the machine's config, not just its env vars.

- Tests that set up their own factory (`default_in_memory_fs_target`) or roots
  (`default_local_target_tmp_path`) override on top and restore back to this
  baseline.
- Config-loader tests (`test_config.py`) that call `clear_config_cache()` and
  load from their own monkeypatched sources are unaffected — the clear drops the
  override, which is re-established for the next test.

Adds `tests/test_hermetic_config.py` locking the offline + local-target-root
contract.

## Result

The 4 previously config-dependent tests now pass regardless of local config, and
the **full suite is green with no remote-config leakage** (664 passed locally on
a machine whose active profile uses a remote default target root — previously 4
failed there; CI was already green because its config is clean).

Test-infrastructure only — no user-facing SDK behavior change, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)