### PR TITLE
self-host: complete setup — dedicated Modal env, primary workspace mapping, one-command DAG-execution hookup

### DIFF
--- a/.claude/skills/stardag/registry-and-platform.md
+++ b/.claude/skills/stardag/registry-and-platform.md
@@ -175,15 +175,31 @@ stardag modal stardag-api-key create        # Create API key for Modal
 
 ### Self-Hosting (API + UI on Modal)
 
-Requires the `selfhost` extra (`pip install "stardag[selfhost]"`) and a
-stardag repo checkout. See docs/how-to/self-host-modal.md.
+Requires the `selfhost` extra (`pip install "stardag[selfhost]"`). Deploys
+the prebuilt server image by default (`--from-source` builds from a repo
+checkout). See docs/how-to/self-host-modal.md.
 
 ```bash
-stardag self-host up        # Provision Neon DB, migrate, deploy API+UI, print URL
-stardag self-host upgrade   # Apply migrations + redeploy from current source
+stardag self-host up        # Provision Neon DB, migrate, deploy API+UI, complete setup
+stardag self-host connect   # (Re)run the post-deploy setup only (idempotent)
+stardag self-host upgrade   # Apply migrations + redeploy
 stardag self-host status    # Deployment status + URL
 stardag self-host destroy   # Stop the Modal app (DB untouched)
 ```
+
+The server app + its secrets live in a dedicated Modal environment
+(default `stardag-server`, flag `--server-modal-env`), isolated from the
+environments where user DAG apps run. `up`/`connect` also complete the
+setup: a primary Stardag workspace (named after the shared Modal workspace,
+or the personal workspace; `--primary-workspace`/`--no-primary-workspace`),
+a `main` environment, an API key pushed as Modal secret `stardag-api-key`
+into the DAG-execution Modal environment (`--execution-modal-env`, default:
+the account's default env), a default target root
+`modalvol://stardag/<workspace-slug>` (`--target-root`/`--no-target-root`),
+and a local SDK registry + profile named `selfhosted`
+(`--registry-name`/`--profile-name`). In OIDC auth mode run
+`stardag self-host connect` after `up` (browser login, then the same setup
+via the API).
 
 ## Configuration System
 

--- a/.claude/skills/stardag/registry-and-platform.md
+++ b/.claude/skills/stardag/registry-and-platform.md
@@ -187,19 +187,20 @@ stardag self-host status    # Deployment status + URL
 stardag self-host destroy   # Stop the Modal app (DB untouched)
 ```
 
-The server app + its secrets live in a dedicated Modal environment
-(default `stardag-server`, flag `--server-modal-env`), isolated from the
-environments where user DAG apps run. `up`/`connect` also complete the
-setup: a primary Stardag workspace (named after the shared Modal workspace,
-or the personal workspace; `--primary-workspace`/`--no-primary-workspace`),
-a `main` environment, an API key pushed as Modal secret `stardag-api-key`
-into the DAG-execution Modal environment (`--execution-modal-env`, default:
-the account's default env), a default target root
-`modalvol://stardag/<workspace-slug>` (`--target-root`/`--no-target-root`),
-and a local SDK registry + profile named `selfhosted`
-(`--registry-name`/`--profile-name`). In OIDC auth mode run
-`stardag self-host connect` after `up` (browser login, then the same setup
-via the API).
+The server app (default name `server`) + its secrets live in a dedicated
+Modal environment (default `stardag-host`, flag `--server-modal-env`),
+isolated from the environments where user DAG apps run; the default URL is
+`https://<workspace>-stardag-host--server.modal.run`. `up`/`connect` also
+complete the setup: a primary Stardag workspace (named after the shared
+Modal workspace, or the personal workspace;
+`--primary-workspace`/`--no-primary-workspace`), a `main` environment, an
+API key pushed as Modal secret `stardag-api-key` into the DAG-execution
+Modal environment (`--execution-modal-env`, default: the account's default
+env), a default target root `modalvol://stardag-targets/<workspace-slug>`
+(`--target-root`/`--no-target-root`), and a local SDK registry + profile
+named `selfhosted` (`--registry-name`/`--profile-name`). In OIDC auth mode
+run `stardag self-host connect` after `up` (browser login, then the same
+setup via the API).
 
 ## Configuration System
 

--- a/.claude/skills/stardag/registry-and-platform.md
+++ b/.claude/skills/stardag/registry-and-platform.md
@@ -196,7 +196,8 @@ Modal workspace, or the personal workspace;
 `--primary-workspace`/`--no-primary-workspace`), a `main` environment, an
 API key pushed as Modal secret `stardag-api-key` into the DAG-execution
 Modal environment (`--execution-modal-env`, default: the account's default
-env), a default target root `modalvol://stardag-targets/<workspace-slug>`
+env), a default target root
+`modalvol://stardag-targets-<workspace-slug>-<environment-slug>/default`
 (`--target-root`/`--no-target-root`), and a local SDK registry + profile
 named `selfhosted` (`--registry-name`/`--profile-name`). In OIDC auth mode
 run `stardag self-host connect` after `up` (browser login, then the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   workspace) with a `main` environment; an API key is minted and pushed
   as the Modal secret `stardag-api-key` into the DAG-execution Modal
   environment (`--execution-modal-env`); a default target root
-  `modalvol://stardag-targets/<workspace-slug>` is registered
+  `modalvol://stardag-targets-<workspace-slug>-<environment-slug>/default`
+  (a dedicated Modal volume per workspace + environment) is registered
   (`--target-root`/`--no-target-root`); and a local SDK registry +
   profile (`selfhosted`) are written. In OIDC auth mode, `connect` runs
   the browser login first and provisions via the API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   (`--server-version`); `--from-source` builds from a repo checkout
   (the UI compiles inside the Modal image build — no local Node/Docker
   required). See the "Self-host on Modal" guide.
+- **`stardag self-host up` completes the whole setup** (new `connect`
+  subcommand re-runs it idempotently): the server app + its secrets are
+  isolated in a dedicated Modal environment (`stardag-server`, flag
+  `--server-modal-env`); a primary Stardag workspace is created mirroring
+  a shared Modal workspace's name (`--primary-workspace` /
+  `--no-primary-workspace`; personal Modal accounts use the personal
+  workspace) with a `main` environment; an API key is minted and pushed
+  as the Modal secret `stardag-api-key` into the DAG-execution Modal
+  environment (`--execution-modal-env`); a default target root
+  `modalvol://stardag/<workspace-slug>` is registered
+  (`--target-root`/`--no-target-root`); and a local SDK registry +
+  profile (`selfhosted`) are written. In OIDC auth mode, `connect` runs
+  the browser login first and provisions via the API.
 - **`stardag auth login` supports local-auth registries**: when the
   registry reports `auth_mode=local` it prompts for email/password and
   stores the session token; the existing token-refresh chain uses it
@@ -34,6 +47,11 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   rate limiting; idempotent bootstrap-admin provisioning at startup
   (`AUTH_BOOTSTRAP_ADMIN_EMAIL`/`_PASSWORD`). OIDC mode (default) is
   unchanged.
+- **Primary workspace bootstrap** (local auth mode): startup idempotently
+  ensures a shared workspace named `AUTH_PRIMARY_WORKSPACE_NAME` (bootstrap
+  admin as owner) and an `AUTH_PRIMARY_WORKSPACE_ENVIRONMENT` environment
+  (default `main`; empty disables) — in the named workspace, or in the
+  bootstrap admin's personal workspace when no name is set.
 - `GET /auth/config` now serves the full client auth configuration
   (auth mode, issuer, UI client id, Cognito domain, registration flag)
   so UIs and CLIs can be configured at runtime.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,15 +19,15 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   (the UI compiles inside the Modal image build — no local Node/Docker
   required). See the "Self-host on Modal" guide.
 - **`stardag self-host up` completes the whole setup** (new `connect`
-  subcommand re-runs it idempotently): the server app + its secrets are
-  isolated in a dedicated Modal environment (`stardag-server`, flag
-  `--server-modal-env`); a primary Stardag workspace is created mirroring
-  a shared Modal workspace's name (`--primary-workspace` /
+  subcommand re-runs it idempotently): the server app (`server`) + its
+  secrets are isolated in a dedicated Modal environment (`stardag-host`,
+  flag `--server-modal-env`); a primary Stardag workspace is created
+  mirroring a shared Modal workspace's name (`--primary-workspace` /
   `--no-primary-workspace`; personal Modal accounts use the personal
   workspace) with a `main` environment; an API key is minted and pushed
   as the Modal secret `stardag-api-key` into the DAG-execution Modal
   environment (`--execution-modal-env`); a default target root
-  `modalvol://stardag/<workspace-slug>` is registered
+  `modalvol://stardag-targets/<workspace-slug>` is registered
   (`--target-root`/`--no-target-root`); and a local SDK registry +
   profile (`selfhosted`) are written. In OIDC auth mode, `connect` runs
   the browser login first and provisions via the API.

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -226,6 +226,16 @@ The image definition is `app/server.Dockerfile` (build context = repo root):
 docker build -f app/server.Dockerfile -t stardag-server .
 ```
 
+> **Python version coupling:** the Dockerfile's base Python version must
+> stay in sync with `PREBUILT_IMAGE_PYTHON` in
+> `lib/stardag/src/stardag/selfhost/_modal_app.py` — the self-host CLI
+> serializes Modal functions with the client interpreter and checks it
+> against that constant before deploying the prebuilt image. Bumping one
+> without the other breaks (or wrongly blocks) `stardag self-host up`.
+> A unit test (`test_prebuilt_image_python_constant_matches_dockerfile`)
+> guards the pairing; docs referencing `uvx --python 3.12 ...` need the
+> same bump.
+
 To release, push a `server-vX.Y.Z` tag on `main`:
 
 ```bash

--- a/app/stardag-api/src/stardag_api/config.py
+++ b/app/stardag-api/src/stardag_api/config.py
@@ -121,6 +121,16 @@ class AuthSettings(BaseSettings):
     # overwritten). Set both or neither.
     bootstrap_admin_email: str | None = None
     bootstrap_admin_password: str | None = None
+    # Primary workspace bootstrap (local mode only, requires the bootstrap
+    # admin): when set, a shared (non-personal) workspace with this name is
+    # idempotently created at startup with the bootstrap admin as owner.
+    # Typically the name of the Modal/cloud workspace the deployment
+    # belongs to, so Stardag mirrors the surrounding platform's structure.
+    primary_workspace_name: str | None = None
+    # Environment idempotently ensured at startup: in the primary workspace
+    # when `primary_workspace_name` is set, otherwise in the bootstrap
+    # admin's personal workspace. Set to an empty string to disable.
+    primary_workspace_environment: str = "main"
 
     model_config = SettingsConfigDict(env_prefix="AUTH_")
 

--- a/app/stardag-api/src/stardag_api/main.py
+++ b/app/stardag-api/src/stardag_api/main.py
@@ -33,13 +33,18 @@ get_token_manager()
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Local auth mode: idempotently provision the bootstrap admin so a
-    # fresh self-hosted deployment has a first user to log in with.
+    # fresh self-hosted deployment has a first user to log in with, then
+    # the primary workspace/environment (AUTH_PRIMARY_WORKSPACE_*).
     if auth_settings.mode == "local" and auth_settings.bootstrap_admin_email:
         from stardag_api.db import async_session_maker
-        from stardag_api.services.local_auth import ensure_bootstrap_admin
+        from stardag_api.services.local_auth import (
+            ensure_bootstrap_admin,
+            ensure_primary_workspace,
+        )
 
         async with async_session_maker() as session:
             await ensure_bootstrap_admin(session)
+            await ensure_primary_workspace(session)
     yield
 
 

--- a/app/stardag-api/src/stardag_api/services/local_auth.py
+++ b/app/stardag-api/src/stardag_api/services/local_auth.py
@@ -185,7 +185,18 @@ async def ensure_bootstrap_admin(db: AsyncSession) -> None:
     )
     user = result.scalar_one_or_none()
     if user is None:
-        await create_local_user(db, email=email, password=password)
+        try:
+            await create_local_user(db, email=email, password=password)
+        except ValueError:
+            # Duplicate-email race: multiple workers (e.g. gunicorn's
+            # default 2) run this lifespan concurrently on a first cold
+            # start; another worker created the admin between our lookup
+            # and the insert (create_local_user already rolled back).
+            logger.info(
+                "Bootstrap admin created concurrently by another worker: %s",
+                email,
+            )
+            return
         logger.info("Bootstrap admin created: %s", email)
     elif user.password_hash is None:
         # Same policy as /auth/register (create_local_user validates in the
@@ -249,19 +260,40 @@ async def ensure_primary_workspace(db: AsyncSession) -> None:
 
     Safe to run on every startup: existing workspaces, memberships, and
     environments are matched (by name/slug) before anything is created, and
-    nothing is ever renamed, demoted, or deleted. No-op outside local auth
-    mode (in OIDC mode there is no known admin at startup; the CLI's
-    ``self-host connect`` flow provisions the workspace via the API instead).
+    nothing is ever renamed, demoted, or deleted. Concurrency-safe across
+    multiple workers running the lifespan simultaneously (a lost create
+    race is retried and resolves to the row the other worker created).
+    No-op outside local auth mode (in OIDC mode there is no known admin at
+    startup; the CLI's ``self-host connect`` flow provisions the workspace
+    via the API instead).
     """
     if auth_settings.mode != "local":
         return
+    if not (
+        auth_settings.primary_workspace_name
+        or auth_settings.primary_workspace_environment
+    ):
+        return
+    if not auth_settings.bootstrap_admin_email:
+        return
+    try:
+        await _ensure_primary_workspace_once(db)
+    except IntegrityError:
+        # Unique-constraint race with another worker's lifespan (e.g.
+        # gunicorn's default 2 workers on a first cold start): "another
+        # worker won" is success - rollback and re-run the match-before-
+        # create logic, which now finds the existing rows.
+        await db.rollback()
+        logger.info("Primary workspace bootstrap raced with another worker; retrying")
+        await _ensure_primary_workspace_once(db)
+
+
+async def _ensure_primary_workspace_once(db: AsyncSession) -> None:
+    """Single pass of the primary workspace/environment provisioning."""
     workspace_name = auth_settings.primary_workspace_name
     environment_name = auth_settings.primary_workspace_environment
-    if not workspace_name and not environment_name:
-        return
     admin_email = auth_settings.bootstrap_admin_email
-    if not admin_email:
-        return
+    assert admin_email is not None  # guarded by the caller
     result = await db.execute(
         select(User).where(func.lower(User.email) == admin_email.lower())
     )
@@ -302,18 +334,38 @@ async def _ensure_shared_workspace(
 ) -> Workspace:
     """Find or create the shared primary workspace; ensure admin membership.
 
-    Matched by exact name (among non-personal workspaces) first — the
-    stable idempotency key across restarts — then by derived slug.
+    Matched by exact name among non-personal workspaces *created by the
+    bootstrap admin* — the stable idempotency key across restarts. The
+    creator scoping matters: with self-registration enabled, any user could
+    pre-create a workspace with the (predictable) primary name; adopting it
+    would silently make the admin an owner of — and wire API keys / target
+    roots into — a workspace that user controls. Such a name collision is
+    logged and a fresh admin-owned workspace is created instead (its slug
+    gets a random suffix via the usual collision handling).
     """
     result = await db.execute(
         select(Workspace).where(
             Workspace.name == name,
             Workspace.is_personal.is_(False),
+            Workspace.created_by_id == admin.id,
         )
     )
     workspace = result.scalars().first()
 
     if workspace is None:
+        foreign_match = await db.execute(
+            select(Workspace).where(
+                Workspace.name == name,
+                Workspace.is_personal.is_(False),
+            )
+        )
+        if foreign_match.scalars().first() is not None:
+            logger.warning(
+                "A workspace named %r exists but was not created by the "
+                "bootstrap admin; not adopting it - creating a separate "
+                "primary workspace instead",
+                name,
+            )
         base_slug = _slugify(name) or "primary"
         slug = base_slug
         for hex_nbytes in [2, 2, 3, 3, 4]:

--- a/app/stardag-api/src/stardag_api/services/local_auth.py
+++ b/app/stardag-api/src/stardag_api/services/local_auth.py
@@ -6,6 +6,8 @@ identity provider is involved.
 """
 
 import logging
+import re
+import secrets as _secrets
 import time
 from collections import deque
 from uuid import uuid4
@@ -20,7 +22,13 @@ from stardag_api.auth.passwords import (
     verify_password_async,
 )
 from stardag_api.config import auth_settings
-from stardag_api.models import User
+from stardag_api.models import (
+    Environment,
+    User,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceRole,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -189,3 +197,161 @@ async def ensure_bootstrap_admin(db: AsyncSession) -> None:
         logger.info("Bootstrap admin password set for existing user: %s", email)
     else:
         logger.debug("Bootstrap admin already provisioned: %s", email)
+
+
+def _slugify(name: str) -> str:
+    """Derive a workspace/environment slug from a display name.
+
+    Same derivation as personal-workspace creation: lowercase, non-alphanumeric
+    runs collapsed to hyphens, trimmed to 50 chars.
+    """
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")[:50]
+
+
+async def _ensure_environment(
+    db: AsyncSession, workspace: Workspace, env_name: str
+) -> None:
+    """Idempotently ensure an environment named ``env_name`` in ``workspace``."""
+    env_slug = _slugify(env_name)
+    if not env_slug:
+        return
+    result = await db.execute(
+        select(Environment).where(
+            Environment.workspace_id == workspace.id,
+            Environment.slug == env_slug,
+        )
+    )
+    if result.scalar_one_or_none() is not None:
+        return
+    db.add(
+        Environment(
+            workspace_id=workspace.id,
+            name=env_name,
+            slug=env_slug,
+        )
+    )
+    logger.info("Created environment %r in workspace %s", env_slug, workspace.slug)
+
+
+async def ensure_primary_workspace(db: AsyncSession) -> None:
+    """Idempotently provision the primary workspace/environment (local mode).
+
+    Driven by ``AUTH_PRIMARY_WORKSPACE_NAME`` / ``AUTH_PRIMARY_WORKSPACE_ENVIRONMENT``
+    and anchored on the bootstrap admin (``ensure_bootstrap_admin`` must have
+    run first):
+
+    - ``primary_workspace_name`` set: ensure a shared (non-personal)
+      workspace with that name exists, with the bootstrap admin as owner,
+      and the primary environment in it.
+    - ``primary_workspace_name`` unset: ensure the primary environment in
+      the bootstrap admin's *personal* workspace instead (the typical
+      single-user deployment).
+
+    Safe to run on every startup: existing workspaces, memberships, and
+    environments are matched (by name/slug) before anything is created, and
+    nothing is ever renamed, demoted, or deleted. No-op outside local auth
+    mode (in OIDC mode there is no known admin at startup; the CLI's
+    ``self-host connect`` flow provisions the workspace via the API instead).
+    """
+    if auth_settings.mode != "local":
+        return
+    workspace_name = auth_settings.primary_workspace_name
+    environment_name = auth_settings.primary_workspace_environment
+    if not workspace_name and not environment_name:
+        return
+    admin_email = auth_settings.bootstrap_admin_email
+    if not admin_email:
+        return
+    result = await db.execute(
+        select(User).where(func.lower(User.email) == admin_email.lower())
+    )
+    admin = result.scalar_one_or_none()
+    if admin is None:
+        logger.warning(
+            "Primary workspace bootstrap skipped: bootstrap admin %s not found",
+            admin_email,
+        )
+        return
+
+    if workspace_name:
+        workspace = await _ensure_shared_workspace(db, admin, workspace_name)
+    else:
+        result = await db.execute(
+            select(Workspace)
+            .join(WorkspaceMember, WorkspaceMember.workspace_id == Workspace.id)
+            .where(
+                WorkspaceMember.user_id == admin.id,
+                Workspace.is_personal.is_(True),
+            )
+        )
+        workspace = result.scalars().first()
+        if workspace is None:
+            logger.warning(
+                "Primary environment bootstrap skipped: no personal workspace "
+                "for bootstrap admin"
+            )
+            return
+
+    if environment_name:
+        await _ensure_environment(db, workspace, environment_name)
+    await db.commit()
+
+
+async def _ensure_shared_workspace(
+    db: AsyncSession, admin: User, name: str
+) -> Workspace:
+    """Find or create the shared primary workspace; ensure admin membership.
+
+    Matched by exact name (among non-personal workspaces) first — the
+    stable idempotency key across restarts — then by derived slug.
+    """
+    result = await db.execute(
+        select(Workspace).where(
+            Workspace.name == name,
+            Workspace.is_personal.is_(False),
+        )
+    )
+    workspace = result.scalars().first()
+
+    if workspace is None:
+        base_slug = _slugify(name) or "primary"
+        slug = base_slug
+        for hex_nbytes in [2, 2, 3, 3, 4]:
+            slug_exists = await db.execute(
+                select(Workspace).where(Workspace.slug == slug)
+            )
+            if not slug_exists.scalar_one_or_none():
+                break
+            slug = f"{base_slug}-{_secrets.token_hex(hex_nbytes)}"
+        else:
+            raise RuntimeError("Failed to generate unique workspace slug")
+
+        workspace = Workspace(
+            name=name,
+            slug=slug,
+            is_personal=False,
+            created_by_id=admin.id,
+        )
+        db.add(workspace)
+        await db.flush()
+        logger.info("Created primary workspace %r (%s)", name, slug)
+
+    membership_result = await db.execute(
+        select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace.id,
+            WorkspaceMember.user_id == admin.id,
+        )
+    )
+    if membership_result.scalar_one_or_none() is None:
+        db.add(
+            WorkspaceMember(
+                workspace_id=workspace.id,
+                user_id=admin.id,
+                role=WorkspaceRole.OWNER,
+            )
+        )
+        logger.info(
+            "Added bootstrap admin as owner of primary workspace %s",
+            workspace.slug,
+        )
+    return workspace

--- a/app/stardag-api/tests/test_primary_workspace.py
+++ b/app/stardag-api/tests/test_primary_workspace.py
@@ -178,6 +178,144 @@ async def test_primary_workspace_existing_membership_not_demoted(
 
 
 @pytest.mark.asyncio
+async def test_primary_workspace_not_adopted_from_other_user(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    local_mode_with_admin,
+):
+    """A same-named workspace created by another user (the primary name is
+    predictable) is NOT adopted: a separate admin-owned workspace is
+    created, so keys/target roots never land in a user-controlled one."""
+    monkeypatch.setattr(auth_settings, "primary_workspace_name", "Acme Corp")
+
+    attacker = User(external_id="local:attacker", email="attacker@example.com")
+    async_session.add(attacker)
+    await async_session.flush()
+    attacker_ws = Workspace(
+        name="Acme Corp",
+        slug="acme-corp",
+        is_personal=False,
+        created_by_id=attacker.id,
+    )
+    async_session.add(attacker_ws)
+    await async_session.flush()
+    async_session.add(
+        WorkspaceMember(
+            workspace_id=attacker_ws.id,
+            user_id=attacker.id,
+            role=WorkspaceRole.OWNER,
+        )
+    )
+    await async_session.commit()
+
+    await ensure_bootstrap_admin(async_session)
+    await ensure_primary_workspace(async_session)
+
+    admin = await _get_admin(async_session)
+    # The admin was never added to the attacker's workspace
+    admin_in_attacker_ws = (
+        await async_session.execute(
+            select(WorkspaceMember).where(
+                WorkspaceMember.workspace_id == attacker_ws.id,
+                WorkspaceMember.user_id == admin.id,
+            )
+        )
+    ).scalar_one_or_none()
+    assert admin_in_attacker_ws is None
+
+    # A fresh admin-owned primary workspace exists (suffixed slug: the
+    # plain slug was taken by the attacker's workspace)
+    primary = (
+        await async_session.execute(
+            select(Workspace).where(
+                Workspace.name == "Acme Corp",
+                Workspace.created_by_id == admin.id,
+            )
+        )
+    ).scalar_one()
+    assert primary.id != attacker_ws.id
+    assert primary.slug.startswith("acme-corp-")
+    assert await _workspace_envs(async_session, primary) == ["main"]
+
+    # Idempotent: re-run adopts the admin-owned workspace, creates nothing
+    await ensure_primary_workspace(async_session)
+    admin_owned = (
+        (
+            await async_session.execute(
+                select(Workspace).where(
+                    Workspace.name == "Acme Corp",
+                    Workspace.created_by_id == admin.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(admin_owned) == 1
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_admin_concurrent_creation_race(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    local_mode_with_admin,
+):
+    """A duplicate-email race (another worker created the admin between
+    lookup and insert) must not crash the worker's startup."""
+    import stardag_api.services.local_auth as local_auth_module
+
+    async def racing_create_local_user(*args, **kwargs):
+        raise ValueError("Email already registered")
+
+    monkeypatch.setattr(
+        local_auth_module, "create_local_user", racing_create_local_user
+    )
+    # Must not raise
+    await ensure_bootstrap_admin(async_session)
+
+
+@pytest.mark.asyncio
+async def test_primary_workspace_retries_on_integrity_error(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    local_mode_with_admin,
+):
+    """A unique-constraint race with another worker's lifespan is retried
+    and resolves idempotently."""
+    from sqlalchemy.exc import IntegrityError
+
+    import stardag_api.services.local_auth as local_auth_module
+
+    monkeypatch.setattr(auth_settings, "primary_workspace_name", "Acme Corp")
+    await ensure_bootstrap_admin(async_session)
+
+    real_ensure = local_auth_module._ensure_shared_workspace
+    calls = {"n": 0}
+
+    async def racing_ensure(db, admin, name):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise IntegrityError("INSERT INTO workspaces ...", {}, Exception("dup"))
+        return await real_ensure(db, admin, name)
+
+    monkeypatch.setattr(local_auth_module, "_ensure_shared_workspace", racing_ensure)
+
+    await ensure_primary_workspace(async_session)
+
+    assert calls["n"] == 2
+    admin = await _get_admin(async_session)
+    workspace = (
+        await async_session.execute(
+            select(Workspace).where(
+                Workspace.name == "Acme Corp",
+                Workspace.created_by_id == admin.id,
+            )
+        )
+    ).scalar_one()
+    assert await _workspace_envs(async_session, workspace) == ["main"]
+
+
+@pytest.mark.asyncio
 async def test_primary_workspace_noop_in_oidc_mode(
     async_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
 ):

--- a/app/stardag-api/tests/test_primary_workspace.py
+++ b/app/stardag-api/tests/test_primary_workspace.py
@@ -1,0 +1,233 @@
+"""Tests for primary workspace/environment bootstrap (local auth mode).
+
+Covers the startup provisioning driven by AUTH_PRIMARY_WORKSPACE_NAME /
+AUTH_PRIMARY_WORKSPACE_ENVIRONMENT (see
+stardag_api.services.local_auth.ensure_primary_workspace).
+"""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from stardag_api.config import auth_settings
+from stardag_api.models import Environment, User, Workspace, WorkspaceMember
+from stardag_api.models.enums import WorkspaceRole
+from stardag_api.services.local_auth import (
+    ensure_bootstrap_admin,
+    ensure_primary_workspace,
+)
+
+ADMIN_EMAIL = "admin@example.com"
+ADMIN_PASSWORD = "adm1n-passw0rd"
+
+
+@pytest.fixture
+def local_mode_with_admin(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(auth_settings, "mode", "local")
+    monkeypatch.setattr(auth_settings, "bootstrap_admin_email", ADMIN_EMAIL)
+    monkeypatch.setattr(auth_settings, "bootstrap_admin_password", ADMIN_PASSWORD)
+    monkeypatch.setattr(auth_settings, "primary_workspace_name", None)
+    monkeypatch.setattr(auth_settings, "primary_workspace_environment", "main")
+
+
+async def _get_admin(session: AsyncSession) -> User:
+    result = await session.execute(select(User).where(User.email == ADMIN_EMAIL))
+    return result.scalar_one()
+
+
+async def _workspace_envs(session: AsyncSession, workspace: Workspace) -> list[str]:
+    result = await session.execute(
+        select(Environment.slug).where(Environment.workspace_id == workspace.id)
+    )
+    return sorted(result.scalars().all())
+
+
+@pytest.mark.asyncio
+async def test_primary_workspace_shared_name(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    local_mode_with_admin,
+):
+    """A named primary workspace is created as non-personal, with the
+    bootstrap admin as owner and the primary environment inside it."""
+    monkeypatch.setattr(auth_settings, "primary_workspace_name", "Acme Corp")
+
+    await ensure_bootstrap_admin(async_session)
+    await ensure_primary_workspace(async_session)
+
+    admin = await _get_admin(async_session)
+    result = await async_session.execute(
+        select(Workspace).where(Workspace.name == "Acme Corp")
+    )
+    workspace = result.scalar_one()
+    assert workspace.slug == "acme-corp"
+    assert workspace.is_personal is False
+    assert workspace.created_by_id == admin.id
+
+    membership_result = await async_session.execute(
+        select(WorkspaceMember).where(
+            WorkspaceMember.workspace_id == workspace.id,
+            WorkspaceMember.user_id == admin.id,
+        )
+    )
+    membership = membership_result.scalar_one()
+    assert membership.role == WorkspaceRole.OWNER
+
+    assert await _workspace_envs(async_session, workspace) == ["main"]
+
+
+@pytest.mark.asyncio
+async def test_primary_workspace_shared_name_idempotent(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    local_mode_with_admin,
+):
+    """Re-running on restart creates nothing new."""
+    monkeypatch.setattr(auth_settings, "primary_workspace_name", "Acme Corp")
+
+    await ensure_bootstrap_admin(async_session)
+    await ensure_primary_workspace(async_session)
+    await ensure_primary_workspace(async_session)
+
+    admin = await _get_admin(async_session)
+    workspaces = (
+        (
+            await async_session.execute(
+                select(Workspace).where(Workspace.name == "Acme Corp")
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(workspaces) == 1
+
+    memberships = (
+        (
+            await async_session.execute(
+                select(WorkspaceMember).where(
+                    WorkspaceMember.workspace_id == workspaces[0].id,
+                    WorkspaceMember.user_id == admin.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(memberships) == 1
+    assert await _workspace_envs(async_session, workspaces[0]) == ["main"]
+
+
+@pytest.mark.asyncio
+async def test_primary_environment_in_personal_workspace(
+    async_session: AsyncSession,
+    local_mode_with_admin,
+):
+    """Without a primary workspace name, the primary environment lands in
+    the bootstrap admin's personal workspace (next to the default 'local')."""
+    await ensure_bootstrap_admin(async_session)
+    await ensure_primary_workspace(async_session)
+
+    admin = await _get_admin(async_session)
+    result = await async_session.execute(
+        select(Workspace)
+        .join(WorkspaceMember, WorkspaceMember.workspace_id == Workspace.id)
+        .where(
+            WorkspaceMember.user_id == admin.id,
+            Workspace.is_personal.is_(True),
+        )
+    )
+    personal = result.scalars().one()
+    assert await _workspace_envs(async_session, personal) == ["local", "main"]
+
+    # Idempotent on restart
+    await ensure_primary_workspace(async_session)
+    assert await _workspace_envs(async_session, personal) == ["local", "main"]
+
+
+@pytest.mark.asyncio
+async def test_primary_workspace_existing_membership_not_demoted(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    local_mode_with_admin,
+):
+    """An existing (manually adjusted) membership is left untouched."""
+    monkeypatch.setattr(auth_settings, "primary_workspace_name", "Acme Corp")
+    await ensure_bootstrap_admin(async_session)
+    await ensure_primary_workspace(async_session)
+
+    admin = await _get_admin(async_session)
+    workspace = (
+        await async_session.execute(
+            select(Workspace).where(Workspace.name == "Acme Corp")
+        )
+    ).scalar_one()
+    membership = (
+        await async_session.execute(
+            select(WorkspaceMember).where(
+                WorkspaceMember.workspace_id == workspace.id,
+                WorkspaceMember.user_id == admin.id,
+            )
+        )
+    ).scalar_one()
+    membership.role = WorkspaceRole.MEMBER
+    await async_session.commit()
+
+    await ensure_primary_workspace(async_session)
+    await async_session.refresh(membership)
+    assert membership.role == WorkspaceRole.MEMBER
+
+
+@pytest.mark.asyncio
+async def test_primary_workspace_noop_in_oidc_mode(
+    async_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(auth_settings, "mode", "oidc")
+    monkeypatch.setattr(auth_settings, "primary_workspace_name", "Acme Corp")
+    monkeypatch.setattr(auth_settings, "primary_workspace_environment", "main")
+
+    await ensure_primary_workspace(async_session)
+
+    result = await async_session.execute(
+        select(Workspace).where(Workspace.name == "Acme Corp")
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_primary_workspace_noop_without_bootstrap_admin(
+    async_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(auth_settings, "mode", "local")
+    monkeypatch.setattr(auth_settings, "bootstrap_admin_email", None)
+    monkeypatch.setattr(auth_settings, "bootstrap_admin_password", None)
+    monkeypatch.setattr(auth_settings, "primary_workspace_name", "Acme Corp")
+    monkeypatch.setattr(auth_settings, "primary_workspace_environment", "main")
+
+    await ensure_primary_workspace(async_session)
+
+    result = await async_session.execute(
+        select(Workspace).where(Workspace.name == "Acme Corp")
+    )
+    assert result.scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_primary_environment_disabled_with_empty_string(
+    async_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    local_mode_with_admin,
+):
+    """AUTH_PRIMARY_WORKSPACE_ENVIRONMENT="" disables environment creation
+    (workspace bootstrap still applies when a name is configured)."""
+    monkeypatch.setattr(auth_settings, "primary_workspace_name", "Acme Corp")
+    monkeypatch.setattr(auth_settings, "primary_workspace_environment", "")
+
+    await ensure_bootstrap_admin(async_session)
+    await ensure_primary_workspace(async_session)
+
+    workspace = (
+        await async_session.execute(
+            select(Workspace).where(Workspace.name == "Acme Corp")
+        )
+    ).scalar_one()
+    assert await _workspace_envs(async_session, workspace) == []

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -48,8 +48,13 @@ that via the API (Postgres 16, project name `stardag`).
 ### 3. Deploy
 
 ```bash
-uvx --from "stardag[selfhost]" stardag self-host up
+uvx --python 3.12 --from "stardag[selfhost]" stardag self-host up
 ```
+
+(`--python 3.12` matches the CLI's interpreter to the prebuilt server
+image's Python — required because the deploy serializes functions with your
+local interpreter. The CLI checks this and tells you the remedy if it
+doesn't match.)
 
 The command walks you through the rest interactively:
 
@@ -103,7 +108,7 @@ stardag self-host connect
 ## Updating to a new version
 
 ```bash
-uvx --from "stardag[selfhost]" stardag self-host upgrade
+uvx --python 3.12 --from "stardag[selfhost]" stardag self-host upgrade
 ```
 
 This applies any new database migrations and redeploys the API + UI. Each
@@ -128,8 +133,10 @@ uvx --from "stardag[selfhost]" stardag self-host up --from-source
 
 The image is then built from the checkout: the UI is compiled with npm
 inside the Modal image build (no local Node needed) and the API package is
-installed from source. `upgrade --from-source` redeploys after local
-changes or a `git pull`.
+installed from source. The image's Python is matched to the interpreter
+running the CLI (any Python ≥ 3.10 works — no `--python 3.12` needed in
+this mode). `upgrade --from-source` redeploys after local changes or a
+`git pull`.
 
 ## Auth mode: `local` (default)
 
@@ -152,7 +159,7 @@ authorization code + PKCE, RS256 tokens). A good free option is
 [Auth0](https://auth0.com)'s free tier also works.
 
 ```bash
-uvx --from "stardag[selfhost]" stardag self-host up --auth-mode oidc \
+uvx --python 3.12 --from "stardag[selfhost]" stardag self-host up --auth-mode oidc \
   --oidc-issuer https://<your-idp-issuer> \
   --oidc-ui-client-id <client-id>
 ```
@@ -163,7 +170,7 @@ browser for the OIDC login, then creates the workspace, `main` environment,
 API key, and local profile exactly like the local-mode flow:
 
 ```bash
-uvx --from "stardag[selfhost]" stardag self-host connect
+uvx --python 3.12 --from "stardag[selfhost]" stardag self-host connect
 ```
 
 Provider setup (example: WorkOS AuthKit):
@@ -244,6 +251,12 @@ equivalent):
 
 - **First request hangs a few seconds** — cold start (Modal container boot
   - Neon wake). Expected with scale-to-zero; use `--keep-warm 1` to avoid.
+- **`InvalidError: The 'migrate' Function (using serialized=True) was defined with Python 3.X, but its Image has 3.12`**
+  — the CLI's interpreter must match the server image's Python. For the
+  prebuilt image, run under 3.12 (`uvx --python 3.12 ...` as in the
+  quickstart — recent CLI versions catch this before deploying); with
+  `--from-source` the image is built to match your interpreter
+  automatically.
 - **`Modal authentication not set up`** — run `uvx modal token new`.
 - **`Neon API key rejected`** — create a key at
   [console.neon.tech/app/settings/api-keys](https://console.neon.tech/app/settings/api-keys).

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -13,6 +13,9 @@ cover a low-traffic deployment).
     - A **Postgres database** on Neon (scale-to-zero, free tier)
     - **Authentication** without extra services (email/password managed by
       the API) — or bring any OIDC provider
+    - A **ready-to-use setup**: workspace + `main` environment mirroring
+      your Modal workspace, an API key wired into Modal for DAG execution,
+      and a local SDK profile — created automatically by `self-host up`
     - The same Modal account then **executes your DAGs** via Stardag's
       [Modal integration](integrate-modal.md)
 
@@ -55,11 +58,15 @@ The command walks you through the rest interactively:
   accounts; see [OIDC mode](#auth-mode-oidc-external-identity-provider)
   for the alternative)
 - **Admin email + password** → your first login account
+- **Primary workspace** → if your Modal workspace is shared (a team
+  workspace), a Stardag workspace with the same name is created; personal
+  Modal accounts use your personal Stardag workspace
 
 It then generates a JWT signing keypair (stored as a Modal secret), applies
 database migrations, deploys the prebuilt server image (Registry API + web
 UI, published to the public GitHub Container Registry — no repo checkout,
-Node, or Docker needed locally), and prints your URL:
+Node, or Docker needed locally), and **completes the setup** — after which
+everything is wired up:
 
 ```
 Stardag is up!
@@ -68,21 +75,30 @@ Stardag is up!
   API: https://<your-workspace>--stardag-server.modal.run/api/v1
 ```
 
-### 4. Sign in and connect the SDK
+### 4. Done — what the defaults create
 
-Open the UI and sign in with the admin account. A personal workspace with a
-`Local` environment is created automatically.
+`up` finishes with a summary panel of everything that now exists:
 
-Point the SDK/CLI at your registry:
+| What                                         | Default                                                             | Purpose                                                                  |
+| -------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Modal env `stardag-server`                   | server app + config/JWT secrets                                     | Isolates the server from the Modal environments where your DAG apps run  |
+| Stardag **workspace**                        | named after your shared Modal workspace, or your personal workspace | Mirrors your Modal account's structure                                   |
+| Stardag **environment**                      | `main`                                                              | Mirrors Modal's default environment; where deployed-DAG runs are tracked |
+| **API key** → Modal secret `stardag-api-key` | in Modal env `main` (your default)                                  | Lets Modal-executed DAGs authenticate against your registry              |
+| **Target root** `default`                    | `modalvol://stardag/<workspace-slug>`                               | Where task outputs land (a Modal volume)                                 |
+| Local **registry + profile** `selfhosted`    | in `~/.stardag/config.toml`                                         | Points your SDK/CLI at the deployment                                    |
+
+Open the UI, sign in with the admin account, and deploy a DAG app with
+[`stardag modal deploy`](integrate-modal.md) — the `stardag-api-key` secret
+and target root are already in place. Everything in
+[Use the API Registry](use-api-registry.md) applies from here.
+
+Re-run the setup phase anytime (it's idempotent — existing workspaces,
+environments, and keys are matched, not duplicated):
 
 ```bash
-stardag config registry add selfhosted --url https://<your-workspace>--stardag-server.modal.run
-stardag auth login -r selfhosted   # prompts for the same email/password
+stardag self-host connect
 ```
-
-From here, everything in [Use the API Registry](use-api-registry.md) and
-[Integrate with Modal](integrate-modal.md) applies — e.g. mint an API key
-for Modal-executed DAGs with `stardag modal stardag-api-key create`.
 
 ## Updating to a new version
 
@@ -141,6 +157,15 @@ uvx --from "stardag[selfhost]" stardag self-host up --auth-mode oidc \
   --oidc-ui-client-id <client-id>
 ```
 
+In OIDC mode the post-deploy setup can't run server-side (there is no known
+admin until someone signs in), so complete it afterwards — this opens the
+browser for the OIDC login, then creates the workspace, `main` environment,
+API key, and local profile exactly like the local-mode flow:
+
+```bash
+uvx --from "stardag[selfhost]" stardag self-host connect
+```
+
 Provider setup (example: WorkOS AuthKit):
 
 1. Create a WorkOS account → enable AuthKit.
@@ -168,7 +193,8 @@ The UI discovers all of this at runtime from the API (`/api/v1/auth/config`)
 ## Commands reference
 
 ```bash
-stardag self-host up         # provision + deploy (idempotent; re-run to reconfigure)
+stardag self-host up         # provision + deploy + connect (idempotent; re-run to reconfigure)
+stardag self-host connect    # (re)run the post-deploy setup only
 stardag self-host upgrade    # migrate DB + redeploy
 stardag self-host status     # deployment status + URL
 stardag self-host destroy    # stop the Modal app (never touches the database)
@@ -189,7 +215,30 @@ Useful flags for `up` (all prompts have flag equivalents for CI):
 - `--keep-warm N` — always-on containers (initially 0 = scale to zero). The
   value is persisted: `up`/`upgrade` without the flag keep the last
   explicitly set value.
-- `--yes` — non-interactive; fails instead of prompting
+- `--server-modal-env NAME` — Modal environment for the server app + its
+  secrets (default `stardag-server`, created if missing). Keeps the server
+  isolated from the environments your DAG apps run in. Also accepted by
+  `connect`/`upgrade`/`status`/`destroy`; pass `''` for Modal's default
+  environment (deployments made with older SDK versions live there).
+- `--yes` — non-interactive; takes the defaults and fails on required prompts
+
+Setup flags shared by `up` and `connect` (each prompt/default has a flag
+equivalent):
+
+- `--primary-workspace NAME` — name of the shared Stardag workspace to
+  create (default: your shared Modal workspace's name); or
+  `--no-primary-workspace` to use only your personal workspace
+- `--execution-modal-env NAME` — Modal environment your DAG apps run in;
+  the `stardag-api-key` secret is pushed there (default: your Modal
+  account's default environment). This is deliberately _not_ the server's
+  environment.
+- `--target-root name=uri` — default target root for the `main` environment
+  (default `default=modalvol://stardag/<workspace-slug>`); or
+  `--no-target-root` to skip
+- `--registry-name` / `--profile-name` — names for the local SDK config
+  entries (both default `selfhosted`)
+- `--skip-connect` (`up` only) — deploy without the setup phase; run
+  `stardag self-host connect` later
 
 ## Troubleshooting
 
@@ -201,7 +250,9 @@ Useful flags for `up` (all prompts have flag equivalents for CI):
 - **Sign-in loops or 401s right after an upgrade** — stale cached tokens;
   sign out and in again. (The JWT keypair is preserved across upgrades, so
   this should be rare.)
-- **Logs** — `uvx modal app logs stardag-server`.
+- **Logs** — `uvx modal app logs stardag-server --env stardag-server` (the
+  server lives in its own Modal environment; drop `--env` for deployments
+  made with older SDK versions).
 - **Migration failures** — `self-host up`/`upgrade` print the Alembic
   output; migrations always run against Neon's direct (non-pooled)
   endpoint. Re-running the command is safe (migrations are idempotent).

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -9,7 +9,7 @@ cover a low-traffic deployment).
 !!! info "What you get"
 
     - The Stardag **UI + Registry API** served from your own Modal workspace
-      at `https://<your-workspace>--stardag-server.modal.run`
+      at `https://<your-workspace>-stardag-host--server.modal.run`
     - A **Postgres database** on Neon (scale-to-zero, free tier)
     - **Authentication** without extra services (email/password managed by
       the API) — or bring any OIDC provider
@@ -76,8 +76,8 @@ everything is wired up:
 ```
 Stardag is up!
 
-  UI:  https://<your-workspace>--stardag-server.modal.run
-  API: https://<your-workspace>--stardag-server.modal.run/api/v1
+  UI:  https://<your-workspace>-stardag-host--server.modal.run
+  API: https://<your-workspace>-stardag-host--server.modal.run/api/v1
 ```
 
 ### 4. Done — what the defaults create
@@ -86,11 +86,11 @@ Stardag is up!
 
 | What                                         | Default                                                             | Purpose                                                                  |
 | -------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| Modal env `stardag-server`                   | server app + config/JWT secrets                                     | Isolates the server from the Modal environments where your DAG apps run  |
+| Modal env `stardag-host` + app `server`      | server app + config/JWT secrets                                     | Isolates the server from the Modal environments where your DAG apps run  |
 | Stardag **workspace**                        | named after your shared Modal workspace, or your personal workspace | Mirrors your Modal account's structure                                   |
 | Stardag **environment**                      | `main`                                                              | Mirrors Modal's default environment; where deployed-DAG runs are tracked |
 | **API key** → Modal secret `stardag-api-key` | in Modal env `main` (your default)                                  | Lets Modal-executed DAGs authenticate against your registry              |
-| **Target root** `default`                    | `modalvol://stardag/<workspace-slug>`                               | Where task outputs land (a Modal volume)                                 |
+| **Target root** `default`                    | `modalvol://stardag-targets/<workspace-slug>`                       | Where task outputs land (a Modal volume, namespaced per workspace)       |
 | Local **registry + profile** `selfhosted`    | in `~/.stardag/config.toml`                                         | Points your SDK/CLI at the deployment                                    |
 
 Open the UI, sign in with the admin account, and deploy a DAG app with
@@ -118,6 +118,13 @@ up a newer SDK also rolls the server forward; pass
 [server release](https://github.com/stardag-dev/stardag/releases). The JWT
 keypair secret is left untouched, so existing sessions and SDK logins
 survive upgrades.
+
+If you deployed with a non-default `--name` or `--server-modal-env`, pass
+the **same** values to `upgrade` (and `status`/`destroy`) — otherwise the
+command looks in the wrong place and reports nothing deployed. In
+particular, a deployment created before these defaults changed (app
+`stardag-server` in Modal's default environment) is upgraded with
+`--name stardag-server --server-modal-env ''`.
 
 ## Deploying from source (development)
 
@@ -178,7 +185,7 @@ Provider setup (example: WorkOS AuthKit):
 1. Create a WorkOS account → enable AuthKit.
 2. Create a client application; note the **issuer URL** and **client ID**.
 3. Add the redirect URI printed by `self-host up`:
-   `https://<your-workspace>--stardag-server.modal.run/callback`
+   `https://<your-workspace>-stardag-host--server.modal.run/callback`
 4. If your provider's JWKS is not at
    `<issuer>/protocol/openid-connect/certs` (the Keycloak convention), pass
    `--oidc-jwks-url` explicitly (e.g. WorkOS: `<issuer>/oauth2/jwks`,
@@ -214,7 +221,7 @@ Useful flags for `up` (all prompts have flag equivalents for CI):
 - `--from-source` — build the image from a local repo checkout instead of
   the prebuilt image (see
   [Deploying from source](#deploying-from-source-development))
-- `--name` — Modal app name / URL label (default `stardag-server`)
+- `--name` — Modal app name / URL label (default `server`)
 - `--neon-project` — Neon project name to find-or-create (default `stardag`)
 - `--database-url` / `--database-url-direct` — bring your own Postgres
   instead of Neon (use `postgresql+asyncpg://...` URLs; pass the direct
@@ -223,7 +230,7 @@ Useful flags for `up` (all prompts have flag equivalents for CI):
   value is persisted: `up`/`upgrade` without the flag keep the last
   explicitly set value.
 - `--server-modal-env NAME` — Modal environment for the server app + its
-  secrets (default `stardag-server`, created if missing). Keeps the server
+  secrets (default `stardag-host`, created if missing). Keeps the server
   isolated from the environments your DAG apps run in. Also accepted by
   `connect`/`upgrade`/`status`/`destroy`; pass `''` for Modal's default
   environment (deployments made with older SDK versions live there).
@@ -240,7 +247,7 @@ equivalent):
   account's default environment). This is deliberately _not_ the server's
   environment.
 - `--target-root name=uri` — default target root for the `main` environment
-  (default `default=modalvol://stardag/<workspace-slug>`); or
+  (default `default=modalvol://stardag-targets/<workspace-slug>`); or
   `--no-target-root` to skip
 - `--registry-name` / `--profile-name` — names for the local SDK config
   entries (both default `selfhosted`)
@@ -263,9 +270,9 @@ equivalent):
 - **Sign-in loops or 401s right after an upgrade** — stale cached tokens;
   sign out and in again. (The JWT keypair is preserved across upgrades, so
   this should be rare.)
-- **Logs** — `uvx modal app logs stardag-server --env stardag-server` (the
-  server lives in its own Modal environment; drop `--env` for deployments
-  made with older SDK versions).
+- **Logs** — `uvx modal app logs server --env stardag-host` (the server
+  lives in its own Modal environment; use `--env ''`/the app name you chose
+  for deployments made with older SDK versions or a custom `--name`).
 - **Migration failures** — `self-host up`/`upgrade` print the Alembic
   output; migrations always run against Neon's direct (non-pooled)
   endpoint. Re-running the command is safe (migrations are idempotent).

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -84,14 +84,14 @@ Stardag is up!
 
 `up` finishes with a summary panel of everything that now exists:
 
-| What                                         | Default                                                             | Purpose                                                                  |
-| -------------------------------------------- | ------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| Modal env `stardag-host` + app `server`      | server app + config/JWT secrets                                     | Isolates the server from the Modal environments where your DAG apps run  |
-| Stardag **workspace**                        | named after your shared Modal workspace, or your personal workspace | Mirrors your Modal account's structure                                   |
-| Stardag **environment**                      | `main`                                                              | Mirrors Modal's default environment; where deployed-DAG runs are tracked |
-| **API key** → Modal secret `stardag-api-key` | in Modal env `main` (your default)                                  | Lets Modal-executed DAGs authenticate against your registry              |
-| **Target root** `default`                    | `modalvol://stardag-targets/<workspace-slug>`                       | Where task outputs land (a Modal volume, namespaced per workspace)       |
-| Local **registry + profile** `selfhosted`    | in `~/.stardag/config.toml`                                         | Points your SDK/CLI at the deployment                                    |
+| What                                         | Default                                                                  | Purpose                                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| Modal env `stardag-host` + app `server`      | server app + config/JWT secrets                                          | Isolates the server from the Modal environments where your DAG apps run        |
+| Stardag **workspace**                        | named after your shared Modal workspace, or your personal workspace      | Mirrors your Modal account's structure                                         |
+| Stardag **environment**                      | `main`                                                                   | Mirrors Modal's default environment; where deployed-DAG runs are tracked       |
+| **API key** → Modal secret `stardag-api-key` | in Modal env `main` (your default)                                       | Lets Modal-executed DAGs authenticate against your registry                    |
+| **Target root** `default`                    | `modalvol://stardag-targets-<workspace-slug>-<environment-slug>/default` | Where task outputs land (a dedicated Modal volume per workspace + environment) |
+| Local **registry + profile** `selfhosted`    | in `~/.stardag/config.toml`                                              | Points your SDK/CLI at the deployment                                          |
 
 Open the UI, sign in with the admin account, and deploy a DAG app with
 [`stardag modal deploy`](integrate-modal.md) — the `stardag-api-key` secret
@@ -247,8 +247,9 @@ equivalent):
   account's default environment). This is deliberately _not_ the server's
   environment.
 - `--target-root name=uri` — default target root for the `main` environment
-  (default `default=modalvol://stardag-targets/<workspace-slug>`); or
-  `--no-target-root` to skip
+  (default
+  `default=modalvol://stardag-targets-<workspace-slug>-<environment-slug>/default`);
+  or `--no-target-root` to skip
 - `--registry-name` / `--profile-name` — names for the local SDK config
   entries (both default `selfhosted`)
 - `--skip-connect` (`up` only) — deploy without the setup phase; run

--- a/lib/stardag/src/stardag/_cli/__init__.py
+++ b/lib/stardag/src/stardag/_cli/__init__.py
@@ -34,10 +34,13 @@ Usage:
     stardag modal deploy <app_ref> [--name name] [-e env] [--stream-logs] [--tag tag] [-m]
     stardag modal stardag-api-key create [--modal-env env] [-w workspace] [-e env] [-p profile]
 
-    stardag self-host up [--neon-api-key key] [--auth-mode local|oidc] [...]
-    stardag self-host upgrade
-    stardag self-host status
-    stardag self-host destroy [--delete-secrets]
+    stardag self-host up [--neon-api-key key] [--auth-mode local|oidc]
+        [--primary-workspace name] [--execution-modal-env env]
+        [--server-modal-env env] [--skip-connect] [...]
+    stardag self-host connect [--primary-workspace name] [...]
+    stardag self-host upgrade [--server-modal-env env]
+    stardag self-host status [--server-modal-env env]
+    stardag self-host destroy [--delete-secrets] [--server-modal-env env]
 
 Configuration:
     Set STARDAG_PROFILE=<profile-name> to use a specific profile.

--- a/lib/stardag/src/stardag/_cli/_selfhost_connect.py
+++ b/lib/stardag/src/stardag/_cli/_selfhost_connect.py
@@ -8,7 +8,8 @@ setup, mirroring the Modal account's structure:
 - a **primary environment** (``main``) in it,
 - an **API key** for that environment pushed as the Modal secret
   ``stardag-api-key`` into the Modal environment where the user's DAGs run,
-- a **default target root** (``modalvol://stardag-targets/<workspace-slug>``),
+- a **default target root**
+  (``modalvol://stardag-targets-<workspace-slug>-<environment-slug>/default``),
 - a **local SDK registry + profile** so ``stardag`` CLI/SDK commands work
   immediately.
 
@@ -21,6 +22,7 @@ the Modal-secret delete+create) - so the flow can be re-run at any time
 
 from __future__ import annotations
 
+import hashlib
 import re
 import time
 from dataclasses import dataclass
@@ -41,14 +43,20 @@ PRIMARY_ENVIRONMENT_SLUG = "main"
 # (the conventional name modal integration docs/examples use).
 API_KEY_SECRET_NAME = "stardag-api-key"
 
-# Modal volume + name for the default target root. The workspace slug is a
-# path segment (not dropped): several Stardag workspaces (a shared org
-# workspace plus members' personal ones) can execute in the same Modal
-# environment and task output paths are deterministic, so a bare
-# ``.../default`` would let identical task defs across workspaces collide in
-# the shared volume - the slug namespaces them.
+# Default target root: a dedicated Modal volume *per (workspace, environment)*
+# with the target-root name as the path. Encoding both identifiers in the
+# volume name (rather than a shared ``stardag-targets`` volume with per-
+# workspace subpaths) makes teardown atomic - the volume is a single
+# deletable unit (``modal volume delete stardag-targets-<ws>-<env>``) instead
+# of orphaning subpaths in a shared volume - and ``stardag-targets-`` stays a
+# globbable namespace. Using the target-root *name* as the path lets several
+# modalvol roots on one environment (e.g. ``default``, ``scratch``) coexist;
+# non-modal target roots are unaffected.
 DEFAULT_TARGET_ROOT_NAME = "default"
 DEFAULT_TARGET_ROOT_VOLUME = "stardag-targets"
+
+# Modal object names are capped at 64 chars (charset ``[a-zA-Z0-9-_.]``).
+_MODAL_OBJECT_NAME_MAX_LEN = 64
 
 DEFAULT_REGISTRY_NAME = "selfhosted"
 DEFAULT_PROFILE_NAME = "selfhosted"
@@ -57,9 +65,34 @@ _LOGIN_ATTEMPTS = 3
 _LOGIN_TIMEOUT = 120.0  # first request cold-starts the container + database
 
 
-def default_target_root_uri(workspace_slug: str) -> str:
-    """Default target-root URI for a workspace (Modal volume, slug-scoped)."""
-    return f"modalvol://{DEFAULT_TARGET_ROOT_VOLUME}/{workspace_slug}"
+def _targets_volume_name(workspace_slug: str, environment_slug: str) -> str:
+    """Modal volume name for a (workspace, environment)'s default target root.
+
+    ``stardag-targets-<workspace-slug>-<environment-slug>``, guarded to fit
+    Modal's 64-char object-name limit: when the composed name overflows it is
+    truncated and a short deterministic hash of the (workspace, environment)
+    pair is appended, so the result stays <=64 chars and distinct pairs never
+    collide (a NUL separator makes the hash input injective on the pair).
+    """
+    name = f"{DEFAULT_TARGET_ROOT_VOLUME}-{workspace_slug}-{environment_slug}"
+    if len(name) <= _MODAL_OBJECT_NAME_MAX_LEN:
+        return name
+    digest = hashlib.sha256(
+        f"{workspace_slug}\x00{environment_slug}".encode()
+    ).hexdigest()[:8]
+    suffix = f"-{digest}"
+    return f"{name[: _MODAL_OBJECT_NAME_MAX_LEN - len(suffix)]}{suffix}"
+
+
+def default_target_root_uri(workspace_slug: str, environment_slug: str) -> str:
+    """Default target-root URI for a (workspace, environment).
+
+    Volume-per-(workspace, environment); the path is the target-root name.
+    """
+    return (
+        f"modalvol://{_targets_volume_name(workspace_slug, environment_slug)}"
+        f"/{DEFAULT_TARGET_ROOT_NAME}"
+    )
 
 
 def _slugify(name: str) -> str:
@@ -73,7 +106,7 @@ def parse_target_root_flag(value: str) -> tuple[str, str]:
     if not sep or not name.strip() or not uri.strip():
         error_console.print(
             f"Invalid --target-root {value!r}: expected the form name=uri "
-            "(e.g. default=modalvol://stardag-targets/my-workspace)"
+            "(e.g. default=modalvol://stardag-targets-my-workspace-main/default)"
         )
         raise typer.Exit(1)
     return name.strip(), uri.strip()
@@ -400,7 +433,7 @@ def run_connect(
         if not no_target_root:
             root_name, root_uri = target_root or (
                 DEFAULT_TARGET_ROOT_NAME,
-                default_target_root_uri(workspace_slug),
+                default_target_root_uri(workspace_slug, environment_slug),
             )
             roots_url = f"{envs_url}/{environment_id}/target-roots"
             roots_response = ws_client.get(roots_url)

--- a/lib/stardag/src/stardag/_cli/_selfhost_connect.py
+++ b/lib/stardag/src/stardag/_cli/_selfhost_connect.py
@@ -1,0 +1,497 @@
+"""Post-deploy "connect" phase for ``stardag self-host``.
+
+Wires a freshly deployed self-hosted Stardag service into a ready-to-use
+setup, mirroring the Modal account's structure:
+
+- a **primary Stardag workspace** (named after the shared Modal workspace,
+  when there is one) or the user's personal workspace,
+- a **primary environment** (``main``) in it,
+- an **API key** for that environment pushed as the Modal secret
+  ``stardag-api-key`` into the Modal environment where the user's DAGs run,
+- a **default target root** (``modalvol://stardag/<workspace-slug>``),
+- a **local SDK registry + profile** so ``stardag`` CLI/SDK commands work
+  immediately.
+
+Everything is idempotent: existing workspaces/environments/target roots are
+matched before anything is created, so the flow can be re-run at any time
+(``stardag self-host connect``).
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from typing import Callable
+
+import httpx
+import typer
+from rich.console import Console
+
+console = Console()
+error_console = Console(stderr=True, style="bold red")
+
+# Stardag environment ensured by the setup ("main", mirroring Modal's
+# default environment name).
+PRIMARY_ENVIRONMENT_SLUG = "main"
+
+# Name of the Modal secret holding the Stardag API key for DAG execution
+# (the conventional name modal integration docs/examples use).
+API_KEY_SECRET_NAME = "stardag-api-key"
+
+# Modal volume name used for the default target root.
+DEFAULT_TARGET_ROOT_NAME = "default"
+DEFAULT_TARGET_ROOT_VOLUME = "stardag"
+
+DEFAULT_REGISTRY_NAME = "selfhosted"
+DEFAULT_PROFILE_NAME = "selfhosted"
+
+_LOGIN_ATTEMPTS = 3
+_LOGIN_TIMEOUT = 120.0  # first request cold-starts the container + database
+
+
+def _slugify(name: str) -> str:
+    """Server-compatible slug derivation (see stardag_api workspace slugs)."""
+    return re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")[:50]
+
+
+def parse_target_root_flag(value: str) -> tuple[str, str]:
+    """Parse a ``--target-root name=uri`` flag value."""
+    name, sep, uri = value.partition("=")
+    if not sep or not name.strip() or not uri.strip():
+        error_console.print(
+            f"Invalid --target-root {value!r}: expected the form name=uri "
+            "(e.g. default=modalvol://stardag/my-workspace)"
+        )
+        raise typer.Exit(1)
+    return name.strip(), uri.strip()
+
+
+def resolve_primary_workspace(
+    explicit: str | None,
+    no_primary_workspace: bool,
+    modal_shared_workspace: str | None,
+    interactive: bool,
+) -> str | None:
+    """Determine the primary (shared) Stardag workspace name.
+
+    Explicit flags win; otherwise the shared Modal workspace's name is the
+    default (confirmed interactively). Personal Modal workspaces get no
+    shared Stardag workspace - the user's personal Stardag workspace is
+    used instead.
+    """
+    if no_primary_workspace:
+        return None
+    if explicit:
+        return explicit
+    if not modal_shared_workspace:
+        return None
+    if interactive and not typer.confirm(
+        f"Primary Stardag workspace: '{modal_shared_workspace}' "
+        "(named after your shared Modal workspace)?",
+        default=True,
+    ):
+        return None
+    return modal_shared_workspace
+
+
+def get_auth_config(
+    api_url: str, transport: httpx.BaseTransport | None = None
+) -> dict | None:
+    """Fetch /auth/config from the deployed service (None if unreachable)."""
+    try:
+        with httpx.Client(timeout=_LOGIN_TIMEOUT, transport=transport) as client:
+            response = client.get(f"{api_url}/api/v1/auth/config")
+            response.raise_for_status()
+            return response.json()
+    except Exception:
+        return None
+
+
+def login_local(
+    api_url: str,
+    email: str,
+    password: str,
+    registry_name: str,
+    transport: httpx.BaseTransport | None = None,
+) -> str:
+    """Email/password login; stores the session token and returns it.
+
+    Retries a few times: the first request after a deploy cold-starts the
+    container (and wakes the database), which can be slow or transiently
+    unavailable.
+    """
+    from stardag._cli.credentials import save_credentials
+
+    last_error: Exception | None = None
+    response = None
+    for attempt in range(_LOGIN_ATTEMPTS):
+        try:
+            with httpx.Client(timeout=_LOGIN_TIMEOUT, transport=transport) as client:
+                response = client.post(
+                    f"{api_url}/api/v1/auth/login",
+                    json={"email": email, "password": password},
+                )
+            if response.status_code < 500:
+                break
+            last_error = RuntimeError(
+                f"Login failed ({response.status_code}): {response.text}"
+            )
+        except httpx.HTTPError as e:
+            last_error = e
+            response = None
+        if attempt < _LOGIN_ATTEMPTS - 1:
+            console.print("  [dim]Service still starting, retrying...[/dim]")
+            time.sleep(3 * (attempt + 1))
+
+    if response is None or response.status_code >= 500:
+        error_console.print(f"Could not reach the service to sign in: {last_error}")
+        raise typer.Exit(1)
+    if response.status_code == 401:
+        error_console.print("Invalid email or password.")
+        raise typer.Exit(1)
+    if response.status_code != 200:
+        error_console.print(f"Login failed ({response.status_code}): {response.text}")
+        raise typer.Exit(1)
+
+    data = response.json()
+    session_token = data["session_token"]
+    expires_in = data.get("expires_in", 3600)
+    save_credentials(
+        {
+            "auth_mode": "local",
+            "session_token": session_token,
+            "session_expires_at": time.time() + expires_in - 30,
+        },
+        registry_name,
+        email,
+    )
+    return session_token
+
+
+@dataclass
+class ConnectOutcome:
+    """What the connect flow ensured - input for the summary panel."""
+
+    api_url: str
+    workspace_name: str
+    workspace_slug: str
+    workspace_is_personal: bool
+    workspace_created: bool
+    environment_slug: str
+    environment_created: bool
+    target_root: tuple[str, str] | None  # (name, uri) ensured, None if skipped
+    api_key_name: str | None  # None if the Modal secret push failed
+    modal_secret_name: str | None
+    execution_modal_env: str | None  # None = Modal's default environment
+    registry_name: str
+    profile_name: str
+    user_email: str
+
+
+def _api_error(response: httpx.Response, action: str) -> typer.Exit:
+    error_console.print(f"Failed to {action} ({response.status_code}): {response.text}")
+    return typer.Exit(1)
+
+
+def run_connect(
+    api_url: str,
+    bearer_token: str,
+    user_email: str,
+    *,
+    primary_workspace: str | None,
+    environment_slug: str = PRIMARY_ENVIRONMENT_SLUG,
+    execution_modal_env: str | None = None,
+    target_root: tuple[str, str] | None = None,
+    no_target_root: bool = False,
+    registry_name: str = DEFAULT_REGISTRY_NAME,
+    profile_name: str = DEFAULT_PROFILE_NAME,
+    push_modal_secret: Callable[[str, dict[str, str], str | None], None] | None = None,
+    transport: httpx.BaseTransport | None = None,
+) -> ConnectOutcome:
+    """Idempotently wire up workspace, environment, API key, and SDK config.
+
+    ``bearer_token`` is a session token (local auth mode) or OIDC token -
+    both are accepted by the bootstrap endpoints and ``/auth/exchange``.
+    ``push_modal_secret`` is injectable for tests; defaults to the Modal
+    secret push used by ``stardag modal stardag-api-key create``.
+    """
+    from stardag._cli.auth import _sync_target_roots
+    from stardag._cli.credentials import (
+        add_profile,
+        add_registry,
+        get_active_profile,
+        set_default_profile,
+    )
+    from stardag._cli.modal import _create_stardag_api_key, _push_modal_secret
+    from stardag.config.cache import cache_environment_id, cache_workspace_id
+    from stardag.registry._auth import save_access_token_cache
+
+    if push_modal_secret is None:
+        push_modal_secret = _push_modal_secret
+
+    api_url = api_url.rstrip("/")
+    client = httpx.Client(
+        timeout=_LOGIN_TIMEOUT,
+        transport=transport,
+        headers={"Authorization": f"Bearer {bearer_token}"},
+    )
+    try:
+        # --- Current user + workspaces ---
+        me_response = client.get(f"{api_url}/api/v1/ui/me")
+        if me_response.status_code != 200:
+            raise _api_error(me_response, "fetch user profile")
+        me = me_response.json()
+        user_email = me.get("user", {}).get("email") or user_email
+        workspaces = me.get("workspaces", [])
+
+        # --- Resolve / create the workspace ---
+        workspace_created = False
+        if primary_workspace:
+            slug = _slugify(primary_workspace)
+            workspace = next(
+                (
+                    ws
+                    for ws in workspaces
+                    if not ws.get("is_personal")
+                    and (ws["name"] == primary_workspace or ws["slug"] == slug)
+                ),
+                None,
+            )
+            if workspace is None:
+                create_response = client.post(
+                    f"{api_url}/api/v1/ui/workspaces",
+                    json={
+                        "name": primary_workspace,
+                        "slug": slug,
+                        "initial_environment_name": environment_slug,
+                        "initial_environment_slug": environment_slug,
+                    },
+                )
+                if create_response.status_code == 409:
+                    error_console.print(
+                        f"Workspace slug {slug!r} already exists but you are "
+                        "not a member of it. Ask an owner for an invite, or "
+                        "pass a different --primary-workspace name."
+                    )
+                    raise typer.Exit(1)
+                if create_response.status_code != 201:
+                    raise _api_error(create_response, "create workspace")
+                workspace = create_response.json()
+                workspace_created = True
+                console.print(
+                    f"Created workspace [bold]{primary_workspace}[/bold] ({slug})"
+                )
+            else:
+                console.print(
+                    f"Using workspace [bold]{workspace['name']}[/bold] "
+                    f"({workspace['slug']})"
+                )
+        else:
+            workspace = next((ws for ws in workspaces if ws.get("is_personal")), None)
+            if workspace is None:
+                error_console.print(
+                    "No personal workspace found for this user. Pass "
+                    "--primary-workspace <name> to create a shared one."
+                )
+                raise typer.Exit(1)
+            console.print(
+                f"Using personal workspace [bold]{workspace['name']}[/bold] "
+                f"({workspace['slug']})"
+            )
+
+        workspace_id = str(workspace["id"])
+        workspace_slug = workspace["slug"]
+
+        # --- Workspace-scoped token (env/API-key/target-root endpoints) ---
+        exchange_response = client.post(
+            f"{api_url}/api/v1/auth/exchange",
+            json={"workspace_id": workspace_id},
+        )
+        if exchange_response.status_code != 200:
+            raise _api_error(exchange_response, "get workspace access token")
+        exchange = exchange_response.json()
+        access_token = exchange["access_token"]
+        expires_in = exchange.get("expires_in", 600)
+        ws_client = httpx.Client(
+            timeout=_LOGIN_TIMEOUT,
+            transport=transport,
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+    finally:
+        client.close()
+
+    try:
+        # --- Ensure the primary environment ---
+        environment_created = False
+        envs_url = f"{api_url}/api/v1/ui/workspaces/{workspace_id}/environments"
+        envs_response = ws_client.get(envs_url)
+        if envs_response.status_code != 200:
+            raise _api_error(envs_response, "list environments")
+        environment = next(
+            (e for e in envs_response.json() if e["slug"] == environment_slug), None
+        )
+        if environment is None:
+            create_env_response = ws_client.post(
+                envs_url,
+                json={"name": environment_slug, "slug": environment_slug},
+            )
+            if create_env_response.status_code != 201:
+                raise _api_error(create_env_response, "create environment")
+            environment = create_env_response.json()
+            environment_created = True
+            console.print(f"Created environment [bold]{environment_slug}[/bold]")
+        else:
+            console.print(f"Using environment [bold]{environment_slug}[/bold]")
+        environment_id = str(environment["id"])
+
+        # --- Ensure a default target root ---
+        ensured_target_root: tuple[str, str] | None = None
+        if not no_target_root:
+            root_name, root_uri = target_root or (
+                DEFAULT_TARGET_ROOT_NAME,
+                f"modalvol://{DEFAULT_TARGET_ROOT_VOLUME}/{workspace_slug}",
+            )
+            roots_url = f"{envs_url}/{environment_id}/target-roots"
+            roots_response = ws_client.get(roots_url)
+            if roots_response.status_code != 200:
+                raise _api_error(roots_response, "list target roots")
+            existing = next(
+                (r for r in roots_response.json() if r["name"] == root_name), None
+            )
+            if existing is None:
+                create_root_response = ws_client.post(
+                    roots_url, json={"name": root_name, "uri_prefix": root_uri}
+                )
+                if create_root_response.status_code != 201:
+                    raise _api_error(create_root_response, "create target root")
+                console.print(
+                    f"Created target root [bold]{root_name}[/bold] -> {root_uri}"
+                )
+                ensured_target_root = (root_name, root_uri)
+            else:
+                ensured_target_root = (root_name, existing["uri_prefix"])
+                console.print(
+                    f"Target root [bold]{root_name}[/bold] exists -> "
+                    f"{existing['uri_prefix']}"
+                )
+
+        # --- API key -> Modal secret (DAG-execution environment) ---
+        api_key_name: str | None = f"modal-{execution_modal_env or 'default'}"
+        modal_secret_name: str | None = API_KEY_SECRET_NAME
+        full_key, key_prefix = _create_stardag_api_key(
+            ws_client, api_url, workspace_id, environment_id, api_key_name
+        )
+        console.print(
+            f'Created Stardag API key "{api_key_name}" (prefix: {key_prefix})'
+        )
+        try:
+            push_modal_secret(
+                API_KEY_SECRET_NAME, {"STARDAG_API_KEY": full_key}, execution_modal_env
+            )
+            modal_env_display = execution_modal_env or "default"
+            console.print(
+                f"Pushed Modal secret [bold]{API_KEY_SECRET_NAME}[/bold] "
+                f"(Modal environment: {modal_env_display})"
+            )
+        except Exception as e:
+            error_console.print(f"Could not push the Modal secret: {e}")
+            console.print(
+                "[yellow]Create it later with:[/yellow] "
+                "stardag modal stardag-api-key create"
+                + (f" --modal-env {execution_modal_env}" if execution_modal_env else "")
+            )
+            api_key_name = None
+            modal_secret_name = None
+
+        # --- Local SDK config: registry + profile + caches ---
+        add_registry(registry_name, api_url)
+        add_profile(
+            profile_name, registry_name, workspace_slug, environment_slug, user_email
+        )
+        cache_workspace_id(registry_name, workspace_slug, workspace_id)
+        cache_environment_id(
+            registry_name, workspace_id, environment_slug, environment_id
+        )
+        save_access_token_cache(
+            registry_name, workspace_id, access_token, expires_in, user_email
+        )
+        if get_active_profile()[0] is None:
+            set_default_profile(profile_name)
+        try:
+            _sync_target_roots(api_url, access_token, workspace_id, environment_id)
+        except Exception as e:
+            # Local cache only - repopulated on the next `stardag auth login`
+            console.print(f"[yellow]Could not sync target-root cache: {e}[/yellow]")
+        console.print(
+            f"Configured local SDK profile [bold]{profile_name}[/bold] "
+            f"(registry: {registry_name})"
+        )
+    finally:
+        ws_client.close()
+
+    return ConnectOutcome(
+        api_url=api_url,
+        workspace_name=workspace["name"],
+        workspace_slug=workspace_slug,
+        workspace_is_personal=bool(workspace.get("is_personal")),
+        workspace_created=workspace_created,
+        environment_slug=environment_slug,
+        environment_created=environment_created,
+        target_root=ensured_target_root,
+        api_key_name=api_key_name,
+        modal_secret_name=modal_secret_name,
+        execution_modal_env=execution_modal_env,
+        registry_name=registry_name,
+        profile_name=profile_name,
+        user_email=user_email,
+    )
+
+
+def print_summary(
+    outcome: ConnectOutcome,
+    app_name: str,
+    server_modal_env: str | None,
+) -> None:
+    """Render the final 'what exists now' panel."""
+    from rich.panel import Panel
+
+    ws_kind = "personal" if outcome.workspace_is_personal else "shared"
+    exec_env = outcome.execution_modal_env or "default"
+    server_env = server_modal_env or "default"
+
+    lines = [
+        "[bold]Server[/bold]",
+        f"  URL:          {outcome.api_url}",
+        f"  Modal app:    {app_name}  (Modal environment: {server_env})",
+        "",
+        "[bold]Stardag registry[/bold]",
+        f"  Workspace:    {outcome.workspace_name} "
+        f"(/{outcome.workspace_slug}, {ws_kind})",
+        f"  Environment:  {outcome.environment_slug}",
+    ]
+    if outcome.target_root:
+        name, uri = outcome.target_root
+        lines.append(f"  Target root:  {name} -> {uri}")
+    if outcome.api_key_name and outcome.modal_secret_name:
+        lines.append(
+            f"  API key:      {outcome.api_key_name} -> Modal secret "
+            f"'{outcome.modal_secret_name}' (Modal environment: {exec_env})"
+        )
+    lines += [
+        "",
+        "[bold]Local SDK config[/bold]",
+        f"  Registry:     {outcome.registry_name} -> {outcome.api_url}",
+        f"  Profile:      {outcome.profile_name} "
+        f"({outcome.user_email} / {outcome.workspace_slug} / "
+        f"{outcome.environment_slug})",
+        "",
+        "[bold]Next steps[/bold]",
+        f"  1. Open the UI: {outcome.api_url}",
+        "  2. Deploy a DAG app to Modal: stardag modal deploy <your_app.py>",
+        "     (see the docs: How-to -> Integrate with Modal)",
+        "  3. Upgrade later: stardag self-host upgrade",
+    ]
+    console.print(
+        Panel("\n".join(lines), title="Stardag is set up", border_style="green")
+    )

--- a/lib/stardag/src/stardag/_cli/_selfhost_connect.py
+++ b/lib/stardag/src/stardag/_cli/_selfhost_connect.py
@@ -13,8 +13,10 @@ setup, mirroring the Modal account's structure:
   immediately.
 
 Everything is idempotent: existing workspaces/environments/target roots are
-matched before anything is created, so the flow can be re-run at any time
-(``stardag self-host connect``).
+matched before anything is created, and the API key is *rotated* (any live
+key with the same name is revoked before a fresh one is minted, mirroring
+the Modal-secret delete+create) - so the flow can be re-run at any time
+(``stardag self-host connect``) without accumulating credentials.
 """
 
 from __future__ import annotations
@@ -181,7 +183,8 @@ class ConnectOutcome:
     environment_slug: str
     environment_created: bool
     target_root: tuple[str, str] | None  # (name, uri) ensured, None if skipped
-    api_key_name: str | None  # None if the Modal secret push failed
+    # None if key creation or the Modal-secret push failed (non-fatal)
+    api_key_name: str | None
     modal_secret_name: str | None
     execution_modal_env: str | None  # None = Modal's default environment
     registry_name: str
@@ -192,6 +195,43 @@ class ConnectOutcome:
 def _api_error(response: httpx.Response, action: str) -> typer.Exit:
     error_console.print(f"Failed to {action} ({response.status_code}): {response.text}")
     return typer.Exit(1)
+
+
+def _rotate_api_key(ws_client: httpx.Client, keys_url: str, name: str) -> str:
+    """Revoke any live API key named ``name``, then mint a fresh one.
+
+    Delete+create (mirroring the Modal-secret push) so re-runs of the
+    connect flow rotate the credential instead of accumulating live keys.
+    Returns the full key value. Raises RuntimeError on API failures - the
+    caller degrades gracefully (unlike ``stardag modal stardag-api-key
+    create``, aborting here would strand the rest of the setup).
+    """
+    list_response = ws_client.get(keys_url)
+    if list_response.status_code != 200:
+        raise RuntimeError(
+            f"listing API keys failed ({list_response.status_code}): "
+            f"{list_response.text}"
+        )
+    for key in list_response.json():
+        if key["name"] == name and not key.get("revoked_at"):
+            revoke_response = ws_client.delete(f"{keys_url}/{key['id']}")
+            if revoke_response.status_code != 204:
+                raise RuntimeError(
+                    f"revoking the previous API key failed "
+                    f"({revoke_response.status_code}): {revoke_response.text}"
+                )
+            console.print(
+                f'Revoked previous API key "{name}" (prefix: {key["key_prefix"]})'
+            )
+    create_response = ws_client.post(keys_url, json={"name": name})
+    if create_response.status_code != 201:
+        raise RuntimeError(
+            f"creating the API key failed ({create_response.status_code}): "
+            f"{create_response.text}"
+        )
+    data = create_response.json()
+    console.print(f'Created Stardag API key "{name}" (prefix: {data["key_prefix"]})')
+    return data["key"]
 
 
 def run_connect(
@@ -223,7 +263,7 @@ def run_connect(
         get_active_profile,
         set_default_profile,
     )
-    from stardag._cli.modal import _create_stardag_api_key, _push_modal_secret
+    from stardag._cli.modal import _push_modal_secret
     from stardag.config.cache import cache_environment_id, cache_workspace_id
     from stardag.registry._auth import save_access_token_cache
 
@@ -377,32 +417,52 @@ def run_connect(
                 )
 
         # --- API key -> Modal secret (DAG-execution environment) ---
+        # Failures here are non-fatal by design: the local SDK config below
+        # is still written, and re-running `stardag self-host connect`
+        # retries this step (the rotate semantics keep that idempotent).
         api_key_name: str | None = f"modal-{execution_modal_env or 'default'}"
         modal_secret_name: str | None = API_KEY_SECRET_NAME
-        full_key, key_prefix = _create_stardag_api_key(
-            ws_client, api_url, workspace_id, environment_id, api_key_name
-        )
-        console.print(
-            f'Created Stardag API key "{api_key_name}" (prefix: {key_prefix})'
-        )
+        full_key: str | None = None
         try:
-            push_modal_secret(
-                API_KEY_SECRET_NAME, {"STARDAG_API_KEY": full_key}, execution_modal_env
-            )
-            modal_env_display = execution_modal_env or "default"
-            console.print(
-                f"Pushed Modal secret [bold]{API_KEY_SECRET_NAME}[/bold] "
-                f"(Modal environment: {modal_env_display})"
+            full_key = _rotate_api_key(
+                ws_client,
+                f"{envs_url}/{environment_id}/api-keys",
+                api_key_name,
             )
         except Exception as e:
-            error_console.print(f"Could not push the Modal secret: {e}")
+            error_console.print(f"Could not create the Stardag API key: {e}")
             console.print(
-                "[yellow]Create it later with:[/yellow] "
-                "stardag modal stardag-api-key create"
-                + (f" --modal-env {execution_modal_env}" if execution_modal_env else "")
+                "[yellow]Modal DAG execution is not wired up yet - re-run "
+                "`stardag self-host connect` to retry (the rest of the "
+                "setup is completed below).[/yellow]"
             )
             api_key_name = None
             modal_secret_name = None
+        if full_key is not None:
+            try:
+                push_modal_secret(
+                    API_KEY_SECRET_NAME,
+                    {"STARDAG_API_KEY": full_key},
+                    execution_modal_env,
+                )
+                modal_env_display = execution_modal_env or "default"
+                console.print(
+                    f"Pushed Modal secret [bold]{API_KEY_SECRET_NAME}[/bold] "
+                    f"(Modal environment: {modal_env_display})"
+                )
+            except Exception as e:
+                error_console.print(f"Could not push the Modal secret: {e}")
+                console.print(
+                    "[yellow]Create it later with:[/yellow] "
+                    "stardag modal stardag-api-key create"
+                    + (
+                        f" --modal-env {execution_modal_env}"
+                        if execution_modal_env
+                        else ""
+                    )
+                )
+                api_key_name = None
+                modal_secret_name = None
 
         # --- Local SDK config: registry + profile + caches ---
         add_registry(registry_name, api_url)

--- a/lib/stardag/src/stardag/_cli/_selfhost_connect.py
+++ b/lib/stardag/src/stardag/_cli/_selfhost_connect.py
@@ -8,7 +8,7 @@ setup, mirroring the Modal account's structure:
 - a **primary environment** (``main``) in it,
 - an **API key** for that environment pushed as the Modal secret
   ``stardag-api-key`` into the Modal environment where the user's DAGs run,
-- a **default target root** (``modalvol://stardag/<workspace-slug>``),
+- a **default target root** (``modalvol://stardag-targets/<workspace-slug>``),
 - a **local SDK registry + profile** so ``stardag`` CLI/SDK commands work
   immediately.
 
@@ -41,15 +41,25 @@ PRIMARY_ENVIRONMENT_SLUG = "main"
 # (the conventional name modal integration docs/examples use).
 API_KEY_SECRET_NAME = "stardag-api-key"
 
-# Modal volume name used for the default target root.
+# Modal volume + name for the default target root. The workspace slug is a
+# path segment (not dropped): several Stardag workspaces (a shared org
+# workspace plus members' personal ones) can execute in the same Modal
+# environment and task output paths are deterministic, so a bare
+# ``.../default`` would let identical task defs across workspaces collide in
+# the shared volume - the slug namespaces them.
 DEFAULT_TARGET_ROOT_NAME = "default"
-DEFAULT_TARGET_ROOT_VOLUME = "stardag"
+DEFAULT_TARGET_ROOT_VOLUME = "stardag-targets"
 
 DEFAULT_REGISTRY_NAME = "selfhosted"
 DEFAULT_PROFILE_NAME = "selfhosted"
 
 _LOGIN_ATTEMPTS = 3
 _LOGIN_TIMEOUT = 120.0  # first request cold-starts the container + database
+
+
+def default_target_root_uri(workspace_slug: str) -> str:
+    """Default target-root URI for a workspace (Modal volume, slug-scoped)."""
+    return f"modalvol://{DEFAULT_TARGET_ROOT_VOLUME}/{workspace_slug}"
 
 
 def _slugify(name: str) -> str:
@@ -63,7 +73,7 @@ def parse_target_root_flag(value: str) -> tuple[str, str]:
     if not sep or not name.strip() or not uri.strip():
         error_console.print(
             f"Invalid --target-root {value!r}: expected the form name=uri "
-            "(e.g. default=modalvol://stardag/my-workspace)"
+            "(e.g. default=modalvol://stardag-targets/my-workspace)"
         )
         raise typer.Exit(1)
     return name.strip(), uri.strip()
@@ -390,7 +400,7 @@ def run_connect(
         if not no_target_root:
             root_name, root_uri = target_root or (
                 DEFAULT_TARGET_ROOT_NAME,
-                f"modalvol://{DEFAULT_TARGET_ROOT_VOLUME}/{workspace_slug}",
+                default_target_root_uri(workspace_slug),
             )
             roots_url = f"{envs_url}/{environment_id}/target-roots"
             roots_response = ws_client.get(roots_url)
@@ -549,7 +559,7 @@ def print_summary(
         "[bold]Next steps[/bold]",
         f"  1. Open the UI: {outcome.api_url}",
         "  2. Deploy a DAG app to Modal: stardag modal deploy <your_app.py>",
-        "     (see the docs: How-to -> Integrate with Modal)",
+        "     https://docs.stardag.com/how-to/integrate-modal/",
         "  3. Upgrade later: stardag self-host upgrade",
     ]
     console.print(

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -764,7 +764,9 @@ def up(
         None,
         "--target-root",
         help="Default target root for the primary environment as name=uri "
-        "(default: default=modalvol://stardag-targets/<workspace-slug>).",
+        "(default: "
+        "default=modalvol://stardag-targets-<workspace-slug>-<environment-slug>"
+        "/default).",
     ),
     no_target_root: bool = typer.Option(
         False, "--no-target-root", help="Skip creating a default target root."
@@ -1193,7 +1195,9 @@ def connect(
         None,
         "--target-root",
         help="Default target root for the primary environment as name=uri "
-        "(default: default=modalvol://stardag-targets/<workspace-slug>).",
+        "(default: "
+        "default=modalvol://stardag-targets-<workspace-slug>-<environment-slug>"
+        "/default).",
     ),
     no_target_root: bool = typer.Option(
         False, "--no-target-root", help="Skip creating a default target root."

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -40,6 +40,7 @@ from stardag.selfhost._modal_app import (
     DEFAULT_APP_NAME,
     DEFAULT_SERVER_MODAL_ENV,
     DEFAULT_SERVER_VERSION,
+    PREBUILT_IMAGE_PYTHON,
     build_server_app,
     find_repo_root,
     server_image_ref,
@@ -97,6 +98,36 @@ def _require_repo_root(repo: Path | None) -> Path:
         )
         raise typer.Exit(1)
     return root
+
+
+def _check_prebuilt_python() -> None:
+    """Fail fast when the client interpreter can't drive the prebuilt image.
+
+    The `migrate`/`web` Modal functions are serialized (cloudpickled) by the
+    running interpreter and unpickled inside the server image; Modal rejects
+    the deploy when the two Python versions differ (``InvalidError: ... was
+    defined with Python X.Y, but its Image has 3.12``). Check up front -
+    before any provisioning - and print the exact remedy.
+    """
+    import sys
+
+    running = tuple(sys.version_info[:2])
+    if running == PREBUILT_IMAGE_PYTHON:
+        return
+    expected = "{}.{}".format(*PREBUILT_IMAGE_PYTHON)
+    actual = "{}.{}".format(*running)
+    error_console.print(
+        f"The prebuilt server image runs Python {expected} but this CLI is "
+        f"running under {actual}; serialized Modal functions require "
+        "matching interpreter versions."
+    )
+    console.print(
+        "\nRe-run with a matching interpreter, e.g.:\n"
+        f"  [bold]uvx --python {expected} --from 'stardag[selfhost]' "
+        "stardag self-host up[/bold]\n"
+        "(or pass --from-source to build an image matching your interpreter)."
+    )
+    raise typer.Exit(1)
 
 
 def _resolve_image_source(
@@ -763,7 +794,9 @@ def up(
     repo_root, resolved_server_version = _resolve_image_source(
         repo, from_source, server_version
     )
-    if repo_root is not None:
+    if repo_root is None:
+        _check_prebuilt_python()
+    else:
         console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
     target_root_override = parse_target_root_flag(target_root) if target_root else None
 
@@ -1071,7 +1104,9 @@ def upgrade(
     repo_root, resolved_server_version = _resolve_image_source(
         repo, from_source, server_version
     )
-    if repo_root is not None:
+    if repo_root is None:
+        _check_prebuilt_python()
+    else:
         console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
     modal_info = _check_modal_auth()
     console.print(f"Modal workspace: [bold]{modal_info.display}[/bold]")

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -14,7 +14,7 @@ needed). Pass --from-source to build from a local checkout of the stardag
 repo instead (run from the checkout or pass --repo).
 
 The server app and its secrets live in a dedicated Modal environment
-(default: "stardag-server", created on demand) so they stay isolated from
+(default: "stardag-host", created on demand) so they stay isolated from
 the Modal environments where your DAG apps run.
 """
 
@@ -764,7 +764,7 @@ def up(
         None,
         "--target-root",
         help="Default target root for the primary environment as name=uri "
-        "(default: default=modalvol://stardag/<workspace-slug>).",
+        "(default: default=modalvol://stardag-targets/<workspace-slug>).",
     ),
     no_target_root: bool = typer.Option(
         False, "--no-target-root", help="Skip creating a default target root."
@@ -1193,7 +1193,7 @@ def connect(
         None,
         "--target-root",
         help="Default target root for the primary environment as name=uri "
-        "(default: default=modalvol://stardag/<workspace-slug>).",
+        "(default: default=modalvol://stardag-targets/<workspace-slug>).",
     ),
     no_target_root: bool = typer.Option(
         False, "--no-target-root", help="Skip creating a default target root."

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -1,7 +1,8 @@
 """CLI for self-hosting the Stardag service (API + UI) on Modal.
 
 Usage:
-    stardag self-host up          # provision + deploy the full stack
+    stardag self-host up          # provision + deploy + connect (complete setup)
+    stardag self-host connect     # (re)run the post-deploy setup only
     stardag self-host upgrade     # migrate DB + redeploy
     stardag self-host status      # show deployment status and URL
     stardag self-host destroy     # stop the Modal app (DB is left untouched)
@@ -11,18 +12,33 @@ Requires the `selfhost` extra: pip install "stardag[selfhost]"
 By default the prebuilt public server image is deployed (no repo checkout
 needed). Pass --from-source to build from a local checkout of the stardag
 repo instead (run from the checkout or pass --repo).
+
+The server app and its secrets live in a dedicated Modal environment
+(default: "stardag-server", created on demand) so they stay isolated from
+the Modal environments where your DAG apps run.
 """
 
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from pathlib import Path
 
 import typer
 from rich.console import Console
 
+from stardag._cli._selfhost_connect import (
+    PRIMARY_ENVIRONMENT_SLUG,
+    get_auth_config,
+    login_local,
+    parse_target_root_flag,
+    print_summary,
+    resolve_primary_workspace,
+    run_connect,
+)
 from stardag.selfhost._modal_app import (
     DEFAULT_APP_NAME,
+    DEFAULT_SERVER_MODAL_ENV,
     DEFAULT_SERVER_VERSION,
     build_server_app,
     find_repo_root,
@@ -106,8 +122,25 @@ def _resolve_image_source(
     return None, server_version or DEFAULT_SERVER_VERSION
 
 
-def _check_modal_auth() -> str:
-    """Verify Modal credentials; returns the workspace name."""
+@dataclass
+class ModalWorkspaceInfo:
+    """The authenticated Modal account's workspace identity.
+
+    ``workspace_name`` is the shared workspace's display name and is None
+    for personal Modal workspaces; ``username`` is the account slug (always
+    present).
+    """
+
+    username: str
+    workspace_name: str | None
+
+    @property
+    def display(self) -> str:
+        return self.workspace_name or self.username
+
+
+def _check_modal_auth() -> ModalWorkspaceInfo:
+    """Verify Modal credentials; returns the workspace identity."""
     import asyncio
 
     import modal.config
@@ -122,7 +155,11 @@ def _check_modal_auth() -> str:
         workspace = asyncio.run(
             modal.config._lookup_workspace(server_url, token_id, token_secret)
         )
-        return workspace.username
+        # workspace_name is empty for personal Modal workspaces
+        return ModalWorkspaceInfo(
+            username=workspace.username,
+            workspace_name=workspace.workspace_name or None,
+        )
     except Exception as e:
         error_console.print(f"Modal authentication not set up: {e}")
         console.print(
@@ -133,23 +170,42 @@ def _check_modal_auth() -> str:
         raise typer.Exit(1)
 
 
-def _secret_exists(name: str) -> bool:
+def _ensure_modal_environment(name: str) -> bool:
+    """Create the Modal environment if it doesn't exist yet.
+
+    Returns True if it was created. The dedicated environment isolates the
+    server app + secrets from the environments where user DAG apps run.
+    """
+    import modal.environments
+
+    existing = {env.name for env in modal.environments.list_environments()}
+    if name in existing:
+        return False
+    modal.environments.create_environment(name)
+    return True
+
+
+def _secret_exists(name: str, environment_name: str | None = None) -> bool:
     import modal
     import modal.exception
 
     try:
-        modal.Secret.from_name(name).hydrate()
+        modal.Secret.from_name(name, environment_name=environment_name).hydrate()
         return True
     except modal.exception.NotFoundError:
         return False
 
 
-def _push_secret(name: str, env: dict[str, str]) -> None:
+def _push_secret(
+    name: str, env: dict[str, str], environment_name: str | None = None
+) -> None:
     """Create or replace a named Modal secret."""
     import modal
 
-    modal.Secret.objects.delete(name, allow_missing=True)
-    modal.Secret.objects.create(name, env)
+    modal.Secret.objects.delete(
+        name, allow_missing=True, environment_name=environment_name
+    )
+    modal.Secret.objects.create(name, env, environment_name=environment_name)
 
 
 def _generate_jwt_keypair() -> tuple[str, str]:
@@ -179,7 +235,9 @@ def _meta_dict_name(app_name: str) -> str:
     return f"{app_name}-meta"
 
 
-def _resolve_keep_warm(app_name: str, keep_warm: int | None) -> int:
+def _resolve_keep_warm(
+    app_name: str, keep_warm: int | None, environment_name: str | None = None
+) -> int:
     """Resolve the effective keep-warm value, persisting it across deploys.
 
     An explicitly provided value wins and is stored in the app's meta Dict;
@@ -188,7 +246,11 @@ def _resolve_keep_warm(app_name: str, keep_warm: int | None) -> int:
     """
     import modal
 
-    meta = modal.Dict.from_name(_meta_dict_name(app_name), create_if_missing=True)
+    meta = modal.Dict.from_name(
+        _meta_dict_name(app_name),
+        create_if_missing=True,
+        environment_name=environment_name,
+    )
     if keep_warm is not None:
         meta["keep_warm"] = keep_warm
         return keep_warm
@@ -211,30 +273,42 @@ def _parse_semver(version: str) -> tuple[int, int, int] | None:
     return major, minor, patch
 
 
-def _record_deployed_server_version(app_name: str, version: str) -> None:
+def _record_deployed_server_version(
+    app_name: str, version: str, environment_name: str | None = None
+) -> None:
     """Persist the just-deployed server version in the app's meta Dict.
 
     ``FROM_SOURCE_VERSION`` is recorded for from-source deploys.
     """
     import modal
 
-    meta = modal.Dict.from_name(_meta_dict_name(app_name), create_if_missing=True)
+    meta = modal.Dict.from_name(
+        _meta_dict_name(app_name),
+        create_if_missing=True,
+        environment_name=environment_name,
+    )
     meta["server_version"] = version
 
 
-def _deployed_server_version(app_name: str) -> str | None:
+def _deployed_server_version(
+    app_name: str, environment_name: str | None = None
+) -> str | None:
     """The recorded deployed server version, or None if never recorded."""
     import modal
     import modal.exception
 
     try:
-        meta = modal.Dict.from_name(_meta_dict_name(app_name))
+        meta = modal.Dict.from_name(
+            _meta_dict_name(app_name), environment_name=environment_name
+        )
     except modal.exception.NotFoundError:
         return None
     return meta.get("server_version")
 
 
-def _resolve_upgrade_server_version(app_name: str, explicit: str | None) -> str:
+def _resolve_upgrade_server_version(
+    app_name: str, explicit: str | None, environment_name: str | None = None
+) -> str:
     """Server version for prebuilt-image `upgrade` runs.
 
     Resolution order: explicit --server-version flag > recorded deployed
@@ -244,7 +318,7 @@ def _resolve_upgrade_server_version(app_name: str, explicit: str | None) -> str:
     advanced the DB schema past what the default server release knows).
     An explicitly passed older version wins, with a warning.
     """
-    deployed = _deployed_server_version(app_name)
+    deployed = _deployed_server_version(app_name, environment_name)
     if explicit is not None:
         explicit_semver = _parse_semver(explicit)
         deployed_semver = _parse_semver(deployed) if deployed else None
@@ -272,15 +346,19 @@ def _resolve_upgrade_server_version(app_name: str, explicit: str | None) -> str:
     return DEFAULT_SERVER_VERSION
 
 
-def _ensure_jwt_secret(name: str) -> bool:
+def _ensure_jwt_secret(name: str, environment_name: str | None = None) -> bool:
     """Create the JWT keypair secret if absent. Never overwrites.
 
     Returns True if a new keypair was created.
     """
-    if _secret_exists(name):
+    if _secret_exists(name, environment_name):
         return False
     private_pem, public_pem = _generate_jwt_keypair()
-    _push_secret(name, {"JWT_PRIVATE_KEY": private_pem, "JWT_PUBLIC_KEY": public_pem})
+    _push_secret(
+        name,
+        {"JWT_PRIVATE_KEY": private_pem, "JWT_PUBLIC_KEY": public_pem},
+        environment_name,
+    )
     return True
 
 
@@ -389,6 +467,8 @@ def _build_config_env(
     oidc_ui_client_id: str | None,
     oidc_audience: str | None,
     oidc_jwks_url: str | None,
+    primary_workspace_name: str | None = None,
+    primary_workspace_environment: str | None = None,
 ) -> dict[str, str]:
     env = {
         "STARDAG_API_DATABASE_URL": pooled_url,
@@ -398,6 +478,14 @@ def _build_config_env(
         # Self-hosted single-endpoint deployment: no SES
         "EMAIL_ENABLED": "false",
     }
+    # Primary workspace/environment bootstrap: acted on by the server in
+    # local auth mode (idempotent, anchored on the bootstrap admin). In
+    # OIDC mode the server has no known admin at startup, so the CLI's
+    # connect flow provisions these via the API instead.
+    if primary_workspace_name:
+        env["AUTH_PRIMARY_WORKSPACE_NAME"] = primary_workspace_name
+    if primary_workspace_environment is not None:
+        env["AUTH_PRIMARY_WORKSPACE_ENVIRONMENT"] = primary_workspace_environment
     if auth_mode == "local":
         if admin_email:
             env["AUTH_BOOTSTRAP_ADMIN_EMAIL"] = admin_email
@@ -426,11 +514,14 @@ def _deploy(
     keep_warm: int,
     server_version: str | None = None,
     run_migrations: bool = True,
+    environment_name: str | None = None,
 ) -> str:
     """Build the Modal app, run migrations, deploy. Returns the web URL.
 
     Exactly one of ``repo_root`` (build from source) and ``server_version``
     (prebuilt image) should be set - see ``_resolve_image_source``.
+    ``environment_name`` is the Modal environment the app (and its secrets)
+    live in; None means Modal's default environment.
     """
     import modal
 
@@ -445,6 +536,7 @@ def _deploy(
             config_secret_name=f"{app_name}-config",
             jwt_secret_name=f"{app_name}-jwt",
             keep_warm=keep_warm,
+            environment_name=environment_name,
         )
     else:
         version = server_version or DEFAULT_SERVER_VERSION
@@ -457,19 +549,20 @@ def _deploy(
             jwt_secret_name=f"{app_name}-jwt",
             keep_warm=keep_warm,
             server_version=version,
+            environment_name=environment_name,
         )
 
     try:
         with modal.enable_output():
             if run_migrations:
                 console.print("Applying database migrations...")
-                with server_app.run():
+                with server_app.run(environment_name=environment_name):
                     output = functions["migrate"].remote()
                 for line in output.strip().splitlines()[-5:]:
                     console.print(f"  [dim]{line}[/dim]")
 
             console.print("Deploying...")
-            server_app.deploy()
+            server_app.deploy(environment_name=environment_name)
     except Exception:
         if repo_root is None:
             error_console.print(
@@ -485,8 +578,23 @@ def _deploy(
     url = functions["web"].get_web_url()
     if not url:
         # Fall back to looking up the deployed function
-        url = modal.Function.from_name(app_name, "web").get_web_url()
+        url = modal.Function.from_name(
+            app_name, "web", environment_name=environment_name
+        ).get_web_url()
     return url or "<unknown - check `modal app list`>"
+
+
+def _deployed_web_url(app_name: str, environment_name: str | None) -> str | None:
+    """Web URL of an already-deployed server app, or None if not deployed."""
+    import modal
+    import modal.exception
+
+    try:
+        return modal.Function.from_name(
+            app_name, "web", environment_name=environment_name
+        ).get_web_url()
+    except modal.exception.NotFoundError:
+        return None
 
 
 # --- commands ----------------------------------------------------------------
@@ -589,24 +697,98 @@ def up(
         "cold start on first request). Persisted: when omitted, the last "
         "explicitly set value is kept (initially 0).",
     ),
+    server_modal_env: str = typer.Option(
+        DEFAULT_SERVER_MODAL_ENV,
+        "--server-modal-env",
+        help="Modal environment for the server app + its secrets (created if "
+        "missing). Keeps the server isolated from the environments where "
+        "your DAG apps run. Pass '' for Modal's default environment.",
+    ),
+    primary_workspace: str = typer.Option(
+        None,
+        "--primary-workspace",
+        help="Name of the primary (shared) Stardag workspace to create. "
+        "Default: your shared Modal workspace's name; skipped for personal "
+        "Modal workspaces (your personal Stardag workspace is used instead).",
+    ),
+    no_primary_workspace: bool = typer.Option(
+        False,
+        "--no-primary-workspace",
+        help="Do not create/map a shared primary workspace.",
+    ),
+    skip_connect: bool = typer.Option(
+        False,
+        "--skip-connect",
+        help="Skip the post-deploy setup (workspace wiring, API key, local "
+        "SDK profile). Run it later with `stardag self-host connect`.",
+    ),
+    execution_modal_env: str = typer.Option(
+        None,
+        "--execution-modal-env",
+        help="Modal environment where your DAG apps run - the stardag-api-key "
+        "secret is pushed there (default: your Modal account's default "
+        "environment, typically 'main'). NOT the server's environment.",
+    ),
+    target_root: str = typer.Option(
+        None,
+        "--target-root",
+        help="Default target root for the primary environment as name=uri "
+        "(default: default=modalvol://stardag/<workspace-slug>).",
+    ),
+    no_target_root: bool = typer.Option(
+        False, "--no-target-root", help="Skip creating a default target root."
+    ),
+    registry_name: str = typer.Option(
+        "selfhosted",
+        "--registry-name",
+        help="Name for the registry entry written to the local SDK config.",
+    ),
+    profile_name: str = typer.Option(
+        "selfhosted",
+        "--profile-name",
+        help="Name for the profile written to the local SDK config.",
+    ),
     yes: bool = typer.Option(
-        False, "--yes", "-y", help="Non-interactive: fail instead of prompting"
+        False, "--yes", "-y", help="Non-interactive: take defaults, fail on prompts"
     ),
 ):
-    """Bring up the full Stardag stack: database, migrations, API + UI on Modal."""
+    """Bring up the full Stardag stack: database, migrations, API + UI on Modal.
+
+    After the deploy, completes the setup (unless --skip-connect): primary
+    workspace + 'main' environment, an API key pushed as the Modal secret
+    'stardag-api-key' into your DAG-execution Modal environment, a default
+    target root, and a local SDK registry + profile.
+    """
     interactive = not yes
     repo_root, resolved_server_version = _resolve_image_source(
         repo, from_source, server_version
     )
     if repo_root is not None:
         console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
+    target_root_override = parse_target_root_flag(target_root) if target_root else None
 
-    workspace = _check_modal_auth()
-    console.print(f"Modal workspace: [bold]{workspace}[/bold]")
+    modal_info = _check_modal_auth()
+    if modal_info.workspace_name:
+        console.print(
+            f"Modal workspace: [bold]{modal_info.workspace_name}[/bold] "
+            f"(shared, signed in as {modal_info.username})"
+        )
+    else:
+        console.print(f"Modal workspace: [bold]{modal_info.username}[/bold] (personal)")
+
+    server_env = server_modal_env or None
+    if server_env:
+        if _ensure_modal_environment(server_env):
+            console.print(
+                f"Created Modal environment [bold]{server_env}[/bold] for the "
+                "server (isolated from the environments where your DAG apps run)."
+            )
+        else:
+            console.print(f"Server Modal environment: [bold]{server_env}[/bold]")
 
     config_secret_name = f"{name}-config"
     jwt_secret_name = f"{name}-jwt"
-    config_exists = _secret_exists(config_secret_name)
+    config_exists = _secret_exists(config_secret_name, server_env)
 
     # --- Database ---
     if config_exists and not (database_url or neon_api_key):
@@ -651,6 +833,8 @@ def up(
         )
 
     # --- Auth config (only when [re]writing the config secret) ---
+    primary_ws_name: str | None = None
+    primary_ws_resolved = False
     if pooled_url is not None:
         if auth_mode is None:
             if interactive:
@@ -706,6 +890,21 @@ def up(
                     default=f"{oidc_ui_client_id},{oidc_sdk_client_id}",
                 )
 
+        # --- Primary workspace mapping (baked into the config secret so the
+        # server bootstraps it on first boot; local mode only - in OIDC mode
+        # only an explicit --primary-workspace is passed through and the
+        # connect flow creates it via the API after login) ---
+        if auth_mode == "local":
+            primary_ws_name = resolve_primary_workspace(
+                primary_workspace,
+                no_primary_workspace,
+                modal_info.workspace_name,
+                interactive,
+            )
+        else:
+            primary_ws_name = primary_workspace if not no_primary_workspace else None
+        primary_ws_resolved = True
+
         env = _build_config_env(
             pooled_url,
             direct_url,  # type: ignore[arg-type]
@@ -719,12 +918,14 @@ def up(
             oidc_ui_client_id,
             oidc_audience,
             oidc_jwks_url,
+            primary_workspace_name=primary_ws_name,
+            primary_workspace_environment=PRIMARY_ENVIRONMENT_SLUG,
         )
         console.print(f"Writing config secret [bold]{config_secret_name}[/bold]...")
-        _push_secret(config_secret_name, env)
+        _push_secret(config_secret_name, env, server_env)
 
     # --- JWT keypair (create once, never overwrite) ---
-    if _ensure_jwt_secret(jwt_secret_name):
+    if _ensure_jwt_secret(jwt_secret_name, server_env):
         console.print(
             f"Generated JWT signing keypair -> [bold]{jwt_secret_name}[/bold]"
         )
@@ -737,36 +938,96 @@ def up(
     url = _deploy(
         repo_root,
         name,
-        _resolve_keep_warm(name, keep_warm),
+        _resolve_keep_warm(name, keep_warm, server_env),
         server_version=resolved_server_version,
+        environment_name=server_env,
     )
     _record_deployed_server_version(
-        name, resolved_server_version or FROM_SOURCE_VERSION
+        name, resolved_server_version or FROM_SOURCE_VERSION, server_env
     )
 
     console.print("\n[bold green]Stardag is up![/bold green]")
     console.print(f"\n  UI:  [bold]{url}[/bold]")
     console.print(f"  API: {url}/api/v1")
-    console.print("\nNext steps:")
-    console.print(
-        "  1. Open the UI and sign in"
-        + (
-            " with the admin account you just configured."
-            if auth_mode == "local"
-            else "."
-        )
-    )
     if auth_mode == "oidc" and oidc_issuer:
         console.print(
-            f"     (Make sure {url}/callback is an allowed redirect URI "
+            f"\n(Make sure {url}/callback is an allowed redirect URI "
             "in your OIDC provider.)"
         )
-    console.print(
-        "  2. Point the SDK at your registry:\n"
-        f"     stardag config registry add selfhosted --url {url}\n"
-        "     stardag auth login -r selfhosted"
+
+    # --- Post-deploy connect phase ---
+    if auth_mode is None:
+        # Re-run against an existing config secret: ask the deployed service
+        auth_config = get_auth_config(url)
+        auth_mode = (auth_config or {}).get("auth_mode")
+
+    if skip_connect:
+        _print_connect_pointer(auth_mode)
+        return
+
+    if auth_mode != "local":
+        # OIDC (or unknown): the connect flow needs a browser login first
+        _print_connect_pointer(auth_mode)
+        return
+
+    if not (admin_email and admin_password):
+        # Re-run without fresh admin credentials: prompt, or point to connect
+        if not interactive:
+            _print_connect_pointer(auth_mode)
+            return
+        console.print("\nSign in to complete the setup (admin account):")
+        admin_email = typer.prompt("Email")
+        admin_password = typer.prompt("Password", hide_input=True)
+
+    if interactive and not typer.confirm(
+        "Complete the setup now (workspace, API key for Modal DAG execution, "
+        "local SDK profile)?",
+        default=True,
+    ):
+        _print_connect_pointer(auth_mode)
+        return
+
+    if not primary_ws_resolved:
+        primary_ws_name = resolve_primary_workspace(
+            primary_workspace,
+            no_primary_workspace,
+            modal_info.workspace_name,
+            interactive,
+        )
+
+    console.print()
+    session_token = login_local(url, admin_email, admin_password, registry_name)
+    outcome = run_connect(
+        url,
+        session_token,
+        admin_email,
+        primary_workspace=primary_ws_name,
+        execution_modal_env=execution_modal_env,
+        target_root=target_root_override,
+        no_target_root=no_target_root,
+        registry_name=registry_name,
+        profile_name=profile_name,
     )
-    console.print("  3. To update to a newer server release: stardag self-host upgrade")
+    console.print()
+    print_summary(outcome, name, server_env)
+
+
+def _print_connect_pointer(auth_mode: str | None) -> None:
+    """Next-steps output when the connect phase is skipped or deferred."""
+    console.print("\nNext steps:")
+    if auth_mode == "local":
+        console.print(
+            "  1. Complete the setup (workspace, API key for Modal DAG "
+            "execution, local SDK profile):\n"
+            "     [bold]stardag self-host connect[/bold]"
+        )
+    else:
+        console.print(
+            "  1. Complete the setup (sign in via your identity provider, "
+            "then workspace, API key, local SDK profile):\n"
+            "     [bold]stardag self-host connect[/bold]"
+        )
+    console.print("  2. To update to a newer server release: stardag self-host upgrade")
 
 
 @app.command()
@@ -798,6 +1059,13 @@ def upgrade(
         help="Containers to keep always-on. Persisted: when omitted, the "
         "last explicitly set value is kept (initially 0).",
     ),
+    server_modal_env: str = typer.Option(
+        DEFAULT_SERVER_MODAL_ENV,
+        "--server-modal-env",
+        help="Modal environment the server app + secrets live in. Pass '' "
+        "for Modal's default environment (deployments made before the "
+        "dedicated server environment existed).",
+    ),
 ):
     """Update the deployment: apply DB migrations and redeploy."""
     repo_root, resolved_server_version = _resolve_image_source(
@@ -805,46 +1073,223 @@ def upgrade(
     )
     if repo_root is not None:
         console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
-    workspace = _check_modal_auth()
-    console.print(f"Modal workspace: [bold]{workspace}[/bold]")
+    modal_info = _check_modal_auth()
+    console.print(f"Modal workspace: [bold]{modal_info.display}[/bold]")
+    server_env = server_modal_env or None
+    if server_env:
+        console.print(f"Server Modal environment: [bold]{server_env}[/bold]")
 
     for secret_name in (f"{name}-config", f"{name}-jwt"):
-        if not _secret_exists(secret_name):
+        if not _secret_exists(secret_name, server_env):
             error_console.print(
-                f"Secret {secret_name!r} not found - run `stardag self-host up` first."
+                f"Secret {secret_name!r} not found"
+                + (f" in Modal environment {server_env!r}" if server_env else "")
+                + " - run `stardag self-host up` first. (Deployed with an "
+                "older SDK? Its objects live in your default Modal "
+                'environment - pass --server-modal-env "".)'
             )
             raise typer.Exit(1)
 
     if repo_root is None:
         # Prebuilt path: default to the recorded deployed version so a plain
         # `upgrade` never silently downgrades (explicit flag still wins).
-        resolved_server_version = _resolve_upgrade_server_version(name, server_version)
+        resolved_server_version = _resolve_upgrade_server_version(
+            name, server_version, server_env
+        )
 
     url = _deploy(
         repo_root,
         name,
-        _resolve_keep_warm(name, keep_warm),
+        _resolve_keep_warm(name, keep_warm, server_env),
         server_version=resolved_server_version,
+        environment_name=server_env,
     )
     _record_deployed_server_version(
-        name, resolved_server_version or FROM_SOURCE_VERSION
+        name, resolved_server_version or FROM_SOURCE_VERSION, server_env
     )
     console.print("\n[bold green]Upgrade complete.[/bold green]")
     console.print(f"  UI: [bold]{url}[/bold]")
 
 
 @app.command()
+def connect(
+    name: str = typer.Option(
+        DEFAULT_APP_NAME, "--name", help="Modal app name of the deployed server"
+    ),
+    url: str = typer.Option(
+        None,
+        "--url",
+        help="Server URL (default: looked up from the deployed Modal app)",
+    ),
+    server_modal_env: str = typer.Option(
+        DEFAULT_SERVER_MODAL_ENV,
+        "--server-modal-env",
+        help="Modal environment the server app lives in (for the URL lookup). "
+        "Pass '' for Modal's default environment.",
+    ),
+    admin_email: str = typer.Option(
+        None, "--admin-email", help="Email to sign in with (local auth mode)"
+    ),
+    admin_password: str = typer.Option(
+        None,
+        "--admin-password",
+        help="Password to sign in with (local auth mode). Prompted if omitted.",
+    ),
+    primary_workspace: str = typer.Option(
+        None,
+        "--primary-workspace",
+        help="Name of the primary (shared) Stardag workspace. Default: your "
+        "shared Modal workspace's name; skipped for personal Modal "
+        "workspaces (your personal Stardag workspace is used instead).",
+    ),
+    no_primary_workspace: bool = typer.Option(
+        False,
+        "--no-primary-workspace",
+        help="Do not create/map a shared primary workspace.",
+    ),
+    execution_modal_env: str = typer.Option(
+        None,
+        "--execution-modal-env",
+        help="Modal environment where your DAG apps run - the stardag-api-key "
+        "secret is pushed there (default: your Modal account's default "
+        "environment, typically 'main').",
+    ),
+    target_root: str = typer.Option(
+        None,
+        "--target-root",
+        help="Default target root for the primary environment as name=uri "
+        "(default: default=modalvol://stardag/<workspace-slug>).",
+    ),
+    no_target_root: bool = typer.Option(
+        False, "--no-target-root", help="Skip creating a default target root."
+    ),
+    registry_name: str = typer.Option(
+        "selfhosted",
+        "--registry-name",
+        help="Name for the registry entry written to the local SDK config.",
+    ),
+    profile_name: str = typer.Option(
+        "selfhosted",
+        "--profile-name",
+        help="Name for the profile written to the local SDK config.",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y", help="Non-interactive: take defaults, fail on prompts"
+    ),
+):
+    """Complete (or re-run) the post-deploy setup for a deployed server.
+
+    Idempotent: ensures the primary workspace + 'main' environment, an API
+    key pushed as the Modal secret 'stardag-api-key' into your DAG-execution
+    Modal environment, a default target root, and a local SDK registry +
+    profile. In OIDC auth mode this signs you in via the browser first.
+    """
+    interactive = not yes
+    target_root_override = parse_target_root_flag(target_root) if target_root else None
+
+    modal_info = _check_modal_auth()
+    server_env = server_modal_env or None
+
+    resolved_url = url or _deployed_web_url(name, server_env)
+    if not resolved_url:
+        error_console.print(
+            f"App {name!r} is not deployed"
+            + (f" in Modal environment {server_env!r}" if server_env else "")
+            + " - run `stardag self-host up` first (or pass --url)."
+        )
+        raise typer.Exit(1)
+    resolved_url = resolved_url.rstrip("/")
+    console.print(f"Server: [bold]{resolved_url}[/bold]")
+
+    auth_config = get_auth_config(resolved_url)
+    if auth_config is None:
+        error_console.print(
+            f"Could not fetch auth configuration from {resolved_url} - is the "
+            "service healthy? (Check `stardag self-host status` and the logs.)"
+        )
+        raise typer.Exit(1)
+
+    if auth_config.get("auth_mode") == "local":
+        if not admin_email:
+            if not interactive:
+                error_console.print("--admin-email is required with --yes")
+                raise typer.Exit(1)
+            admin_email = typer.prompt("Email")
+        if not admin_password:
+            if not interactive:
+                error_console.print("--admin-password is required with --yes")
+                raise typer.Exit(1)
+            admin_password = typer.prompt("Password", hide_input=True)
+        bearer_token = login_local(
+            resolved_url, admin_email, admin_password, registry_name
+        )
+        user_email = admin_email
+    else:
+        if not interactive:
+            error_console.print(
+                "This registry uses OIDC authentication, which needs a "
+                "browser login. Re-run without --yes, or authenticate first "
+                f"with `stardag auth login -r {registry_name} --api-url "
+                f"{resolved_url}` and re-run."
+            )
+            raise typer.Exit(1)
+        # Same browser PKCE flow as `stardag auth login`
+        from stardag._cli.auth import _login_oidc_flow
+        from stardag._cli.credentials import add_registry
+
+        add_registry(registry_name, resolved_url)
+        bearer_token, user_email = _login_oidc_flow(
+            registry=registry_name,
+            api_url=resolved_url,
+            oidc_issuer=None,
+            client_id=None,
+            auth_config=auth_config,
+        )
+
+    primary_ws_name = resolve_primary_workspace(
+        primary_workspace,
+        no_primary_workspace,
+        modal_info.workspace_name,
+        interactive,
+    )
+
+    console.print()
+    outcome = run_connect(
+        resolved_url,
+        bearer_token,
+        user_email,
+        primary_workspace=primary_ws_name,
+        execution_modal_env=execution_modal_env,
+        target_root=target_root_override,
+        no_target_root=no_target_root,
+        registry_name=registry_name,
+        profile_name=profile_name,
+    )
+    console.print()
+    print_summary(outcome, name, server_env)
+
+
+@app.command()
 def status(
     name: str = typer.Option(DEFAULT_APP_NAME, "--name", help="Modal app name"),
+    server_modal_env: str = typer.Option(
+        DEFAULT_SERVER_MODAL_ENV,
+        "--server-modal-env",
+        help="Modal environment the server app + secrets live in. Pass '' "
+        "for Modal's default environment.",
+    ),
 ):
     """Show deployment status."""
     import modal
     import modal.exception
 
     _check_modal_auth()
+    server_env = server_modal_env or None
+    if server_env:
+        console.print(f"Server Modal environment: [bold]{server_env}[/bold]")
 
     try:
-        web = modal.Function.from_name(name, "web")
+        web = modal.Function.from_name(name, "web", environment_name=server_env)
         url = web.get_web_url()
         console.print(f"App [bold]{name}[/bold]: deployed")
         console.print(f"  UI: [bold]{url}[/bold]")
@@ -852,11 +1297,11 @@ def status(
         console.print(f"App [bold]{name}[/bold]: not deployed")
 
     for secret_name in (f"{name}-config", f"{name}-jwt"):
-        state = "present" if _secret_exists(secret_name) else "missing"
+        state = "present" if _secret_exists(secret_name, server_env) else "missing"
         console.print(f"  Secret {secret_name}: {state}")
 
     try:
-        meta = modal.Dict.from_name(_meta_dict_name(name))
+        meta = modal.Dict.from_name(_meta_dict_name(name), environment_name=server_env)
         server_version = meta.get("server_version")
         if server_version == FROM_SOURCE_VERSION:
             console.print("  Server version: built from source")
@@ -876,6 +1321,12 @@ def destroy(
         help="Also delete the config + JWT secrets and the settings Dict "
         "(existing sessions and SDK logins become invalid)",
     ),
+    server_modal_env: str = typer.Option(
+        DEFAULT_SERVER_MODAL_ENV,
+        "--server-modal-env",
+        help="Modal environment the server app + secrets live in. Pass '' "
+        "for Modal's default environment.",
+    ),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip confirmation"),
 ):
     """Stop the Modal app. The database (Neon project) is never touched."""
@@ -889,8 +1340,12 @@ def destroy(
         )
 
     _check_modal_auth()
+    server_env = server_modal_env or None
+    stop_command = [sys.executable, "-m", "modal", "app", "stop", name]
+    if server_env:
+        stop_command += ["--env", server_env]
     result = subprocess.run(
-        [sys.executable, "-m", "modal", "app", "stop", name],
+        stop_command,
         capture_output=True,
         text=True,
     )
@@ -903,12 +1358,17 @@ def destroy(
         import modal
 
         for secret_name in (f"{name}-config", f"{name}-jwt"):
-            modal.Secret.objects.delete(secret_name, allow_missing=True)
+            modal.Secret.objects.delete(
+                secret_name, allow_missing=True, environment_name=server_env
+            )
             console.print(f"Deleted secret {secret_name}")
-        modal.Dict.objects.delete(_meta_dict_name(name), allow_missing=True)
+        modal.Dict.objects.delete(
+            _meta_dict_name(name), allow_missing=True, environment_name=server_env
+        )
         console.print(f"Deleted dict {_meta_dict_name(name)}")
 
     console.print(
         "\nNote: the Neon project/database was NOT deleted. Manage it at "
-        "https://console.neon.tech if you want to remove it."
+        "https://console.neon.tech if you want to remove it. The Modal "
+        "environment is also kept (delete with `modal environment delete`)."
     )

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -21,6 +21,7 @@ function bodies are mode-agnostic.
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -46,10 +47,42 @@ SERVER_IMAGE_REPO = "ghcr.io/stardag-dev/stardag-server"
 # release time; override per deployment with --server-version.
 DEFAULT_SERVER_VERSION = "0.1.0"
 
+# Python (major, minor) baked into the prebuilt server image - MUST match
+# the base image in app/server.Dockerfile. The `migrate`/`web` functions are
+# serialized (cloudpickled) by the *client* interpreter and unpickled inside
+# the image, so Modal requires the two versions to match exactly; the CLI
+# fails fast with a remedy when they don't. Bumping the Dockerfile's Python
+# version must be coordinated with this constant (see DEV_README.md,
+# "Releasing the Server").
+PREBUILT_IMAGE_PYTHON = (3, 12)
+
+# Minimum client interpreter for from-source image builds (stardag-api's
+# requires-python; the image gets the client's version via add_python).
+MIN_IMAGE_PYTHON = (3, 10)
+
 
 def server_image_ref(version: str) -> str:
     """Full image reference for a released server version (or "latest")."""
     return f"{SERVER_IMAGE_REPO}:{version}"
+
+
+def client_python_version() -> str:
+    """The running interpreter's "major.minor", validated for image use.
+
+    Used as the from-source image's Python so it matches the client that
+    serializes the Modal function bodies (a mismatch fails at deploy time
+    with Modal's ``InvalidError``). Raises RuntimeError when the client
+    interpreter is older than stardag-api supports.
+    """
+    version = tuple(sys.version_info[:2])
+    if version < MIN_IMAGE_PYTHON:
+        raise RuntimeError(
+            "The stardag server requires Python >= {}.{}".format(*MIN_IMAGE_PYTHON)
+            + ", but this CLI is running under {}.{}".format(*version)
+            + ". Re-run under a newer interpreter, e.g.: "
+            'uvx --python 3.12 --from "stardag[selfhost]" stardag self-host up'
+        )
+    return "{}.{}".format(*version)
 
 
 def find_repo_root(start: Path | None = None) -> Path | None:
@@ -72,7 +105,7 @@ def build_server_app(
     config_secret_name: str | None = None,
     jwt_secret_name: str | None = None,
     keep_warm: int = 0,
-    python_version: str = "3.12",
+    python_version: str | None = None,
     server_version: str = DEFAULT_SERVER_VERSION,
     environment_name: str | None = None,
 ) -> tuple["modal.App", dict[str, Any]]:
@@ -81,7 +114,12 @@ def build_server_app(
     When ``repo_root`` is None (default) the prebuilt public server image
     ``ghcr.io/stardag-dev/stardag-server:<server_version>`` is used.
     When ``repo_root`` is given the image is built from that checkout
-    (``server_version`` is ignored).
+    (``server_version`` is ignored). ``python_version`` applies to the
+    from-source image only and defaults to the running interpreter's
+    version: the function bodies are serialized by *this* process, and
+    Modal requires the image's Python to match the serializing one. (The
+    prebuilt image is fixed at ``PREBUILT_IMAGE_PYTHON``; the CLI checks
+    the client interpreter against it before deploying.)
 
     ``environment_name`` is the Modal environment the referenced secrets
     live in (the app itself is placed there by the caller at deploy time);
@@ -97,16 +135,21 @@ def build_server_app(
 
     if repo_root is None:
         # Prebuilt release image (public registry, no secret needed). The
-        # image ships python 3.12 + the API package + built UI + alembic
-        # config at the same paths as the from-source build below.
+        # image ships python (PREBUILT_IMAGE_PYTHON) + the API package +
+        # built UI + alembic config at the same paths as the from-source
+        # build below.
         image = modal.Image.from_registry(server_image_ref(server_version))
     else:
         api_dir = repo_root / "app" / "stardag-api"
         ui_dir = repo_root / "app" / "stardag-ui"
 
         image = (
-            # node:22-slim for the in-image UI build; add_python for the API
-            modal.Image.from_registry("node:22-slim", add_python=python_version)
+            # node:22-slim for the in-image UI build; add_python for the
+            # API - matching the client interpreter (see docstring)
+            modal.Image.from_registry(
+                "node:22-slim",
+                add_python=python_version or client_python_version(),
+            )
             .add_local_dir(
                 ui_dir.as_posix(),
                 UI_SRC_REMOTE_DIR,

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -32,15 +32,19 @@ API_REMOTE_DIR = "/opt/stardag/api"
 UI_SRC_REMOTE_DIR = "/opt/stardag/ui-src"
 UI_DIST_REMOTE_DIR = "/opt/stardag/ui"
 
-DEFAULT_APP_NAME = "stardag-server"
-DEFAULT_CONFIG_SECRET = "stardag-server-config"
-DEFAULT_JWT_SECRET = "stardag-server-jwt"
+# The Modal app name (and URL label). Kept short: the deployed URL is
+# https://<workspace>-<modal-env>--<app>.modal.run, so with the default
+# server Modal environment below that reads ...-stardag-host--server....
+DEFAULT_APP_NAME = "server"
+DEFAULT_CONFIG_SECRET = "server-config"
+DEFAULT_JWT_SECRET = "server-jwt"
 
 # Modal environment the server app and its secrets live in, created on
-# demand. Keeping the server in its own Modal environment isolates it from
-# the environments where the user's DAG apps run (no name collisions with
-# user apps/secrets/volumes, and `modal app list` etc. stay uncluttered).
-DEFAULT_SERVER_MODAL_ENV = "stardag-server"
+# demand. Keeping the server/control-plane in its own Modal environment
+# isolates it from the environments where the user's DAG apps run (no name
+# collisions with user apps/secrets/volumes, and `modal app list` etc. stay
+# uncluttered).
+DEFAULT_SERVER_MODAL_ENV = "stardag-host"
 
 SERVER_IMAGE_REPO = "ghcr.io/stardag-dev/stardag-server"
 # The server release this SDK version is tested against. Bumped at SDK

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -35,6 +35,12 @@ DEFAULT_APP_NAME = "stardag-server"
 DEFAULT_CONFIG_SECRET = "stardag-server-config"
 DEFAULT_JWT_SECRET = "stardag-server-jwt"
 
+# Modal environment the server app and its secrets live in, created on
+# demand. Keeping the server in its own Modal environment isolates it from
+# the environments where the user's DAG apps run (no name collisions with
+# user apps/secrets/volumes, and `modal app list` etc. stay uncluttered).
+DEFAULT_SERVER_MODAL_ENV = "stardag-server"
+
 SERVER_IMAGE_REPO = "ghcr.io/stardag-dev/stardag-server"
 # The server release this SDK version is tested against. Bumped at SDK
 # release time; override per deployment with --server-version.
@@ -68,6 +74,7 @@ def build_server_app(
     keep_warm: int = 0,
     python_version: str = "3.12",
     server_version: str = DEFAULT_SERVER_VERSION,
+    environment_name: str | None = None,
 ) -> tuple["modal.App", dict[str, Any]]:
     """Build the Modal app serving the Stardag service.
 
@@ -75,6 +82,10 @@ def build_server_app(
     ``ghcr.io/stardag-dev/stardag-server:<server_version>`` is used.
     When ``repo_root`` is given the image is built from that checkout
     (``server_version`` is ignored).
+
+    ``environment_name`` is the Modal environment the referenced secrets
+    live in (the app itself is placed there by the caller at deploy time);
+    None means Modal's default environment.
 
     Secret names default to "<app_name>-config" and "<app_name>-jwt".
     Returns (app, {"web": web_fn, "migrate": migrate_fn}).
@@ -116,9 +127,11 @@ def build_server_app(
         )
 
     app = modal.App(app_name)
+    # The secrets must be resolved in the same Modal environment the app is
+    # deployed to (from_name lookups are environment-scoped).
     secrets = [
-        modal.Secret.from_name(config_secret_name),
-        modal.Secret.from_name(jwt_secret_name),
+        modal.Secret.from_name(config_secret_name, environment_name=environment_name),
+        modal.Secret.from_name(jwt_secret_name, environment_name=environment_name),
     ]
 
     # NOTE: the function bodies below are defined as closures (not module-

--- a/lib/stardag/tests/test_selfhost/test_cli_config.py
+++ b/lib/stardag/tests/test_selfhost/test_cli_config.py
@@ -128,14 +128,24 @@ def test_admin_password_validation():
     assert _admin_password_error("€" * 25) is not None  # 75 bytes
 
 
-def _patch_meta_dict(monkeypatch: pytest.MonkeyPatch, store: dict) -> list[str]:
-    """Patch modal.Dict.from_name to return `store`; records requested names."""
+def _patch_meta_dict(
+    monkeypatch: pytest.MonkeyPatch, store: dict, environments: list | None = None
+) -> list[str]:
+    """Patch modal.Dict.from_name to return `store`; records requested names
+    (and, when ``environments`` is given, the environment_name of each call)."""
     import modal
 
     names: list[str] = []
 
-    def fake_from_name(name: str, *, create_if_missing: bool = False):
+    def fake_from_name(
+        name: str,
+        *,
+        create_if_missing: bool = False,
+        environment_name: str | None = None,
+    ):
         names.append(name)
+        if environments is not None:
+            environments.append(environment_name)
         return store
 
     monkeypatch.setattr(modal.Dict, "from_name", fake_from_name)
@@ -202,7 +212,12 @@ def test_upgrade_version_no_meta_dict(monkeypatch: pytest.MonkeyPatch):
     import modal
     import modal.exception
 
-    def raise_not_found(name: str, *, create_if_missing: bool = False):
+    def raise_not_found(
+        name: str,
+        *,
+        create_if_missing: bool = False,
+        environment_name: str | None = None,
+    ):
         raise modal.exception.NotFoundError(f"Dict {name} not found")
 
     monkeypatch.setattr(modal.Dict, "from_name", raise_not_found)

--- a/lib/stardag/tests/test_selfhost/test_complete_setup.py
+++ b/lib/stardag/tests/test_selfhost/test_complete_setup.py
@@ -258,6 +258,7 @@ class FakeRegistryApi:
         self.workspaces = workspaces if workspaces is not None else []
         self.api_key_requests: list[dict] = []
         self.requests: list[str] = []
+        self.fail_api_key_create = False
 
     def _find_workspace(self, workspace_id: str) -> dict:
         return next(ws for ws in self.workspaces if ws["id"] == workspace_id)
@@ -269,12 +270,37 @@ class FakeRegistryApi:
             "slug": slug,
             "is_personal": is_personal,
             "envs": {
-                s: {"id": str(uuid4()), "slug": s, "name": s, "target_roots": []}
+                s: {
+                    "id": str(uuid4()),
+                    "slug": s,
+                    "name": s,
+                    "target_roots": [],
+                    "api_keys": [],
+                }
                 for s in env_slugs
             },
         }
         self.workspaces.append(ws)
         return ws
+
+    def add_api_key(self, env: dict, name: str, revoked_at=None) -> dict:
+        key = {
+            "id": str(uuid4()),
+            "environment_id": env["id"],
+            "name": name,
+            "key_prefix": f"sk_old{len(env['api_keys'])}",
+            "created_by_id": self.user_id,
+            "created_at": "2026-01-01T00:00:00",
+            "last_used_at": None,
+            "revoked_at": revoked_at,
+        }
+        env["api_keys"].append(key)
+        return key
+
+    def live_keys(self, env: dict, name: str) -> list[dict]:
+        return [
+            k for k in env["api_keys"] if k["name"] == name and k["revoked_at"] is None
+        ]
 
     def handler(self, request: httpx.Request) -> httpx.Response:
         path = request.url.path
@@ -384,25 +410,25 @@ class FakeRegistryApi:
                     }
                     env["target_roots"].append(root)
                     return httpx.Response(201, json=root)
-            if len(parts) == 8 and parts[7] == "api-keys" and method == "POST":
-                data = json.loads(request.content)
-                self.api_key_requests.append(
-                    {"environment_id": env["id"], "name": data["name"]}
-                )
-                return httpx.Response(
-                    201,
-                    json={
-                        "id": str(uuid4()),
-                        "environment_id": env["id"],
-                        "name": data["name"],
-                        "key_prefix": "sk_test1234",
-                        "created_by_id": self.user_id,
-                        "created_at": "2026-01-01T00:00:00",
-                        "last_used_at": None,
-                        "revoked_at": None,
-                        "key": "sk_test1234_full_key_value",
-                    },
-                )
+            if len(parts) == 8 and parts[7] == "api-keys":
+                if method == "GET":
+                    return httpx.Response(200, json=env["api_keys"])
+                if method == "POST":
+                    if self.fail_api_key_create:
+                        return httpx.Response(500, json={"detail": "boom"})
+                    data = json.loads(request.content)
+                    self.api_key_requests.append(
+                        {"environment_id": env["id"], "name": data["name"]}
+                    )
+                    key = self.add_api_key(env, data["name"])
+                    key["key_prefix"] = "sk_test1234"
+                    return httpx.Response(
+                        201, json={**key, "key": "sk_test1234_full_key_value"}
+                    )
+            if len(parts) == 9 and parts[7] == "api-keys" and method == "DELETE":
+                key = next(k for k in env["api_keys"] if k["id"] == parts[8])
+                key["revoked_at"] = "2026-01-02T00:00:00"
+                return httpx.Response(204)
 
         raise AssertionError(f"Unexpected request: {method} {path}")
 
@@ -565,6 +591,54 @@ def test_connect_target_root_override_and_skip(isolated_home):
     outcome2, _ = _run_connect(api2, primary_workspace=None, no_target_root=True)
     assert outcome2.target_root is None
     assert not any("target-roots" in r for r in api2.requests)
+
+
+def test_connect_rotates_existing_api_key(isolated_home):
+    """Re-running connect revokes the previous same-named key before
+    minting a new one - no live-credential accumulation."""
+    api = FakeRegistryApi()
+    ws = api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("main",)
+    )
+    env = ws["envs"]["main"]
+    api.add_api_key(env, "modal-default")
+    # An already-revoked key and a differently-named key are left alone
+    api.add_api_key(env, "modal-default", revoked_at="2025-01-01T00:00:00")
+    api.add_api_key(env, "other-key")
+
+    outcome, push = _run_connect(api, primary_workspace=None)
+
+    assert outcome.api_key_name == "modal-default"
+    assert len(api.live_keys(env, "modal-default")) == 1
+    assert api.live_keys(env, "modal-default")[0]["key_prefix"] == "sk_test1234"
+    assert len(api.live_keys(env, "other-key")) == 1
+    assert len(push.calls) == 1
+
+    # Second run: still exactly one live key with that name
+    _run_connect(api, primary_workspace=None)
+    assert len(api.live_keys(env, "modal-default")) == 1
+
+
+def test_connect_api_key_creation_failure_is_not_fatal(isolated_home):
+    """API-key creation failures degrade gracefully (connect-specific
+    handling, no typer.Exit): no secret pushed, SDK config still written."""
+    api = FakeRegistryApi()
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("main",)
+    )
+    api.fail_api_key_create = True
+
+    outcome, push = _run_connect(api, primary_workspace=None)
+
+    assert outcome.api_key_name is None
+    assert outcome.modal_secret_name is None
+    assert push.calls == []
+
+    # The rest of the setup completed: profile + registry written
+    from stardag._cli.credentials import list_profiles, list_registries
+
+    assert list_registries() == {"selfhosted": API_URL}
+    assert "selfhosted" in list_profiles()
 
 
 def test_connect_modal_secret_push_failure_is_not_fatal(isolated_home):

--- a/lib/stardag/tests/test_selfhost/test_complete_setup.py
+++ b/lib/stardag/tests/test_selfhost/test_complete_setup.py
@@ -257,14 +257,45 @@ def test_default_names_avoid_doubled_url_label():
     assert DEFAULT_APP_NAME != DEFAULT_SERVER_MODAL_ENV
 
 
-def test_default_target_root_uri_namespaces_by_workspace():
+def test_default_target_root_uri_volume_per_workspace_environment():
     from stardag._cli._selfhost_connect import default_target_root_uri
 
+    # Both identifiers live in the *volume name*; the path is the root name.
     assert (
-        default_target_root_uri("acme-corp") == "modalvol://stardag-targets/acme-corp"
+        default_target_root_uri("acme-corp", "main")
+        == "modalvol://stardag-targets-acme-corp-main/default"
     )
-    # The workspace slug is retained (namespacing), not dropped
-    assert default_target_root_uri("acme-corp").endswith("/acme-corp")
+
+
+def test_targets_volume_name_length_guard():
+    import re
+
+    from stardag._cli._selfhost_connect import _targets_volume_name
+
+    # Volume-name charset per Modal (max 64 chars, [a-zA-Z0-9-_.]).
+    charset = re.compile(r"^[a-zA-Z0-9._-]+$")
+
+    # Short (ws, env): composed verbatim, no hashing.
+    assert _targets_volume_name("acme-corp", "main") == "stardag-targets-acme-corp-main"
+
+    long_ws = "w" * 60
+    long_env = "e" * 40
+    name = _targets_volume_name(long_ws, long_env)
+    assert len(name) <= 64
+    assert charset.match(name)
+
+    # Deterministic: same inputs -> same name.
+    assert name == _targets_volume_name(long_ws, long_env)
+
+    # Distinct overflowing (ws, env) pairs -> distinct names (no collision).
+    other = _targets_volume_name(long_ws, long_env + "x")
+    assert len(other) <= 64
+    assert other != name
+    # A pair that composes to the same string under a naive "-".join but is a
+    # genuinely different (ws, env) split must still differ.
+    assert _targets_volume_name("a" * 40 + "-b", "c" * 40) != _targets_volume_name(
+        "a" * 40, "b-" + "c" * 40
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -507,7 +538,10 @@ def test_connect_personal_workspace(isolated_home):
     assert outcome.workspace_created is False
     assert outcome.environment_slug == "main"
     assert outcome.environment_created is False
-    assert outcome.target_root == ("default", "modalvol://stardag-targets/admin")
+    assert outcome.target_root == (
+        "default",
+        "modalvol://stardag-targets-admin-main/default",
+    )
     assert outcome.api_key_name == "modal-default"
     assert outcome.modal_secret_name == API_KEY_SECRET_NAME
 
@@ -549,7 +583,10 @@ def test_connect_creates_primary_workspace(isolated_home):
     assert outcome.workspace_is_personal is False
     # main env was included in workspace creation, so not created separately
     assert outcome.environment_created is False
-    assert outcome.target_root == ("default", "modalvol://stardag-targets/acme-corp")
+    assert outcome.target_root == (
+        "default",
+        "modalvol://stardag-targets-acme-corp-main/default",
+    )
     assert outcome.api_key_name == "modal-staging"
     assert push.calls[0][2] == "staging"
     assert api.api_key_requests[0]["name"] == "modal-staging"

--- a/lib/stardag/tests/test_selfhost/test_complete_setup.py
+++ b/lib/stardag/tests/test_selfhost/test_complete_setup.py
@@ -1,0 +1,593 @@
+"""Tests for the self-host "complete setup": Modal-environment isolation
+plumbing and the post-deploy connect flow (mocked Modal + mocked HTTP API).
+"""
+
+import json
+from uuid import uuid4
+
+import httpx
+import pytest
+
+pytest.importorskip("modal")
+pytest.importorskip("cryptography")
+
+import typer  # noqa: E402
+
+from stardag._cli._selfhost_connect import (  # noqa: E402
+    API_KEY_SECRET_NAME,
+    ConnectOutcome,
+    parse_target_root_flag,
+    resolve_primary_workspace,
+    run_connect,
+)
+from stardag._cli.selfhost import (  # noqa: E402
+    ModalWorkspaceInfo,
+    _build_config_env,
+    _ensure_jwt_secret,
+    _push_secret,
+    _resolve_keep_warm,
+    _secret_exists,
+)
+from stardag.selfhost._modal_app import (  # noqa: E402
+    DEFAULT_SERVER_MODAL_ENV,
+    build_server_app,
+)
+
+API_URL = "http://stardag.test"
+
+
+# ---------------------------------------------------------------------------
+# Primary workspace derivation
+# ---------------------------------------------------------------------------
+
+
+def test_modal_workspace_info_display():
+    shared = ModalWorkspaceInfo(username="alice", workspace_name="Acme Corp")
+    personal = ModalWorkspaceInfo(username="alice", workspace_name=None)
+    assert shared.display == "Acme Corp"
+    assert personal.display == "alice"
+
+
+def test_resolve_primary_workspace_shared_modal_workspace():
+    # Non-interactive: the shared Modal workspace name is the default
+    assert (
+        resolve_primary_workspace(None, False, "Acme Corp", interactive=False)
+        == "Acme Corp"
+    )
+
+
+def test_resolve_primary_workspace_personal_modal_workspace():
+    # Personal Modal workspace: no shared Stardag workspace by default
+    assert resolve_primary_workspace(None, False, None, interactive=False) is None
+
+
+def test_resolve_primary_workspace_explicit_wins():
+    assert (
+        resolve_primary_workspace("My Team", False, "Acme Corp", interactive=False)
+        == "My Team"
+    )
+    # Explicit also works for personal Modal workspaces
+    assert (
+        resolve_primary_workspace("My Team", False, None, interactive=False)
+        == "My Team"
+    )
+
+
+def test_resolve_primary_workspace_opt_out():
+    assert resolve_primary_workspace(None, True, "Acme Corp", interactive=False) is None
+
+
+def test_resolve_primary_workspace_interactive_confirm(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(typer, "confirm", lambda *a, **k: True)
+    assert (
+        resolve_primary_workspace(None, False, "Acme Corp", interactive=True)
+        == "Acme Corp"
+    )
+    monkeypatch.setattr(typer, "confirm", lambda *a, **k: False)
+    assert resolve_primary_workspace(None, False, "Acme Corp", interactive=True) is None
+
+
+def test_parse_target_root_flag():
+    assert parse_target_root_flag("default=modalvol://stardag/acme") == (
+        "default",
+        "modalvol://stardag/acme",
+    )
+    with pytest.raises(typer.Exit):
+        parse_target_root_flag("no-equals-sign")
+    with pytest.raises(typer.Exit):
+        parse_target_root_flag("=uri-only")
+
+
+# ---------------------------------------------------------------------------
+# Config secret assembly (primary workspace env vars)
+# ---------------------------------------------------------------------------
+
+
+def _config_env(auth_mode="local", **kwargs):
+    return _build_config_env(
+        pooled_url="postgresql+asyncpg://u:p@pooled/db",
+        direct_url="postgresql+asyncpg://u:p@direct/db",
+        pooler_compat=True,
+        auth_mode=auth_mode,
+        admin_email="admin@example.com" if auth_mode == "local" else None,
+        admin_password="s3cret-pass" if auth_mode == "local" else None,
+        enable_registration=False,
+        oidc_issuer="https://idp.example.com" if auth_mode == "oidc" else None,
+        oidc_sdk_client_id=None,
+        oidc_ui_client_id=None,
+        oidc_audience=None,
+        oidc_jwks_url=None,
+        **kwargs,
+    )
+
+
+def test_build_config_env_primary_workspace():
+    env = _config_env(
+        primary_workspace_name="Acme Corp",
+        primary_workspace_environment="main",
+    )
+    assert env["AUTH_PRIMARY_WORKSPACE_NAME"] == "Acme Corp"
+    assert env["AUTH_PRIMARY_WORKSPACE_ENVIRONMENT"] == "main"
+
+
+def test_build_config_env_no_primary_workspace():
+    # Personal Modal workspace: no name, but the primary environment is
+    # still ensured (in the admin's personal workspace, server-side)
+    env = _config_env(primary_workspace_environment="main")
+    assert "AUTH_PRIMARY_WORKSPACE_NAME" not in env
+    assert env["AUTH_PRIMARY_WORKSPACE_ENVIRONMENT"] == "main"
+
+
+def test_build_config_env_defaults_omit_primary_vars():
+    env = _config_env()
+    assert "AUTH_PRIMARY_WORKSPACE_NAME" not in env
+    assert "AUTH_PRIMARY_WORKSPACE_ENVIRONMENT" not in env
+
+
+# ---------------------------------------------------------------------------
+# Modal environment plumbing (server-side objects)
+# ---------------------------------------------------------------------------
+
+
+class _FakeSecretObjects:
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    def delete(self, name, *, allow_missing=False, environment_name=None):
+        self.calls.append(("delete", name, environment_name))
+
+    def create(self, name, env_dict, *, environment_name=None, **kwargs):
+        self.calls.append(("create", name, environment_name, env_dict))
+
+
+@pytest.fixture
+def fake_secret_objects(monkeypatch: pytest.MonkeyPatch) -> _FakeSecretObjects:
+    import modal
+
+    fake = _FakeSecretObjects()
+    monkeypatch.setattr(modal.Secret, "objects", fake)
+    return fake
+
+
+def test_push_secret_passes_environment(fake_secret_objects: _FakeSecretObjects):
+    _push_secret("my-secret", {"A": "1"}, "stardag-server")
+    assert fake_secret_objects.calls == [
+        ("delete", "my-secret", "stardag-server"),
+        ("create", "my-secret", "stardag-server", {"A": "1"}),
+    ]
+
+
+def test_secret_exists_passes_environment(monkeypatch: pytest.MonkeyPatch):
+    import modal
+
+    seen: list[tuple] = []
+
+    class FakeRef:
+        def hydrate(self):
+            raise modal.exception.NotFoundError("nope")
+
+    def fake_from_name(name, *, environment_name=None, **kwargs):
+        seen.append((name, environment_name))
+        return FakeRef()
+
+    monkeypatch.setattr(modal.Secret, "from_name", fake_from_name)
+    assert _secret_exists("my-secret", "stardag-server") is False
+    assert seen == [("my-secret", "stardag-server")]
+
+
+def test_ensure_jwt_secret_creates_in_environment(
+    monkeypatch: pytest.MonkeyPatch, fake_secret_objects: _FakeSecretObjects
+):
+    monkeypatch.setattr(
+        "stardag._cli.selfhost._secret_exists", lambda name, env=None: False
+    )
+    assert _ensure_jwt_secret("app-jwt", "stardag-server") is True
+    kinds = [(kind, name, env) for kind, name, env, *rest in fake_secret_objects.calls]
+    assert ("create", "app-jwt", "stardag-server") in kinds
+
+
+def test_resolve_keep_warm_passes_environment(monkeypatch: pytest.MonkeyPatch):
+    import modal
+
+    envs: list = []
+    store: dict = {}
+
+    def fake_from_name(name, *, create_if_missing=False, environment_name=None):
+        envs.append(environment_name)
+        return store
+
+    monkeypatch.setattr(modal.Dict, "from_name", fake_from_name)
+    assert _resolve_keep_warm("myapp", 1, "stardag-server") == 1
+    assert envs == ["stardag-server"]
+
+
+def test_build_server_app_resolves_secrets_in_environment(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import modal
+
+    seen: list[tuple] = []
+    real_from_name = modal.Secret.from_name
+
+    def recording_from_name(name, *, environment_name=None, **kwargs):
+        seen.append((name, environment_name))
+        return real_from_name(name, environment_name=environment_name, **kwargs)
+
+    monkeypatch.setattr(modal.Secret, "from_name", recording_from_name)
+    build_server_app(server_version="1.2.3", environment_name=DEFAULT_SERVER_MODAL_ENV)
+    assert seen == [
+        ("stardag-server-config", DEFAULT_SERVER_MODAL_ENV),
+        ("stardag-server-jwt", DEFAULT_SERVER_MODAL_ENV),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Connect flow (mocked registry API)
+# ---------------------------------------------------------------------------
+
+
+class FakeRegistryApi:
+    """Minimal in-memory fake of the registry endpoints the connect flow uses."""
+
+    def __init__(self, user_email="admin@example.com", workspaces=None):
+        self.user_id = str(uuid4())
+        self.user_email = user_email
+        # workspace: {id, name, slug, is_personal, envs: {slug: {...}}}
+        self.workspaces = workspaces if workspaces is not None else []
+        self.api_key_requests: list[dict] = []
+        self.requests: list[str] = []
+
+    def _find_workspace(self, workspace_id: str) -> dict:
+        return next(ws for ws in self.workspaces if ws["id"] == workspace_id)
+
+    def add_workspace(self, name, slug, is_personal=False, env_slugs=()):
+        ws = {
+            "id": str(uuid4()),
+            "name": name,
+            "slug": slug,
+            "is_personal": is_personal,
+            "envs": {
+                s: {"id": str(uuid4()), "slug": s, "name": s, "target_roots": []}
+                for s in env_slugs
+            },
+        }
+        self.workspaces.append(ws)
+        return ws
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        method = request.method
+        self.requests.append(f"{method} {path}")
+
+        if path == "/api/v1/ui/me" and method == "GET":
+            return httpx.Response(
+                200,
+                json={
+                    "user": {
+                        "id": self.user_id,
+                        "external_id": "local:x",
+                        "email": self.user_email,
+                        "display_name": None,
+                    },
+                    "workspaces": [
+                        {
+                            "id": ws["id"],
+                            "name": ws["name"],
+                            "slug": ws["slug"],
+                            "role": "owner",
+                            "is_personal": ws["is_personal"],
+                        }
+                        for ws in self.workspaces
+                    ],
+                },
+            )
+
+        if path == "/api/v1/ui/workspaces" and method == "POST":
+            data = json.loads(request.content)
+            if any(ws["slug"] == data["slug"] for ws in self.workspaces):
+                return httpx.Response(409, json={"detail": "slug exists"})
+            env_slug = data.get("initial_environment_slug") or "default"
+            ws = self.add_workspace(data["name"], data["slug"], env_slugs=(env_slug,))
+            return httpx.Response(
+                201,
+                json={
+                    "id": ws["id"],
+                    "name": ws["name"],
+                    "slug": ws["slug"],
+                    "description": None,
+                    "is_personal": False,
+                },
+            )
+
+        if path == "/api/v1/auth/exchange" and method == "POST":
+            data = json.loads(request.content)
+            return httpx.Response(
+                200,
+                json={
+                    "access_token": f"ws-token-{data['workspace_id']}",
+                    "expires_in": 600,
+                },
+            )
+
+        parts = path.strip("/").split("/")
+        # /api/v1/ui/workspaces/{ws}/environments[...]
+        if len(parts) >= 6 and parts[3] == "workspaces" and parts[5] == "environments":
+            ws = self._find_workspace(parts[4])
+            if len(parts) == 6:
+                if method == "GET":
+                    return httpx.Response(
+                        200,
+                        json=[
+                            {
+                                "id": env["id"],
+                                "workspace_id": ws["id"],
+                                "name": env["name"],
+                                "slug": env["slug"],
+                                "description": None,
+                            }
+                            for env in ws["envs"].values()
+                        ],
+                    )
+                if method == "POST":
+                    data = json.loads(request.content)
+                    env = {
+                        "id": str(uuid4()),
+                        "slug": data["slug"],
+                        "name": data["name"],
+                        "target_roots": [],
+                    }
+                    ws["envs"][data["slug"]] = env
+                    return httpx.Response(
+                        201,
+                        json={
+                            "id": env["id"],
+                            "workspace_id": ws["id"],
+                            "name": env["name"],
+                            "slug": env["slug"],
+                            "description": None,
+                        },
+                    )
+            env = next(e for e in ws["envs"].values() if e["id"] == parts[6])
+            if len(parts) == 8 and parts[7] == "target-roots":
+                if method == "GET":
+                    return httpx.Response(200, json=env["target_roots"])
+                if method == "POST":
+                    data = json.loads(request.content)
+                    root = {
+                        "id": str(uuid4()),
+                        "environment_id": env["id"],
+                        "name": data["name"],
+                        "uri_prefix": data["uri_prefix"],
+                        "created_at": "2026-01-01T00:00:00",
+                    }
+                    env["target_roots"].append(root)
+                    return httpx.Response(201, json=root)
+            if len(parts) == 8 and parts[7] == "api-keys" and method == "POST":
+                data = json.loads(request.content)
+                self.api_key_requests.append(
+                    {"environment_id": env["id"], "name": data["name"]}
+                )
+                return httpx.Response(
+                    201,
+                    json={
+                        "id": str(uuid4()),
+                        "environment_id": env["id"],
+                        "name": data["name"],
+                        "key_prefix": "sk_test1234",
+                        "created_by_id": self.user_id,
+                        "created_at": "2026-01-01T00:00:00",
+                        "last_used_at": None,
+                        "revoked_at": None,
+                        "key": "sk_test1234_full_key_value",
+                    },
+                )
+
+        raise AssertionError(f"Unexpected request: {method} {path}")
+
+
+@pytest.fixture
+def isolated_home(monkeypatch: pytest.MonkeyPatch, tmp_path):
+    """Point ~ (and the stardag config dir) at a temp directory."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("STARDAG_PROFILE", raising=False)
+    from stardag.config.loader import clear_config_cache
+
+    clear_config_cache()
+    yield tmp_path
+    clear_config_cache()
+
+
+class _SecretPushRecorder:
+    def __init__(self):
+        self.calls: list[tuple] = []
+
+    def __call__(self, secret_name, env_dict, modal_env):
+        self.calls.append((secret_name, env_dict, modal_env))
+
+
+def _run_connect(
+    api: FakeRegistryApi, **kwargs
+) -> tuple[ConnectOutcome, "_SecretPushRecorder"]:
+    push = _SecretPushRecorder()
+    outcome = run_connect(
+        API_URL,
+        "session-token",
+        api.user_email,
+        push_modal_secret=push,
+        transport=httpx.MockTransport(api.handler),
+        **kwargs,
+    )
+    return outcome, push
+
+
+def test_connect_personal_workspace(isolated_home):
+    """Personal Modal workspace: personal Stardag workspace + main env
+    (pre-created server-side), API key pushed to the default Modal env."""
+    api = FakeRegistryApi()
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("local", "main")
+    )
+
+    outcome, push = _run_connect(api, primary_workspace=None)
+
+    assert outcome.workspace_slug == "admin"
+    assert outcome.workspace_is_personal is True
+    assert outcome.workspace_created is False
+    assert outcome.environment_slug == "main"
+    assert outcome.environment_created is False
+    assert outcome.target_root == ("default", "modalvol://stardag/admin")
+    assert outcome.api_key_name == "modal-default"
+    assert outcome.modal_secret_name == API_KEY_SECRET_NAME
+
+    # API key pushed as Modal secret into the default (None) Modal env
+    assert len(push.calls) == 1
+    secret_name, env_dict, modal_env = push.calls[0]
+    assert secret_name == API_KEY_SECRET_NAME
+    assert env_dict == {"STARDAG_API_KEY": "sk_test1234_full_key_value"}
+    assert modal_env is None
+
+    # Local SDK config written
+    from stardag._cli.credentials import list_profiles, list_registries
+
+    assert list_registries() == {"selfhosted": API_URL}
+    profiles = list_profiles()
+    assert profiles["selfhosted"] == {
+        "registry": "selfhosted",
+        "user": "admin@example.com",
+        "workspace": "admin",
+        "environment": "main",
+    }
+
+
+def test_connect_creates_primary_workspace(isolated_home):
+    """Shared Modal workspace: the primary Stardag workspace + main env are
+    created via the API when missing (e.g. OIDC mode or --skip-connect)."""
+    api = FakeRegistryApi()
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("local",)
+    )
+
+    outcome, push = _run_connect(
+        api, primary_workspace="Acme Corp", execution_modal_env="staging"
+    )
+
+    assert outcome.workspace_name == "Acme Corp"
+    assert outcome.workspace_slug == "acme-corp"
+    assert outcome.workspace_created is True
+    assert outcome.workspace_is_personal is False
+    # main env was included in workspace creation, so not created separately
+    assert outcome.environment_created is False
+    assert outcome.target_root == ("default", "modalvol://stardag/acme-corp")
+    assert outcome.api_key_name == "modal-staging"
+    assert push.calls[0][2] == "staging"
+    assert api.api_key_requests[0]["name"] == "modal-staging"
+
+
+def test_connect_existing_primary_workspace_idempotent(isolated_home):
+    """Re-running connect matches the existing workspace/env/target root."""
+    api = FakeRegistryApi()
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("local",)
+    )
+    ws = api.add_workspace("Acme Corp", "acme-corp", env_slugs=("main",))
+    env = ws["envs"]["main"]
+    env["target_roots"].append(
+        {
+            "id": str(uuid4()),
+            "environment_id": env["id"],
+            "name": "default",
+            "uri_prefix": "modalvol://custom/acme",
+            "created_at": "2026-01-01T00:00:00",
+        }
+    )
+
+    outcome, _ = _run_connect(api, primary_workspace="Acme Corp")
+
+    assert outcome.workspace_created is False
+    assert outcome.environment_created is False
+    # Existing target root is kept, not overwritten
+    assert outcome.target_root == ("default", "modalvol://custom/acme")
+    assert "POST /api/v1/ui/workspaces" not in api.requests
+
+
+def test_connect_creates_missing_environment(isolated_home):
+    """The primary env is created when absent (e.g. pre-existing workspace)."""
+    api = FakeRegistryApi()
+    api.add_workspace("Acme Corp", "acme-corp", env_slugs=("default",))
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("local",)
+    )
+
+    outcome, _ = _run_connect(api, primary_workspace="Acme Corp")
+
+    assert outcome.environment_created is True
+    assert outcome.environment_slug == "main"
+
+
+def test_connect_target_root_override_and_skip(isolated_home):
+    api = FakeRegistryApi()
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("main",)
+    )
+    outcome, _ = _run_connect(
+        api,
+        primary_workspace=None,
+        target_root=("blobs", "modalvol://myvol/data"),
+    )
+    assert outcome.target_root == ("blobs", "modalvol://myvol/data")
+
+    api2 = FakeRegistryApi()
+    api2.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("main",)
+    )
+    outcome2, _ = _run_connect(api2, primary_workspace=None, no_target_root=True)
+    assert outcome2.target_root is None
+    assert not any("target-roots" in r for r in api2.requests)
+
+
+def test_connect_modal_secret_push_failure_is_not_fatal(isolated_home):
+    """A failed Modal secret push degrades gracefully: config still written."""
+    api = FakeRegistryApi()
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("main",)
+    )
+
+    def failing_push(*args):
+        raise RuntimeError("modal down")
+
+    outcome = run_connect(
+        API_URL,
+        "session-token",
+        api.user_email,
+        primary_workspace=None,
+        push_modal_secret=failing_push,
+        transport=httpx.MockTransport(api.handler),
+    )
+    assert outcome.api_key_name is None
+    assert outcome.modal_secret_name is None
+
+    from stardag._cli.credentials import list_registries
+
+    assert list_registries() == {"selfhosted": API_URL}

--- a/lib/stardag/tests/test_selfhost/test_complete_setup.py
+++ b/lib/stardag/tests/test_selfhost/test_complete_setup.py
@@ -172,10 +172,10 @@ def fake_secret_objects(monkeypatch: pytest.MonkeyPatch) -> _FakeSecretObjects:
 
 
 def test_push_secret_passes_environment(fake_secret_objects: _FakeSecretObjects):
-    _push_secret("my-secret", {"A": "1"}, "stardag-server")
+    _push_secret("my-secret", {"A": "1"}, "stardag-host")
     assert fake_secret_objects.calls == [
-        ("delete", "my-secret", "stardag-server"),
-        ("create", "my-secret", "stardag-server", {"A": "1"}),
+        ("delete", "my-secret", "stardag-host"),
+        ("create", "my-secret", "stardag-host", {"A": "1"}),
     ]
 
 
@@ -193,8 +193,8 @@ def test_secret_exists_passes_environment(monkeypatch: pytest.MonkeyPatch):
         return FakeRef()
 
     monkeypatch.setattr(modal.Secret, "from_name", fake_from_name)
-    assert _secret_exists("my-secret", "stardag-server") is False
-    assert seen == [("my-secret", "stardag-server")]
+    assert _secret_exists("my-secret", "stardag-host") is False
+    assert seen == [("my-secret", "stardag-host")]
 
 
 def test_ensure_jwt_secret_creates_in_environment(
@@ -203,9 +203,9 @@ def test_ensure_jwt_secret_creates_in_environment(
     monkeypatch.setattr(
         "stardag._cli.selfhost._secret_exists", lambda name, env=None: False
     )
-    assert _ensure_jwt_secret("app-jwt", "stardag-server") is True
+    assert _ensure_jwt_secret("app-jwt", "stardag-host") is True
     kinds = [(kind, name, env) for kind, name, env, *rest in fake_secret_objects.calls]
-    assert ("create", "app-jwt", "stardag-server") in kinds
+    assert ("create", "app-jwt", "stardag-host") in kinds
 
 
 def test_resolve_keep_warm_passes_environment(monkeypatch: pytest.MonkeyPatch):
@@ -219,8 +219,8 @@ def test_resolve_keep_warm_passes_environment(monkeypatch: pytest.MonkeyPatch):
         return store
 
     monkeypatch.setattr(modal.Dict, "from_name", fake_from_name)
-    assert _resolve_keep_warm("myapp", 1, "stardag-server") == 1
-    assert envs == ["stardag-server"]
+    assert _resolve_keep_warm("myapp", 1, "stardag-host") == 1
+    assert envs == ["stardag-host"]
 
 
 def test_build_server_app_resolves_secrets_in_environment(
@@ -237,10 +237,34 @@ def test_build_server_app_resolves_secrets_in_environment(
 
     monkeypatch.setattr(modal.Secret, "from_name", recording_from_name)
     build_server_app(server_version="1.2.3", environment_name=DEFAULT_SERVER_MODAL_ENV)
+    # Secret names derive from the default app name ("server")
     assert seen == [
-        ("stardag-server-config", DEFAULT_SERVER_MODAL_ENV),
-        ("stardag-server-jwt", DEFAULT_SERVER_MODAL_ENV),
+        ("server-config", DEFAULT_SERVER_MODAL_ENV),
+        ("server-jwt", DEFAULT_SERVER_MODAL_ENV),
     ]
+
+
+def test_default_names_avoid_doubled_url_label():
+    """The Modal env and app name differ, so the default URL reads
+    ...-stardag-host--server.modal.run rather than a doubled label."""
+    from stardag.selfhost._modal_app import (
+        DEFAULT_APP_NAME,
+        DEFAULT_SERVER_MODAL_ENV,
+    )
+
+    assert DEFAULT_APP_NAME == "server"
+    assert DEFAULT_SERVER_MODAL_ENV == "stardag-host"
+    assert DEFAULT_APP_NAME != DEFAULT_SERVER_MODAL_ENV
+
+
+def test_default_target_root_uri_namespaces_by_workspace():
+    from stardag._cli._selfhost_connect import default_target_root_uri
+
+    assert (
+        default_target_root_uri("acme-corp") == "modalvol://stardag-targets/acme-corp"
+    )
+    # The workspace slug is retained (namespacing), not dropped
+    assert default_target_root_uri("acme-corp").endswith("/acme-corp")
 
 
 # ---------------------------------------------------------------------------
@@ -483,7 +507,7 @@ def test_connect_personal_workspace(isolated_home):
     assert outcome.workspace_created is False
     assert outcome.environment_slug == "main"
     assert outcome.environment_created is False
-    assert outcome.target_root == ("default", "modalvol://stardag/admin")
+    assert outcome.target_root == ("default", "modalvol://stardag-targets/admin")
     assert outcome.api_key_name == "modal-default"
     assert outcome.modal_secret_name == API_KEY_SECRET_NAME
 
@@ -525,7 +549,7 @@ def test_connect_creates_primary_workspace(isolated_home):
     assert outcome.workspace_is_personal is False
     # main env was included in workspace creation, so not created separately
     assert outcome.environment_created is False
-    assert outcome.target_root == ("default", "modalvol://stardag/acme-corp")
+    assert outcome.target_root == ("default", "modalvol://stardag-targets/acme-corp")
     assert outcome.api_key_name == "modal-staging"
     assert push.calls[0][2] == "staging"
     assert api.api_key_requests[0]["name"] == "modal-staging"

--- a/lib/stardag/tests/test_selfhost/test_image_source.py
+++ b/lib/stardag/tests/test_selfhost/test_image_source.py
@@ -79,3 +79,98 @@ def test_build_server_app_prebuilt_needs_no_repo():
 
     app, functions = build_server_app(server_version="1.2.3")
     assert set(functions) == {"web", "migrate"}
+
+
+# ---------------------------------------------------------------------------
+# Client-Python / image-Python matching (serialized=True functions are
+# cloudpickled by the client and unpickled in the image: versions must match)
+# ---------------------------------------------------------------------------
+
+
+def test_client_python_version_matches_interpreter(monkeypatch: pytest.MonkeyPatch):
+    import sys
+
+    from stardag.selfhost._modal_app import client_python_version
+
+    monkeypatch.setattr(sys, "version_info", (3, 14, 0, "final", 0))
+    assert client_python_version() == "3.14"
+
+
+def test_client_python_version_rejects_too_old(monkeypatch: pytest.MonkeyPatch):
+    import sys
+
+    from stardag.selfhost._modal_app import client_python_version
+
+    monkeypatch.setattr(sys, "version_info", (3, 9, 0, "final", 0))
+    with pytest.raises(RuntimeError, match="requires Python >= 3.10"):
+        client_python_version()
+
+
+def _record_add_python(monkeypatch: pytest.MonkeyPatch) -> dict:
+    import modal
+
+    seen: dict = {}
+    real_from_registry = modal.Image.from_registry
+
+    def recording_from_registry(ref, **kwargs):
+        if "add_python" in kwargs:
+            seen["add_python"] = kwargs["add_python"]
+        return real_from_registry(ref, **kwargs)
+
+    monkeypatch.setattr(modal.Image, "from_registry", recording_from_registry)
+    return seen
+
+
+def test_build_server_app_from_source_uses_client_python(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """The from-source image's Python defaults to the running interpreter's."""
+    import sys
+
+    from stardag.selfhost._modal_app import build_server_app
+
+    monkeypatch.setattr(sys, "version_info", (3, 13, 1, "final", 0))
+    seen = _record_add_python(monkeypatch)
+    build_server_app(repo_root=REPO_ROOT)
+    assert seen["add_python"] == "3.13"
+
+
+def test_build_server_app_from_source_python_override(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from stardag.selfhost._modal_app import build_server_app
+
+    seen = _record_add_python(monkeypatch)
+    build_server_app(repo_root=REPO_ROOT, python_version="3.11")
+    assert seen["add_python"] == "3.11"
+
+
+def test_prebuilt_image_python_constant_matches_dockerfile():
+    """PREBUILT_IMAGE_PYTHON must track app/server.Dockerfile's base image."""
+    from stardag.selfhost._modal_app import PREBUILT_IMAGE_PYTHON
+
+    dockerfile = (REPO_ROOT / "app" / "server.Dockerfile").read_text()
+    expected = "FROM python:{}.{}-slim".format(*PREBUILT_IMAGE_PYTHON)
+    assert expected in dockerfile
+
+
+def test_check_prebuilt_python_matching(monkeypatch: pytest.MonkeyPatch):
+    import sys
+
+    from stardag._cli.selfhost import _check_prebuilt_python
+    from stardag.selfhost._modal_app import PREBUILT_IMAGE_PYTHON
+
+    monkeypatch.setattr(sys, "version_info", (*PREBUILT_IMAGE_PYTHON, 0, "final", 0))
+    _check_prebuilt_python()  # no-op
+
+
+def test_check_prebuilt_python_mismatch_fails_fast(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import sys
+
+    from stardag._cli.selfhost import _check_prebuilt_python
+
+    monkeypatch.setattr(sys, "version_info", (3, 14, 0, "final", 0))
+    with pytest.raises(typer.Exit):
+        _check_prebuilt_python()


### PR DESCRIPTION
> **Stacked PR**: based on `server-release-pipeline` (#191). Only the last three commits are new here.

## Motivation

`stardag self-host up` previously left you with a bare server: you still had to add a registry entry, log in, create a workspace/environment, mint an API key, push it to Modal, and configure a target root before the first DAG could run. This PR makes `up` finish the job, mirroring Modal's own workspace/environment model:

- **Shared Modal workspace** (team account): you get a shared Stardag workspace with the same name — teammates who sign in land in the same place.
- **Personal Modal workspace**: your personal Stardag workspace is used — no artificial shared workspace.
- Either way, a **`main` Stardag environment** mirrors Modal's default environment, and DAG execution on Modal is wired up with one API key.

## What the defaults create

| What | Default | Purpose |
| --- | --- | --- |
| Modal environment `stardag-server` | server app + `-config`/`-jwt` secrets + `-meta` Dict | Isolates the server from the Modal environments where DAG apps run |
| Stardag workspace | named after the shared Modal workspace, or the personal workspace | Mirrors the Modal account structure |
| Stardag environment | `main` | Mirrors Modal's default environment |
| API key → Modal secret `stardag-api-key` | pushed into the DAG-execution Modal environment (account default) | Modal-executed DAGs authenticate against the registry |
| Target root `default` | `modalvol://stardag/<workspace-slug>` | Task outputs on a Modal volume |
| Local registry + profile `selfhosted` | `~/.stardag/config.toml` | SDK/CLI ready immediately |

The connect phase is also a standalone, idempotent command: `stardag self-host connect` (re-runs, `--skip-connect` recovery, OIDC mode).

## Server-side bootstrap (local auth mode)

New `AUTH_PRIMARY_WORKSPACE_NAME` / `AUTH_PRIMARY_WORKSPACE_ENVIRONMENT` (default `main`, empty disables) settings: startup idempotently ensures the named shared workspace (bootstrap admin as owner) + environment — or the environment in the admin's personal workspace when no name is set. The CLI bakes these into the config secret so the server provisions them on first boot. No-op in OIDC mode.

## Flags

| Flag | Commands | Default |
| --- | --- | --- |
| `--server-modal-env` | up/connect/upgrade/status/destroy | `stardag-server` (created on demand; `''` = Modal default env, for pre-existing deployments) |
| `--primary-workspace` / `--no-primary-workspace` | up/connect | shared Modal workspace name / skipped for personal accounts |
| `--execution-modal-env` | up/connect | account's default Modal environment |
| `--target-root name=uri` / `--no-target-root` | up/connect | `default=modalvol://stardag/<workspace-slug>` |
| `--registry-name` / `--profile-name` | up/connect | `selfhosted` |
| `--skip-connect` | up | off |

Every prompt has a flag equivalent; `--yes` takes all defaults.

## OIDC mode

Server-side bootstrap is local-mode-only, so `up --auth-mode oidc` prints a pointer to `stardag self-host connect`, which runs the same browser PKCE login as `stardag auth login` and then provisions workspace/environment/API key/target root/profile via the API (the workspace-create and `/auth/exchange` endpoints accept the login token directly).

## Tests

- `app/stardag-api`: 358 passed, 18 skipped — includes new `test_primary_workspace.py` (shared-name workspace + owner + `main` env, personal-workspace env, idempotency on restart, no demotion of adjusted memberships, OIDC/unset no-ops, empty-env disable).
- `lib/stardag`: 751 passed (full unit suite) — new `test_selfhost/test_complete_setup.py` covers primary-workspace derivation (shared/personal/explicit/opt-out/interactive), `environment_name` plumbing for secrets/Dict/`build_server_app` (mocked Modal), and the connect flow end-to-end against a mocked registry API (`httpx.MockTransport`, isolated home dir): personal + created + existing-idempotent workspace paths, missing-env creation, target-root override/skip/keep-existing, non-fatal Modal-secret push failure.
- `docs`: `mkdocs build` clean.

## Notes

- `--execution-modal-env` defaults to *Modal's default environment* (push with `environment_name=None`) rather than hard-coding `main` — same result for standard accounts, but robust for workspaces whose default env is named differently.
- `upgrade`/`status`/`destroy` against deployments created by older SDK versions (whose objects live in the default Modal env) work via `--server-modal-env ''`; the `upgrade` missing-secret error says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf