### PR TITLE
Release v0.15.0 — self-host on Modal + local auth mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-07-17
+
 ### SDK
 
 - **Self-host the Stardag service on Modal with one command

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,17 +6,20 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
-## Unreleased — Self-host the Stardag service on Modal
+## v0.15.0 — Self-host the Stardag service on Modal
 
 You can now run your own private Stardag service (Registry API + web UI)
 on [Modal](https://modal.com) with a single command — database on
 [Neon](https://neon.com), free-tier friendly, no AWS or Docker required:
 
 ```bash
-uvx --from "stardag[selfhost]" stardag self-host up
+uvx --python 3.12 --from "stardag[selfhost]" stardag self-host up
 # → prompts for a Neon API key and an admin account, then prints your UI URL
-uvx --from "stardag[selfhost]" stardag self-host upgrade   # migrate + redeploy
+uvx --python 3.12 --from "stardag[selfhost]" stardag self-host upgrade  # migrate + redeploy
 ```
+
+(The `--python 3.12` pin matches the prebuilt server image's interpreter,
+required for the default prebuilt deploy; see the guide for details.)
 
 Alongside it, a new **local authentication mode**: the self-hosted API
 manages email/password accounts directly (no external identity


### PR DESCRIPTION
Versions the `[Unreleased]` CHANGELOG + RELEASE_NOTES entry as **0.15.0** ahead of tagging. Minor bump: additive feature set (self-host CLI, local auth mode, runtime UI config), no SDK breaking changes.

After merge: tag `v0.15.0` → the Publish workflow builds + publishes to PyPI and creates the GitHub release. Then the docs' `uvx --from "stardag[selfhost]" stardag self-host up` flow works from PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf