### PR TITLE
AWS CDK: deploy from prebuilt public server images (apiImageUri, uiApiProxy, deploy-ui --release)

### DIFF
--- a/infra/aws-cdk/.env.deploy.example
+++ b/infra/aws-cdk/.env.deploy.example
@@ -14,3 +14,12 @@ GOOGLE_CLIENT_SECRET=GOCSPX-xxx
 
 # Optional Features (opt-in)
 # SES_ENABLED=true  # Enable AWS SES for transactional emails (invites, etc.)
+
+# Prebuilt public images (opt-in) — see README "Use prebuilt public images"
+# Pin the API service to a prebuilt release image instead of the locally
+# built ECR :latest image. Prefer an ECR pull-through cache URI in prod.
+# STARDAG_API_IMAGE_URI=ghcr.io/stardag-dev/stardag-server:0.1.0
+# Route /api/* (and /health, /.well-known/*) through CloudFront to the API
+# so the UI and API are same-origin. Required for prebuilt UI dists
+# (deploy-ui.sh --release), which resolve their config at runtime.
+# STARDAG_UI_API_PROXY=true

--- a/infra/aws-cdk/README.md
+++ b/infra/aws-cdk/README.md
@@ -172,7 +172,11 @@ configured (the CloudFront origin points at the API custom domain).
 When the proxy is enabled, SPA routing switches from distribution-wide
 403/404 → `index.html` error responses to a CloudFront viewer-request
 function on the S3 behavior (otherwise legitimate API 403/404 responses
-would be rewritten to the app shell).
+would be rewritten to the app shell). The function serves `/assets/*` and
+root-level files with a known static extension as-is and rewrites every
+other path to `/index.html`, so client routes may safely contain dots; if
+the UI dist ever ships static files outside `/assets/` with a new
+extension, add it to the allowlist in `lib/frontend-stack.ts`.
 
 The locally-built flow (plain `./scripts/deploy-ui.sh`) is unaffected and
 does not need the proxy: it bakes `VITE_API_BASE_URL` etc. at build time.

--- a/infra/aws-cdk/README.md
+++ b/infra/aws-cdk/README.md
@@ -36,6 +36,11 @@ Use the deployment scripts in `scripts/`:
 ./scripts/deploy-api.sh            # Build, push, and deploy API
 ./scripts/deploy-ui.sh             # Build and deploy UI
 ./scripts/run-migrations.sh        # Run database migrations
+
+# Prebuilt public release images (no local docker/npm builds)
+# See "Use Prebuilt Public Images" below
+./scripts/deploy-api.sh --image-uri ghcr.io/stardag-dev/stardag-server:X.Y.Z
+./scripts/deploy-ui.sh --release server-vX.Y.Z
 ```
 
 ### Deployment Order
@@ -49,6 +54,139 @@ For first-time deployments, the correct order is:
 5. Update API service
 
 The `deploy-all.sh` script handles this automatically.
+
+## Use Prebuilt Public Images (no local builds)
+
+Each server release (git tag `server-vX.Y.Z`) publishes:
+
+- A combined server container image: `ghcr.io/stardag-dev/stardag-server:X.Y.Z`
+  (Registry API + built web UI served same-origin + Alembic migrations).
+- The built UI dist as a GitHub Release asset: `stardag-ui-dist-X.Y.Z.tar.gz`.
+
+These let you deploy without Docker or Node installed locally.
+
+### API from a prebuilt image
+
+```bash
+# One-off deploy of a specific release image
+./scripts/deploy-api.sh --image-uri ghcr.io/stardag-dev/stardag-server:0.1.0
+
+# Or pass through the infra deploy (used by deploy-all.sh)
+./scripts/deploy-infra.sh --all --image-uri ghcr.io/stardag-dev/stardag-server:0.1.0
+```
+
+Under the hood this is a CDK context value (`-c apiImageUri=<uri>`), so it
+also works with plain CDK commands:
+
+```bash
+npx cdk deploy StardagApi -c apiImageUri=ghcr.io/stardag-dev/stardag-server:0.1.0
+```
+
+To make the choice persistent (so later deploys don't silently fall back to
+the ECR `:latest` image), pin it in `.env.deploy`:
+
+```bash
+STARDAG_API_IMAGE_URI=ghcr.io/stardag-dev/stardag-server:0.1.0
+```
+
+Notes:
+
+- **Always pin an explicit version** (`:0.1.0`), never a moving tag. ECS
+  resolves the tag at task start, so a moving tag would make scale-out
+  events and task replacements pull a different build than the running
+  tasks. Upgrades are then an explicit `.env.deploy` edit + `cdk deploy`.
+- The combined `stardag-server` image also contains the built web UI
+  (the API serves it same-origin when no external UI is configured). That
+  is harmless here: this CDK setup keeps serving the UI via S3 +
+  CloudFront, and the image is a strict superset of the API-only image —
+  including `alembic.ini` + `migrations/` at the same working directory,
+  so `run-migrations.sh` works unchanged.
+- `run-migrations.sh` overrides the container command with
+  `alembic upgrade head` (configurable via `MIGRATION_COMMAND` for images
+  with a different layout).
+
+### Recommended for production: ECR pull-through cache
+
+Pulling from `ghcr.io` puts an external registry on your ECS scale-up /
+recovery path (rate limits, availability). The recommended production
+pattern is an ECR pull-through cache: ECS pulls from your own ECR, which
+transparently mirrors GHCR on first pull.
+
+```bash
+# 1. Store GitHub credentials for GHCR upstream (a PAT with read:packages;
+#    required by ECR for ghcr.io upstreams). The secret name must start
+#    with "ecr-pullthroughcache/".
+aws secretsmanager create-secret \
+    --name ecr-pullthroughcache/ghcr \
+    --secret-string '{"username":"<github-username>","accessToken":"<github-pat>"}'
+
+# 2. Create the pull-through cache rule
+aws ecr create-pull-through-cache-rule \
+    --ecr-repository-prefix ghcr \
+    --upstream-registry-url ghcr.io \
+    --credential-arn arn:aws:secretsmanager:<region>:<account-id>:secret:ecr-pullthroughcache/ghcr-xxxxxx
+
+# 3. Prime the cache (first pull creates the repo and mirrors the image)
+aws ecr get-login-password --region <region> | \
+    docker login --username AWS --password-stdin <account-id>.dkr.ecr.<region>.amazonaws.com
+docker pull <account-id>.dkr.ecr.<region>.amazonaws.com/ghcr/stardag-dev/stardag-server:0.1.0
+
+# 4. Use the cached URI as the API image
+./scripts/deploy-api.sh \
+    --image-uri <account-id>.dkr.ecr.<region>.amazonaws.com/ghcr/stardag-dev/stardag-server:0.1.0
+```
+
+The ECS task execution role created by CDK already has ECR pull
+permissions via the managed `AmazonECSTaskExecutionRolePolicy`; add
+`ecr:BatchImportUpstreamImage` on the cache repositories if you want ECS
+itself (rather than a manual `docker pull`) to trigger first-time imports.
+
+### UI from a prebuilt release dist
+
+```bash
+./scripts/deploy-ui.sh --release server-v0.1.0
+```
+
+This downloads `stardag-ui-dist-0.1.0.tar.gz` from the GitHub release
+(via `gh` if installed, else `curl`) and syncs it to S3 — no `npm` needed.
+
+**Important caveat — same-origin requirement:** the prebuilt dist contains
+no baked `VITE_*` configuration. It resolves auth/API configuration at
+runtime from `GET /api/v1/auth/config` on its own origin
+(`window.location.origin`). In this CDK setup the UI (CloudFront) and API
+(ALB) are different origins by default, so the prebuilt dist only works if
+CloudFront routes `/api/*` (plus `/health` and `/.well-known/*`) to the
+API. Enable the same-origin proxy and redeploy the Frontend stack first:
+
+```bash
+# via .env.deploy: STARDAG_UI_API_PROXY=true, then ./scripts/deploy-infra.sh
+# or one-off:
+npx cdk deploy StardagFrontend -c uiApiProxy=true
+```
+
+`deploy-ui.sh --release` verifies the deployed distribution has the
+`/api/*` behavior and refuses to deploy without it
+(`--skip-same-origin-check` overrides). The proxy requires DNS to be
+configured (the CloudFront origin points at the API custom domain).
+
+When the proxy is enabled, SPA routing switches from distribution-wide
+403/404 → `index.html` error responses to a CloudFront viewer-request
+function on the S3 behavior (otherwise legitimate API 403/404 responses
+would be rewritten to the app shell).
+
+The locally-built flow (plain `./scripts/deploy-ui.sh`) is unaffected and
+does not need the proxy: it bakes `VITE_API_BASE_URL` etc. at build time.
+
+### Fully prebuilt deployment
+
+```bash
+STARDAG_UI_API_PROXY=true ./scripts/deploy-all.sh \
+    --image-uri ghcr.io/stardag-dev/stardag-server:0.1.0 \
+    --release server-v0.1.0
+```
+
+Keep the API image version and the UI `--release` tag in lockstep (same
+`X.Y.Z`) unless a release note says otherwise.
 
 ## Operations
 

--- a/infra/aws-cdk/lib/api-stack.ts
+++ b/infra/aws-cdk/lib/api-stack.ts
@@ -17,6 +17,25 @@ import { FoundationStack } from "./foundation-stack";
 export interface ApiStackProps extends cdk.StackProps {
   config: StardagConfig;
   foundation: FoundationStack;
+
+  /**
+   * Optional explicit container image URI for the API service.
+   *
+   * When set, the ECS task uses this image directly (e.g. a prebuilt
+   * public release image such as
+   * ``ghcr.io/stardag-dev/stardag-server:X.Y.Z``) instead of the
+   * ``:latest`` tag of the ECR repository created by the Foundation
+   * stack. Can also be provided via CDK context (``-c apiImageUri=...``)
+   * or the ``STARDAG_API_IMAGE_URI`` environment variable.
+   *
+   * Note: the combined ``stardag-server`` image also bundles the built
+   * web UI (served same-origin by the API). That is harmless here — this
+   * CDK setup keeps serving the UI via S3 + CloudFront — the image is
+   * simply also a superset of the API-only image.
+   *
+   * @default - image from the Foundation stack's ECR repository (:latest)
+   */
+  apiImageUri?: string;
 }
 
 /**
@@ -38,6 +57,18 @@ export class ApiStack extends cdk.Stack {
     super(scope, id, props);
 
     const { config, foundation } = props;
+
+    // Optional explicit image URI (prebuilt public release image).
+    // Resolution order: stack prop > CDK context > environment variable.
+    // Trim whitespace so a blank value in an env file is treated as unset.
+    const rawImageUri: unknown =
+      props.apiImageUri ??
+      this.node.tryGetContext("apiImageUri") ??
+      process.env.STARDAG_API_IMAGE_URI;
+    const apiImageUri =
+      typeof rawImageUri === "string" && rawImageUri.trim() !== ""
+        ? rawImageUri.trim()
+        : undefined;
 
     // Sizing knobs that ops may want to tune at deploy time without
     // editing this file. Defaults match the OSS-friendly free-tier shape;
@@ -171,8 +202,11 @@ export class ApiStack extends cdk.Stack {
 
     // Add container
     taskDefinition.addContainer("Api", {
-      // Use image from ECR repository
-      image: ecs.ContainerImage.fromEcrRepository(foundation.ecrRepository, "latest"),
+      // Either an explicit (typically prebuilt public) image, or the
+      // locally-built image pushed to the Foundation stack's ECR repo.
+      image: apiImageUri
+        ? ecs.ContainerImage.fromRegistry(apiImageUri)
+        : ecs.ContainerImage.fromEcrRepository(foundation.ecrRepository, "latest"),
       logging: ecs.LogDrivers.awsLogs({
         logGroup,
         streamPrefix: "api",

--- a/infra/aws-cdk/lib/api-stack.ts
+++ b/infra/aws-cdk/lib/api-stack.ts
@@ -222,6 +222,15 @@ export class ApiStack extends cdk.Stack {
         OIDC_AUDIENCE: foundation.cognitoClientId,
         // SDK client ID (same Cognito client used for both UI and SDK)
         OIDC_SDK_CLIENT_ID: foundation.cognitoClientId,
+        // UI client ID and Cognito hosted-UI domain, served to the web UI
+        // at runtime via GET /api/v1/auth/config. Required for prebuilt UI
+        // dists (deploy-ui.sh --release), which have no baked VITE_* config
+        // and would otherwise fall back to the API defaults (client id
+        // "stardag-ui", no Cognito logout). Harmless for locally-built
+        // dists, which bake their config at build time.
+        OIDC_UI_CLIENT_ID: foundation.cognitoClientId,
+        // Bare host, no scheme — the UI builds https://{domain}/logout.
+        OIDC_COGNITO_DOMAIN: foundation.cognitoDomain,
         // Cognito JWKS URL format: {issuer}/.well-known/jwks.json
         // (different from Keycloak which uses /protocol/openid-connect/certs)
         OIDC_JWKS_URL: `${foundation.cognitoIssuerUrl}/.well-known/jwks.json`,

--- a/infra/aws-cdk/lib/constructs/api.ts
+++ b/infra/aws-cdk/lib/constructs/api.ts
@@ -125,8 +125,13 @@ export class StardagApi extends Construct {
       memoryLimitMiB = 512,
       desiredCount = 1,
       certificate,
-      imageUri,
+      imageUri: rawImageUri,
     } = props;
+
+    // Normalize: treat a whitespace-only imageUri (e.g. from an unset or
+    // sloppily-quoted env/context value) as "not set" instead of
+    // synthesizing fromRegistry("   "), which would fail at deploy time.
+    const imageUri = rawImageUri?.trim() || undefined;
 
     // =============================================================
     // ECR Repository

--- a/infra/aws-cdk/lib/constructs/api.ts
+++ b/infra/aws-cdk/lib/constructs/api.ts
@@ -88,6 +88,16 @@ export interface StardagApiProps {
    * If provided, enables HTTPS on the ALB
    */
   certificate?: acm.ICertificate;
+
+  /**
+   * Optional explicit container image URI (e.g. a prebuilt public
+   * release image such as ``ghcr.io/stardag-dev/stardag-server:X.Y.Z``).
+   * When set, the ECS task uses this image directly instead of the
+   * ``:latest`` tag of the ECR repository created by this construct.
+   *
+   * @default - image from this construct's ECR repository (:latest)
+   */
+  imageUri?: string;
 }
 
 export class StardagApi extends Construct {
@@ -115,6 +125,7 @@ export class StardagApi extends Construct {
       memoryLimitMiB = 512,
       desiredCount = 1,
       certificate,
+      imageUri,
     } = props;
 
     // =============================================================
@@ -184,8 +195,11 @@ export class StardagApi extends Construct {
 
     // Add container
     const container = taskDefinition.addContainer("Api", {
-      // Use image from ECR repository
-      image: ecs.ContainerImage.fromEcrRepository(this.repository, "latest"),
+      // Either an explicit (typically prebuilt public) image, or the
+      // locally-built image pushed to this construct's ECR repository.
+      image: imageUri
+        ? ecs.ContainerImage.fromRegistry(imageUri)
+        : ecs.ContainerImage.fromEcrRepository(this.repository, "latest"),
       logging: ecs.LogDrivers.awsLogs({
         logGroup,
         streamPrefix: "api",

--- a/infra/aws-cdk/lib/frontend-stack.ts
+++ b/infra/aws-cdk/lib/frontend-stack.ts
@@ -11,6 +11,31 @@ import { FoundationStack } from "./foundation-stack";
 export interface FrontendStackProps extends cdk.StackProps {
   config: StardagConfig;
   foundation: FoundationStack;
+
+  /**
+   * Route ``/api/*`` (plus ``/health`` and ``/.well-known/*``) through
+   * CloudFront to the API, making the UI and API same-origin.
+   *
+   * Required when deploying a prebuilt UI dist from a GitHub release
+   * (``deploy-ui.sh --release server-vX.Y.Z``): the prebuilt bundle has
+   * no baked ``VITE_*`` config and resolves its auth/API configuration at
+   * runtime from ``GET /api/v1/auth/config`` on ``window.location.origin``
+   * — which only reaches the API if CloudFront forwards ``/api/*`` to it.
+   *
+   * Can also be enabled via CDK context (``-c uiApiProxy=true``) or the
+   * ``STARDAG_UI_API_PROXY`` environment variable.
+   *
+   * Only supported when DNS is configured (the CloudFront origin points
+   * at the API custom domain, which needs a valid certificate).
+   *
+   * Side effect: SPA fallback switches from distribution-wide 403/404
+   * error responses (which would also rewrite legitimate API error
+   * responses to ``index.html``) to a viewer-request CloudFront Function
+   * scoped to the S3 behavior.
+   *
+   * @default false
+   */
+  apiProxy?: boolean;
 }
 
 /**
@@ -27,6 +52,25 @@ export class FrontendStack extends cdk.Stack {
     super(scope, id, props);
 
     const { config, foundation } = props;
+
+    // Optional same-origin API proxy (see FrontendStackProps.apiProxy).
+    // Resolution order: stack prop > CDK context > environment variable.
+    const rawApiProxy: unknown =
+      props.apiProxy ??
+      this.node.tryGetContext("uiApiProxy") ??
+      process.env.STARDAG_UI_API_PROXY;
+    const apiProxy =
+      rawApiProxy === true ||
+      (typeof rawApiProxy === "string" &&
+        ["true", "1"].includes(rawApiProxy.trim().toLowerCase()));
+
+    if (apiProxy && !foundation.dns) {
+      throw new Error(
+        "uiApiProxy requires DNS to be configured (a real DOMAIN_NAME): " +
+          "the CloudFront API origin points at the API custom domain " +
+          `(https://${config.apiDomain}) which needs a valid certificate.`,
+      );
+    }
 
     // =============================================================
     // S3 Bucket for Static Assets
@@ -67,6 +111,54 @@ export class FrontendStack extends cdk.Stack {
     });
 
     // =============================================================
+    // Optional same-origin API proxy behaviors
+    // =============================================================
+    // In apiProxy mode, CloudFront forwards API paths to the API custom
+    // domain so the UI and API share an origin. The distribution-wide
+    // 403/404 -> index.html error responses used for SPA routing in the
+    // default mode would also rewrite legitimate API error responses
+    // (CloudFront custom error responses apply to every cache behavior),
+    // so SPA routing switches to a viewer-request function scoped to the
+    // S3 behavior: extensionless paths are rewritten to /index.html.
+    const spaRewriteFunction = apiProxy
+      ? new cloudfront.Function(this, "SpaRewriteFn", {
+          comment: "Rewrite extensionless paths to /index.html (SPA routing)",
+          runtime: cloudfront.FunctionRuntime.JS_2_0,
+          code: cloudfront.FunctionCode.fromInline(
+            [
+              "function handler(event) {",
+              "  var request = event.request;",
+              "  // Paths without a file extension are SPA routes.",
+              "  if (!request.uri.includes('.')) {",
+              "    request.uri = '/index.html';",
+              "  }",
+              "  return request;",
+              "}",
+            ].join("\n"),
+          ),
+        })
+      : undefined;
+
+    const apiBehavior: cloudfront.BehaviorOptions | undefined = apiProxy
+      ? {
+          // Point at the API custom domain (resolves to the ALB via
+          // Route53); avoids a cross-stack reference to the Api stack and
+          // presents a certificate that matches the origin hostname.
+          origin: new cloudfront_origins.HttpOrigin(config.apiDomain, {
+            protocolPolicy: cloudfront.OriginProtocolPolicy.HTTPS_ONLY,
+          }),
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_ALL,
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+          // Forward all viewer headers (incl. Authorization) except Host,
+          // which must stay the origin's own hostname for TLS/routing.
+          originRequestPolicy:
+            cloudfront.OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          compress: true,
+        }
+      : undefined;
+
+    // =============================================================
     // CloudFront Distribution
     // =============================================================
     const certificate = foundation.dns?.uiCertificate;
@@ -95,23 +187,52 @@ export class FrontendStack extends cdk.Stack {
           cloudfront.ResponseHeadersPolicy
             .CORS_ALLOW_ALL_ORIGINS_WITH_PREFLIGHT_AND_SECURITY_HEADERS,
         compress: true,
+        ...(spaRewriteFunction
+          ? {
+              functionAssociations: [
+                {
+                  function: spaRewriteFunction,
+                  eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+                },
+              ],
+            }
+          : {}),
       },
 
-      // SPA routing: serve index.html for all 403/404 errors
-      errorResponses: [
-        {
-          httpStatus: 403,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-          ttl: cdk.Duration.minutes(5),
-        },
-        {
-          httpStatus: 404,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-          ttl: cdk.Duration.minutes(5),
-        },
-      ],
+      // Same-origin API proxy behaviors (apiProxy mode only)
+      ...(apiBehavior
+        ? {
+            additionalBehaviors: {
+              "/api/*": apiBehavior,
+              "/health": apiBehavior,
+              // JWKS is served at the root-level standard location too
+              "/.well-known/*": apiBehavior,
+            },
+          }
+        : {}),
+
+      // SPA routing (default mode): serve index.html for all 403/404
+      // errors. In apiProxy mode the viewer-request function on the S3
+      // behavior handles SPA routing instead, so API error responses
+      // pass through untouched.
+      ...(apiProxy
+        ? {}
+        : {
+            errorResponses: [
+              {
+                httpStatus: 403,
+                responseHttpStatus: 200,
+                responsePagePath: "/index.html",
+                ttl: cdk.Duration.minutes(5),
+              },
+              {
+                httpStatus: 404,
+                responseHttpStatus: 200,
+                responsePagePath: "/index.html",
+                ttl: cdk.Duration.minutes(5),
+              },
+            ],
+          }),
 
       // Default root object
       defaultRootObject: "index.html",
@@ -156,6 +277,14 @@ export class FrontendStack extends cdk.Stack {
       value: this.distribution.distributionId,
       description: "CloudFront distribution ID",
       exportName: "StardagFrontendDistributionId",
+    });
+
+    new cdk.CfnOutput(this, "ApiProxyEnabled", {
+      value: apiProxy ? "true" : "false",
+      description:
+        "Whether CloudFront routes /api/* to the API (required for " +
+        "prebuilt UI dists deployed with deploy-ui.sh --release)",
+      exportName: "StardagFrontendApiProxyEnabled",
     });
 
     new cdk.CfnOutput(this, "DistributionDomain", {

--- a/infra/aws-cdk/lib/frontend-stack.ts
+++ b/infra/aws-cdk/lib/frontend-stack.ts
@@ -119,17 +119,33 @@ export class FrontendStack extends cdk.Stack {
     // default mode would also rewrite legitimate API error responses
     // (CloudFront custom error responses apply to every cache behavior),
     // so SPA routing switches to a viewer-request function scoped to the
-    // S3 behavior: extensionless paths are rewritten to /index.html.
+    // S3 behavior. The function uses a static-asset allowlist rather than
+    // a "URI contains a dot" heuristic: the dist layout is under our
+    // control (Vite emits the fingerprinted bundle under /assets/ plus a
+    // handful of root-level files with well-known extensions), while
+    // future client route params are not — a dotted route param must fall
+    // through to the SPA (which renders its own not-found state), not to
+    // a raw S3 AccessDenied/NoSuchKey XML response (proxy mode has no
+    // distribution-wide error responses to catch the miss).
     const spaRewriteFunction = apiProxy
       ? new cloudfront.Function(this, "SpaRewriteFn", {
-          comment: "Rewrite extensionless paths to /index.html (SPA routing)",
+          comment: "SPA routing: rewrite non-static-asset paths to /index.html",
           runtime: cloudfront.FunctionRuntime.JS_2_0,
           code: cloudfront.FunctionCode.fromInline(
             [
               "function handler(event) {",
               "  var request = event.request;",
-              "  // Paths without a file extension are SPA routes.",
-              "  if (!request.uri.includes('.')) {",
+              "  var uri = request.uri;",
+              "  // Static assets are served as-is: the fingerprinted Vite",
+              "  // bundle under /assets/, and root-level files with a",
+              "  // known static extension (favicon.svg, robots.txt, ...).",
+              "  // Everything else is an SPA route -> /index.html. If the",
+              "  // UI dist ever ships static files outside /assets/ with",
+              "  // an extension not listed here, extend the allowlist.",
+              "  var isStaticAsset =",
+              "    uri.startsWith('/assets/') ||",
+              "    /\\.(html|js|css|map|json|svg|png|jpe?g|gif|webp|avif|ico|txt|xml|webmanifest|woff2?|ttf|eot)$/.test(uri);",
+              "  if (!isStaticAsset) {",
               "    request.uri = '/index.html';",
               "  }",
               "  return request;",

--- a/infra/aws-cdk/scripts/deploy-all.sh
+++ b/infra/aws-cdk/scripts/deploy-all.sh
@@ -1,16 +1,65 @@
 #!/bin/bash
 # Full deployment: infrastructure + API + migrations + UI
+# Usage: deploy-all.sh [--image-uri <uri>] [--release server-vX.Y.Z]
+#   --image-uri <uri>: Use an explicit (typically prebuilt public) API
+#       container image, e.g. ghcr.io/stardag-dev/stardag-server:X.Y.Z,
+#       instead of building and pushing the API image locally.
+#   --release server-vX.Y.Z: Deploy the prebuilt UI dist attached to that
+#       GitHub release instead of building the UI locally with npm.
+#       Requires the CloudFront same-origin API proxy
+#       (STARDAG_UI_API_PROXY=true) — see deploy-ui.sh / README.md.
+#
+# Fully prebuilt deployment (no local docker/npm builds):
+#   STARDAG_UI_API_PROXY=true ./scripts/deploy-all.sh \
+#       --image-uri ghcr.io/stardag-dev/stardag-server:X.Y.Z \
+#       --release server-vX.Y.Z
+#
 # Order ensures:
-#   1. ECR exists before pushing image
+#   1. ECR exists before pushing image (local build mode)
 #   2. Image exists before ECS service is created
 #   3. Migrations run before API service starts
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# Parse arguments
+IMAGE_URI=""
+RELEASE=""
+while [ $# -gt 0 ]; do
+    case $1 in
+        --image-uri)
+            IMAGE_URI="$2"
+            if [ -z "$IMAGE_URI" ]; then
+                echo "ERROR: --image-uri requires a value"
+                exit 1
+            fi
+            shift 2
+            ;;
+        --release)
+            RELEASE="$2"
+            if [ -z "$RELEASE" ]; then
+                echo "ERROR: --release requires a value (e.g. server-v0.1.0)"
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo "Usage: deploy-all.sh [--image-uri <uri>] [--release server-vX.Y.Z]"
+            exit 1
+            ;;
+    esac
+done
+
 echo "=========================================="
 echo "     Stardag Full Deployment"
 echo "=========================================="
+if [ -n "$IMAGE_URI" ]; then
+    echo "API image: $IMAGE_URI (prebuilt, no local docker build)"
+fi
+if [ -n "$RELEASE" ]; then
+    echo "UI dist:   from GitHub release $RELEASE (no local npm build)"
+fi
 echo ""
 
 # Step 1: Deploy Foundation (VPC, Database, ECR, Cognito, DNS)
@@ -21,15 +70,25 @@ echo ""
 echo ""
 
 # Step 2: Build and push API image (now ECR exists)
-echo "Step 2/6: Building and pushing API image..."
-echo ""
-"$SCRIPT_DIR/deploy-api.sh" --skip-update
-echo ""
+# Skipped when an explicit prebuilt image is used.
+if [ -n "$IMAGE_URI" ]; then
+    echo "Step 2/6: Skipping local API image build (--image-uri given)"
+    echo ""
+else
+    echo "Step 2/6: Building and pushing API image..."
+    echo ""
+    "$SCRIPT_DIR/deploy-api.sh" --skip-update
+    echo ""
+fi
 
 # Step 3: Deploy API and Frontend stacks (now image exists)
 echo "Step 3/6: Deploying API and Frontend stacks..."
 echo ""
-"$SCRIPT_DIR/deploy-infra.sh" --all
+if [ -n "$IMAGE_URI" ]; then
+    "$SCRIPT_DIR/deploy-infra.sh" --all --image-uri "$IMAGE_URI"
+else
+    "$SCRIPT_DIR/deploy-infra.sh" --all
+fi
 echo ""
 
 # Step 4: Run migrations (before API service uses new code)
@@ -45,9 +104,13 @@ echo ""
 echo ""
 
 # Step 6: Deploy UI assets
-echo "Step 6/6: Building and deploying UI..."
+echo "Step 6/6: Deploying UI..."
 echo ""
-"$SCRIPT_DIR/deploy-ui.sh"
+if [ -n "$RELEASE" ]; then
+    "$SCRIPT_DIR/deploy-ui.sh" --release "$RELEASE"
+else
+    "$SCRIPT_DIR/deploy-ui.sh"
+fi
 echo ""
 
 echo "=========================================="

--- a/infra/aws-cdk/scripts/deploy-api.sh
+++ b/infra/aws-cdk/scripts/deploy-api.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 # Build, push, and deploy API to ECS
-# Usage: deploy-api.sh [--skip-update]
+# Usage: deploy-api.sh [--skip-update] [--image-uri <uri>]
 #   --skip-update: Only build and push, don't update the ECS service
+#   --image-uri <uri>: Skip the local docker build+push entirely and deploy
+#       the given (typically prebuilt public) image, e.g.
+#       ghcr.io/stardag-dev/stardag-server:X.Y.Z
+#       This runs `cdk deploy StardagApi -c apiImageUri=<uri>` so the ECS
+#       task definition points at the image directly (no ECR involved).
+#       Recommended for production: mirror the image through an ECR
+#       pull-through cache first — see infra/aws-cdk/README.md.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -10,14 +17,34 @@ REPO_ROOT="$(cd "$CDK_DIR/../.." && pwd)"
 
 # Parse arguments
 SKIP_UPDATE=false
-for arg in "$@"; do
-    case $arg in
+IMAGE_URI=""
+while [ $# -gt 0 ]; do
+    case $1 in
         --skip-update)
             SKIP_UPDATE=true
             shift
             ;;
+        --image-uri)
+            IMAGE_URI="$2"
+            if [ -z "$IMAGE_URI" ]; then
+                echo "ERROR: --image-uri requires a value"
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo "Usage: deploy-api.sh [--skip-update] [--image-uri <uri>]"
+            exit 1
+            ;;
     esac
 done
+
+if [ -n "$IMAGE_URI" ] && [ "$SKIP_UPDATE" = true ]; then
+    echo "ERROR: --skip-update only applies to the local build+push flow;"
+    echo "it cannot be combined with --image-uri."
+    exit 1
+fi
 
 cd "$CDK_DIR"
 
@@ -31,15 +58,46 @@ AWS_REGION="${AWS_REGION:-us-east-1}"
 # Only use AWS_PROFILE if credentials aren't already set (CI uses OIDC env vars)
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then
     AWS_PROFILE="${AWS_PROFILE:-stardag}"
+    export AWS_PROFILE
     AWS_CMD="aws --profile $AWS_PROFILE"
-    echo "=== Building and Deploying API ==="
+    echo "=== Deploying API ==="
     echo "AWS Profile: $AWS_PROFILE"
 else
+    # Unset AWS_PROFILE to ensure env credentials are used (also by cdk)
+    unset AWS_PROFILE
     AWS_CMD="aws"
-    echo "=== Building and Deploying API ==="
+    echo "=== Deploying API ==="
     echo "Using environment credentials (CI mode)"
 fi
 echo "Region: $AWS_REGION"
+
+# =============================================================
+# Prebuilt image mode: no local docker build, no ECR push.
+# The image URI is baked into the ECS task definition via CDK.
+# =============================================================
+if [ -n "$IMAGE_URI" ]; then
+    echo "Mode: Prebuilt image (no local build)"
+    echo "Image: $IMAGE_URI"
+    echo ""
+    echo "=== Deploying StardagApi stack with explicit image ==="
+    npx cdk deploy StardagApi \
+        --require-approval never \
+        -c "apiImageUri=$IMAGE_URI"
+
+    echo ""
+    echo "=== API deployment initiated ==="
+    echo ""
+    echo "The ECS service now rolls out a task definition pointing at:"
+    echo "  $IMAGE_URI"
+    echo ""
+    echo "NOTE: subsequent 'cdk deploy StardagApi' runs without"
+    echo "-c apiImageUri=... will revert the service to the ECR :latest"
+    echo "image. Pin the value in .env.deploy to make it stick:"
+    echo "  STARDAG_API_IMAGE_URI=$IMAGE_URI"
+    exit 0
+fi
+
+echo "Mode: Local docker build + push to ECR"
 if [ "$SKIP_UPDATE" = true ]; then
     echo "Mode: Build and push only (--skip-update)"
 fi

--- a/infra/aws-cdk/scripts/deploy-infra.sh
+++ b/infra/aws-cdk/scripts/deploy-infra.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 # Deploy CDK infrastructure to AWS
-# Usage: deploy-infra.sh [--foundation-only | --all]
+# Usage: deploy-infra.sh [--foundation-only | --all] [--image-uri <uri>]
 #   --foundation-only: Deploy only Foundation stack (for first-time setup)
 #   --all: Deploy all stacks (default for subsequent deployments)
+#   --image-uri <uri>: Use an explicit (typically prebuilt public) API
+#       container image, e.g. ghcr.io/stardag-dev/stardag-server:X.Y.Z.
+#       Passed through to CDK as -c apiImageUri=<uri>. Alternatively set
+#       STARDAG_API_IMAGE_URI in .env.deploy to pin it persistently.
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,8 +17,9 @@ cd "$CDK_DIR"
 # Parse arguments
 # Default: deploy main stacks (Foundation, Api, Frontend) but NOT Bastion
 STACKS="StardagFoundation StardagApi StardagFrontend"
-for arg in "$@"; do
-    case $arg in
+IMAGE_URI=""
+while [ $# -gt 0 ]; do
+    case $1 in
         --foundation-only)
             STACKS="StardagFoundation"
             shift
@@ -24,8 +29,27 @@ for arg in "$@"; do
             STACKS="StardagFoundation StardagApi StardagFrontend"
             shift
             ;;
+        --image-uri)
+            IMAGE_URI="$2"
+            if [ -z "$IMAGE_URI" ]; then
+                echo "ERROR: --image-uri requires a value"
+                exit 1
+            fi
+            shift 2
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo "Usage: deploy-infra.sh [--foundation-only | --all] [--image-uri <uri>]"
+            exit 1
+            ;;
     esac
 done
+
+# Extra CDK context args (applies to synth and deploy)
+CDK_CONTEXT_ARGS=()
+if [ -n "$IMAGE_URI" ]; then
+    CDK_CONTEXT_ARGS+=(-c "apiImageUri=$IMAGE_URI")
+fi
 
 # Load config
 if [ -f .env.deploy ]; then
@@ -46,16 +70,19 @@ fi
 echo "Region: $AWS_REGION"
 echo "Account: $AWS_ACCOUNT_ID"
 echo "Stacks: $STACKS"
+if [ -n "$IMAGE_URI" ]; then
+    echo "API Image: $IMAGE_URI (explicit, no ECR build)"
+fi
 echo ""
 
 # Synthesize first to catch errors
 echo "=== Synthesizing CloudFormation template ==="
-npx cdk synth --quiet
+npx cdk synth --quiet "${CDK_CONTEXT_ARGS[@]}"
 
 # Deploy
 echo ""
 echo "=== Deploying stack ==="
-npx cdk deploy $STACKS --require-approval never
+npx cdk deploy $STACKS --require-approval never "${CDK_CONTEXT_ARGS[@]}"
 
 echo ""
 echo "=== Infrastructure deployment complete ==="

--- a/infra/aws-cdk/scripts/deploy-ui.sh
+++ b/infra/aws-cdk/scripts/deploy-ui.sh
@@ -1,10 +1,66 @@
 #!/bin/bash
-# Build and deploy UI to S3/CloudFront
+# Build (or download) and deploy UI to S3/CloudFront
+# Usage: deploy-ui.sh [--release server-vX.Y.Z] [--skip-same-origin-check]
+#   (no args): Build the UI locally with npm, baking VITE_* config
+#       (OIDC issuer, API base URL, ...) from the deployed stacks' outputs.
+#   --release server-vX.Y.Z: Skip the local npm build and deploy the
+#       prebuilt UI dist attached to the GitHub release with that tag
+#       (asset: stardag-ui-dist-X.Y.Z.tar.gz).
+#
+#       IMPORTANT: the prebuilt dist contains NO baked VITE_* config. It
+#       resolves auth/API configuration at runtime from
+#       GET <window.location.origin>/api/v1/auth/config — which only
+#       reaches the API if CloudFront forwards /api/* to it (the UI and
+#       API are different origins in this setup otherwise). Deploy the
+#       Frontend stack with the same-origin API proxy enabled first:
+#           STARDAG_UI_API_PROXY=true ./scripts/deploy-infra.sh
+#       (or: npx cdk deploy StardagFrontend -c uiApiProxy=true)
+#       This script verifies the deployed distribution has the /api/*
+#       behavior and refuses to deploy a prebuilt dist without it.
+#   --skip-same-origin-check: Skip that verification (use only if you
+#       know the distribution routes /api/* to the API).
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CDK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$CDK_DIR/../.." && pwd)"
+
+GITHUB_REPO="${STARDAG_GITHUB_REPO:-stardag-dev/stardag}"
+
+# Parse arguments
+RELEASE=""
+SKIP_SAME_ORIGIN_CHECK=false
+while [ $# -gt 0 ]; do
+    case $1 in
+        --release)
+            RELEASE="$2"
+            if [ -z "$RELEASE" ]; then
+                echo "ERROR: --release requires a value (e.g. server-v0.1.0)"
+                exit 1
+            fi
+            shift 2
+            ;;
+        --skip-same-origin-check)
+            SKIP_SAME_ORIGIN_CHECK=true
+            shift
+            ;;
+        *)
+            echo "ERROR: Unknown argument: $1"
+            echo "Usage: deploy-ui.sh [--release server-vX.Y.Z] [--skip-same-origin-check]"
+            exit 1
+            ;;
+    esac
+done
+
+if [ -n "$RELEASE" ]; then
+    case "$RELEASE" in
+        server-v*) ;;
+        *)
+            echo "ERROR: --release expects a server release tag (server-vX.Y.Z), got: $RELEASE"
+            exit 1
+            ;;
+    esac
+fi
 
 cd "$CDK_DIR"
 
@@ -35,13 +91,18 @@ if [ -z "$DOMAIN_NAME" ]; then
     exit 1
 fi
 
-echo "=== Building and Deploying UI ==="
+echo "=== Deploying UI ==="
 if [ -z "$AWS_ACCESS_KEY_ID" ]; then
     echo "AWS Profile: $AWS_PROFILE"
 else
     echo "Using environment credentials (CI mode)"
 fi
 echo "Region: $AWS_REGION"
+if [ -n "$RELEASE" ]; then
+    echo "Mode: Prebuilt dist from GitHub release $RELEASE"
+else
+    echo "Mode: Local npm build"
+fi
 echo ""
 
 # Get stack exports
@@ -65,49 +126,133 @@ echo "S3 Bucket: $BUCKET_NAME"
 echo "CloudFront Distribution: $DISTRIBUTION_ID"
 echo ""
 
-# Get Cognito config for UI build
-COGNITO_USER_POOL_ID=$($AWS_CMD cloudformation list-exports \
-    --query "Exports[?Name=='StardagCognitoUserPoolId'].Value" \
-    --output text \
-    --region $AWS_REGION 2>/dev/null || echo "")
+if [ -n "$RELEASE" ]; then
+    # =========================================================
+    # Prebuilt dist mode
+    # =========================================================
+    VERSION="${RELEASE#server-v}"
+    ASSET="stardag-ui-dist-${VERSION}.tar.gz"
 
-COGNITO_CLIENT_ID=$($AWS_CMD cloudformation list-exports \
-    --query "Exports[?Name=='StardagCognitoClientId'].Value" \
-    --output text \
-    --region $AWS_REGION 2>/dev/null || echo "")
+    if [ "$SKIP_SAME_ORIGIN_CHECK" = true ]; then
+        echo "=== Skipping same-origin check (--skip-same-origin-check) ==="
+    else
+        # The prebuilt dist has no baked VITE_* config: it fetches its
+        # runtime config from /api/v1/auth/config on its own origin, so
+        # CloudFront must route /api/* to the API.
+        echo "=== Verifying CloudFront routes /api/* to the API ==="
+        API_BEHAVIOR_COUNT=$($AWS_CMD cloudfront get-distribution-config \
+            --id "$DISTRIBUTION_ID" \
+            --query "length(DistributionConfig.CacheBehaviors.Items[?PathPattern=='/api/*'] || \`[]\`)" \
+            --output text)
+        if [ "$API_BEHAVIOR_COUNT" == "0" ] || [ -z "$API_BEHAVIOR_COUNT" ] || [ "$API_BEHAVIOR_COUNT" == "None" ]; then
+            echo ""
+            echo "ERROR: The CloudFront distribution has no /api/* behavior, so a"
+            echo "prebuilt UI dist cannot reach the API (it has no baked VITE_*"
+            echo "config and relies on same-origin runtime config)."
+            echo ""
+            echo "Enable the same-origin API proxy and redeploy the Frontend stack:"
+            echo "  STARDAG_UI_API_PROXY=true ./scripts/deploy-infra.sh"
+            echo "or:"
+            echo "  npx cdk deploy StardagFrontend -c uiApiProxy=true"
+            echo ""
+            echo "(Or pass --skip-same-origin-check to override.)"
+            exit 1
+        fi
+        echo "OK: /api/* behavior present"
+        echo ""
+    fi
 
-COGNITO_DOMAIN=$($AWS_CMD cloudformation list-exports \
-    --query "Exports[?Name=='StardagCognitoDomain'].Value" \
-    --output text \
-    --region $AWS_REGION 2>/dev/null || echo "")
+    echo "=== Downloading $ASSET from release $RELEASE ==="
+    DOWNLOAD_DIR="$(mktemp -d)"
+    trap 'rm -rf "$DOWNLOAD_DIR"' EXIT
 
-# Build the UI
-echo "=== Building UI ==="
-cd "$REPO_ROOT/app/stardag-ui"
+    if command -v gh > /dev/null 2>&1; then
+        gh release download "$RELEASE" \
+            --repo "$GITHUB_REPO" \
+            --pattern "$ASSET" \
+            --dir "$DOWNLOAD_DIR"
+    else
+        curl -fL --retry 3 \
+            -o "$DOWNLOAD_DIR/$ASSET" \
+            "https://github.com/$GITHUB_REPO/releases/download/$RELEASE/$ASSET"
+    fi
 
-# Set environment variables for the build
-export VITE_OIDC_ISSUER="https://cognito-idp.${AWS_REGION}.amazonaws.com/${COGNITO_USER_POOL_ID}"
-export VITE_OIDC_CLIENT_ID="${COGNITO_CLIENT_ID}"
-export VITE_OIDC_REDIRECT_URI="https://${UI_SUBDOMAIN:-app}.${DOMAIN_NAME}/callback"
-export VITE_API_BASE_URL="https://${API_SUBDOMAIN:-api}.${DOMAIN_NAME}"
-# Cognito domain for logout (Cognito uses non-standard logout endpoint)
-export VITE_COGNITO_DOMAIN="${COGNITO_DOMAIN}"
+    if [ ! -f "$DOWNLOAD_DIR/$ASSET" ]; then
+        echo "ERROR: Failed to download $ASSET from release $RELEASE"
+        exit 1
+    fi
 
-echo "OIDC Issuer: $VITE_OIDC_ISSUER"
-echo "OIDC Client ID: $VITE_OIDC_CLIENT_ID"
-echo "OIDC Redirect URI: $VITE_OIDC_REDIRECT_URI"
-echo "API Base URL: $VITE_API_BASE_URL"
-echo "Cognito Domain: $VITE_COGNITO_DOMAIN"
-echo ""
+    echo ""
+    echo "=== Extracting UI dist ==="
+    EXTRACT_DIR="$DOWNLOAD_DIR/extract"
+    mkdir -p "$EXTRACT_DIR"
+    tar -xzf "$DOWNLOAD_DIR/$ASSET" -C "$EXTRACT_DIR"
 
-# Install dependencies and build
-npm ci
-npm run build
+    # Locate the dist root (index.html) — tolerate both a flat tarball
+    # and one wrapped in a single top-level directory (e.g. dist/).
+    if [ -f "$EXTRACT_DIR/index.html" ]; then
+        DIST_DIR="$EXTRACT_DIR"
+    elif [ -f "$EXTRACT_DIR/dist/index.html" ]; then
+        DIST_DIR="$EXTRACT_DIR/dist"
+    else
+        DIST_DIR="$(dirname "$(find "$EXTRACT_DIR" -maxdepth 2 -name index.html | head -n 1)")"
+        if [ ! -f "$DIST_DIR/index.html" ]; then
+            echo "ERROR: Could not find index.html in the extracted UI dist"
+            exit 1
+        fi
+    fi
+    echo "Dist directory: $DIST_DIR"
+else
+    # =========================================================
+    # Local build mode
+    # =========================================================
+
+    # Get Cognito config for UI build
+    COGNITO_USER_POOL_ID=$($AWS_CMD cloudformation list-exports \
+        --query "Exports[?Name=='StardagCognitoUserPoolId'].Value" \
+        --output text \
+        --region $AWS_REGION 2>/dev/null || echo "")
+
+    COGNITO_CLIENT_ID=$($AWS_CMD cloudformation list-exports \
+        --query "Exports[?Name=='StardagCognitoClientId'].Value" \
+        --output text \
+        --region $AWS_REGION 2>/dev/null || echo "")
+
+    COGNITO_DOMAIN=$($AWS_CMD cloudformation list-exports \
+        --query "Exports[?Name=='StardagCognitoDomain'].Value" \
+        --output text \
+        --region $AWS_REGION 2>/dev/null || echo "")
+
+    # Build the UI
+    echo "=== Building UI ==="
+    cd "$REPO_ROOT/app/stardag-ui"
+
+    # Set environment variables for the build
+    export VITE_OIDC_ISSUER="https://cognito-idp.${AWS_REGION}.amazonaws.com/${COGNITO_USER_POOL_ID}"
+    export VITE_OIDC_CLIENT_ID="${COGNITO_CLIENT_ID}"
+    export VITE_OIDC_REDIRECT_URI="https://${UI_SUBDOMAIN:-app}.${DOMAIN_NAME}/callback"
+    export VITE_API_BASE_URL="https://${API_SUBDOMAIN:-api}.${DOMAIN_NAME}"
+    # Cognito domain for logout (Cognito uses non-standard logout endpoint)
+    export VITE_COGNITO_DOMAIN="${COGNITO_DOMAIN}"
+
+    echo "OIDC Issuer: $VITE_OIDC_ISSUER"
+    echo "OIDC Client ID: $VITE_OIDC_CLIENT_ID"
+    echo "OIDC Redirect URI: $VITE_OIDC_REDIRECT_URI"
+    echo "API Base URL: $VITE_API_BASE_URL"
+    echo "Cognito Domain: $VITE_COGNITO_DOMAIN"
+    echo ""
+
+    # Install dependencies and build
+    npm ci
+    npm run build
+
+    DIST_DIR="$REPO_ROOT/app/stardag-ui/dist"
+fi
 
 # Deploy to S3
 echo ""
 echo "=== Uploading to S3 ==="
-$AWS_CMD s3 sync ./dist s3://$BUCKET_NAME --delete --region $AWS_REGION
+$AWS_CMD s3 sync "$DIST_DIR" s3://$BUCKET_NAME --delete --region $AWS_REGION
 
 # Invalidate CloudFront cache
 echo ""

--- a/infra/aws-cdk/scripts/run-migrations.sh
+++ b/infra/aws-cdk/scripts/run-migrations.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
 # Run database migrations on AWS
 # Uses ECS to run migrations task against Aurora database
+#
+# The migration task reuses the API service's task definition and overrides
+# the container command with `alembic upgrade head`. This assumes the image
+# working directory contains alembic.ini and migrations/ — true for both
+# the locally-built stardag-api image and the prebuilt public server image
+# (ghcr.io/stardag-dev/stardag-server:X.Y.Z), which keep the same layout.
+# For images with a different layout, override with e.g.:
+#   MIGRATION_COMMAND="alembic -c /path/to/alembic.ini upgrade head" ./scripts/run-migrations.sh
 set -e
+
+# Command to run inside the container (split on whitespace into argv)
+MIGRATION_COMMAND="${MIGRATION_COMMAND:-alembic upgrade head}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CDK_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -96,19 +107,22 @@ ADMIN_SECRET_ARN=$($AWS_CMD secretsmanager list-secrets \
 
 echo "Admin Secret: $ADMIN_SECRET_ARN"
 
-# Create a migration-specific task definition that uses admin credentials
-# This overrides the command to run alembic instead of uvicorn
+# Run a one-off task from the API service's task definition, overriding
+# the command to run alembic instead of the API server. The command is
+# configurable via MIGRATION_COMMAND (see header comment).
+echo "Migration command: $MIGRATION_COMMAND"
+OVERRIDES=$(python3 -c "
+import json, sys
+command = sys.argv[1].split()
+print(json.dumps({'containerOverrides': [{'name': 'Api', 'command': command}]}))
+" "$MIGRATION_COMMAND")
+
 TASK_RUN_RESULT=$($AWS_CMD ecs run-task \
     --cluster $CLUSTER_NAME \
     --task-definition $TASK_DEF_ARN \
     --launch-type FARGATE \
     --network-configuration "awsvpcConfiguration={subnets=[$SUBNET_ID],securityGroups=[$SECURITY_GROUP],assignPublicIp=DISABLED}" \
-    --overrides '{
-        "containerOverrides": [{
-            "name": "Api",
-            "command": ["alembic", "upgrade", "head"]
-        }]
-    }' \
+    --overrides "$OVERRIDES" \
     --region $AWS_REGION \
     --output json)
 

--- a/infra/aws-cdk/scripts/run-migrations.sh
+++ b/infra/aws-cdk/scripts/run-migrations.sh
@@ -11,7 +11,8 @@
 #   MIGRATION_COMMAND="alembic -c /path/to/alembic.ini upgrade head" ./scripts/run-migrations.sh
 set -e
 
-# Command to run inside the container (split on whitespace into argv)
+# Command to run inside the container (split into argv with shell-style
+# quoting, so arguments containing spaces can be quoted)
 MIGRATION_COMMAND="${MIGRATION_COMMAND:-alembic upgrade head}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -112,8 +113,8 @@ echo "Admin Secret: $ADMIN_SECRET_ARN"
 # configurable via MIGRATION_COMMAND (see header comment).
 echo "Migration command: $MIGRATION_COMMAND"
 OVERRIDES=$(python3 -c "
-import json, sys
-command = sys.argv[1].split()
+import json, shlex, sys
+command = shlex.split(sys.argv[1])
 print(json.dumps({'containerOverrides': [{'name': 'Api', 'command': command}]}))
 " "$MIGRATION_COMMAND")
 

--- a/infra/aws-cdk/test/stardag.test.ts
+++ b/infra/aws-cdk/test/stardag.test.ts
@@ -3,6 +3,7 @@ import { Match, Template } from "aws-cdk-lib/assertions";
 import { ApiStack } from "../lib/api-stack";
 import { FoundationStack } from "../lib/foundation-stack";
 import { StardagStack } from "../lib/stardag-stack";
+import { FrontendStack } from "../lib/frontend-stack";
 
 // Mock config for testing
 const mockConfig = {
@@ -345,5 +346,182 @@ describe("ApiStack JWT_PRIVATE_KEY secret wiring", () => {
       const names = secrets.map((s: { Name: string }) => s.Name);
       expect(names).not.toContain("JWT_PRIVATE_KEY");
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ApiStack — optional explicit container image (prebuilt public release
+// image, e.g. ghcr.io/stardag-dev/stardag-server:X.Y.Z).
+// ---------------------------------------------------------------------------
+
+function synthApiStackWithImage(apiImageUri?: string): Template {
+  const app = new cdk.App();
+  const env = {
+    account: mockConfig.awsAccountId,
+    region: mockConfig.awsRegion,
+  };
+  const foundation = new FoundationStack(app, "Foundation", {
+    env,
+    config: mockConfig,
+  });
+  const apiStack = new ApiStack(app, "Api", {
+    env,
+    config: mockConfig,
+    foundation,
+    apiImageUri,
+  });
+  return Template.fromStack(apiStack);
+}
+
+function getApiContainerImage(template: Template): unknown {
+  const taskDefs = template.findResources("AWS::ECS::TaskDefinition");
+  const apiTaskDef = Object.values(taskDefs).find(
+    (td) =>
+      td.Properties.ContainerDefinitions?.some(
+        (c: { Name?: string }) => c.Name === "Api",
+      ),
+  );
+  expect(apiTaskDef).toBeDefined();
+  return apiTaskDef!.Properties.ContainerDefinitions[0].Image;
+}
+
+describe("ApiStack explicit image URI (apiImageUri)", () => {
+  test("defaults to the Foundation ECR repository image", () => {
+    const image = getApiContainerImage(synthApiStackWithImage(undefined));
+    // The ECR image URI is assembled from the imported repository name
+    // (an Fn::Join over the ECR ARN export) — assert it is NOT a plain
+    // public registry string and references the ECR repository ARN export.
+    expect(typeof image).not.toBe("string");
+    expect(JSON.stringify(image)).toContain("dkr.ecr");
+  });
+
+  test("uses the literal image URI when provided", () => {
+    const uri = "ghcr.io/stardag-dev/stardag-server:0.1.0";
+    const image = getApiContainerImage(synthApiStackWithImage(uri));
+    expect(image).toBe(uri);
+  });
+
+  test("treats a whitespace-only value as unset", () => {
+    const image = getApiContainerImage(synthApiStackWithImage("   "));
+    expect(typeof image).not.toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FrontendStack — optional same-origin API proxy (uiApiProxy). Required for
+// prebuilt UI dists, which resolve their config at runtime from
+// /api/v1/auth/config on their own origin.
+// ---------------------------------------------------------------------------
+
+// A config with a non-example.com domain so FoundationStack creates the
+// DNS construct (HostedZone.fromLookup returns a dummy zone during tests).
+const dnsConfig = {
+  ...mockConfig,
+  domainName: "stardag-cdk-test.dev",
+  apiDomain: "api.stardag-cdk-test.dev",
+  uiDomain: "app.stardag-cdk-test.dev",
+};
+
+function synthFrontendStack(config: typeof mockConfig, apiProxy: boolean): Template {
+  const app = new cdk.App();
+  const env = {
+    account: mockConfig.awsAccountId,
+    region: mockConfig.awsRegion,
+  };
+  const foundation = new FoundationStack(app, "Foundation", { env, config });
+  const frontend = new FrontendStack(app, "Frontend", {
+    env,
+    config,
+    foundation,
+    apiProxy,
+  });
+  return Template.fromStack(frontend);
+}
+
+function getDistributionConfig(template: Template): any {
+  const distributions = template.findResources("AWS::CloudFront::Distribution");
+  const values = Object.values(distributions);
+  expect(values).toHaveLength(1);
+  return values[0].Properties.DistributionConfig;
+}
+
+describe("FrontendStack same-origin API proxy (apiProxy)", () => {
+  describe("default (disabled)", () => {
+    let template: Template;
+
+    beforeAll(() => {
+      template = synthFrontendStack(dnsConfig, false);
+    });
+
+    test("keeps SPA routing via 403/404 error responses", () => {
+      const config = getDistributionConfig(template);
+      const codes = (config.CustomErrorResponses ?? []).map(
+        (r: { ErrorCode: number }) => r.ErrorCode,
+      );
+      expect(codes).toEqual(expect.arrayContaining([403, 404]));
+    });
+
+    test("has no additional cache behaviors and no CloudFront function", () => {
+      const config = getDistributionConfig(template);
+      expect(config.CacheBehaviors ?? []).toHaveLength(0);
+      template.resourceCountIs("AWS::CloudFront::Function", 0);
+    });
+  });
+
+  describe("enabled", () => {
+    let template: Template;
+
+    beforeAll(() => {
+      template = synthFrontendStack(dnsConfig, true);
+    });
+
+    test("routes /api/*, /health and /.well-known/* to the API domain", () => {
+      const config = getDistributionConfig(template);
+      const behaviors = config.CacheBehaviors as Array<{
+        PathPattern: string;
+        TargetOriginId: string;
+        CachePolicyId: string;
+        AllowedMethods: string[];
+      }>;
+      const patterns = behaviors.map((b) => b.PathPattern);
+      expect(patterns).toEqual(
+        expect.arrayContaining(["/api/*", "/health", "/.well-known/*"]),
+      );
+
+      // All API behaviors share the custom-domain HTTPS origin
+      const apiBehavior = behaviors.find((b) => b.PathPattern === "/api/*")!;
+      const origins = config.Origins as Array<{
+        Id: string;
+        DomainName: string;
+        CustomOriginConfig?: { OriginProtocolPolicy: string };
+      }>;
+      const apiOrigin = origins.find((o) => o.Id === apiBehavior.TargetOriginId)!;
+      expect(apiOrigin.DomainName).toBe(dnsConfig.apiDomain);
+      expect(apiOrigin.CustomOriginConfig?.OriginProtocolPolicy).toBe("https-only");
+
+      // Caching disabled (managed policy id), all methods allowed
+      expect(apiBehavior.CachePolicyId).toBe("4135ea2d-6df8-44a3-9df3-4b5a84be39ad");
+      expect(apiBehavior.AllowedMethods).toEqual(
+        expect.arrayContaining(["GET", "POST", "PUT", "DELETE"]),
+      );
+    });
+
+    test("switches SPA routing to a viewer-request function (no error responses)", () => {
+      const config = getDistributionConfig(template);
+      expect(config.CustomErrorResponses ?? []).toHaveLength(0);
+      template.resourceCountIs("AWS::CloudFront::Function", 1);
+      const defaultAssociations = config.DefaultCacheBehavior
+        .FunctionAssociations as Array<{
+        EventType: string;
+      }>;
+      expect(defaultAssociations).toHaveLength(1);
+      expect(defaultAssociations[0].EventType).toBe("viewer-request");
+    });
+  });
+
+  test("throws when enabled without DNS (example.com config)", () => {
+    expect(() => synthFrontendStack(mockConfig, true)).toThrow(
+      /uiApiProxy requires DNS/,
+    );
   });
 });

--- a/infra/aws-cdk/test/stardag.test.ts
+++ b/infra/aws-cdk/test/stardag.test.ts
@@ -411,6 +411,51 @@ describe("ApiStack explicit image URI (apiImageUri)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// ApiStack — runtime UI OIDC configuration. Prebuilt UI dists resolve their
+// client id and Cognito logout domain at runtime from GET /api/v1/auth/config,
+// which serves OIDC_UI_CLIENT_ID and OIDC_COGNITO_DOMAIN. Without these env
+// vars the API would serve its defaults (client id "stardag-ui", no Cognito
+// domain) and Cognito authorize/logout would break for runtime-config UIs.
+// ---------------------------------------------------------------------------
+
+describe("ApiStack runtime-UI OIDC environment", () => {
+  let environment: Array<{ Name: string; Value: unknown }>;
+
+  beforeAll(() => {
+    const template = synthApiStackWithImage(undefined);
+    const taskDefs = template.findResources("AWS::ECS::TaskDefinition");
+    const apiTaskDef = Object.values(taskDefs).find(
+      (td) =>
+        td.Properties.ContainerDefinitions?.some(
+          (c: { Name?: string }) => c.Name === "Api",
+        ),
+    );
+    expect(apiTaskDef).toBeDefined();
+    environment = apiTaskDef!.Properties.ContainerDefinitions[0].Environment;
+  });
+
+  function envValue(name: string): unknown {
+    const entry = environment.find((e) => e.Name === name);
+    expect(entry).toBeDefined();
+    return entry!.Value;
+  }
+
+  test("sets OIDC_UI_CLIENT_ID to the same Cognito client as the SDK", () => {
+    // The Foundation stack creates a single user-pool client shared by UI
+    // and SDK; both env vars must reference the same (imported) client id.
+    expect(envValue("OIDC_UI_CLIENT_ID")).toEqual(envValue("OIDC_SDK_CLIENT_ID"));
+  });
+
+  test("sets OIDC_COGNITO_DOMAIN to the bare hosted-UI host (no scheme)", () => {
+    // The UI builds https://{cognito_domain}/logout, so the value must be
+    // the bare host.
+    expect(envValue("OIDC_COGNITO_DOMAIN")).toBe(
+      `stardag.auth.${mockConfig.awsRegion}.amazoncognito.com`,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // StardagApi construct — imageUri normalization. The reusable construct must
 // be safe on its own (independent of ApiStack's env/context normalization):
 // a whitespace-only imageUri prop is treated as unset, and surrounding
@@ -565,6 +610,45 @@ describe("FrontendStack same-origin API proxy (apiProxy)", () => {
       }>;
       expect(defaultAssociations).toHaveLength(1);
       expect(defaultAssociations[0].EventType).toBe("viewer-request");
+    });
+
+    describe("SPA rewrite function behavior", () => {
+      // Extract the inline CloudFront Function code from the template and
+      // execute it directly. The function is plain (CloudFront JS 2.0
+      // compatible) JavaScript, so evaluating it in Node exercises the
+      // real rewrite logic rather than string-matching the source.
+      let rewrite: (uri: string) => string;
+
+      beforeAll(() => {
+        const fns = template.findResources("AWS::CloudFront::Function");
+        const values = Object.values(fns);
+        expect(values).toHaveLength(1);
+        const code = values[0].Properties.FunctionCode as string;
+        // eslint-disable-next-line @typescript-eslint/no-implied-eval
+        const handler = new Function(`${code}; return handler;`)() as (event: {
+          request: { uri: string };
+        }) => { uri: string };
+        rewrite = (uri: string) => handler({ request: { uri } }).uri;
+      });
+
+      test("rewrites SPA routes (including dotted path params) to /index.html", () => {
+        expect(rewrite("/")).toBe("/index.html");
+        expect(rewrite("/workspaces/acme/builds")).toBe("/index.html");
+        // A future dotted route param must reach the SPA, not surface a
+        // raw S3 XML error (proxy mode has no distribution-wide error
+        // responses to catch the miss).
+        expect(rewrite("/tasks/v1.2.3")).toBe("/index.html");
+        expect(rewrite("/builds/some.dotted.id/details")).toBe("/index.html");
+      });
+
+      test("serves static assets as-is", () => {
+        expect(rewrite("/index.html")).toBe("/index.html");
+        expect(rewrite("/assets/index-B3xQ9z.js")).toBe("/assets/index-B3xQ9z.js");
+        expect(rewrite("/assets/index-C4yR1w.css")).toBe("/assets/index-C4yR1w.css");
+        expect(rewrite("/favicon.svg")).toBe("/favicon.svg");
+        expect(rewrite("/logo.svg")).toBe("/logo.svg");
+        expect(rewrite("/robots.txt")).toBe("/robots.txt");
+      });
     });
   });
 

--- a/infra/aws-cdk/test/stardag.test.ts
+++ b/infra/aws-cdk/test/stardag.test.ts
@@ -1,9 +1,12 @@
 import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as secretsmanager from "aws-cdk-lib/aws-secretsmanager";
 import { Match, Template } from "aws-cdk-lib/assertions";
 import { ApiStack } from "../lib/api-stack";
 import { FoundationStack } from "../lib/foundation-stack";
 import { StardagStack } from "../lib/stardag-stack";
 import { FrontendStack } from "../lib/frontend-stack";
+import { StardagApi } from "../lib/constructs/api";
 
 // Mock config for testing
 const mockConfig = {
@@ -404,6 +407,52 @@ describe("ApiStack explicit image URI (apiImageUri)", () => {
   test("treats a whitespace-only value as unset", () => {
     const image = getApiContainerImage(synthApiStackWithImage("   "));
     expect(typeof image).not.toBe("string");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StardagApi construct — imageUri normalization. The reusable construct must
+// be safe on its own (independent of ApiStack's env/context normalization):
+// a whitespace-only imageUri prop is treated as unset, and surrounding
+// whitespace on a real URI is trimmed.
+// ---------------------------------------------------------------------------
+
+function synthStardagApiConstruct(imageUri?: string): Template {
+  const app = new cdk.App();
+  const stack = new cdk.Stack(app, "ConstructTest", {
+    env: { account: mockConfig.awsAccountId, region: mockConfig.awsRegion },
+  });
+  const vpc = new ec2.Vpc(stack, "Vpc", { maxAzs: 2 });
+  new StardagApi(stack, "Api", {
+    vpc,
+    dbClusterEndpoint: "db.example.internal",
+    dbPort: 5432,
+    dbName: "stardag",
+    dbServiceSecret: new secretsmanager.Secret(stack, "ServiceSecret"),
+    dbAdminSecret: new secretsmanager.Secret(stack, "AdminSecret"),
+    dbSecurityGroup: new ec2.SecurityGroup(stack, "DbSg", { vpc }),
+    oidcIssuerUrl: "https://issuer.example.com",
+    oidcAudience: "test-audience",
+    apiDomain: "api.example.com",
+    uiDomain: "app.example.com",
+    imageUri,
+  });
+  return Template.fromStack(stack);
+}
+
+describe("StardagApi construct imageUri normalization", () => {
+  test("treats a whitespace-only imageUri prop as unset", () => {
+    const image = getApiContainerImage(synthStardagApiConstruct("   "));
+    // Falls back to the construct's own ECR repository (a token, not a
+    // plain string), rather than fromRegistry("   ").
+    expect(typeof image).not.toBe("string");
+    expect(JSON.stringify(image)).toContain("dkr.ecr");
+  });
+
+  test("trims surrounding whitespace from a real imageUri", () => {
+    const uri = "ghcr.io/stardag-dev/stardag-server:0.1.0";
+    const image = getApiContainerImage(synthStardagApiConstruct(` ${uri}\n`));
+    expect(image).toBe(uri);
   });
 });
 


### PR DESCRIPTION
## What

Lets the public AWS CDK deployment consume prebuilt release artifacts instead of building locally — **no-op by default** (without the new context/env/flags, synthesized templates and script behavior are unchanged):

- **API from a prebuilt image**: `ApiStack` (and the reusable `StardagApi` construct) accept an optional explicit container image URI — `-c apiImageUri=ghcr.io/stardag-dev/stardag-server:X.Y.Z`, `STARDAG_API_IMAGE_URI` in `.env.deploy`, or a stack prop. When set, the ECS task uses `ContainerImage.fromRegistry(<uri>)` instead of the ECR `:latest` image built by `deploy-api.sh`. The combined server image also bundles the built web UI; that's harmless here (this setup keeps serving the UI via S3 + CloudFront).
- **Scripts**: `deploy-api.sh`, `deploy-infra.sh` and `deploy-all.sh` gain `--image-uri <uri>` (skips the local docker build+push, passes the URI through to CDK); `deploy-ui.sh` gains `--release server-vX.Y.Z` (downloads the `stardag-ui-dist-X.Y.Z.tar.gz` release asset via `gh` or `curl` instead of npm-building).
- **Migrations**: `run-migrations.sh` works unchanged with the combined image — it reuses the API service's task definition and overrides the command with `alembic upgrade head`, and the server image keeps `alembic.ini` + `migrations/` at the same image working directory as the API-only image. The override command is now configurable via `MIGRATION_COMMAND` for images with a different layout.
- **Docs**: new README section "Use Prebuilt Public Images" with version-pinning guidance (always pin `X.Y.Z`; ECS resolves tags at task start, so moving tags would make scale-out pull a different build) and an **ECR pull-through cache recipe** (`aws ecr create-pull-through-cache-rule` with a `ghcr.io` upstream) as the recommended production pattern — no pull-through infra is added to the stacks.

## Same-origin / runtime-config decision

The prebuilt UI dist contains no baked `VITE_*` config; it resolves auth/API configuration at runtime from `GET /api/v1/auth/config` on `window.location.origin`. In this CDK setup the UI (CloudFront) and API (ALB) are different origins, so the prebuilt dist cannot reach the API out of the box.

The current CloudFront distribution has a single S3 origin and no API behavior, so this PR **adds an opt-in same-origin proxy** to `FrontendStack` (`-c uiApiProxy=true` / `STARDAG_UI_API_PROXY=true`): additional behaviors forward `/api/*`, `/health` and `/.well-known/*` to the API custom domain (HTTPS-only origin, `CACHING_DISABLED`, `ALL_VIEWER_EXCEPT_HOST_HEADER`). Two deliberate design points:

1. **Origin = API custom domain, not the ALB DNS name.** The ALB's certificate only matches the custom domain, and pointing at the domain avoids a cross-stack reference (Frontend keeps depending only on Foundation). Consequently the proxy requires DNS to be configured; enabling it without a real domain fails at synth with a clear error.
2. **SPA routing changes in proxy mode.** The default mode uses distribution-wide 403/404 → `index.html` error responses; CloudFront applies those to *every* behavior, which would rewrite legitimate API 403/404 JSON responses into the app shell. In proxy mode SPA routing therefore switches to a viewer-request CloudFront Function (extensionless paths → `/index.html`) scoped to the S3 behavior, and the error responses are dropped. Default mode is untouched.

`deploy-ui.sh --release` verifies the deployed distribution actually has the `/api/*` behavior (via `get-distribution-config`) and refuses to deploy a prebuilt dist without it (`--skip-same-origin-check` overrides). The locally-built flow keeps working without the proxy, since it bakes `VITE_API_BASE_URL` at build time.

## Depends on (pending)

Authored against the release convention for prebuilt server images — `ghcr.io/stardag-dev/stardag-server:X.Y.Z` published on `server-vX.Y.Z` tags, with the built UI dist attached as `stardag-ui-dist-X.Y.Z.tar.gz` — being introduced in parallel. **Draft until the first `server-v*` release exists** (also needed: the UI runtime-config resolution from #188). The CDK/stack changes are independently mergeable since they are opt-in, but `--image-uri` / `--release` can't be exercised end-to-end before then.

## Validation

- `npm ci && npm run build` (tsc) passes.
- `npx jest`: 31/31 tests pass, including new coverage: explicit image URI (literal URI in the task definition; default/whitespace fall back to ECR), proxy mode (behaviors + origin + cache policy, viewer-request function, no error responses), default mode unchanged, and the no-DNS synth error.
- `cdk synth` with dummy env/context (documented test pattern + seeded AZ context): succeeds both with and without `-c apiImageUri=...`; the template contains the literal URI when set and no `ghcr.io` reference otherwise.
- `bash -n` on all scripts; smoke-tested arg validation paths and the migrations override JSON generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf