### PR TITLE
CDK/ECS API image: stamp STARDAG_SERVER_VERSION (git-describe) so /version isn't 'dev'

### DIFF
--- a/app/stardag-api/Dockerfile
+++ b/app/stardag-api/Dockerfile
@@ -16,6 +16,13 @@ RUN uv pip install --system .
 COPY alembic.ini .
 COPY migrations/ migrations/
 
+# Server version, surfaced at GET /api/v1/version (read from this env var by
+# stardag_api.main). Injected at build time by infra/aws-cdk/scripts/deploy-api.sh
+# from scripts/server-version.sh (git-describe). Defaults to "dev" when unset.
+# Placed near the end so changing it only rebuilds the trivial trailing layers.
+ARG STARDAG_SERVER_VERSION=dev
+ENV STARDAG_SERVER_VERSION=${STARDAG_SERVER_VERSION}
+
 EXPOSE 8000
 
 # gunicorn with multiple uvicorn workers absorbs CPU-bound bursts (auth /

--- a/infra/aws-cdk/README.md
+++ b/infra/aws-cdk/README.md
@@ -55,6 +55,34 @@ For first-time deployments, the correct order is:
 
 The `deploy-all.sh` script handles this automatically.
 
+## Server version stamping
+
+`deploy-api.sh` stamps a server version into the locally-built API image via
+the `STARDAG_SERVER_VERSION` build arg, so the deployment reports a truthful
+version at `GET /api/v1/version` instead of the `"dev"` default.
+
+The version is resolved in this order:
+
+1. An already-exported `$STARDAG_SERVER_VERSION` (set it explicitly to override).
+2. Otherwise `scripts/server-version.sh` (git-describe against `server-v*` tags):
+   - exactly at a `server-vX.Y.Z` tag → `X.Y.Z`
+   - `N` commits past the nearest tag → `X.Y.Z+N.g<sha>`
+   - no `server-v*` tag reachable → `0.0.0+g<sha>`
+   - not a git checkout → `dev`
+3. If the script is missing or errors, it falls back to `"dev"` — versioning
+   never fails the deploy.
+
+**CI caveat — check out tags.** A clean tagged version requires the `server-v*`
+tags to be present in the checkout. A shallow or tagless CI checkout yields
+`0.0.0+g<sha>` or `"dev"`. In CI, check out with full history and tags — e.g.
+`actions/checkout` with `fetch-depth: 0` (and the same for any submodule
+checkout that contains this repo) — so `server-version.sh` can find the tags.
+Deployments degrade gracefully to a sha-based or `dev` version otherwise; no
+consumer code change is needed beyond ensuring tags are fetched.
+
+Prebuilt public images (`--image-uri …`) are already stamped at publish time
+by the release workflow, so this only concerns the local docker build path.
+
 ## Use Prebuilt Public Images (no local builds)
 
 Each server release (git tag `server-vX.Y.Z`) publishes:

--- a/infra/aws-cdk/scripts/deploy-api.sh
+++ b/infra/aws-cdk/scripts/deploy-api.sh
@@ -137,13 +137,32 @@ echo "=== Logging in to ECR ==="
 $AWS_CMD ecr get-login-password --region $AWS_REGION | \
     docker login --username AWS --password-stdin "${ECR_URI%%/*}"
 
+# Resolve the server version to stamp into the image (surfaced at
+# GET /api/v1/version; otherwise the deployment reports "dev").
+#
+# Honor an already-exported $STARDAG_SERVER_VERSION; otherwise derive it from
+# scripts/server-version.sh (git-describe). Never fail the deploy over
+# versioning: if the script is missing or errors, fall back to "dev".
+#
+# CAVEAT: server-version.sh needs the `server-v*` tags present in the checkout
+# to produce a clean X.Y.Z (or X.Y.Z+N.g<sha>); a shallow/tagless CI checkout
+# yields 0.0.0+g<sha> or "dev". CI should check out with full history and tags
+# (e.g. actions/checkout with fetch-depth: 0, including for submodules) for a
+# clean version. It degrades gracefully otherwise. See infra/aws-cdk/README.md.
+if [ -z "$STARDAG_SERVER_VERSION" ]; then
+    STARDAG_SERVER_VERSION="$(bash "$REPO_ROOT/scripts/server-version.sh" 2>/dev/null || echo dev)"
+fi
+echo "Server version (STARDAG_SERVER_VERSION): $STARDAG_SERVER_VERSION"
+
 # Build the API image
 echo ""
 echo "=== Building API Docker image ==="
 cd "$REPO_ROOT/app/stardag-api"
 
 IMAGE_TAG="${IMAGE_TAG:-latest}"
-docker build -t stardag-api:$IMAGE_TAG .
+docker build \
+    --build-arg STARDAG_SERVER_VERSION="$STARDAG_SERVER_VERSION" \
+    -t stardag-api:$IMAGE_TAG .
 
 # Tag and push to ECR
 echo ""


### PR DESCRIPTION
## What this does

The CDK/ECS API-only image (`app/stardag-api/Dockerfile`), built and pushed by `infra/aws-cdk/scripts/deploy-api.sh`, never set `STARDAG_SERVER_VERSION`, so AWS/self-host and production deployments reported `"dev"` at `GET /api/v1/version`. This makes those deployments report a truthful version.

- **`app/stardag-api/Dockerfile`**: add `ARG STARDAG_SERVER_VERSION=dev` + `ENV STARDAG_SERVER_VERSION=${STARDAG_SERVER_VERSION}`, placed near the end so overriding it only rebuilds the trivial trailing layers. The API already reads this env var (`stardag_api.main` → `/api/v1/version`).
- **`infra/aws-cdk/scripts/deploy-api.sh`**: resolve the version before the build — honor an already-exported `$STARDAG_SERVER_VERSION`, else `scripts/server-version.sh` (git-describe), else fall back to `"dev"` — and pass it as `--build-arg`. The resolved value is echoed for deploy logs. Versioning never fails the deploy.
- **`infra/aws-cdk/README.md`**: document the resolution order and the CI tags caveat.

`deploy-all.sh` builds the API image only by delegating to `deploy-api.sh`, so no separate change is needed there. Prebuilt public images (`--image-uri`) are already stamped at publish time.

## CI-tags caveat

`scripts/server-version.sh` derives the version from `git describe` against `server-v*` tags. A shallow or tagless CI checkout yields `0.0.0+g<sha>` or `"dev"`. For a clean tagged version, CI must check out with full history and tags (e.g. `actions/checkout` with `fetch-depth: 0`, including for any submodule checkout that contains this repo). It degrades gracefully otherwise.

## For downstream consumers

A consumer's deploy pipeline picks this up automatically on the next image build — no consumer code change is needed beyond ensuring the `server-v*` tags are fetched in CI.

## Verified

- `bash -n` on `deploy-api.sh` and `deploy-all.sh` (both OK).
- `server-version.sh` resolves correctly in a tagged checkout (`0.1.0+N.g<sha>`).
- `docker build --build-arg STARDAG_SERVER_VERSION=9.9.9-test` succeeds; `docker run ... printenv STARDAG_SERVER_VERSION` prints `9.9.9-test`.
- `pre-commit` (prettier) passes on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf