### PR TITLE
self-host prebuilt: deploy Modal functions by-reference — drop the client Python 3.12 requirement (#196)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+- **`stardag self-host` prebuilt deploys no longer require a matching
+  client Python
+  ([#196](https://github.com/stardag-dev/stardag/issues/196)).** The
+  prebuilt-image path now defines the Modal `web`/`migrate` functions by
+  reference (`serialized=False`) against a module-level entry point that
+  Modal imports inside the server image, instead of cloudpickling closures
+  with the client interpreter. Because nothing is serialized, the CLI runs
+  under any supported Python (≥ 3.10) — the previous `uvx --python 3.12 …`
+  requirement (and its fail-fast check) is gone. `--from-source` is
+  unchanged (still serialized closures with a client-matched image Python).
+
 ## [0.15.0] — 2026-07-17
 
 ### SDK

--- a/DEV_README.md
+++ b/DEV_README.md
@@ -226,15 +226,15 @@ The image definition is `app/server.Dockerfile` (build context = repo root):
 docker build -f app/server.Dockerfile -t stardag-server .
 ```
 
-> **Python version coupling:** the Dockerfile's base Python version must
-> stay in sync with `PREBUILT_IMAGE_PYTHON` in
-> `lib/stardag/src/stardag/selfhost/_modal_app.py` — the self-host CLI
-> serializes Modal functions with the client interpreter and checks it
-> against that constant before deploying the prebuilt image. Bumping one
-> without the other breaks (or wrongly blocks) `stardag self-host up`.
-> A unit test (`test_prebuilt_image_python_constant_matches_dockerfile`)
-> guards the pairing; docs referencing `uvx --python 3.12 ...` need the
-> same bump.
+> **Python versions are decoupled for the prebuilt path.** `stardag
+self-host up` deploys the prebuilt image by _reference_: it points the
+> Modal `web`/`migrate` functions at module-level entry points in
+> `lib/stardag/src/stardag/selfhost/_modal_entry.py` (`serialized=False`),
+> which Modal imports inside the image. Nothing is cloudpickled, so the
+> CLI's interpreter is independent of the Dockerfile's base Python — bump
+> the Dockerfile freely. (Only `--from-source` still serializes function
+> bodies with the client interpreter, and there the image's Python is
+> matched to it automatically.)
 
 To release, push a `server-vX.Y.Z` tag on `main`:
 

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -48,13 +48,11 @@ that via the API (Postgres 16, project name `stardag`).
 ### 3. Deploy
 
 ```bash
-uvx --python 3.12 --from "stardag[selfhost]" stardag self-host up
+uvx --from "stardag[selfhost]" stardag self-host up
 ```
 
-(`--python 3.12` matches the CLI's interpreter to the prebuilt server
-image's Python — required because the deploy serializes functions with your
-local interpreter. The CLI checks this and tells you the remedy if it
-doesn't match.)
+(Any Python ≥ 3.10 works — the prebuilt image is deployed by reference, so
+the CLI's interpreter is independent of the image's.)
 
 The command walks you through the rest interactively:
 
@@ -108,7 +106,7 @@ stardag self-host connect
 ## Updating to a new version
 
 ```bash
-uvx --python 3.12 --from "stardag[selfhost]" stardag self-host upgrade
+uvx --from "stardag[selfhost]" stardag self-host upgrade
 ```
 
 This applies any new database migrations and redeploys the API + UI. Each
@@ -140,10 +138,10 @@ uvx --from "stardag[selfhost]" stardag self-host up --from-source
 
 The image is then built from the checkout: the UI is compiled with npm
 inside the Modal image build (no local Node needed) and the API package is
-installed from source. The image's Python is matched to the interpreter
-running the CLI (any Python ≥ 3.10 works — no `--python 3.12` needed in
-this mode). `upgrade --from-source` redeploys after local changes or a
-`git pull`.
+installed from source. In this mode the function bodies are serialized with
+the CLI's interpreter, so the image's Python is matched to it automatically
+(any Python ≥ 3.10 works). `upgrade --from-source` redeploys after local
+changes or a `git pull`.
 
 ## Auth mode: `local` (default)
 
@@ -166,7 +164,7 @@ authorization code + PKCE, RS256 tokens). A good free option is
 [Auth0](https://auth0.com)'s free tier also works.
 
 ```bash
-uvx --python 3.12 --from "stardag[selfhost]" stardag self-host up --auth-mode oidc \
+uvx --from "stardag[selfhost]" stardag self-host up --auth-mode oidc \
   --oidc-issuer https://<your-idp-issuer> \
   --oidc-ui-client-id <client-id>
 ```
@@ -177,7 +175,7 @@ browser for the OIDC login, then creates the workspace, `main` environment,
 API key, and local profile exactly like the local-mode flow:
 
 ```bash
-uvx --python 3.12 --from "stardag[selfhost]" stardag self-host connect
+uvx --from "stardag[selfhost]" stardag self-host connect
 ```
 
 Provider setup (example: WorkOS AuthKit):
@@ -259,12 +257,13 @@ equivalent):
 
 - **First request hangs a few seconds** — cold start (Modal container boot
   - Neon wake). Expected with scale-to-zero; use `--keep-warm 1` to avoid.
-- **`InvalidError: The 'migrate' Function (using serialized=True) was defined with Python 3.X, but its Image has 3.12`**
-  — the CLI's interpreter must match the server image's Python. For the
-  prebuilt image, run under 3.12 (`uvx --python 3.12 ...` as in the
-  quickstart — recent CLI versions catch this before deploying); with
-  `--from-source` the image is built to match your interpreter
-  automatically.
+- **`InvalidError: The 'migrate' Function (using serialized=True) was defined with Python 3.X, but its Image has 3.Y`**
+  — only possible with `--from-source`, where the CLI serializes the
+  function bodies with your interpreter and the image is normally built to
+  match it. If you see it, drop any `--python`/`python_version` override so
+  the image tracks your interpreter. The default prebuilt path is deployed
+  by reference (not serialized), so it is immune to this and runs under any
+  Python ≥ 3.10.
 - **`Modal authentication not set up`** — run `uvx modal token new`.
 - **`Neon API key rejected`** — create a key at
   [console.neon.tech/app/settings/api-keys](https://console.neon.tech/app/settings/api-keys).

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -40,7 +40,6 @@ from stardag.selfhost._modal_app import (
     DEFAULT_APP_NAME,
     DEFAULT_SERVER_MODAL_ENV,
     DEFAULT_SERVER_VERSION,
-    PREBUILT_IMAGE_PYTHON,
     build_server_app,
     find_repo_root,
     server_image_ref,
@@ -98,36 +97,6 @@ def _require_repo_root(repo: Path | None) -> Path:
         )
         raise typer.Exit(1)
     return root
-
-
-def _check_prebuilt_python() -> None:
-    """Fail fast when the client interpreter can't drive the prebuilt image.
-
-    The `migrate`/`web` Modal functions are serialized (cloudpickled) by the
-    running interpreter and unpickled inside the server image; Modal rejects
-    the deploy when the two Python versions differ (``InvalidError: ... was
-    defined with Python X.Y, but its Image has 3.12``). Check up front -
-    before any provisioning - and print the exact remedy.
-    """
-    import sys
-
-    running = tuple(sys.version_info[:2])
-    if running == PREBUILT_IMAGE_PYTHON:
-        return
-    expected = "{}.{}".format(*PREBUILT_IMAGE_PYTHON)
-    actual = "{}.{}".format(*running)
-    error_console.print(
-        f"The prebuilt server image runs Python {expected} but this CLI is "
-        f"running under {actual}; serialized Modal functions require "
-        "matching interpreter versions."
-    )
-    console.print(
-        "\nRe-run with a matching interpreter, e.g.:\n"
-        f"  [bold]uvx --python {expected} --from 'stardag[selfhost]' "
-        "stardag self-host up[/bold]\n"
-        "(or pass --from-source to build an image matching your interpreter)."
-    )
-    raise typer.Exit(1)
 
 
 def _resolve_image_source(
@@ -796,9 +765,7 @@ def up(
     repo_root, resolved_server_version = _resolve_image_source(
         repo, from_source, server_version
     )
-    if repo_root is None:
-        _check_prebuilt_python()
-    else:
+    if repo_root is not None:
         console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
     target_root_override = parse_target_root_flag(target_root) if target_root else None
 
@@ -1106,9 +1073,7 @@ def upgrade(
     repo_root, resolved_server_version = _resolve_image_source(
         repo, from_source, server_version
     )
-    if repo_root is None:
-        _check_prebuilt_python()
-    else:
+    if repo_root is not None:
         console.print(f"Using stardag repo: [bold]{repo_root}[/bold]")
     modal_info = _check_modal_auth()
     console.print(f"Modal workspace: [bold]{modal_info.display}[/bold]")

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -16,13 +16,26 @@ Two image modes:
 
 Both modes place the alembic config at ``/opt/stardag/api`` and the built
 UI at ``/opt/stardag/ui`` (see ``app/server.Dockerfile``), so the Modal
-function bodies are mode-agnostic.
+functions are mode-agnostic.
+
+The two modes define their Modal functions differently:
+
+- **From source** serializes closures (``serialized=True``): the function
+  bodies travel *by value*, so the freshly built image needn't contain the
+  code. Cloudpickle bytecode isn't portable across Python minors, so the
+  image's Python is matched to the client that pickles it.
+- **Prebuilt** references module-level functions in ``_modal_entry`` *by
+  name* (``serialized=False``): the image already ships ``stardag_api``, so
+  Modal imports the referenced functions in-container instead of unpickling
+  client bytes. Nothing is cloudpickled, so the client's own Python is
+  irrelevant to the deploy.
 """
 
 from __future__ import annotations
 
 import sys
 from pathlib import Path
+from types import ModuleType
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -51,15 +64,6 @@ SERVER_IMAGE_REPO = "ghcr.io/stardag-dev/stardag-server"
 # release time; override per deployment with --server-version.
 DEFAULT_SERVER_VERSION = "0.1.0"
 
-# Python (major, minor) baked into the prebuilt server image - MUST match
-# the base image in app/server.Dockerfile. The `migrate`/`web` functions are
-# serialized (cloudpickled) by the *client* interpreter and unpickled inside
-# the image, so Modal requires the two versions to match exactly; the CLI
-# fails fast with a remedy when they don't. Bumping the Dockerfile's Python
-# version must be coordinated with this constant (see DEV_README.md,
-# "Releasing the Server").
-PREBUILT_IMAGE_PYTHON = (3, 12)
-
 # Minimum client interpreter for from-source image builds (stardag-api's
 # requires-python; the image gets the client's version via add_python).
 MIN_IMAGE_PYTHON = (3, 10)
@@ -80,11 +84,13 @@ def client_python_version() -> str:
     """
     version = tuple(sys.version_info[:2])
     if version < MIN_IMAGE_PYTHON:
+        min_version = "{}.{}".format(*MIN_IMAGE_PYTHON)
         raise RuntimeError(
-            "The stardag server requires Python >= {}.{}".format(*MIN_IMAGE_PYTHON)
+            f"The stardag server requires Python >= {min_version}"
             + ", but this CLI is running under {}.{}".format(*version)
             + ". Re-run under a newer interpreter, e.g.: "
-            'uvx --python 3.12 --from "stardag[selfhost]" stardag self-host up'
+            f'uvx --python {min_version} --from "stardag[selfhost]" '
+            "stardag self-host up --from-source"
         )
     return "{}.{}".format(*version)
 
@@ -103,6 +109,37 @@ def find_repo_root(start: Path | None = None) -> Path | None:
     return None
 
 
+def _load_prebuilt_entry_module() -> ModuleType:
+    """Load ``_modal_entry`` as a standalone single-file module.
+
+    Loading it under a dotless name (rather than importing it as
+    ``stardag.selfhost._modal_entry``) makes Modal treat it as a *file*
+    entrypoint: it mounts just this one file into the container and imports
+    it there by its stem. Importing it as a package submodule instead would
+    make Modal (a) auto-mount the whole ``stardag`` package and (b) try to
+    ``import stardag.selfhost._modal_entry`` in-container — but the server
+    image ships only ``stardag_api``, not the ``stardag`` SDK.
+
+    The module is import-safe on a stardag-SDK-only client (its
+    ``stardag_api`` imports are deferred into the function bodies), so this
+    loads cleanly even though the client lacks ``stardag_api``.
+    """
+    import importlib.util
+
+    entry_path = Path(__file__).with_name("_modal_entry.py")
+    # A dotless module name keeps ``__package__`` empty, which is what makes
+    # Modal's FunctionInfo classify it as a single-file entrypoint.
+    module_name = "_modal_entry"
+    spec = importlib.util.spec_from_file_location(module_name, entry_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so inspect.getmodule() can resolve the functions
+    # back to this module when Modal builds the (by-reference) app graph.
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 def build_server_app(
     repo_root: Path | None = None,
     app_name: str = DEFAULT_APP_NAME,
@@ -116,14 +153,16 @@ def build_server_app(
     """Build the Modal app serving the Stardag service.
 
     When ``repo_root`` is None (default) the prebuilt public server image
-    ``ghcr.io/stardag-dev/stardag-server:<server_version>`` is used.
+    ``ghcr.io/stardag-dev/stardag-server:<server_version>`` is used and the
+    Modal functions are referenced *by name* from ``_modal_entry``
+    (``serialized=False``); the client's Python is irrelevant.
+
     When ``repo_root`` is given the image is built from that checkout
-    (``server_version`` is ignored). ``python_version`` applies to the
+    (``server_version`` is ignored) and the functions are serialized
+    closures (``serialized=True``). ``python_version`` applies to that
     from-source image only and defaults to the running interpreter's
-    version: the function bodies are serialized by *this* process, and
-    Modal requires the image's Python to match the serializing one. (The
-    prebuilt image is fixed at ``PREBUILT_IMAGE_PYTHON``; the CLI checks
-    the client interpreter against it before deploying.)
+    version: the closures are cloudpickled by *this* process, and Modal
+    requires the image's Python to match the pickling one.
 
     ``environment_name`` is the Modal environment the referenced secrets
     live in (the app itself is placed there by the caller at deploy time);
@@ -137,42 +176,6 @@ def build_server_app(
     config_secret_name = config_secret_name or f"{app_name}-config"
     jwt_secret_name = jwt_secret_name or f"{app_name}-jwt"
 
-    if repo_root is None:
-        # Prebuilt release image (public registry, no secret needed). The
-        # image ships python (PREBUILT_IMAGE_PYTHON) + the API package +
-        # built UI + alembic config at the same paths as the from-source
-        # build below.
-        image = modal.Image.from_registry(server_image_ref(server_version))
-    else:
-        api_dir = repo_root / "app" / "stardag-api"
-        ui_dir = repo_root / "app" / "stardag-ui"
-
-        image = (
-            # node:22-slim for the in-image UI build; add_python for the
-            # API - matching the client interpreter (see docstring)
-            modal.Image.from_registry(
-                "node:22-slim",
-                add_python=python_version or client_python_version(),
-            )
-            .add_local_dir(
-                ui_dir.as_posix(),
-                UI_SRC_REMOTE_DIR,
-                copy=True,
-                ignore=["node_modules", "dist", ".env", ".env.*"],
-            )
-            .run_commands(
-                f"cd {UI_SRC_REMOTE_DIR} && npm ci && npm run build"
-                f" && mv dist {UI_DIST_REMOTE_DIR}",
-            )
-            .add_local_dir(
-                api_dir.as_posix(),
-                API_REMOTE_DIR,
-                copy=True,
-                ignore=[".venv", "__pycache__", ".pytest_cache", "tests"],
-            )
-            .run_commands(f"python -m pip install {API_REMOTE_DIR}")
-        )
-
     app = modal.App(app_name)
     # The secrets must be resolved in the same Modal environment the app is
     # deployed to (from_name lookups are environment-scoped).
@@ -180,6 +183,101 @@ def build_server_app(
         modal.Secret.from_name(config_secret_name, environment_name=environment_name),
         modal.Secret.from_name(jwt_secret_name, environment_name=environment_name),
     ]
+
+    if repo_root is None:
+        return _build_prebuilt_app(app, secrets, app_name, server_version, keep_warm)
+    return _build_from_source_app(
+        app, secrets, app_name, repo_root, python_version, keep_warm
+    )
+
+
+def _build_prebuilt_app(
+    app: "modal.App",
+    secrets: list,
+    app_name: str,
+    server_version: str,
+    keep_warm: int,
+) -> tuple["modal.App", dict[str, Any]]:
+    """Prebuilt image path: functions referenced by-name (not serialized).
+
+    The released image ships python + the API package + built UI + alembic
+    config, so the ``web``/``migrate`` functions in ``_modal_entry`` are
+    referenced by (module, name) and imported in-container. No cloudpickle
+    happens, so the CLI's own interpreter version doesn't matter.
+    """
+    import modal
+
+    # Prebuilt release image (public registry, no secret needed).
+    image = modal.Image.from_registry(server_image_ref(server_version))
+    entry = _load_prebuilt_entry_module()
+
+    migrate = app.function(
+        image=image,
+        secrets=secrets,
+        serialized=False,
+        timeout=600,
+        name="migrate",
+    )(entry.migrate)
+
+    web_wrapped = modal.asgi_app(label=app_name)(entry.web)
+    web = app.function(
+        image=image,
+        secrets=secrets,
+        serialized=False,
+        min_containers=keep_warm or None,
+        scaledown_window=300,
+        timeout=300,
+        name="web",
+    )(modal.concurrent(max_inputs=100)(web_wrapped))
+
+    return app, {"web": web, "migrate": migrate}
+
+
+def _build_from_source_app(
+    app: "modal.App",
+    secrets: list,
+    app_name: str,
+    repo_root: Path,
+    python_version: str | None,
+    keep_warm: int,
+) -> tuple["modal.App", dict[str, Any]]:
+    """From-source path: image built from a checkout; functions serialized.
+
+    The image is built fresh (UI compiled with npm inside the build, API
+    pip-installed from source), so it needn't contain the code the closures
+    reference - ``serialized=True`` ships the bodies by value. That requires
+    the image's Python to match this interpreter (see ``client_python_version``).
+    """
+    import modal
+
+    api_dir = repo_root / "app" / "stardag-api"
+    ui_dir = repo_root / "app" / "stardag-ui"
+
+    image = (
+        # node:22-slim for the in-image UI build; add_python for the
+        # API - matching the client interpreter (see docstring)
+        modal.Image.from_registry(
+            "node:22-slim",
+            add_python=python_version or client_python_version(),
+        )
+        .add_local_dir(
+            ui_dir.as_posix(),
+            UI_SRC_REMOTE_DIR,
+            copy=True,
+            ignore=["node_modules", "dist", ".env", ".env.*"],
+        )
+        .run_commands(
+            f"cd {UI_SRC_REMOTE_DIR} && npm ci && npm run build"
+            f" && mv dist {UI_DIST_REMOTE_DIR}",
+        )
+        .add_local_dir(
+            api_dir.as_posix(),
+            API_REMOTE_DIR,
+            copy=True,
+            ignore=[".venv", "__pycache__", ".pytest_cache", "tests"],
+        )
+        .run_commands(f"python -m pip install {API_REMOTE_DIR}")
+    )
 
     # NOTE: the function bodies below are defined as closures (not module-
     # level functions) on purpose: serialized=True pickles closures BY VALUE,

--- a/lib/stardag/src/stardag/selfhost/_modal_entry.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_entry.py
@@ -1,0 +1,54 @@
+"""Module-level Modal entry points for the *prebuilt* self-host server image.
+
+The prebuilt server image already contains ``stardag_api`` (and the built
+UI + alembic config), so shipping cloudpickled function bodies to it is
+redundant. Instead ``build_server_app`` references the ``web`` / ``migrate``
+functions below *by name* (``serialized=False``): Modal ships this single
+file into the container and imports it there, then calls the referenced
+function. Because nothing is cloudpickled, the CLI's own interpreter no
+longer has to match the image's Python.
+
+Two invariants make that work:
+
+- **Import-safe on a stardag-SDK-only client.** ``build_server_app`` imports
+  this module to build the (by-reference) app graph, and the client does not
+  have ``stardag_api`` installed. So every ``stardag_api`` import stays
+  inside a function body, evaluated only in-container.
+- **Loaded as a standalone single-file module** (see
+  ``_load_prebuilt_entry_module`` in ``_modal_app.py``): Modal then treats it
+  as a file entrypoint, mounting just this file and importing it in the
+  container by its stem — rather than trying to import it as a submodule of
+  the ``stardag`` package, which the server image doesn't contain.
+
+The container paths below mirror ``app/server.Dockerfile``'s layout contract
+(kept in sync with ``_modal_app.py``); they are resolved in-image.
+"""
+
+from __future__ import annotations
+
+API_REMOTE_DIR = "/opt/stardag/api"
+UI_DIST_REMOTE_DIR = "/opt/stardag/ui"
+
+
+def migrate() -> str:
+    """Run ``alembic upgrade head`` inside the server container."""
+    import subprocess
+
+    result = subprocess.run(
+        ["python", "-m", "alembic", "-c", "alembic.ini", "upgrade", "head"],
+        cwd=API_REMOTE_DIR,
+        capture_output=True,
+        text=True,
+    )
+    output = (result.stdout or "") + (result.stderr or "")
+    if result.returncode != 0:
+        raise RuntimeError(f"Migration failed:\n{output}")
+    return output
+
+
+def web():
+    """Construct the combined API + static-UI ASGI app (in-container)."""
+    # Installed in the server image, not in the SDK/client environment.
+    from stardag_api.server import create_app  # type: ignore[import-not-found] # pyright: ignore[reportMissingImports]
+
+    return create_app(UI_DIST_REMOTE_DIR)

--- a/lib/stardag/tests/test_selfhost/test_image_source.py
+++ b/lib/stardag/tests/test_selfhost/test_image_source.py
@@ -82,8 +82,50 @@ def test_build_server_app_prebuilt_needs_no_repo():
 
 
 # ---------------------------------------------------------------------------
-# Client-Python / image-Python matching (serialized=True functions are
-# cloudpickled by the client and unpickled in the image: versions must match)
+# Prebuilt path: functions referenced BY NAME (serialized=False), so the
+# client's Python is decoupled from the image's. The entry module is loaded
+# as a standalone single-file module and mounted into the container.
+# ---------------------------------------------------------------------------
+
+
+def test_prebuilt_entry_module_imports_without_stardag_api():
+    """The entry module must load on a stardag-SDK-only client.
+
+    Its ``stardag_api`` imports are deferred into the function bodies, so
+    importing the module (to build the by-reference app graph) never needs
+    ``stardag_api`` - which the SDK client does not install.
+    """
+    from stardag.selfhost._modal_app import _load_prebuilt_entry_module
+
+    entry = _load_prebuilt_entry_module()
+    assert callable(entry.web)
+    assert callable(entry.migrate)
+
+
+def test_prebuilt_functions_are_by_reference_file_entrypoints():
+    """Prebuilt functions are non-serialized, file-entrypoint references.
+
+    A FILE-type FunctionInfo means Modal ships just the entry file and
+    imports it in-container by its stem (``_modal_entry``) - no cloudpickle,
+    so the deploy is independent of the client interpreter version.
+    """
+    from modal._utils.function_utils import FunctionInfo
+
+    from stardag.selfhost._modal_app import _load_prebuilt_entry_module
+
+    entry = _load_prebuilt_entry_module()
+    for fn in (entry.web, entry.migrate):
+        info = FunctionInfo(fn, serialized=False)
+        assert not info.is_serialized()
+        # Stem of _modal_entry.py: the module Modal imports in-container.
+        assert info.module_name == "_modal_entry"
+        # A single-part qualname is required for by-reference resolution.
+        assert "." not in (info.function_name or "")
+
+
+# ---------------------------------------------------------------------------
+# Client-Python / image-Python matching for --from-source (serialized=True
+# closures are cloudpickled by the client and unpickled in the image)
 # ---------------------------------------------------------------------------
 
 
@@ -143,34 +185,3 @@ def test_build_server_app_from_source_python_override(
     seen = _record_add_python(monkeypatch)
     build_server_app(repo_root=REPO_ROOT, python_version="3.11")
     assert seen["add_python"] == "3.11"
-
-
-def test_prebuilt_image_python_constant_matches_dockerfile():
-    """PREBUILT_IMAGE_PYTHON must track app/server.Dockerfile's base image."""
-    from stardag.selfhost._modal_app import PREBUILT_IMAGE_PYTHON
-
-    dockerfile = (REPO_ROOT / "app" / "server.Dockerfile").read_text()
-    expected = "FROM python:{}.{}-slim".format(*PREBUILT_IMAGE_PYTHON)
-    assert expected in dockerfile
-
-
-def test_check_prebuilt_python_matching(monkeypatch: pytest.MonkeyPatch):
-    import sys
-
-    from stardag._cli.selfhost import _check_prebuilt_python
-    from stardag.selfhost._modal_app import PREBUILT_IMAGE_PYTHON
-
-    monkeypatch.setattr(sys, "version_info", (*PREBUILT_IMAGE_PYTHON, 0, "final", 0))
-    _check_prebuilt_python()  # no-op
-
-
-def test_check_prebuilt_python_mismatch_fails_fast(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    import sys
-
-    from stardag._cli.selfhost import _check_prebuilt_python
-
-    monkeypatch.setattr(sys, "version_info", (3, 14, 0, "final", 0))
-    with pytest.raises(typer.Exit):
-        _check_prebuilt_python()


### PR DESCRIPTION
Closes #196.

## Problem

The prebuilt self-host path defined the `migrate`/`web` Modal functions as `serialized=True` closures: the CLI cloudpickled the bodies client-side and Modal unpickled them in-container. Pickle bytecode isn't portable across Python minor versions, so Modal hard-errored unless the CLI ran under the image's exact Python (`uvx --python 3.12 …`, enforced by a fail-fast check). But the prebuilt image already ships `stardag_api`, so serializing the bodies to it was redundant.

## Approach

For the **prebuilt path only**, define the functions **by reference** (`serialized=False`) instead of serializing closures:

- New module `stardag/selfhost/_modal_entry.py` defines module-level `web()` / `migrate()`. Its `stardag_api` imports are deferred into the function bodies, so the module loads cleanly on a stardag-SDK-only client (which has no `stardag_api`).
- `build_server_app` loads that file as a **standalone (dotless) module** via `_load_prebuilt_entry_module`. This makes Modal's `FunctionInfo` classify it as a **file entrypoint**: Modal ships just that one file into the container and imports it there by its stem (`_modal_entry`), then resolves the referenced functions in-image. Nothing is cloudpickled, so the CLI's own interpreter no longer has to match the image's Python.

### Why the entry module ships in the SDK, not baked into the image

The issue floated baking `stardag_api.modal_entry` into the image and referencing it by `(module, qualname)`. Modal 1.5 makes that infeasible from an SDK-only client: building a non-serialized `FunctionInfo` calls `inspect.getmodule(fn)` on the **local** callable and auto-mounts its top-level package — both require the module to be importable on the client, which `stardag_api` is not. The file-entrypoint approach sidesteps this entirely and, as a bonus, works against the **already-published** image (no new server release needed to adopt it).

## What changed

- `selfhost/_modal_entry.py` (new): module-level `web`/`migrate`.
- `selfhost/_modal_app.py`: `build_server_app` split into `_build_prebuilt_app` (by-reference, `serialized=False`) and `_build_from_source_app` (unchanged serialized closures). Removed `PREBUILT_IMAGE_PYTHON`.
- `_cli/selfhost.py`: removed `_check_prebuilt_python` and its call sites — the prebuilt path has no remaining client-Python constraint beyond the SDK's own `>=3.10`.
- Docs/DEV_README/CHANGELOG/CLI guidance: dropped `uvx --python 3.12` for prebuilt; reframed the from-source-only serialization note and the `InvalidError` troubleshooting entry.
- Unit tests: replaced the Python-match-check tests with by-reference tests (functions are non-serialized file entrypoints; entry module imports without `stardag_api`).

## `--from-source` is unchanged

It still builds a fresh image (which needn't contain the code) and ships serialized closures with a client-matched image Python — correct there.

## Verification

- `pytest tests/test_selfhost/` — 62 passed; `uvx pre-commit` green; `mkdocs build` clean (the only `--strict` failures are pre-existing griffe warnings in `build/_base.py`, untouched here).
- **Live proof under Python 3.14** (previously an `InvalidError`): deployed the prebuilt `0.1.0` image by reference into a fully sandboxed, dedicated Modal environment (unique app name, dummy DB — no bootstrap admin, so no DB connection). Modal mounted the single `_modal_entry.py` file and deployed in ~3.5s; `GET /health` → `200 {"status":"healthy"}` and `GET /api/v1/version` → `200 {"server_version":"0.1.0","api_version":"0.0.1"}`. All sandbox resources (app, secrets, Modal environment) were torn down afterward with zero residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf