### PR TITLE
Fix e2e-test.sh: broken since examples reorg + auth-era API

### DIFF
--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -2,6 +2,7 @@
 # End-to-end integration test
 # Brings up docker-compose, runs demo, verifies API and UI
 set -e
+set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -74,7 +75,7 @@ done
 # Bootstrap SDK credentials: test user -> workspace -> environment -> API key
 # (mirrors the flow in integration-tests/src/stardag_integration_tests/conftest.py)
 echo "=== Bootstrapping API credentials ==="
-OIDC_TOKEN=$(curl -sf -X POST http://localhost:8080/realms/stardag/protocol/openid-connect/token \
+OIDC_TOKEN=$(curl -fsS -X POST http://localhost:8080/realms/stardag/protocol/openid-connect/token \
     -d "grant_type=password" \
     -d "client_id=stardag-test" \
     -d "username=testuser" \
@@ -84,23 +85,23 @@ OIDC_TOKEN=$(curl -sf -X POST http://localhost:8080/realms/stardag/protocol/open
 
 # First authenticated request auto-creates the test user
 # and their personal workspace (with a default environment)
-WORKSPACE_ID=$(curl -sf http://localhost:8000/api/v1/ui/me \
+WORKSPACE_ID=$(curl -fsS http://localhost:8000/api/v1/ui/me \
     -H "Authorization: Bearer $OIDC_TOKEN" \
     | python3 -c "import sys, json; print(json.load(sys.stdin)['workspaces'][0]['id'])")
 echo "Using workspace: $WORKSPACE_ID"
 
-INTERNAL_TOKEN=$(curl -sf -X POST http://localhost:8000/api/v1/auth/exchange \
+INTERNAL_TOKEN=$(curl -fsS -X POST http://localhost:8000/api/v1/auth/exchange \
     -H "Authorization: Bearer $OIDC_TOKEN" \
     -H "Content-Type: application/json" \
     -d "{\"workspace_id\": \"$WORKSPACE_ID\"}" \
     | python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
 
-ENVIRONMENT_ID=$(curl -sf "http://localhost:8000/api/v1/ui/workspaces/$WORKSPACE_ID/environments" \
+ENVIRONMENT_ID=$(curl -fsS "http://localhost:8000/api/v1/ui/workspaces/$WORKSPACE_ID/environments" \
     -H "Authorization: Bearer $INTERNAL_TOKEN" \
     | python3 -c "import sys, json; print(json.load(sys.stdin)[0]['id'])")
 echo "Using environment: $ENVIRONMENT_ID"
 
-API_KEY=$(curl -sf -X POST "http://localhost:8000/api/v1/ui/workspaces/$WORKSPACE_ID/environments/$ENVIRONMENT_ID/api-keys" \
+API_KEY=$(curl -fsS -X POST "http://localhost:8000/api/v1/ui/workspaces/$WORKSPACE_ID/environments/$ENVIRONMENT_ID/api-keys" \
     -H "Authorization: Bearer $INTERNAL_TOKEN" \
     -H "Content-Type: application/json" \
     -d '{"name": "e2e-test"}' \

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -59,7 +59,7 @@ done
 # Wait for Keycloak (realm import can take a while)
 echo "=== Waiting for Keycloak ==="
 for i in {1..60}; do
-    if curl -s http://localhost:8080/realms/stardag/.well-known/openid-configuration > /dev/null 2>&1; then
+    if curl -sf --max-time 5 http://localhost:8080/realms/stardag/.well-known/openid-configuration > /dev/null 2>&1; then
         echo "Keycloak is ready"
         break
     fi
@@ -114,12 +114,16 @@ export STARDAG_TARGET_ROOTS__DEFAULT="$TARGET_ROOT"
 export STARDAG_API_URL="http://localhost:8000"
 export STARDAG_API_KEY="$API_KEY"
 
-cd "$REPO_ROOT/lib/stardag-examples"
-uv run python -m stardag_examples.general.artifacts_demo
+# Subshell so the working directory stays at the repo root (the cleanup
+# trap relies on it to find the compose file).
+(
+    cd "$REPO_ROOT/lib/stardag-examples"
+    uv run python -m stardag_examples.general.artifacts_demo
+)
 
 # Verify API has builds
 echo "=== Verifying API - Builds ==="
-BUILDS_RESPONSE=$(curl -s -H "X-API-Key: $API_KEY" http://localhost:8000/api/v1/builds)
+BUILDS_RESPONSE=$(curl -fsS -H "X-API-Key: $API_KEY" http://localhost:8000/api/v1/builds)
 BUILD_COUNT=$(echo "$BUILDS_RESPONSE" | python3 -c "import sys, json; data=json.load(sys.stdin); print(data.get('total', 0))")
 if [ "$BUILD_COUNT" -lt 1 ]; then
     echo "ERROR: No builds found in API"
@@ -130,7 +134,7 @@ echo "Found $BUILD_COUNT build(s) in API"
 
 # Verify API has tasks
 echo "=== Verifying API - Tasks ==="
-TASKS_RESPONSE=$(curl -s -H "X-API-Key: $API_KEY" http://localhost:8000/api/v1/tasks)
+TASKS_RESPONSE=$(curl -fsS -H "X-API-Key: $API_KEY" http://localhost:8000/api/v1/tasks)
 TASK_COUNT=$(echo "$TASKS_RESPONSE" | python3 -c "import sys, json; data=json.load(sys.stdin); print(data.get('total', 0))")
 if [ "$TASK_COUNT" -lt 1 ]; then
     echo "ERROR: No tasks found in API"

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -56,18 +56,70 @@ for i in {1..30}; do
     sleep 1
 done
 
+# Wait for Keycloak (realm import can take a while)
+echo "=== Waiting for Keycloak ==="
+for i in {1..60}; do
+    if curl -s http://localhost:8080/realms/stardag/.well-known/openid-configuration > /dev/null 2>&1; then
+        echo "Keycloak is ready"
+        break
+    fi
+    if [ $i -eq 60 ]; then
+        echo "ERROR: Keycloak failed to start"
+        docker-compose logs keycloak
+        exit 1
+    fi
+    sleep 2
+done
+
+# Bootstrap SDK credentials: test user -> workspace -> environment -> API key
+# (mirrors the flow in integration-tests/src/stardag_integration_tests/conftest.py)
+echo "=== Bootstrapping API credentials ==="
+OIDC_TOKEN=$(curl -sf -X POST http://localhost:8080/realms/stardag/protocol/openid-connect/token \
+    -d "grant_type=password" \
+    -d "client_id=stardag-test" \
+    -d "username=testuser" \
+    -d "password=testpassword" \
+    -d "scope=openid profile email" \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
+
+# First authenticated request auto-creates the test user
+# and their personal workspace (with a default environment)
+WORKSPACE_ID=$(curl -sf http://localhost:8000/api/v1/ui/me \
+    -H "Authorization: Bearer $OIDC_TOKEN" \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)['workspaces'][0]['id'])")
+echo "Using workspace: $WORKSPACE_ID"
+
+INTERNAL_TOKEN=$(curl -sf -X POST http://localhost:8000/api/v1/auth/exchange \
+    -H "Authorization: Bearer $OIDC_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d "{\"workspace_id\": \"$WORKSPACE_ID\"}" \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
+
+ENVIRONMENT_ID=$(curl -sf "http://localhost:8000/api/v1/ui/workspaces/$WORKSPACE_ID/environments" \
+    -H "Authorization: Bearer $INTERNAL_TOKEN" \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)[0]['id'])")
+echo "Using environment: $ENVIRONMENT_ID"
+
+API_KEY=$(curl -sf -X POST "http://localhost:8000/api/v1/ui/workspaces/$WORKSPACE_ID/environments/$ENVIRONMENT_ID/api-keys" \
+    -H "Authorization: Bearer $INTERNAL_TOKEN" \
+    -H "Content-Type: application/json" \
+    -d '{"name": "e2e-test"}' \
+    | python3 -c "import sys, json; print(json.load(sys.stdin)['key'])")
+echo "API key created"
+
 # Run demo script
 echo "=== Running demo script ==="
 TARGET_ROOT=$(mktemp -d)
 export STARDAG_TARGET_ROOTS__DEFAULT="$TARGET_ROOT"
-export STARDAG_API_REGISTRY_URL="http://localhost:8000"
+export STARDAG_API_URL="http://localhost:8000"
+export STARDAG_API_KEY="$API_KEY"
 
 cd "$REPO_ROOT/lib/stardag-examples"
-uv run python src/stardag_examples/api_registry_demo.py
+uv run python -m stardag_examples.general.artifacts_demo
 
 # Verify API has builds
 echo "=== Verifying API - Builds ==="
-BUILDS_RESPONSE=$(curl -s http://localhost:8000/api/v1/builds)
+BUILDS_RESPONSE=$(curl -s -H "X-API-Key: $API_KEY" http://localhost:8000/api/v1/builds)
 BUILD_COUNT=$(echo "$BUILDS_RESPONSE" | python3 -c "import sys, json; data=json.load(sys.stdin); print(data.get('total', 0))")
 if [ "$BUILD_COUNT" -lt 1 ]; then
     echo "ERROR: No builds found in API"
@@ -78,7 +130,7 @@ echo "Found $BUILD_COUNT build(s) in API"
 
 # Verify API has tasks
 echo "=== Verifying API - Tasks ==="
-TASKS_RESPONSE=$(curl -s http://localhost:8000/api/v1/tasks)
+TASKS_RESPONSE=$(curl -s -H "X-API-Key: $API_KEY" http://localhost:8000/api/v1/tasks)
 TASK_COUNT=$(echo "$TASKS_RESPONSE" | python3 -c "import sys, json; data=json.load(sys.stdin); print(data.get('total', 0))")
 if [ "$TASK_COUNT" -lt 1 ]; then
     echo "ERROR: No tasks found in API"


### PR DESCRIPTION
## Summary

`./scripts/e2e-test.sh` has been broken on `main` since the examples package reorganization (#64): it still invoked `src/stardag_examples/api_registry_demo.py`, which was removed in that reorg (with no direct successor), so the script failed at "Running demo script" with *No such file or directory*.

Beyond the missing file, the script predated the current auth model, so a pure path fix would still fail. This PR keeps the script's structure and verifications intact and updates the wiring:

- **Demo**: run `python -m stardag_examples.general.artifacts_demo` — the closest existing Registry-exercising example (registers a build, tasks, and artifacts against the local API).
- **Credentials bootstrap**: mirror the integration-tests flow — Keycloak password grant for the test user → `/api/v1/ui/me` (auto-creates the personal workspace + environment on first login) → token exchange → create an environment-scoped API key.
- **Env vars**: `STARDAG_API_URL` (replaces the removed `STARDAG_API_REGISTRY_URL`) + `STARDAG_API_KEY`.
- **Verification curls**: `/api/v1/builds` and `/api/v1/tasks` now require SDK auth — send the `X-API-Key` header.
- **Keycloak wait**: wait for the realm's OIDC discovery endpoint before requesting tokens (realm import can outlast the API/UI readiness checks).

## Verification

Full run of `./scripts/e2e-test.sh` from the repo root exits 0:

```
=== Waiting for API ===
API is ready
=== Waiting for UI ===
UI is ready
=== Waiting for Keycloak ===
Keycloak is ready
=== Bootstrapping API credentials ===
Using workspace: 019f6c6a-11e5-7e00-b9a3-c8c5ae992e1d
Using environment: 019f6c6a-11eb-7470-8618-6d288cd469be
API key created
=== Running demo script ===
Configuration loaded. Running against Registry at: http://localhost:8000
Building DAG with artifacts...
  - DataCollector: produces JSON artifacts (raw-data, statistics)
  - AnalysisReport: produces markdown artifact (analysis-report)

Result: Analysis complete. Mean: 0.0902, StdDev: 0.8863
=== Verifying API - Builds ===
Found 1 build(s) in API
=== Verifying API - Tasks ===
Found 2 task(s) in API
=== Verifying UI ===
UI is serving HTML correctly

=== E2E Integration Test PASSED ===
```

Note: `DEV_README.md` and `app/README.md` still reference the removed `api_registry_demo` module in prose; left out of scope here to keep the change minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf