### PR TITLE
Server release pipeline: prebuilt GHCR images + independent server versioning

### DIFF
--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -1,0 +1,109 @@
+# Server release pipeline: pushing a `server-vX.Y.Z` tag publishes the
+# combined server image (Registry API + web UI, one joint version) to
+# ghcr.io/stardag-dev/stardag-server:{X.Y.Z,latest} and creates a GitHub
+# Release with the built UI dist attached (for deployments that serve the
+# UI separately, e.g. from S3/CDN).
+#
+# The server is versioned independently of the SDK (`v*` tags — see
+# publish.yml). The single image definition lives in app/server.Dockerfile.
+name: Publish Server Image
+
+on:
+  push:
+    tags:
+      - "server-v[0-9]+.[0-9]+.[0-9]+"
+
+jobs:
+  publish-image:
+    name: Build and push to GHCR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#server-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: app/server.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/stardag-server:${{ steps.version.outputs.version }}
+            ghcr.io/${{ github.repository_owner }}/stardag-server:latest
+          build-args: |
+            STARDAG_SERVER_VERSION=${{ steps.version.outputs.version }}
+
+  github-release:
+    name: GitHub Release with UI dist
+    needs:
+      - publish-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#server-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+          cache-dependency-path: app/stardag-ui/package-lock.json
+
+      - name: Build web UI
+        working-directory: app/stardag-ui
+        run: |
+          npm ci
+          npm run build
+
+      - name: Package UI dist
+        run: >-
+          tar -czf
+          "stardag-ui-dist-${{ steps.version.outputs.version }}.tar.gz"
+          -C app/stardag-ui/dist .
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release create
+          '${{ github.ref_name }}'
+          --repo '${{ github.repository }}'
+          --title 'Stardag Server ${{ steps.version.outputs.version }}'
+          --notes 'Combined server image (Registry API + web UI):
+          `ghcr.io/${{ github.repository_owner }}/stardag-server:${{ steps.version.outputs.version }}`
+
+
+          The attached `stardag-ui-dist-${{ steps.version.outputs.version }}.tar.gz`
+          contains the built web UI for deployments that serve it separately.'
+
+      - name: Upload UI dist to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          gh release upload
+          '${{ github.ref_name }}'
+          'stardag-ui-dist-${{ steps.version.outputs.version }}.tar.gz'
+          --repo '${{ github.repository }}'

--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -96,6 +96,10 @@ jobs:
           `ghcr.io/${{ github.repository_owner }}/stardag-server:${{ steps.version.outputs.version }}`
 
 
+          See the [changelog](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/CHANGELOG.md)
+          for what changed (Registry API / UI / Deployment sections).
+
+
           The attached `stardag-ui-dist-${{ steps.version.outputs.version }}.tar.gz`
           contains the built web UI for deployments that serve it separately.'
 

--- a/.github/workflows/publish-server-image.yml
+++ b/.github/workflows/publish-server-image.yml
@@ -38,6 +38,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # One-time note (first release only): the initial push creates the
+      # GHCR package with PRIVATE visibility. `stardag self-host` pulls the
+      # image anonymously (`modal.Image.from_registry` without credentials),
+      # so the package must be switched to public — see "Releasing the
+      # Server" in DEV_README.md for the step.
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -57,32 +62,38 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: read
 
     steps:
-      - uses: actions/checkout@v4
-
       - name: Extract version from tag
         id: version
         run: echo "version=${GITHUB_REF_NAME#server-v}" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          node-version: "22"
-          cache: "npm"
-          cache-dependency-path: app/stardag-ui/package-lock.json
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build web UI
-        working-directory: app/stardag-ui
+      # Extract the UI dist from the image that was just pushed (instead of
+      # rebuilding it on the runner) so the release asset is byte-identical
+      # to what the image serves. Flat layout (index.html at the tar root) —
+      # downstream extractors depend on it.
+      - name: Extract UI dist from the pushed image
+        env:
+          IMAGE: ghcr.io/${{ github.repository_owner }}/stardag-server:${{ steps.version.outputs.version }}
         run: |
-          npm ci
-          npm run build
+          docker pull "$IMAGE"
+          cid=$(docker create "$IMAGE")
+          docker cp "$cid:/opt/stardag/ui" ./ui-dist
+          docker rm "$cid"
 
       - name: Package UI dist
         run: >-
           tar -czf
           "stardag-ui-dist-${{ steps.version.outputs.version }}.tar.gz"
-          -C app/stardag-ui/dist .
+          -C ui-dist .
 
       - name: Create GitHub Release
         env:

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -216,6 +216,10 @@ uv run stardag auth logout
 
 The server (Registry API + web UI) is released as one image with its own
 semver, independent of the SDK. API and UI share a single joint version.
+
+Before tagging, make sure `CHANGELOG.md` has an entry covering the
+release's Registry API / UI / Deployment changes (move them out of
+`[Unreleased]`) — the GitHub release links to it.
 The image definition is `app/server.Dockerfile` (build context = repo root):
 
 ```bash

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -212,6 +212,38 @@ You should see tasks appearing in the web UI at http://localhost:3000.
 uv run stardag auth logout
 ```
 
+## Releasing the Server
+
+The server (Registry API + web UI) is released as one image with its own
+semver, independent of the SDK. API and UI share a single joint version.
+The image definition is `app/server.Dockerfile` (build context = repo root):
+
+```bash
+docker build -f app/server.Dockerfile -t stardag-server .
+```
+
+To release, push a `server-vX.Y.Z` tag on `main`:
+
+```bash
+git tag server-vX.Y.Z
+git push origin server-vX.Y.Z
+```
+
+CI (`.github/workflows/publish-server-image.yml`) then:
+
+1. Builds the image and pushes it to
+   `ghcr.io/stardag-dev/stardag-server:X.Y.Z` and `:latest`, with
+   `STARDAG_SERVER_VERSION=X.Y.Z` baked in (surfaced at
+   `GET /api/v1/version`).
+2. Creates a GitHub Release for the tag with the built web UI attached as
+   `stardag-ui-dist-X.Y.Z.tar.gz` (for deployments that serve the UI
+   separately, e.g. from S3/CDN).
+
+`stardag self-host` deploys the prebuilt image by default; each SDK release
+pins the server version it was tested against
+(`DEFAULT_SERVER_VERSION` in `lib/stardag/src/stardag/selfhost/_modal_app.py`
+— bump it when a new server version becomes the tested pairing).
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on submitting changes.

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -239,9 +239,27 @@ CI (`.github/workflows/publish-server-image.yml`) then:
    `ghcr.io/stardag-dev/stardag-server:X.Y.Z` and `:latest`, with
    `STARDAG_SERVER_VERSION=X.Y.Z` baked in (surfaced at
    `GET /api/v1/version`).
-2. Creates a GitHub Release for the tag with the built web UI attached as
-   `stardag-ui-dist-X.Y.Z.tar.gz` (for deployments that serve the UI
+2. Creates a GitHub Release for the tag with the web UI (extracted from the
+   pushed image, so it is byte-identical to what the image serves) attached
+   as `stardag-ui-dist-X.Y.Z.tar.gz` (for deployments that serve the UI
    separately, e.g. from S3/CDN).
+
+### First release only: make the GHCR package public
+
+The first push creates the `stardag-server` GHCR package with **private**
+visibility. `stardag self-host` pulls the image anonymously
+(`modal.Image.from_registry` without credentials), so the prebuilt-image
+path fails for everyone until the package is made public. One-time step
+after the first release workflow completes:
+
+1. Go to the package settings:
+   <https://github.com/orgs/stardag-dev/packages/container/stardag-server/settings>
+2. Under "Danger Zone" → "Change package visibility", set it to **Public**.
+3. While there, connect the package to the repository (adds the README and
+   links it from the repo's Packages sidebar).
+
+Verify with an anonymous pull: `docker logout ghcr.io && docker pull
+ghcr.io/stardag-dev/stardag-server:X.Y.Z`.
 
 `stardag self-host` deploys the prebuilt image by default; each SDK release
 pins the server version it was tested against

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -244,6 +244,27 @@ pins the server version it was tested against
 (`DEFAULT_SERVER_VERSION` in `lib/stardag/src/stardag/selfhost/_modal_app.py`
 — bump it when a new server version becomes the tested pairing).
 
+### Version convention for non-release builds
+
+Release builds get a clean `X.Y.Z` from the tag (CI passes it as the
+`STARDAG_SERVER_VERSION` build arg). Any _other_ build of
+`app/server.Dockerfile` (e.g. a deployment pipeline building from an
+arbitrary commit) should derive the version with `scripts/server-version.sh`,
+which normalizes `git describe --tags --match "server-v*"` to semver
+build-metadata form — so deployments truthfully report their deviation from
+the nearest release:
+
+| State                          | Version          |
+| ------------------------------ | ---------------- |
+| Exactly at `server-vX.Y.Z`     | `X.Y.Z`          |
+| N commits past the nearest tag | `X.Y.Z+N.g<sha>` |
+| No `server-v*` tag reachable   | `0.0.0+g<sha>`   |
+
+```bash
+docker build -f app/server.Dockerfile \
+  --build-arg STARDAG_SERVER_VERSION="$(scripts/server-version.sh)" .
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on submitting changes.

--- a/app/server.Dockerfile
+++ b/app/server.Dockerfile
@@ -1,0 +1,64 @@
+# Combined Stardag server image: Registry API + web UI in one container.
+#
+# This is the single image definition for server releases: CI builds and
+# publishes it to ghcr.io/stardag-dev/stardag-server on `server-v*` tags
+# (see .github/workflows/publish-server-image.yml), and `stardag self-host`
+# consumes the published image via modal.Image.from_registry.
+#
+# Build from the repo root:
+#   docker build -f app/server.Dockerfile -t stardag-server .
+#
+# Layout contract (keep in sync with the from-source build in
+# lib/stardag/src/stardag/selfhost/_modal_app.py — the self-host Modal
+# functions reference these paths in both modes):
+#   /opt/stardag/api  - alembic.ini + migrations/ (DB migrations run with
+#                       this as cwd: python -m alembic -c alembic.ini upgrade head)
+#   /opt/stardag/ui   - built web UI (static files; all UI config is
+#                       fetched from the API at runtime, no build-time env)
+#
+# No ENTRYPOINT and a plain python install: Modal (and other platforms)
+# must be able to use the image's python directly.
+
+# --- Stage 1: build the web UI ------------------------------------------------
+FROM node:22-slim AS ui-build
+
+WORKDIR /build/stardag-ui
+
+COPY app/stardag-ui/package.json app/stardag-ui/package-lock.json ./
+RUN npm ci
+
+COPY app/stardag-ui/ ./
+RUN npm run build
+
+# --- Stage 2: runtime ---------------------------------------------------------
+FROM python:3.12-slim
+
+# Install the API package
+COPY app/stardag-api /tmp/stardag-api
+RUN pip install --no-cache-dir /tmp/stardag-api && rm -rf /tmp/stardag-api
+
+# Alembic config + migrations (not part of the installed python package)
+COPY app/stardag-api/alembic.ini /opt/stardag/api/alembic.ini
+COPY app/stardag-api/migrations /opt/stardag/api/migrations
+
+# Built web UI
+COPY --from=ui-build /build/stardag-ui/dist /opt/stardag/ui
+ENV STARDAG_UI_DIST=/opt/stardag/ui
+
+# Server release version, injected by CI from the `server-vX.Y.Z` tag;
+# surfaced at GET /api/v1/version.
+ARG STARDAG_SERVER_VERSION=dev
+ENV STARDAG_SERVER_VERSION=${STARDAG_SERVER_VERSION}
+
+EXPOSE 8000
+
+# gunicorn with multiple uvicorn workers absorbs CPU-bound bursts (auth /
+# JWT verification, bcrypt cache misses) better than a single uvicorn
+# process; override worker count at deploy time via GUNICORN_WORKERS.
+#
+# --preload imports the app module once in the master process before
+# fork()-ing workers, so the (potentially ephemeral) RSA keypair created
+# at import time is shared by all workers (see app/stardag-api/Dockerfile
+# for the full rationale).
+ENV GUNICORN_WORKERS=2
+CMD ["sh", "-c", "exec gunicorn stardag_api.server:app -k uvicorn.workers.UvicornWorker -w ${GUNICORN_WORKERS} --preload --bind 0.0.0.0:8000 --access-logfile - --error-logfile -"]

--- a/app/server.Dockerfile.dockerignore
+++ b/app/server.Dockerfile.dockerignore
@@ -1,0 +1,15 @@
+# Dockerfile-specific ignore for app/server.Dockerfile (BuildKit picks this
+# up because it sits next to the Dockerfile and matches its name).
+# The build context is the repo root; only app/stardag-api and app/stardag-ui
+# are COPY'd, so exclude everything else plus local build/dev artifacts.
+*
+!app/stardag-api
+!app/stardag-ui
+**/node_modules
+**/dist
+**/.venv
+**/__pycache__
+**/.pytest_cache
+**/.env
+**/.env.*
+app/stardag-api/tests

--- a/app/stardag-api/src/stardag_api/main.py
+++ b/app/stardag-api/src/stardag_api/main.py
@@ -1,4 +1,7 @@
+import os
 from contextlib import asynccontextmanager
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
@@ -86,3 +89,22 @@ app.include_router(target_roots_router, prefix="/api/v1")
 @app.get("/health")
 async def health_check():
     return {"status": "healthy"}
+
+
+@app.get("/api/v1/version")
+async def version():
+    """Server + API package versions.
+
+    ``server_version`` is the release version of the combined server
+    (API + UI) image, injected via the STARDAG_SERVER_VERSION environment
+    variable at image build time ("dev" when unset, e.g. running from
+    source). ``api_version`` is the installed stardag-api package version.
+    """
+    try:
+        api_version = _package_version("stardag-api")
+    except PackageNotFoundError:  # pragma: no cover - running from a raw checkout
+        api_version = "unknown"
+    return {
+        "server_version": os.environ.get("STARDAG_SERVER_VERSION", "dev"),
+        "api_version": api_version,
+    }

--- a/app/stardag-api/src/stardag_api/main.py
+++ b/app/stardag-api/src/stardag_api/main.py
@@ -99,6 +99,15 @@ async def version():
     (API + UI) image, injected via the STARDAG_SERVER_VERSION environment
     variable at image build time ("dev" when unset, e.g. running from
     source). ``api_version`` is the installed stardag-api package version.
+
+    Expected ``server_version`` forms (see scripts/server-version.sh and
+    DEV_README.md "Releasing the Server"):
+
+    - ``X.Y.Z`` - a release build (from a ``server-vX.Y.Z`` tag)
+    - ``X.Y.Z+N.g<sha>`` - a non-release build, N commits past the
+      nearest release tag (semver build metadata)
+    - ``0.0.0+g<sha>`` - a build with no release tag reachable
+    - ``dev`` - the env var was not set
     """
     try:
         api_version = _package_version("stardag-api")

--- a/app/stardag-api/src/stardag_api/server.py
+++ b/app/stardag-api/src/stardag_api/server.py
@@ -1,0 +1,74 @@
+"""Combined server: Registry API + static web UI in a single ASGI app.
+
+This module is the single source of truth for serving the API and the
+built web UI from one process/origin (no CORS, no UI API-URL config):
+
+- ``mount_ui(app, ui_dist_dir)`` mounts the UI dist directory with an
+  SPA fallback (unknown paths serve ``index.html`` so client-side routes
+  work on hard reloads). Mounts are matched *after* routes, so
+  ``/api/v1/*``, ``/health`` and ``/.well-known/jwks.json`` keep working.
+- ``create_app(ui_dist_dir)`` returns the API app with the UI mounted
+  when the directory exists (API-only otherwise).
+- ``app`` is a module-level ASGI app configured from the
+  ``STARDAG_UI_DIST`` environment variable, for use as an ASGI target:
+  ``uvicorn stardag_api.server:app``.
+"""
+
+import os
+from pathlib import Path
+
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+UI_MOUNT_NAME = "ui"
+
+
+class SPAStaticFiles(StaticFiles):
+    """Static files with SPA fallback.
+
+    Unknown paths serve ``index.html`` so client-side routes
+    (e.g. ``/builds/<id>``) work on hard reloads.
+    """
+
+    async def get_response(self, path: str, scope):
+        try:
+            return await super().get_response(path, scope)
+        except StarletteHTTPException as e:
+            if e.status_code == 404:
+                return await super().get_response("index.html", scope)
+            raise
+
+
+def mount_ui(app: FastAPI, ui_dist_dir: str | Path) -> None:
+    """Mount the built web UI (SPA) at ``/`` on ``app``. Idempotent.
+
+    Mounts are matched after routes, so all API routes keep working;
+    everything else serves the UI.
+    """
+    already_mounted = any(
+        getattr(route, "name", None) == UI_MOUNT_NAME for route in app.router.routes
+    )
+    if already_mounted:
+        return
+    app.mount(
+        "/",
+        SPAStaticFiles(directory=str(ui_dist_dir), html=True),
+        name=UI_MOUNT_NAME,
+    )
+
+
+def create_app(ui_dist_dir: str | None = None) -> FastAPI:
+    """Return the combined ASGI app: Registry API + web UI (when available).
+
+    When ``ui_dist_dir`` is unset or does not exist the API app is
+    returned as-is (API only).
+    """
+    from stardag_api.main import app as api_app
+
+    if ui_dist_dir and Path(ui_dist_dir).is_dir():
+        mount_ui(api_app, ui_dist_dir)
+    return api_app
+
+
+app = create_app(os.environ.get("STARDAG_UI_DIST"))

--- a/app/stardag-api/src/stardag_api/server.py
+++ b/app/stardag-api/src/stardag_api/server.py
@@ -28,14 +28,19 @@ class SPAStaticFiles(StaticFiles):
     """Static files with SPA fallback.
 
     Unknown paths serve ``index.html`` so client-side routes
-    (e.g. ``/builds/<id>``) work on hard reloads.
+    (e.g. ``/builds/<id>``) work on hard reloads. API-shaped paths
+    (``api/``, ``health*``, ``.well-known/``) are excluded so unknown
+    API endpoints return a proper 404 instead of 200 with HTML.
+    (Inside the mount, ``path`` has no leading slash.)
     """
 
     async def get_response(self, path: str, scope):
         try:
             return await super().get_response(path, scope)
         except StarletteHTTPException as e:
-            if e.status_code == 404:
+            if e.status_code == 404 and not path.startswith(
+                ("api/", "health", ".well-known/")
+            ):
                 return await super().get_response("index.html", scope)
             raise
 

--- a/app/stardag-api/tests/test_server.py
+++ b/app/stardag-api/tests/test_server.py
@@ -97,6 +97,27 @@ async def test_create_app_serves_ui_with_spa_fallback(ui_dist: Path):
 
 
 @pytest.mark.asyncio
+async def test_spa_fallback_does_not_swallow_api_paths(ui_dist: Path):
+    """Unknown API-shaped paths must return a real 404 (JSON), not 200 with
+    index.html - otherwise SDK/API clients hitting a typo'd or
+    version-skewed endpoint get opaque JSON decode errors."""
+    app = create_app(str(ui_dist))
+    async with _client(app) as client:
+        for path in (
+            "/api/v1/nonexistent",
+            "/api/nope",
+            "/health-nonexistent",
+            "/.well-known/nonexistent",
+        ):
+            response = await client.get(path)
+            assert response.status_code == 404, path
+            assert "stardag ui" not in response.text, path
+        response = await client.get("/api/v1/nonexistent")
+        assert response.headers["content-type"].startswith("application/json")
+        assert response.json() == {"detail": "Not Found"}
+
+
+@pytest.mark.asyncio
 async def test_mount_ui_is_idempotent(ui_dist: Path):
     app = create_app(str(ui_dist))
     mount_ui(app, ui_dist)  # second mount must be a no-op

--- a/app/stardag-api/tests/test_server.py
+++ b/app/stardag-api/tests/test_server.py
@@ -1,0 +1,108 @@
+"""Tests for the version endpoint and the combined API + UI server module."""
+
+from pathlib import Path
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from stardag_api.server import UI_MOUNT_NAME, create_app, mount_ui
+
+
+@pytest.mark.asyncio
+async def test_version_endpoint_defaults(client: AsyncClient, monkeypatch):
+    monkeypatch.delenv("STARDAG_SERVER_VERSION", raising=False)
+    response = await client.get("/api/v1/version")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["server_version"] == "dev"
+    # Installed package version (whatever it is, it must be non-empty)
+    assert data["api_version"]
+
+
+@pytest.mark.asyncio
+async def test_version_endpoint_server_version_from_env(
+    client: AsyncClient, monkeypatch
+):
+    monkeypatch.setenv("STARDAG_SERVER_VERSION", "1.2.3")
+    response = await client.get("/api/v1/version")
+    assert response.status_code == 200
+    assert response.json()["server_version"] == "1.2.3"
+
+
+@pytest.fixture
+def ui_dist(tmp_path: Path):
+    """A minimal built-UI directory; unmounts the UI from the shared app after."""
+    (tmp_path / "index.html").write_text("<html><body>stardag ui</body></html>")
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "main.js").write_text("console.log('ui')")
+    yield tmp_path
+    # create_app mounts onto the shared app from stardag_api.main; remove the
+    # mount so other tests see the API-only app.
+    from stardag_api.main import app as api_app
+
+    api_app.router.routes[:] = [
+        route
+        for route in api_app.router.routes
+        if getattr(route, "name", None) != UI_MOUNT_NAME
+    ]
+
+
+def _client(app) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+@pytest.mark.asyncio
+async def test_create_app_without_ui_dist_is_api_only():
+    app = create_app(None)
+    assert not any(
+        getattr(route, "name", None) == UI_MOUNT_NAME for route in app.router.routes
+    )
+    async with _client(app) as client:
+        response = await client.get("/some/spa/route")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_create_app_with_missing_dir_is_api_only(tmp_path: Path):
+    app = create_app(str(tmp_path / "does-not-exist"))
+    assert not any(
+        getattr(route, "name", None) == UI_MOUNT_NAME for route in app.router.routes
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_app_serves_ui_with_spa_fallback(ui_dist: Path):
+    app = create_app(str(ui_dist))
+    async with _client(app) as client:
+        # Index
+        response = await client.get("/")
+        assert response.status_code == 200
+        assert "stardag ui" in response.text
+        # Static asset
+        response = await client.get("/assets/main.js")
+        assert response.status_code == 200
+        # SPA fallback: unknown path serves index.html
+        response = await client.get("/builds/some-client-side-route")
+        assert response.status_code == 200
+        assert "stardag ui" in response.text
+        # API routes still win over the mount
+        response = await client.get("/health")
+        assert response.status_code == 200
+        assert response.json() == {"status": "healthy"}
+        response = await client.get("/api/v1/version")
+        assert response.status_code == 200
+        response = await client.get("/.well-known/jwks.json")
+        assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_mount_ui_is_idempotent(ui_dist: Path):
+    app = create_app(str(ui_dist))
+    mount_ui(app, ui_dist)  # second mount must be a no-op
+    ui_mounts = [
+        route
+        for route in app.router.routes
+        if getattr(route, "name", None) == UI_MOUNT_NAME
+    ]
+    assert len(ui_mounts) == 1

--- a/app/stardag-ui/src/App.tsx
+++ b/app/stardag-ui/src/App.tsx
@@ -9,6 +9,7 @@ import { LandingPageDemo } from "./components/LandingPageDemo";
 import { LocalLoginPage } from "./components/LocalLoginPage";
 import { Logo } from "./components/Logo";
 import { OnboardingModal } from "./components/OnboardingModal";
+import { ServerVersionFooter } from "./components/ServerVersionFooter";
 import { SessionExpiredOverlay } from "./components/SessionExpiredOverlay";
 import { WorkspaceSelector } from "./components/WorkspaceSelector";
 import { WorkspaceSettings } from "./components/WorkspaceSettings";
@@ -233,6 +234,7 @@ function SettingsPage({
       onToggleSidebar={onToggleSidebar}
     >
       <WorkspaceSettings onNavigate={onNavigatePath} />
+      <ServerVersionFooter />
     </MainLayout>
   );
 }

--- a/app/stardag-ui/src/api/version.ts
+++ b/app/stardag-ui/src/api/version.ts
@@ -1,0 +1,21 @@
+// Server version API (unauthenticated endpoint)
+import { API_V1 } from "./config";
+
+export interface ServerVersion {
+  /**
+   * Version of the combined server (API + UI) release. Clean `X.Y.Z` for
+   * release images, `X.Y.Z+N.g<sha>` for builds past a release tag, and
+   * `dev` when running from source.
+   */
+  server_version: string;
+  /** Installed stardag-api package version. */
+  api_version: string;
+}
+
+export async function fetchServerVersion(): Promise<ServerVersion> {
+  const response = await fetch(`${API_V1}/version`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch server version: ${response.statusText}`);
+  }
+  return response.json();
+}

--- a/app/stardag-ui/src/components/ServerVersionFooter.test.tsx
+++ b/app/stardag-ui/src/components/ServerVersionFooter.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ServerVersionFooter } from "./ServerVersionFooter";
+
+describe("ServerVersionFooter", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("shows the server version once loaded", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ server_version: "0.1.0", api_version: "0.0.1" }), {
+        status: 200,
+      }),
+    );
+
+    render(<ServerVersionFooter />);
+    expect(await screen.findByText("Stardag server v0.1.0")).toBeInTheDocument();
+    expect(fetchMock.mock.calls[0][0] as string).toContain("/api/v1/version");
+  });
+
+  it("renders nothing while loading", () => {
+    fetchMock.mockReturnValueOnce(new Promise(() => {}));
+    const { container } = render(<ServerVersionFooter />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the fetch fails", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network down"));
+    const { container } = render(<ServerVersionFooter />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing on a non-OK response", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("nope", { status: 500 }));
+    const { container } = render(<ServerVersionFooter />);
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/app/stardag-ui/src/components/ServerVersionFooter.tsx
+++ b/app/stardag-ui/src/components/ServerVersionFooter.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from "react";
+import { fetchServerVersion } from "../api/version";
+
+/**
+ * Small muted footer line showing the server release version.
+ *
+ * Fetches GET /api/v1/version lazily on mount and renders nothing while
+ * loading or when the fetch fails - it must never break the page it sits on.
+ */
+export function ServerVersionFooter() {
+  const [version, setVersion] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchServerVersion()
+      .then((v) => {
+        if (!cancelled) setVersion(v.server_version);
+      })
+      .catch(() => {
+        // Omit the footer entirely on error.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!version) return null;
+
+  return (
+    <p className="mx-auto max-w-4xl px-4 pb-6 text-xs text-gray-400 dark:text-gray-500">
+      Stardag server v{version}
+    </p>
+  );
+}

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -37,19 +37,12 @@ This opens the browser and stores a token in `~/.modal.toml`.
 Sign up at [console.neon.tech](https://console.neon.tech) (free plan), then
 create an API key at
 [console.neon.tech/app/settings/api-keys](https://console.neon.tech/app/settings/api-keys)
-→ **Create key**. Copy the key — you'll paste it in step 4.
+→ **Create key**. Copy the key — you'll paste it in step 3.
 
 You do _not_ need to create a database or project — the deploy command does
 that via the API (Postgres 16, project name `stardag`).
 
-### 3. Clone the stardag repo
-
-```bash
-git clone https://github.com/stardag-dev/stardag.git
-cd stardag
-```
-
-### 4. Deploy
+### 3. Deploy
 
 ```bash
 uvx --from "stardag[selfhost]" stardag self-host up
@@ -64,8 +57,9 @@ The command walks you through the rest interactively:
 - **Admin email + password** → your first login account
 
 It then generates a JWT signing keypair (stored as a Modal secret), applies
-database migrations, builds the container image (the UI is compiled inside
-the image build — no local Node needed), deploys, and prints your URL:
+database migrations, deploys the prebuilt server image (Registry API + web
+UI, published to the public GitHub Container Registry — no repo checkout,
+Node, or Docker needed locally), and prints your URL:
 
 ```
 Stardag is up!
@@ -74,7 +68,7 @@ Stardag is up!
   API: https://<your-workspace>--stardag-server.modal.run/api/v1
 ```
 
-### 5. Sign in and connect the SDK
+### 4. Sign in and connect the SDK
 
 Open the UI and sign in with the admin account. A personal workspace with a
 `Local` environment is created automatically.
@@ -92,16 +86,34 @@ for Modal-executed DAGs with `stardag modal stardag-api-key create`.
 
 ## Updating to a new version
 
-From the repo checkout:
-
 ```bash
-git pull
 uvx --from "stardag[selfhost]" stardag self-host upgrade
 ```
 
-This applies any new database migrations and redeploys the API + UI from
-the current source. The JWT keypair secret is left untouched, so existing
-sessions and SDK logins survive upgrades.
+This applies any new database migrations and redeploys the API + UI. Each
+SDK release pins the server version it was tested against, so `uvx` picking
+up a newer SDK also rolls the server forward; pass
+`--server-version X.Y.Z` (or `latest`) to deploy a specific
+[server release](https://github.com/stardag-dev/stardag/releases). The JWT
+keypair secret is left untouched, so existing sessions and SDK logins
+survive upgrades.
+
+## Deploying from source (development)
+
+The prebuilt image `ghcr.io/stardag-dev/stardag-server` is the default and
+needs no repo checkout. To deploy your own modifications instead, clone the
+repo and pass `--from-source`:
+
+```bash
+git clone https://github.com/stardag-dev/stardag.git
+cd stardag
+uvx --from "stardag[selfhost]" stardag self-host up --from-source
+```
+
+The image is then built from the checkout: the UI is compiled with npm
+inside the Modal image build (no local Node needed) and the API package is
+installed from source. `upgrade --from-source` redeploys after local
+changes or a `git pull`.
 
 ## Auth mode: `local` (default)
 
@@ -157,13 +169,18 @@ The UI discovers all of this at runtime from the API (`/api/v1/auth/config`)
 
 ```bash
 stardag self-host up         # provision + deploy (idempotent; re-run to reconfigure)
-stardag self-host upgrade    # migrate DB + redeploy from current source
+stardag self-host upgrade    # migrate DB + redeploy
 stardag self-host status     # deployment status + URL
 stardag self-host destroy    # stop the Modal app (never touches the database)
 ```
 
 Useful flags for `up` (all prompts have flag equivalents for CI):
 
+- `--server-version X.Y.Z` (or `latest`) — prebuilt server image version to
+  deploy (default: the version this SDK release is tested against)
+- `--from-source` — build the image from a local repo checkout instead of
+  the prebuilt image (see
+  [Deploying from source](#deploying-from-source-development))
 - `--name` — Modal app name / URL label (default `stardag-server`)
 - `--neon-project` — Neon project name to find-or-create (default `stardag`)
 - `--database-url` / `--database-url-direct` — bring your own Postgres

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -195,6 +195,83 @@ def _resolve_keep_warm(app_name: str, keep_warm: int | None) -> int:
     return meta.get("keep_warm", 0)
 
 
+# Sentinel recorded as the deployed "version" for --from-source deploys.
+FROM_SOURCE_VERSION = "source"
+
+
+def _parse_semver(version: str) -> tuple[int, int, int] | None:
+    """Parse 'X.Y.Z' into a comparable tuple; None for anything else."""
+    parts = version.split(".")
+    if len(parts) != 3:
+        return None
+    try:
+        major, minor, patch = (int(p) for p in parts)
+    except ValueError:
+        return None
+    return major, minor, patch
+
+
+def _record_deployed_server_version(app_name: str, version: str) -> None:
+    """Persist the just-deployed server version in the app's meta Dict.
+
+    ``FROM_SOURCE_VERSION`` is recorded for from-source deploys.
+    """
+    import modal
+
+    meta = modal.Dict.from_name(_meta_dict_name(app_name), create_if_missing=True)
+    meta["server_version"] = version
+
+
+def _deployed_server_version(app_name: str) -> str | None:
+    """The recorded deployed server version, or None if never recorded."""
+    import modal
+    import modal.exception
+
+    try:
+        meta = modal.Dict.from_name(_meta_dict_name(app_name))
+    except modal.exception.NotFoundError:
+        return None
+    return meta.get("server_version")
+
+
+def _resolve_upgrade_server_version(app_name: str, explicit: str | None) -> str:
+    """Server version for prebuilt-image `upgrade` runs.
+
+    Resolution order: explicit --server-version flag > recorded deployed
+    version > DEFAULT_SERVER_VERSION. Defaulting to the recorded version
+    means a plain `upgrade` never silently downgrades a deployment running
+    a version newer than this SDK's default (whose migrations may have
+    advanced the DB schema past what the default server release knows).
+    An explicitly passed older version wins, with a warning.
+    """
+    deployed = _deployed_server_version(app_name)
+    if explicit is not None:
+        explicit_semver = _parse_semver(explicit)
+        deployed_semver = _parse_semver(deployed) if deployed else None
+        if (
+            explicit_semver is not None
+            and deployed_semver is not None
+            and explicit_semver < deployed_semver
+        ):
+            console.print(
+                f"[yellow]Warning:[/yellow] deploying server {explicit} over the "
+                f"currently deployed {deployed}. Downgrading does not roll back "
+                "database migrations, so the older server may run against a "
+                "newer schema."
+            )
+        return explicit
+    if deployed == FROM_SOURCE_VERSION:
+        console.print(
+            "Last deploy was built from source; deploying the prebuilt image "
+            f"[bold]{DEFAULT_SERVER_VERSION}[/bold] instead (pass --from-source "
+            "to keep building from a local checkout)."
+        )
+        return DEFAULT_SERVER_VERSION
+    if deployed is not None:
+        return deployed
+    return DEFAULT_SERVER_VERSION
+
+
 def _ensure_jwt_secret(name: str) -> bool:
     """Create the JWT keypair secret if absent. Never overwrites.
 
@@ -399,9 +476,9 @@ def _deploy(
                 f"\nDeployment with the prebuilt image "
                 f"{server_image_ref(server_version or DEFAULT_SERVER_VERSION)} "
                 "failed (see output above). If the image could not be pulled "
-                "(e.g. the version does not exist yet), retry with "
-                "--from-source from a checkout of "
-                "https://github.com/stardag-dev/stardag."
+                "(e.g. the version does not exist yet, or the GHCR package "
+                "is not public yet), retry with --from-source from a "
+                "checkout of https://github.com/stardag-dev/stardag."
             )
         raise
 
@@ -663,6 +740,9 @@ def up(
         _resolve_keep_warm(name, keep_warm),
         server_version=resolved_server_version,
     )
+    _record_deployed_server_version(
+        name, resolved_server_version or FROM_SOURCE_VERSION
+    )
 
     console.print("\n[bold green]Stardag is up![/bold green]")
     console.print(f"\n  UI:  [bold]{url}[/bold]")
@@ -695,8 +775,9 @@ def upgrade(
         None,
         "--server-version",
         help="Prebuilt server image version to deploy: X.Y.Z or 'latest' "
-        f"(default: {DEFAULT_SERVER_VERSION}, the version this SDK release "
-        "is tested against)",
+        "(default: the currently deployed version, falling back to "
+        f"{DEFAULT_SERVER_VERSION}, the version this SDK release is tested "
+        "against)",
     ),
     from_source: bool = typer.Option(
         False,
@@ -734,11 +815,19 @@ def upgrade(
             )
             raise typer.Exit(1)
 
+    if repo_root is None:
+        # Prebuilt path: default to the recorded deployed version so a plain
+        # `upgrade` never silently downgrades (explicit flag still wins).
+        resolved_server_version = _resolve_upgrade_server_version(name, server_version)
+
     url = _deploy(
         repo_root,
         name,
         _resolve_keep_warm(name, keep_warm),
         server_version=resolved_server_version,
+    )
+    _record_deployed_server_version(
+        name, resolved_server_version or FROM_SOURCE_VERSION
     )
     console.print("\n[bold green]Upgrade complete.[/bold green]")
     console.print(f"  UI: [bold]{url}[/bold]")
@@ -768,6 +857,11 @@ def status(
 
     try:
         meta = modal.Dict.from_name(_meta_dict_name(name))
+        server_version = meta.get("server_version")
+        if server_version == FROM_SOURCE_VERSION:
+            console.print("  Server version: built from source")
+        elif server_version:
+            console.print(f"  Server version: {server_version}")
         console.print(f"  Keep-warm containers: {meta.get('keep_warm', 0)}")
     except modal.exception.NotFoundError:
         pass

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -2,12 +2,15 @@
 
 Usage:
     stardag self-host up          # provision + deploy the full stack
-    stardag self-host upgrade     # migrate DB + redeploy from current source
+    stardag self-host upgrade     # migrate DB + redeploy
     stardag self-host status      # show deployment status and URL
     stardag self-host destroy     # stop the Modal app (DB is left untouched)
 
 Requires the `selfhost` extra: pip install "stardag[selfhost]"
-Run from a checkout of the stardag repo (or pass --repo).
+
+By default the prebuilt public server image is deployed (no repo checkout
+needed). Pass --from-source to build from a local checkout of the stardag
+repo instead (run from the checkout or pass --repo).
 """
 
 from __future__ import annotations
@@ -20,8 +23,10 @@ from rich.console import Console
 
 from stardag.selfhost._modal_app import (
     DEFAULT_APP_NAME,
+    DEFAULT_SERVER_VERSION,
     build_server_app,
     find_repo_root,
+    server_image_ref,
 )
 from stardag.selfhost._neon import (
     NeonAuthError,
@@ -69,11 +74,36 @@ def _require_repo_root(repo: Path | None) -> Path:
     if root is None:
         error_console.print(
             "Could not locate a stardag repo checkout (looked for "
-            "app/stardag-api and app/stardag-ui). Run this command from a "
-            "clone of https://github.com/stardag-dev/stardag or pass --repo."
+            "app/stardag-api and app/stardag-ui). --from-source requires a "
+            "clone of https://github.com/stardag-dev/stardag: run this "
+            "command from the clone or pass --repo. (Or drop --from-source "
+            "to deploy the prebuilt server image - no checkout needed.)"
         )
         raise typer.Exit(1)
     return root
+
+
+def _resolve_image_source(
+    repo: Path | None,
+    from_source: bool,
+    server_version: str | None,
+) -> tuple[Path | None, str | None]:
+    """Resolve (repo_root, server_version) - exactly one is non-None.
+
+    Default: prebuilt image at the given (or default) server version.
+    --from-source (or an explicit --repo) builds from a local checkout;
+    combining it with --server-version is an error.
+    """
+    build_from_source = from_source or repo is not None
+    if build_from_source and server_version is not None:
+        error_console.print(
+            "--server-version only applies to prebuilt images and cannot be "
+            "combined with --from-source/--repo."
+        )
+        raise typer.Exit(1)
+    if build_from_source:
+        return _require_repo_root(repo), None
+    return None, server_version or DEFAULT_SERVER_VERSION
 
 
 def _check_modal_auth() -> str:
@@ -314,33 +344,66 @@ def _build_config_env(
 
 
 def _deploy(
-    repo_root: Path,
+    repo_root: Path | None,
     app_name: str,
     keep_warm: int,
+    server_version: str | None = None,
     run_migrations: bool = True,
 ) -> str:
-    """Build the Modal app, run migrations, deploy. Returns the web URL."""
+    """Build the Modal app, run migrations, deploy. Returns the web URL.
+
+    Exactly one of ``repo_root`` (build from source) and ``server_version``
+    (prebuilt image) should be set - see ``_resolve_image_source``.
+    """
     import modal
 
-    console.print("\nBuilding server app (UI build runs inside the Modal image)...")
-    server_app, functions = build_server_app(
-        repo_root=repo_root,
-        app_name=app_name,
-        config_secret_name=f"{app_name}-config",
-        jwt_secret_name=f"{app_name}-jwt",
-        keep_warm=keep_warm,
-    )
+    if repo_root is not None:
+        console.print(
+            "\nBuilding server app from source "
+            "(UI build runs inside the Modal image)..."
+        )
+        server_app, functions = build_server_app(
+            repo_root=repo_root,
+            app_name=app_name,
+            config_secret_name=f"{app_name}-config",
+            jwt_secret_name=f"{app_name}-jwt",
+            keep_warm=keep_warm,
+        )
+    else:
+        version = server_version or DEFAULT_SERVER_VERSION
+        console.print(
+            f"\nUsing prebuilt server image [bold]{server_image_ref(version)}[/bold]..."
+        )
+        server_app, functions = build_server_app(
+            app_name=app_name,
+            config_secret_name=f"{app_name}-config",
+            jwt_secret_name=f"{app_name}-jwt",
+            keep_warm=keep_warm,
+            server_version=version,
+        )
 
-    with modal.enable_output():
-        if run_migrations:
-            console.print("Applying database migrations...")
-            with server_app.run():
-                output = functions["migrate"].remote()
-            for line in output.strip().splitlines()[-5:]:
-                console.print(f"  [dim]{line}[/dim]")
+    try:
+        with modal.enable_output():
+            if run_migrations:
+                console.print("Applying database migrations...")
+                with server_app.run():
+                    output = functions["migrate"].remote()
+                for line in output.strip().splitlines()[-5:]:
+                    console.print(f"  [dim]{line}[/dim]")
 
-        console.print("Deploying...")
-        server_app.deploy()
+            console.print("Deploying...")
+            server_app.deploy()
+    except Exception:
+        if repo_root is None:
+            error_console.print(
+                f"\nDeployment with the prebuilt image "
+                f"{server_image_ref(server_version or DEFAULT_SERVER_VERSION)} "
+                "failed (see output above). If the image could not be pulled "
+                "(e.g. the version does not exist yet), retry with "
+                "--from-source from a checkout of "
+                "https://github.com/stardag-dev/stardag."
+            )
+        raise
 
     url = functions["web"].get_web_url()
     if not url:
@@ -354,8 +417,24 @@ def _deploy(
 
 @app.command()
 def up(
+    server_version: str = typer.Option(
+        None,
+        "--server-version",
+        help="Prebuilt server image version to deploy: X.Y.Z or 'latest' "
+        f"(default: {DEFAULT_SERVER_VERSION}, the version this SDK release "
+        "is tested against)",
+    ),
+    from_source: bool = typer.Option(
+        False,
+        "--from-source",
+        help="Build the image from a local stardag repo checkout instead of "
+        "using the prebuilt image (development workflow)",
+    ),
     repo: Path = typer.Option(
-        None, "--repo", help="Path to the stardag repo checkout (default: auto-detect)"
+        None,
+        "--repo",
+        help="Path to the stardag repo checkout (implies --from-source; "
+        "default: auto-detect from cwd)",
     ),
     name: str = typer.Option(
         DEFAULT_APP_NAME, "--name", help="Modal app name (and URL label)"
@@ -439,8 +518,11 @@ def up(
 ):
     """Bring up the full Stardag stack: database, migrations, API + UI on Modal."""
     interactive = not yes
-    repo_root = _require_repo_root(repo)
-    console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
+    repo_root, resolved_server_version = _resolve_image_source(
+        repo, from_source, server_version
+    )
+    if repo_root is not None:
+        console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
 
     workspace = _check_modal_auth()
     console.print(f"Modal workspace: [bold]{workspace}[/bold]")
@@ -575,7 +657,12 @@ def up(
         )
 
     # --- Migrate + deploy ---
-    url = _deploy(repo_root, name, _resolve_keep_warm(name, keep_warm))
+    url = _deploy(
+        repo_root,
+        name,
+        _resolve_keep_warm(name, keep_warm),
+        server_version=resolved_server_version,
+    )
 
     console.print("\n[bold green]Stardag is up![/bold green]")
     console.print(f"\n  UI:  [bold]{url}[/bold]")
@@ -599,12 +686,30 @@ def up(
         f"     stardag config registry add selfhosted --url {url}\n"
         "     stardag auth login -r selfhosted"
     )
-    console.print("  3. To update after pulling new code: stardag self-host upgrade")
+    console.print("  3. To update to a newer server release: stardag self-host upgrade")
 
 
 @app.command()
 def upgrade(
-    repo: Path = typer.Option(None, "--repo", help="Path to the stardag repo checkout"),
+    server_version: str = typer.Option(
+        None,
+        "--server-version",
+        help="Prebuilt server image version to deploy: X.Y.Z or 'latest' "
+        f"(default: {DEFAULT_SERVER_VERSION}, the version this SDK release "
+        "is tested against)",
+    ),
+    from_source: bool = typer.Option(
+        False,
+        "--from-source",
+        help="Build the image from a local stardag repo checkout instead of "
+        "using the prebuilt image (development workflow)",
+    ),
+    repo: Path = typer.Option(
+        None,
+        "--repo",
+        help="Path to the stardag repo checkout (implies --from-source; "
+        "default: auto-detect from cwd)",
+    ),
     name: str = typer.Option(DEFAULT_APP_NAME, "--name", help="Modal app name"),
     keep_warm: int = typer.Option(
         None,
@@ -613,9 +718,12 @@ def upgrade(
         "last explicitly set value is kept (initially 0).",
     ),
 ):
-    """Update the deployment: apply DB migrations and redeploy from current source."""
-    repo_root = _require_repo_root(repo)
-    console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
+    """Update the deployment: apply DB migrations and redeploy."""
+    repo_root, resolved_server_version = _resolve_image_source(
+        repo, from_source, server_version
+    )
+    if repo_root is not None:
+        console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
     workspace = _check_modal_auth()
     console.print(f"Modal workspace: [bold]{workspace}[/bold]")
 
@@ -626,7 +734,12 @@ def upgrade(
             )
             raise typer.Exit(1)
 
-    url = _deploy(repo_root, name, _resolve_keep_warm(name, keep_warm))
+    url = _deploy(
+        repo_root,
+        name,
+        _resolve_keep_warm(name, keep_warm),
+        server_version=resolved_server_version,
+    )
     console.print("\n[bold green]Upgrade complete.[/bold green]")
     console.print(f"  UI: [bold]{url}[/bold]")
 

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -417,7 +417,7 @@ def _deploy(
 
 @app.command()
 def up(
-    server_version: str = typer.Option(
+    server_version: str | None = typer.Option(
         None,
         "--server-version",
         help="Prebuilt server image version to deploy: X.Y.Z or 'latest' "
@@ -691,7 +691,7 @@ def up(
 
 @app.command()
 def upgrade(
-    server_version: str = typer.Option(
+    server_version: str | None = typer.Option(
         None,
         "--server-version",
         help="Prebuilt server image version to deploy: X.Y.Z or 'latest' "

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -4,9 +4,19 @@ Builds a single Modal app that serves the Registry API and the web UI from
 one ASGI endpoint (same-origin, so no CORS or UI API-URL configuration),
 plus a one-off ``migrate`` function that applies Alembic migrations.
 
-The container image is built from a local checkout of the stardag repo:
-the UI is compiled with npm *inside* the image build (no local Node
-required) and the API package is pip-installed from source.
+Two image modes:
+
+- **Prebuilt** (default): the released server image
+  ``ghcr.io/stardag-dev/stardag-server:<version>`` is pulled from the
+  public GitHub Container Registry — no repo checkout needed.
+- **From source**: the image is built from a local checkout of the
+  stardag repo: the UI is compiled with npm *inside* the image build
+  (no local Node required) and the API package is pip-installed from
+  source.
+
+Both modes place the alembic config at ``/opt/stardag/api`` and the built
+UI at ``/opt/stardag/ui`` (see ``app/server.Dockerfile``), so the Modal
+function bodies are mode-agnostic.
 """
 
 from __future__ import annotations
@@ -25,6 +35,16 @@ DEFAULT_APP_NAME = "stardag-server"
 DEFAULT_CONFIG_SECRET = "stardag-server-config"
 DEFAULT_JWT_SECRET = "stardag-server-jwt"
 
+SERVER_IMAGE_REPO = "ghcr.io/stardag-dev/stardag-server"
+# The server release this SDK version is tested against. Bumped at SDK
+# release time; override per deployment with --server-version.
+DEFAULT_SERVER_VERSION = "0.1.0"
+
+
+def server_image_ref(version: str) -> str:
+    """Full image reference for a released server version (or "latest")."""
+    return f"{SERVER_IMAGE_REPO}:{version}"
+
 
 def find_repo_root(start: Path | None = None) -> Path | None:
     """Locate the stardag repo root by walking up from ``start`` (or cwd).
@@ -41,14 +61,20 @@ def find_repo_root(start: Path | None = None) -> Path | None:
 
 
 def build_server_app(
-    repo_root: Path,
+    repo_root: Path | None = None,
     app_name: str = DEFAULT_APP_NAME,
     config_secret_name: str | None = None,
     jwt_secret_name: str | None = None,
     keep_warm: int = 0,
     python_version: str = "3.12",
+    server_version: str = DEFAULT_SERVER_VERSION,
 ) -> tuple["modal.App", dict[str, Any]]:
-    """Build the Modal app serving the Stardag service from a repo checkout.
+    """Build the Modal app serving the Stardag service.
+
+    When ``repo_root`` is None (default) the prebuilt public server image
+    ``ghcr.io/stardag-dev/stardag-server:<server_version>`` is used.
+    When ``repo_root`` is given the image is built from that checkout
+    (``server_version`` is ignored).
 
     Secret names default to "<app_name>-config" and "<app_name>-jwt".
     Returns (app, {"web": web_fn, "migrate": migrate_fn}).
@@ -58,30 +84,36 @@ def build_server_app(
     config_secret_name = config_secret_name or f"{app_name}-config"
     jwt_secret_name = jwt_secret_name or f"{app_name}-jwt"
 
-    api_dir = repo_root / "app" / "stardag-api"
-    ui_dir = repo_root / "app" / "stardag-ui"
+    if repo_root is None:
+        # Prebuilt release image (public registry, no secret needed). The
+        # image ships python 3.12 + the API package + built UI + alembic
+        # config at the same paths as the from-source build below.
+        image = modal.Image.from_registry(server_image_ref(server_version))
+    else:
+        api_dir = repo_root / "app" / "stardag-api"
+        ui_dir = repo_root / "app" / "stardag-ui"
 
-    image = (
-        # node:22-slim for the in-image UI build; add_python for the API
-        modal.Image.from_registry("node:22-slim", add_python=python_version)
-        .add_local_dir(
-            ui_dir.as_posix(),
-            UI_SRC_REMOTE_DIR,
-            copy=True,
-            ignore=["node_modules", "dist", ".env", ".env.*"],
+        image = (
+            # node:22-slim for the in-image UI build; add_python for the API
+            modal.Image.from_registry("node:22-slim", add_python=python_version)
+            .add_local_dir(
+                ui_dir.as_posix(),
+                UI_SRC_REMOTE_DIR,
+                copy=True,
+                ignore=["node_modules", "dist", ".env", ".env.*"],
+            )
+            .run_commands(
+                f"cd {UI_SRC_REMOTE_DIR} && npm ci && npm run build"
+                f" && mv dist {UI_DIST_REMOTE_DIR}",
+            )
+            .add_local_dir(
+                api_dir.as_posix(),
+                API_REMOTE_DIR,
+                copy=True,
+                ignore=[".venv", "__pycache__", ".pytest_cache", "tests"],
+            )
+            .run_commands(f"python -m pip install {API_REMOTE_DIR}")
         )
-        .run_commands(
-            f"cd {UI_SRC_REMOTE_DIR} && npm ci && npm run build"
-            f" && mv dist {UI_DIST_REMOTE_DIR}",
-        )
-        .add_local_dir(
-            api_dir.as_posix(),
-            API_REMOTE_DIR,
-            copy=True,
-            ignore=[".venv", "__pycache__", ".pytest_cache", "tests"],
-        )
-        .run_commands(f"python -m pip install {API_REMOTE_DIR}")
-    )
 
     app = modal.App(app_name)
     secrets = [
@@ -113,34 +145,10 @@ def build_server_app(
 
     def _web_impl():
         """Construct the combined API + static-UI ASGI app."""
-        from fastapi.staticfiles import StaticFiles
-        from starlette.exceptions import HTTPException as StarletteHTTPException
-
         # Installed in the container image, not in the SDK environment
-        from stardag_api.main import app as api_app  # type: ignore[import-not-found] # pyright: ignore[reportMissingImports]
+        from stardag_api.server import create_app  # type: ignore[import-not-found] # pyright: ignore[reportMissingImports]
 
-        class SPAStaticFiles(StaticFiles):
-            # SPA fallback: unknown paths serve index.html so client-side
-            # routes (e.g. /builds/<id>) work on hard reloads. API-shaped
-            # paths (api/, health*, .well-known/) are excluded so unknown
-            # API endpoints return a proper 404 instead of 200 with HTML.
-            # (Inside the mount, `path` has no leading slash.)
-            async def get_response(self, path: str, scope):
-                try:
-                    return await super().get_response(path, scope)
-                except StarletteHTTPException as e:
-                    if e.status_code == 404 and not path.startswith(
-                        ("api/", "health", ".well-known/")
-                    ):
-                        return await super().get_response("index.html", scope)
-                    raise
-
-        # Mounts are matched after routes, so /api/v1/*, /health and
-        # /.well-known/jwks.json keep working; everything else serves the UI.
-        api_app.mount(
-            "/", SPAStaticFiles(directory=ui_dist_remote_dir, html=True), name="ui"
-        )
-        return api_app
+        return create_app(ui_dist_remote_dir)
 
     migrate = app.function(
         image=image,

--- a/lib/stardag/tests/test_selfhost/test_cli_config.py
+++ b/lib/stardag/tests/test_selfhost/test_cli_config.py
@@ -8,14 +8,18 @@ pytest.importorskip("modal")
 pytest.importorskip("cryptography")
 
 from stardag._cli.selfhost import (  # noqa: E402
+    FROM_SOURCE_VERSION,
     MAX_ADMIN_PASSWORD_BYTES,
     MIN_ADMIN_PASSWORD_CHARS,
     _admin_password_error,
     _build_config_env,
     _generate_jwt_keypair,
     _provided_config_flags,
+    _record_deployed_server_version,
     _resolve_keep_warm,
+    _resolve_upgrade_server_version,
 )
+from stardag.selfhost._modal_app import DEFAULT_SERVER_VERSION  # noqa: E402
 from stardag.selfhost._modal_app import find_repo_root  # noqa: E402
 
 
@@ -165,6 +169,75 @@ def test_resolve_keep_warm_defaults_to_zero(monkeypatch: pytest.MonkeyPatch):
     # Explicit 0 is persisted (distinguishable from "not provided")
     assert _resolve_keep_warm("myapp", 0) == 0
     assert store["keep_warm"] == 0
+
+
+def test_record_deployed_server_version(monkeypatch: pytest.MonkeyPatch):
+    store: dict = {}
+    names = _patch_meta_dict(monkeypatch, store)
+    _record_deployed_server_version("myapp", "0.2.0")
+    assert store["server_version"] == "0.2.0"
+    assert names == ["myapp-meta"]
+    _record_deployed_server_version("myapp", FROM_SOURCE_VERSION)
+    assert store["server_version"] == FROM_SOURCE_VERSION
+
+
+def test_upgrade_version_defaults_to_deployed(monkeypatch: pytest.MonkeyPatch):
+    """A plain `upgrade` must never silently downgrade: the recorded
+    deployed version wins over DEFAULT_SERVER_VERSION."""
+    store: dict = {"server_version": "99.0.0"}
+    _patch_meta_dict(monkeypatch, store)
+    assert _resolve_upgrade_server_version("myapp", None) == "99.0.0"
+    # The recorded value is not modified by resolution alone
+    assert store["server_version"] == "99.0.0"
+
+
+def test_upgrade_version_falls_back_to_default(monkeypatch: pytest.MonkeyPatch):
+    # Meta dict exists but no version recorded (pre-existing deployments)
+    store: dict = {"keep_warm": 1}
+    _patch_meta_dict(monkeypatch, store)
+    assert _resolve_upgrade_server_version("myapp", None) == DEFAULT_SERVER_VERSION
+
+
+def test_upgrade_version_no_meta_dict(monkeypatch: pytest.MonkeyPatch):
+    import modal
+    import modal.exception
+
+    def raise_not_found(name: str, *, create_if_missing: bool = False):
+        raise modal.exception.NotFoundError(f"Dict {name} not found")
+
+    monkeypatch.setattr(modal.Dict, "from_name", raise_not_found)
+    assert _resolve_upgrade_server_version("myapp", None) == DEFAULT_SERVER_VERSION
+
+
+def test_upgrade_version_explicit_flag_wins(monkeypatch: pytest.MonkeyPatch):
+    store: dict = {"server_version": "0.2.0"}
+    _patch_meta_dict(monkeypatch, store)
+    # Explicit newer version: no warning path, explicit wins
+    assert _resolve_upgrade_server_version("myapp", "0.3.0") == "0.3.0"
+    # Explicit 'latest' (not comparable): explicit wins
+    assert _resolve_upgrade_server_version("myapp", "latest") == "latest"
+
+
+def test_upgrade_version_explicit_downgrade_warns_but_proceeds(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+):
+    store: dict = {"server_version": "0.10.0"}
+    _patch_meta_dict(monkeypatch, store)
+    # Explicit older version wins (semver-aware: 0.2.0 < 0.10.0), with warning
+    assert _resolve_upgrade_server_version("myapp", "0.2.0") == "0.2.0"
+    captured = capsys.readouterr()
+    assert "Warning" in captured.out
+    assert "0.10.0" in captured.out
+
+
+def test_upgrade_version_from_source_deploy_uses_default(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # Last deploy was from source: a plain prebuilt `upgrade` cannot infer a
+    # version from it, so it falls back to the SDK's tested default.
+    store: dict = {"server_version": FROM_SOURCE_VERSION}
+    _patch_meta_dict(monkeypatch, store)
+    assert _resolve_upgrade_server_version("myapp", None) == DEFAULT_SERVER_VERSION
 
 
 def test_generate_jwt_keypair_pem():

--- a/lib/stardag/tests/test_selfhost/test_image_source.py
+++ b/lib/stardag/tests/test_selfhost/test_image_source.py
@@ -1,0 +1,81 @@
+"""Tests for prebuilt-image vs from-source resolution in the self-host CLI."""
+
+import re
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("modal")
+pytest.importorskip("cryptography")
+
+import typer  # noqa: E402
+
+from stardag._cli.selfhost import _resolve_image_source  # noqa: E402
+from stardag.selfhost._modal_app import (  # noqa: E402
+    DEFAULT_SERVER_VERSION,
+    SERVER_IMAGE_REPO,
+    server_image_ref,
+)
+
+REPO_ROOT = Path(__file__).parents[4]
+
+
+def test_server_image_ref():
+    assert server_image_ref("1.2.3") == f"{SERVER_IMAGE_REPO}:1.2.3"
+    assert server_image_ref("latest") == f"{SERVER_IMAGE_REPO}:latest"
+
+
+def test_default_server_version_is_semver():
+    assert re.fullmatch(r"\d+\.\d+\.\d+", DEFAULT_SERVER_VERSION)
+
+
+def test_resolve_default_is_prebuilt_at_default_version():
+    repo_root, version = _resolve_image_source(None, False, None)
+    assert repo_root is None
+    assert version == DEFAULT_SERVER_VERSION
+
+
+def test_resolve_explicit_server_version():
+    repo_root, version = _resolve_image_source(None, False, "9.9.9")
+    assert repo_root is None
+    assert version == "9.9.9"
+
+    repo_root, version = _resolve_image_source(None, False, "latest")
+    assert repo_root is None
+    assert version == "latest"
+
+
+def test_resolve_from_source_requires_repo_checkout(tmp_path: Path):
+    # tmp_path is not a stardag checkout
+    with pytest.raises(typer.Exit):
+        _resolve_image_source(tmp_path, True, None)
+
+
+def test_resolve_from_source_with_repo():
+    repo_root, version = _resolve_image_source(REPO_ROOT, True, None)
+    assert repo_root == REPO_ROOT.resolve()
+    assert version is None
+
+
+def test_resolve_explicit_repo_implies_from_source():
+    repo_root, version = _resolve_image_source(REPO_ROOT, False, None)
+    assert repo_root == REPO_ROOT.resolve()
+    assert version is None
+
+
+def test_resolve_from_source_and_server_version_conflict():
+    with pytest.raises(typer.Exit):
+        _resolve_image_source(None, True, "1.2.3")
+    with pytest.raises(typer.Exit):
+        _resolve_image_source(REPO_ROOT, False, "1.2.3")
+
+
+def test_build_server_app_prebuilt_needs_no_repo():
+    """Prebuilt mode constructs the Modal app without any repo checkout.
+
+    (Image definitions are lazy in Modal - nothing is pulled here.)
+    """
+    from stardag.selfhost._modal_app import build_server_app
+
+    app, functions = build_server_app(server_version="1.2.3")
+    assert set(functions) == {"web", "migrate"}

--- a/scripts/server-version.sh
+++ b/scripts/server-version.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Print the server version for builds of app/server.Dockerfile.
+#
+# Convention (see DEV_README.md "Releasing the Server"): release builds get
+# a clean X.Y.Z from the server-vX.Y.Z tag (the tag workflow passes it
+# directly); any other build derives the version from git describe so the
+# deployment truthfully reports its deviation from the nearest release:
+#
+#   exactly at a server-vX.Y.Z tag  ->  X.Y.Z            (clean, same as CI)
+#   N commits past the nearest tag  ->  X.Y.Z+N.g<sha>   (semver build metadata)
+#   no server-v* tag reachable      ->  0.0.0+g<sha>     (before the first release)
+#   not a git checkout              ->  dev
+#
+# Usage:
+#   docker build -f app/server.Dockerfile \
+#     --build-arg STARDAG_SERVER_VERSION="$(scripts/server-version.sh)" .
+set -euo pipefail
+
+describe="$(git describe --tags --match 'server-v*' --always 2>/dev/null || true)"
+
+if [[ "$describe" == server-v* ]]; then
+  version="${describe#server-v}"
+  # git describe forms: X.Y.Z (exactly at tag) or X.Y.Z-N-g<sha> (past it)
+  if [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)-g([0-9a-f]+)$ ]]; then
+    echo "${BASH_REMATCH[1]}+${BASH_REMATCH[2]}.g${BASH_REMATCH[3]}"
+  else
+    echo "$version"
+  fi
+elif [[ -n "$describe" ]]; then
+  # --always fallback: a bare commit sha - no server-v* tag reachable yet
+  echo "0.0.0+g${describe}"
+else
+  echo "dev"
+fi


### PR DESCRIPTION
Stacks on #188 (the `stardag self-host` CLI) — merge that first; this PR targets the `self-host-modal` branch.

Implements the server release pipeline and versioning scheme: the server (Registry API + web UI) gets its own semver, independent of the SDK, driven by `server-vX.Y.Z` git tags. API and UI share **one joint version** and ship in **one image**: `ghcr.io/stardag-dev/stardag-server:X.Y.Z` (+ `:latest`).

## What's in here

### One image definition: `app/server.Dockerfile`

Build context = repo root. Stage 1 builds the UI (node:22-slim, no build-time `VITE_*` config — the UI configures itself from the API at runtime); stage 2 (python:3.12-slim) pip-installs the API package, places `alembic.ini` + `migrations/` at `/opt/stardag/api` and the UI dist at `/opt/stardag/ui`. No `ENTRYPOINT`, plain python/pip — so Modal (`Image.from_registry`) can consume it directly; the default CMD serves gunicorn+uvicorn workers like the existing API-only image. `STARDAG_SERVER_VERSION` is baked in as a build arg.

### Combined server module: `stardag_api.server`

Single source of truth for serving API + UI from one ASGI app: `mount_ui()` (SPA-fallback static mount, matched after routes so `/api/v1/*`, `/health`, `/.well-known/jwks.json` keep working), `create_app(ui_dist_dir)`, and a module-level `app` configured from `STARDAG_UI_DIST` (API-only when unset). The self-host Modal web function now delegates to `create_app` instead of inlining the SPA mount (still a by-value-pickled closure).

New endpoint: `GET /api/v1/version` → `{"server_version": <STARDAG_SERVER_VERSION or "dev">, "api_version": <installed stardag-api version>}`.

### CI: `.github/workflows/publish-server-image.yml`

On `server-v*` tag push: build + push the image to GHCR (`:X.Y.Z` and `:latest`, `GITHUB_TOKEN` with `packages: write`), then create a GitHub Release with the built UI dist attached as `stardag-ui-dist-X.Y.Z.tar.gz` for deployments that serve the UI separately (e.g. S3/CDN).

### CLI: prebuilt image is the new default

`stardag self-host up/upgrade`:

- default: deploy `ghcr.io/stardag-dev/stardag-server:<DEFAULT_SERVER_VERSION>` (`0.1.0`, the pairing tested at SDK release time) via `modal.Image.from_registry` — public image, no registry secret, **no repo checkout needed**
- `--server-version X.Y.Z|latest` to pick a release
- `--from-source` keeps the build-from-checkout path (dev workflow; `--repo` implies it); a repo checkout is only required in this mode, and prebuilt-deploy failures suggest `--from-source` as fallback
- the migrate/web closures are mode-agnostic: both image modes use the same `/opt/stardag/api` + `/opt/stardag/ui` layout

### Docs

- `how-to/self-host-modal.md`: quickstart no longer clones the repo; new "Deploying from source (development)" section
- `DEV_README.md`: "Releasing the Server" (tag → CI publishes image + UI dist; bump `DEFAULT_SERVER_VERSION` at SDK release time)

## Verified

- `app/stardag-api`: `uv run pytest tests -q` — 341 passed (incl. new version-endpoint and server-module tests: SPA fallback, route precedence, idempotent mount)
- `lib/stardag`: `uv run pytest tests/test_selfhost -q` — 18 passed (incl. new flag-plumbing / image-ref tests)
- `docker build -f app/server.Dockerfile .` succeeds locally; the container serves `/health`, `/api/v1/version` (with injected version), the UI at `/` and SPA-fallback routes; `python`/`pip` available, alembic layout in place
- UI `npm run build`, `mkdocs build`, and `pre-commit` on all changed files — green

## Needs verification after first release

No `server-v*` tag exists yet, so the prebuilt deploy path could not be live-tested end-to-end. After tagging `server-v0.1.0`: verify the workflow publishes the image + release asset, then run `stardag self-host up` (default prebuilt mode) against a fresh Modal workspace. The from-source path is unchanged in behavior and remains fully working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf
