### PR TITLE
ui: don't render 'vdev' — prefix 'v' only for numeric server versions

### DIFF
--- a/app/stardag-ui/src/components/ServerVersionFooter.test.tsx
+++ b/app/stardag-ui/src/components/ServerVersionFooter.test.tsx
@@ -14,16 +14,28 @@ describe("ServerVersionFooter", () => {
     vi.unstubAllGlobals();
   });
 
-  it("shows the server version once loaded", async () => {
+  it("shows a numeric server version with a v prefix", async () => {
     fetchMock.mockResolvedValueOnce(
-      new Response(JSON.stringify({ server_version: "0.1.0", api_version: "0.0.1" }), {
+      new Response(
+        JSON.stringify({ server_version: "0.1.0+1.gabc", api_version: "0.0.1" }),
+        { status: 200 },
+      ),
+    );
+
+    render(<ServerVersionFooter />);
+    expect(await screen.findByText("Stardag server v0.1.0+1.gabc")).toBeInTheDocument();
+    expect(fetchMock.mock.calls[0][0] as string).toContain("/api/v1/version");
+  });
+
+  it("shows a non-numeric version (e.g. dev) without a v prefix", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ server_version: "dev", api_version: "0.0.1" }), {
         status: 200,
       }),
     );
 
     render(<ServerVersionFooter />);
-    expect(await screen.findByText("Stardag server v0.1.0")).toBeInTheDocument();
-    expect(fetchMock.mock.calls[0][0] as string).toContain("/api/v1/version");
+    expect(await screen.findByText("Stardag server dev")).toBeInTheDocument();
   });
 
   it("renders nothing while loading", () => {

--- a/app/stardag-ui/src/components/ServerVersionFooter.tsx
+++ b/app/stardag-ui/src/components/ServerVersionFooter.tsx
@@ -26,9 +26,13 @@ export function ServerVersionFooter() {
 
   if (!version) return null;
 
+  // Prefix "v" only for actual version numbers (e.g. "0.1.0+1.gabc" → "v0.1.0…");
+  // non-numeric labels like "dev" render as-is so it doesn't read "vdev".
+  const label = /^\d/.test(version) ? `v${version}` : version;
+
   return (
     <p className="mx-auto max-w-4xl px-4 pb-6 text-xs text-gray-400 dark:text-gray-500">
-      Stardag server v{version}
+      Stardag server {label}
     </p>
   );
 }


### PR DESCRIPTION
The settings-page `ServerVersionFooter` rendered `Stardag server v${version}` unconditionally, so a non-release build reporting `"dev"` displayed as "Stardag server **vdev**" (spotted live on app.stardag.com/settings).

Fix: prefix `v` only when the version starts with a digit; otherwise render the label as-is (`dev` → "Stardag server dev", `0.1.0+1.gabc` → "Stardag server v0.1.0+1.gabc"). Added a test for the non-numeric case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf