### PR TITLE
Release v0.16.0 — by-reference prebuilt deploy, default server-v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-07-17
+
 ### SDK
 
+- Default prebuilt server image bumped to `server-v0.1.1` (rebuilt from
+  the v0.15.0+ line, so a prebuilt `self-host up` now serves the UI with
+  the corrected version footer). `DEFAULT_SERVER_VERSION = "0.1.1"`.
 - **`stardag self-host` prebuilt deploys no longer require a matching
   client Python
   ([#196](https://github.com/stardag-dev/stardag/issues/196)).** The

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,26 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.16.0 — Self-host: no Python pin, cleaner defaults
+
+The prebuilt `self-host` deploy no longer needs its interpreter to match
+the server image — run it under any supported Python (≥ 3.10), no
+`--python 3.12` pin:
+
+```bash
+uvx --from "stardag[selfhost]" stardag self-host up
+```
+
+Under the hood the Modal `web`/`migrate` functions are now defined
+by-reference and imported inside the server image, so nothing is
+cloudpickled by the client ([#196](https://github.com/stardag-dev/stardag/issues/196)).
+The default prebuilt image is now `server-v0.1.1` (fixes the settings
+footer that read "vdev"). `--from-source` is unchanged.
+
+No breaking changes; upgrade in place with `stardag self-host upgrade`.
+
+---
+
 ## v0.15.0 — Self-host the Stardag service on Modal
 
 You can now run your own private Stardag service (Registry API + web UI)

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -62,7 +62,7 @@ DEFAULT_SERVER_MODAL_ENV = "stardag-host"
 SERVER_IMAGE_REPO = "ghcr.io/stardag-dev/stardag-server"
 # The server release this SDK version is tested against. Bumped at SDK
 # release time; override per deployment with --server-version.
-DEFAULT_SERVER_VERSION = "0.1.0"
+DEFAULT_SERVER_VERSION = "0.1.1"
 
 # Minimum client interpreter for from-source image builds (stardag-api's
 # requires-python; the image gets the client's version via add_python).


### PR DESCRIPTION
Versions the `[Unreleased]` changelog as **0.16.0** and bumps `DEFAULT_SERVER_VERSION` → `0.1.1`.

After merge: tag **server-v0.1.1** (rebuild image incl. the vdev-footer fix), then **v0.16.0** (SDK → PyPI). Prebuilt `self-host up` then works under any Python (no `--python 3.12`) and serves a clean version footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf