### PR TITLE
ui: change-password dialog for local auth mode

### DIFF
--- a/app/stardag-ui/src/api/auth.ts
+++ b/app/stardag-ui/src/api/auth.ts
@@ -87,3 +87,30 @@ export async function registerLocal(
     display_name: displayName || null,
   });
 }
+
+/**
+ * Change the current user's password (local auth mode). Requires a valid
+ * session (or workspace) token; the API verifies the current password.
+ * Resolves on success (204), throws Error with the API's detail otherwise.
+ */
+export async function changePasswordLocal(
+  currentPassword: string,
+  newPassword: string,
+  sessionToken: string,
+): Promise<void> {
+  const response = await fetch(`${API_BASE}/auth/change-password`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${sessionToken}`,
+    },
+    body: JSON.stringify({
+      current_password: currentPassword,
+      new_password: newPassword,
+    }),
+  });
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({}));
+    throw new Error(error.detail || `Request failed: ${response.statusText}`);
+  }
+}

--- a/app/stardag-ui/src/components/ChangePasswordModal.test.tsx
+++ b/app/stardag-ui/src/components/ChangePasswordModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChangePasswordModal } from "./ChangePasswordModal";
@@ -17,8 +17,12 @@ vi.mock("../api/auth", () => ({
 
 import { changePasswordLocal } from "../api/auth";
 
-async function fillForm(current: string, next: string, confirm: string) {
-  const user = userEvent.setup();
+async function fillForm(
+  current: string,
+  next: string,
+  confirm: string,
+  user = userEvent.setup(),
+) {
   await user.type(screen.getByLabelText("Current password"), current);
   await user.type(screen.getByLabelText("New password"), next);
   await user.type(screen.getByLabelText("Confirm new password"), confirm);
@@ -72,20 +76,59 @@ describe("ChangePasswordModal", () => {
   it("submits and shows a confirmation, then closes", async () => {
     vi.mocked(changePasswordLocal).mockResolvedValue(undefined);
     const onClose = vi.fn();
+
+    // Capture the 1.5s auto-close callback instead of waiting real time.
+    // Other setTimeout calls (userEvent, waitFor) pass through untouched.
+    let closeCallback: (() => void) | undefined;
+    const nativeSetTimeout = window.setTimeout.bind(window);
+    const setTimeoutSpy = vi.spyOn(window, "setTimeout").mockImplementation(((
+      handler: TimerHandler,
+      timeout?: number,
+      ...args: unknown[]
+    ) => {
+      if (timeout === 1500) {
+        closeCallback = handler as () => void;
+        return 0;
+      }
+      return nativeSetTimeout(handler, timeout, ...args);
+    }) as typeof window.setTimeout);
+
+    try {
+      render(<ChangePasswordModal isOpen={true} onClose={onClose} />);
+
+      await fillForm("old-password", "new-password", "new-password");
+
+      expect(
+        await screen.findByText("Password changed successfully."),
+      ).toBeInTheDocument();
+      expect(changePasswordLocal).toHaveBeenCalledWith(
+        "old-password",
+        "new-password",
+        "session-token-123",
+      );
+
+      // The close was scheduled with the confirmation delay; run it now
+      expect(onClose).not.toHaveBeenCalled();
+      expect(closeCallback).toBeDefined();
+      act(() => closeCallback!());
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  it("ignores close attempts while the request is in flight", async () => {
+    // Keep the request pending for the duration of the test
+    vi.mocked(changePasswordLocal).mockImplementation(() => new Promise(() => {}));
+    const onClose = vi.fn();
     render(<ChangePasswordModal isOpen={true} onClose={onClose} />);
 
-    await fillForm("old-password", "new-password", "new-password");
+    const user = userEvent.setup();
+    await fillForm("old-password", "new-password", "new-password", user);
 
-    expect(
-      await screen.findByText("Password changed successfully."),
-    ).toBeInTheDocument();
-    expect(changePasswordLocal).toHaveBeenCalledWith(
-      "old-password",
-      "new-password",
-      "session-token-123",
-    );
-    // Closes after the brief confirmation
-    await waitFor(() => expect(onClose).toHaveBeenCalled(), { timeout: 3000 });
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeDisabled();
+    await user.keyboard("{Escape}");
+    expect(onClose).not.toHaveBeenCalled();
   });
 
   it("shows the API error on wrong current password (401)", async () => {

--- a/app/stardag-ui/src/components/ChangePasswordModal.test.tsx
+++ b/app/stardag-ui/src/components/ChangePasswordModal.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ChangePasswordModal } from "./ChangePasswordModal";
+
+const mockGetAccessToken = vi.fn();
+vi.mock("../context/AuthContext", () => ({
+  useAuth: () => ({
+    authMode: "local",
+    getAccessToken: mockGetAccessToken,
+  }),
+}));
+
+vi.mock("../api/auth", () => ({
+  changePasswordLocal: vi.fn(),
+}));
+
+import { changePasswordLocal } from "../api/auth";
+
+async function fillForm(current: string, next: string, confirm: string) {
+  const user = userEvent.setup();
+  await user.type(screen.getByLabelText("Current password"), current);
+  await user.type(screen.getByLabelText("New password"), next);
+  await user.type(screen.getByLabelText("Confirm new password"), confirm);
+  await user.click(screen.getByRole("button", { name: "Change password" }));
+}
+
+describe("ChangePasswordModal", () => {
+  beforeEach(() => {
+    mockGetAccessToken.mockResolvedValue("session-token-123");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the password fields when open", () => {
+    render(<ChangePasswordModal isOpen={true} onClose={vi.fn()} />);
+
+    expect(screen.getByLabelText("Current password")).toBeInTheDocument();
+    expect(screen.getByLabelText("New password")).toBeInTheDocument();
+    expect(screen.getByLabelText("Confirm new password")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Change password" })).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    render(<ChangePasswordModal isOpen={false} onClose={vi.fn()} />);
+
+    expect(screen.queryByLabelText("Current password")).not.toBeInTheDocument();
+  });
+
+  it("rejects a too-short new password client-side", async () => {
+    render(<ChangePasswordModal isOpen={true} onClose={vi.fn()} />);
+
+    await fillForm("old-password", "short", "short");
+
+    expect(
+      await screen.findByText("New password must be at least 8 characters"),
+    ).toBeInTheDocument();
+    expect(changePasswordLocal).not.toHaveBeenCalled();
+  });
+
+  it("rejects mismatched new passwords client-side", async () => {
+    render(<ChangePasswordModal isOpen={true} onClose={vi.fn()} />);
+
+    await fillForm("old-password", "new-password-1", "new-password-2");
+
+    expect(await screen.findByText("New passwords do not match")).toBeInTheDocument();
+    expect(changePasswordLocal).not.toHaveBeenCalled();
+  });
+
+  it("submits and shows a confirmation, then closes", async () => {
+    vi.mocked(changePasswordLocal).mockResolvedValue(undefined);
+    const onClose = vi.fn();
+    render(<ChangePasswordModal isOpen={true} onClose={onClose} />);
+
+    await fillForm("old-password", "new-password", "new-password");
+
+    expect(
+      await screen.findByText("Password changed successfully."),
+    ).toBeInTheDocument();
+    expect(changePasswordLocal).toHaveBeenCalledWith(
+      "old-password",
+      "new-password",
+      "session-token-123",
+    );
+    // Closes after the brief confirmation
+    await waitFor(() => expect(onClose).toHaveBeenCalled(), { timeout: 3000 });
+  });
+
+  it("shows the API error on wrong current password (401)", async () => {
+    vi.mocked(changePasswordLocal).mockRejectedValue(
+      new Error("Current password is incorrect"),
+    );
+    const onClose = vi.fn();
+    render(<ChangePasswordModal isOpen={true} onClose={onClose} />);
+
+    await fillForm("wrong-password", "new-password", "new-password");
+
+    expect(
+      await screen.findByText("Current password is incorrect"),
+    ).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+    // Form is still usable for a retry
+    expect(screen.getByRole("button", { name: "Change password" })).not.toBeDisabled();
+  });
+});

--- a/app/stardag-ui/src/components/ChangePasswordModal.tsx
+++ b/app/stardag-ui/src/components/ChangePasswordModal.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { changePasswordLocal } from "../api/auth";
 import { useAuth } from "../context/AuthContext";
 import { Modal } from "./Modal";
@@ -13,7 +13,7 @@ interface ChangePasswordModalProps {
 /**
  * Change-password dialog for local auth mode (email/password accounts
  * managed by the API). Verifies the current password server-side via
- * POST /auth/change-password.
+ * POST /api/v1/auth/change-password.
  */
 export function ChangePasswordModal({ isOpen, onClose }: ChangePasswordModalProps) {
   const { getAccessToken } = useAuth();
@@ -23,8 +23,22 @@ export function ChangePasswordModal({ isOpen, onClose }: ChangePasswordModalProp
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [success, setSuccess] = useState(false);
+  const closeTimeoutRef = useRef<number | null>(null);
+
+  // Clear any pending auto-close timer on unmount
+  useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current !== null) {
+        window.clearTimeout(closeTimeoutRef.current);
+      }
+    };
+  }, []);
 
   function resetAndClose() {
+    if (closeTimeoutRef.current !== null) {
+      window.clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
     setCurrentPassword("");
     setNewPassword("");
     setConfirmPassword("");
@@ -32,6 +46,16 @@ export function ChangePasswordModal({ isOpen, onClose }: ChangePasswordModalProp
     setIsSubmitting(false);
     setSuccess(false);
     onClose();
+  }
+
+  /**
+   * User-initiated close (Cancel, X button, overlay click, Escape).
+   * Ignored while the request is in flight so an in-flight submit can't
+   * later flip to the success state / schedule a stale delayed close.
+   */
+  function handleClose() {
+    if (isSubmitting) return;
+    resetAndClose();
   }
 
   async function handleSubmit(event: FormEvent) {
@@ -56,9 +80,10 @@ export function ChangePasswordModal({ isOpen, onClose }: ChangePasswordModalProp
         throw new Error("Your session has expired — please sign in again");
       }
       await changePasswordLocal(currentPassword, newPassword, token);
+      setIsSubmitting(false);
       setSuccess(true);
-      // Brief confirmation, then close
-      setTimeout(resetAndClose, 1500);
+      // Brief confirmation, then close (dismissable early by the user)
+      closeTimeoutRef.current = window.setTimeout(resetAndClose, 1500);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to change password");
       setIsSubmitting(false);
@@ -71,7 +96,7 @@ export function ChangePasswordModal({ isOpen, onClose }: ChangePasswordModalProp
     "mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300";
 
   return (
-    <Modal isOpen={isOpen} onClose={resetAndClose} title="Change password">
+    <Modal isOpen={isOpen} onClose={handleClose} title="Change password">
       {success ? (
         <p className="py-2 text-sm text-green-600 dark:text-green-400" role="status">
           Password changed successfully.
@@ -128,8 +153,9 @@ export function ChangePasswordModal({ isOpen, onClose }: ChangePasswordModalProp
           <div className="flex justify-end gap-2 pt-2">
             <button
               type="button"
-              onClick={resetAndClose}
-              className="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+              onClick={handleClose}
+              disabled={isSubmitting}
+              className="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-60 dark:text-gray-200 dark:hover:bg-gray-700"
             >
               Cancel
             </button>

--- a/app/stardag-ui/src/components/ChangePasswordModal.tsx
+++ b/app/stardag-ui/src/components/ChangePasswordModal.tsx
@@ -1,0 +1,148 @@
+import { useState, type FormEvent } from "react";
+import { changePasswordLocal } from "../api/auth";
+import { useAuth } from "../context/AuthContext";
+import { Modal } from "./Modal";
+
+const MIN_PASSWORD_LENGTH = 8;
+
+interface ChangePasswordModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Change-password dialog for local auth mode (email/password accounts
+ * managed by the API). Verifies the current password server-side via
+ * POST /auth/change-password.
+ */
+export function ChangePasswordModal({ isOpen, onClose }: ChangePasswordModalProps) {
+  const { getAccessToken } = useAuth();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  function resetAndClose() {
+    setCurrentPassword("");
+    setNewPassword("");
+    setConfirmPassword("");
+    setError(null);
+    setIsSubmitting(false);
+    setSuccess(false);
+    onClose();
+  }
+
+  async function handleSubmit(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+
+    // Client-side checks (the API enforces the policy authoritatively)
+    if (newPassword.length < MIN_PASSWORD_LENGTH) {
+      setError(`New password must be at least ${MIN_PASSWORD_LENGTH} characters`);
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      setError("New passwords do not match");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      // No workspace ID: returns the user-scoped session token in local mode
+      const token = await getAccessToken(null);
+      if (!token) {
+        throw new Error("Your session has expired — please sign in again");
+      }
+      await changePasswordLocal(currentPassword, newPassword, token);
+      setSuccess(true);
+      // Brief confirmation, then close
+      setTimeout(resetAndClose, 1500);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to change password");
+      setIsSubmitting(false);
+    }
+  }
+
+  const inputClassName =
+    "w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100";
+  const labelClassName =
+    "mb-1 block text-sm font-medium text-gray-700 dark:text-gray-300";
+
+  return (
+    <Modal isOpen={isOpen} onClose={resetAndClose} title="Change password">
+      {success ? (
+        <p className="py-2 text-sm text-green-600 dark:text-green-400" role="status">
+          Password changed successfully.
+        </p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label htmlFor="currentPassword" className={labelClassName}>
+              Current password
+            </label>
+            <input
+              id="currentPassword"
+              type="password"
+              required
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              autoComplete="current-password"
+              className={inputClassName}
+            />
+          </div>
+          <div>
+            <label htmlFor="newPassword" className={labelClassName}>
+              New password
+            </label>
+            <input
+              id="newPassword"
+              type="password"
+              required
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              autoComplete="new-password"
+              className={inputClassName}
+            />
+          </div>
+          <div>
+            <label htmlFor="confirmPassword" className={labelClassName}>
+              Confirm new password
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              required
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              autoComplete="new-password"
+              className={inputClassName}
+            />
+          </div>
+          {error && (
+            <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+              {error}
+            </p>
+          )}
+          <div className="flex justify-end gap-2 pt-2">
+            <button
+              type="button"
+              onClick={resetAndClose}
+              className="rounded-md px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting}
+              className="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isSubmitting ? "Changing…" : "Change password"}
+            </button>
+          </div>
+        </form>
+      )}
+    </Modal>
+  );
+}

--- a/app/stardag-ui/src/components/UserMenu.tsx
+++ b/app/stardag-ui/src/components/UserMenu.tsx
@@ -1,10 +1,12 @@
 import { useState, useRef, useEffect } from "react";
 import { isAuthConfigured } from "../auth/config";
 import { useAuth } from "../context/AuthContext";
+import { ChangePasswordModal } from "./ChangePasswordModal";
 
 export function UserMenu() {
-  const { user, isLoading, isAuthenticated, login, logout } = useAuth();
+  const { user, isLoading, isAuthenticated, login, logout, authMode } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
+  const [isChangePasswordOpen, setIsChangePasswordOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
 
   // Close menu when clicking outside
@@ -80,6 +82,17 @@ export function UserMenu() {
             )}
           </div>
           <div className="py-1">
+            {authMode === "local" && (
+              <button
+                onClick={() => {
+                  setIsOpen(false);
+                  setIsChangePasswordOpen(true);
+                }}
+                className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+              >
+                Change password
+              </button>
+            )}
             <button
               onClick={() => {
                 setIsOpen(false);
@@ -92,6 +105,11 @@ export function UserMenu() {
           </div>
         </div>
       )}
+
+      <ChangePasswordModal
+        isOpen={isChangePasswordOpen}
+        onClose={() => setIsChangePasswordOpen(false)}
+      />
     </div>
   );
 }

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -113,8 +113,8 @@ no external identity provider.
   everyone register, then re-run without it to close signup again. Members
   are added to shared workspaces from the UI's workspace settings.
 - Passwords: min 8 characters, bcrypt-hashed; login is rate-limited.
-- Change your password anytime via `POST /api/v1/auth/change-password` (UI
-  support: sign out/in flow).
+- Change your password anytime from the UI (user menu → Change password),
+  or via `POST /api/v1/auth/change-password`.
 
 ## Auth mode: `oidc` (external identity provider)
 


### PR DESCRIPTION
Stacked on #188 (base branch: `self-host-modal`) — adds the UI counterpart to the local-auth `POST /api/v1/auth/change-password` endpoint introduced there.

## What

- **User menu → "Change password"** (rendered only when `authMode === "local"`): opens a modal with current password, new password, and confirm fields.
- Client-side validation (min 8 characters, confirmation match) before hitting the API; API errors (wrong current password, policy violations) are surfaced in the dialog.
- Success shows a brief confirmation, then closes the modal.
- `changePasswordLocal()` API helper in `src/api/auth.ts`, following the existing `loginLocal`/`registerLocal` pattern; the session token is obtained via `getAccessToken(null)` from `useAuth()`.
- Docs: the self-host guide now points to the UI flow instead of describing the endpoint as API-only.

## Tests

- New `ChangePasswordModal.test.tsx` (6 tests): field rendering, closed state, client-side length + mismatch validation, mocked success (confirmation + close), mocked 401 (error shown, form stays usable).
- `npm test`: 90/90 passing; `npm run build`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf