### PR TITLE
fix(self-host): create shared workspace named after the Modal workspace (workspace_name unreliable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,35 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.16.1] — 2026-07-17
+
+### Fixed
+
+- **`stardag self-host` now creates a shared workspace named after your
+  Modal workspace by default.** Modal's token lookup returns an empty
+  `workspace_name` for _both_ personal and team/org workspaces (only
+  `username` differs), so the CLI could no longer tell them apart and
+  misclassified org workspaces as "personal": it never set
+  `AUTH_PRIMARY_WORKSPACE_NAME`, and the server bootstrapped `main` in the
+  admin's personal workspace instead of a shared one. The primary workspace
+  is now an explicit, well-defaulted choice keyed off the Modal `username`
+  (always present): `up`/`connect` default to creating a **shared** Stardag
+  workspace named after the Modal workspace (with the admin as owner) and
+  wire the target root, API key, and local profile to _that_ workspace's
+  `main` environment. Use `--no-primary-workspace` for solo/individual use
+  (personal workspace), or `--primary-workspace NAME` for an explicit name.
+- **`stardag self-host connect`/`up` no longer overwrite an existing
+  `stardag-api-key` Modal secret without confirmation.** Pushing the secret
+  into an execution Modal environment that already had one could silently
+  repoint all DAG execution in that environment (e.g. an existing
+  cloud/app.stardag.com setup) to the self-hosted registry. When the secret
+  already exists the CLI now warns and requires a typed confirmation phrase
+  interactively, or the explicit `--overwrite-api-key-secret` flag under
+  `--yes`; otherwise it leaves the secret untouched and completes the rest
+  of the setup. (The standalone `stardag modal stardag-api-key create`,
+  whose purpose is to (re)push the secret, now prints a warning when it
+  replaces an existing one.)
+
 ## [0.16.0] — 2026-07-17
 
 ### SDK

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,27 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.16.1 — Self-host: shared-workspace default + API-key secret safety
+
+Two `stardag self-host` fixes:
+
+- The setup now defaults to creating a **shared** Stardag workspace named
+  after your Modal workspace (with you as owner), and wires the API key,
+  target root, and local profile to it. Modal's token lookup can't
+  distinguish a personal from a team/org workspace, so this is now an
+  explicit, shared-by-default choice — use `--no-primary-workspace` for
+  solo/individual use, or `--primary-workspace NAME` to name it.
+- `connect`/`up` no longer silently overwrite an existing `stardag-api-key`
+  Modal secret in your execution environment (which would repoint DAG
+  execution there, possibly away from another registry). You're warned and
+  must confirm — a typed phrase interactively, or `--overwrite-api-key-secret`
+  under `--yes`.
+
+CLI-only; no server image change. Upgrade in place with
+`stardag self-host upgrade`.
+
+---
+
 ## v0.16.0 — Self-host: no Python pin, cleaner defaults
 
 The prebuilt `self-host` deploy no longer needs its interpreter to match

--- a/docs/docs/how-to/self-host-modal.md
+++ b/docs/docs/how-to/self-host-modal.md
@@ -61,9 +61,10 @@ The command walks you through the rest interactively:
   accounts; see [OIDC mode](#auth-mode-oidc-external-identity-provider)
   for the alternative)
 - **Admin email + password** → your first login account
-- **Primary workspace** → if your Modal workspace is shared (a team
-  workspace), a Stardag workspace with the same name is created; personal
-  Modal accounts use your personal Stardag workspace
+- **Primary workspace** → by default a **shared** Stardag workspace named
+  after your Modal workspace is created (with you as owner), mirroring your
+  Modal account. Press Enter to accept, or decline to use your personal
+  Stardag workspace instead (solo/individual use)
 
 It then generates a JWT signing keypair (stored as a Modal secret), applies
 database migrations, deploys the prebuilt server image (Registry API + web
@@ -82,14 +83,14 @@ Stardag is up!
 
 `up` finishes with a summary panel of everything that now exists:
 
-| What                                         | Default                                                                  | Purpose                                                                        |
-| -------------------------------------------- | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------ |
-| Modal env `stardag-host` + app `server`      | server app + config/JWT secrets                                          | Isolates the server from the Modal environments where your DAG apps run        |
-| Stardag **workspace**                        | named after your shared Modal workspace, or your personal workspace      | Mirrors your Modal account's structure                                         |
-| Stardag **environment**                      | `main`                                                                   | Mirrors Modal's default environment; where deployed-DAG runs are tracked       |
-| **API key** → Modal secret `stardag-api-key` | in Modal env `main` (your default)                                       | Lets Modal-executed DAGs authenticate against your registry                    |
-| **Target root** `default`                    | `modalvol://stardag-targets-<workspace-slug>-<environment-slug>/default` | Where task outputs land (a dedicated Modal volume per workspace + environment) |
-| Local **registry + profile** `selfhosted`    | in `~/.stardag/config.toml`                                              | Points your SDK/CLI at the deployment                                          |
+| What                                         | Default                                                                                                  | Purpose                                                                        |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Modal env `stardag-host` + app `server`      | server app + config/JWT secrets                                                                          | Isolates the server from the Modal environments where your DAG apps run        |
+| Stardag **workspace**                        | a shared workspace named after your Modal workspace (or your personal one with `--no-primary-workspace`) | Mirrors your Modal account's structure                                         |
+| Stardag **environment**                      | `main`                                                                                                   | Mirrors Modal's default environment; where deployed-DAG runs are tracked       |
+| **API key** → Modal secret `stardag-api-key` | in Modal env `main` (your default)                                                                       | Lets Modal-executed DAGs authenticate against your registry                    |
+| **Target root** `default`                    | `modalvol://stardag-targets-<workspace-slug>-<environment-slug>/default`                                 | Where task outputs land (a dedicated Modal volume per workspace + environment) |
+| Local **registry + profile** `selfhosted`    | in `~/.stardag/config.toml`                                                                              | Points your SDK/CLI at the deployment                                          |
 
 Open the UI, sign in with the admin account, and deploy a DAG app with
 [`stardag modal deploy`](integrate-modal.md) — the `stardag-api-key` secret
@@ -238,12 +239,20 @@ Setup flags shared by `up` and `connect` (each prompt/default has a flag
 equivalent):
 
 - `--primary-workspace NAME` — name of the shared Stardag workspace to
-  create (default: your shared Modal workspace's name); or
-  `--no-primary-workspace` to use only your personal workspace
+  create (default: your Modal workspace's name — a shared workspace with you
+  as owner); or `--no-primary-workspace` to use only your personal workspace
+  (solo/individual use). Modal exposes no reliable personal-vs-team signal,
+  so this is an explicit, shared-by-default choice.
 - `--execution-modal-env NAME` — Modal environment your DAG apps run in;
   the `stardag-api-key` secret is pushed there (default: your Modal
   account's default environment). This is deliberately _not_ the server's
   environment.
+- `--overwrite-api-key-secret` — with `--yes`, replace an existing
+  `stardag-api-key` secret in the execution Modal environment. Without it,
+  `connect`/`up` **never overwrite** a `stardag-api-key` secret that already
+  exists there (interactively you're warned and must type a confirmation
+  phrase; non-interactively the push is skipped) — this protects a Modal
+  environment already wired for DAG execution against another registry.
 - `--target-root name=uri` — default target root for the `main` environment
   (default
   `default=modalvol://stardag-targets-<workspace-slug>-<environment-slug>/default`);

--- a/lib/stardag/src/stardag/_cli/_selfhost_connect.py
+++ b/lib/stardag/src/stardag/_cli/_selfhost_connect.py
@@ -3,8 +3,8 @@
 Wires a freshly deployed self-hosted Stardag service into a ready-to-use
 setup, mirroring the Modal account's structure:
 
-- a **primary Stardag workspace** (named after the shared Modal workspace,
-  when there is one) or the user's personal workspace,
+- a **primary Stardag workspace** (shared, named after the Modal workspace)
+  or, when opted out, the user's personal workspace,
 - a **primary environment** (``main``) in it,
 - an **API key** for that environment pushed as the Modal secret
   ``stardag-api-key`` into the Modal environment where the user's DAGs run,
@@ -115,29 +115,130 @@ def parse_target_root_flag(value: str) -> tuple[str, str]:
 def resolve_primary_workspace(
     explicit: str | None,
     no_primary_workspace: bool,
-    modal_shared_workspace: str | None,
+    modal_workspace: str,
     interactive: bool,
 ) -> str | None:
     """Determine the primary (shared) Stardag workspace name.
 
-    Explicit flags win; otherwise the shared Modal workspace's name is the
-    default (confirmed interactively). Personal Modal workspaces get no
-    shared Stardag workspace - the user's personal Stardag workspace is
-    used instead.
+    Modal's token lookup exposes no reliable personal-vs-team signal (the
+    workspace name is empty for both), so this is an explicit, well-defaulted
+    choice rather than auto-detection. ``modal_workspace`` is the Modal
+    workspace's identity (its ``username``), which is always present.
+
+    Default: create a shared Stardag workspace named after the Modal
+    workspace (confirmed interactively; the default answer is Yes).
+    ``--primary-workspace NAME`` overrides the name; ``--no-primary-workspace``
+    opts out entirely, using the caller's personal Stardag workspace instead
+    (for solo/individual use).
     """
     if no_primary_workspace:
         return None
     if explicit:
         return explicit
-    if not modal_shared_workspace:
-        return None
     if interactive and not typer.confirm(
-        f"Primary Stardag workspace: '{modal_shared_workspace}' "
-        "(named after your shared Modal workspace)?",
+        f"Create a shared Stardag workspace '{modal_workspace}' mirroring your "
+        "Modal workspace? (No = use your personal workspace for solo/"
+        "individual use.)",
         default=True,
     ):
         return None
-    return modal_shared_workspace
+    return modal_workspace
+
+
+def _default_modal_secret_exists(name: str, environment_name: str | None) -> bool:
+    """Whether a named Modal secret already exists in the target env.
+
+    Mirrors ``stardag._cli.selfhost._secret_exists`` (kept local to avoid a
+    circular import) and honors the target ``environment_name`` (the
+    DAG-execution Modal env, ``None`` meaning Modal's default environment).
+    """
+    import modal
+    import modal.exception
+
+    try:
+        modal.Secret.from_name(name, environment_name=environment_name).hydrate()
+        return True
+    except modal.exception.NotFoundError:
+        return False
+
+
+# Phrase the user must type to confirm a destructive secret overwrite.
+_OVERWRITE_CONFIRM_PHRASE = "replace key"
+
+
+def _confirm_overwrite_api_key_secret(
+    secret_exists: Callable[[str, str | None], bool],
+    execution_modal_env: str | None,
+    *,
+    interactive: bool,
+    overwrite: bool,
+) -> bool:
+    """Decide whether to (over)write the ``stardag-api-key`` Modal secret.
+
+    Returns True when the secret may be written. If no secret exists yet this
+    is always True (nothing to clobber). When one already exists in the target
+    execution Modal env, replacing it is a destructive action - it repoints
+    all DAG execution in that env, possibly away from another registry - so:
+
+    - non-interactive (``--yes``): only proceed when ``overwrite`` is set
+      (the explicit ``--overwrite-api-key-secret`` flag); otherwise skip;
+    - interactive: show a prominent warning and require the user to type an
+      exact confirmation phrase; anything else skips the push.
+    """
+    if not secret_exists(API_KEY_SECRET_NAME, execution_modal_env):
+        return True
+
+    from rich.panel import Panel
+
+    modal_env_display = execution_modal_env or "default"
+    if not interactive:
+        if overwrite:
+            console.print(
+                f"[yellow]Overwriting the existing '{API_KEY_SECRET_NAME}' "
+                f"Modal secret in environment '{modal_env_display}' "
+                "(--overwrite-api-key-secret).[/yellow]"
+            )
+            return True
+        console.print(
+            f"[yellow]A '{API_KEY_SECRET_NAME}' secret already exists in Modal "
+            f"environment '{modal_env_display}'; leaving it untouched. Re-run "
+            "with --overwrite-api-key-secret to replace it, or point DAG "
+            "execution here later with:[/yellow] stardag modal stardag-api-key "
+            "create"
+            + (f" --modal-env {execution_modal_env}" if execution_modal_env else "")
+        )
+        return False
+
+    console.print(
+        Panel(
+            f"[bold]A '{API_KEY_SECRET_NAME}' secret already exists in Modal "
+            f"environment '{modal_env_display}'.[/bold]\n\n"
+            "This environment appears to be connected to Stardag DAG execution "
+            "already - it's likely used by existing DAG apps, possibly against "
+            "a DIFFERENT registry (e.g. an app.stardag.com / cloud setup). "
+            "Replacing it will repoint ALL DAG execution in this environment to "
+            "THIS self-hosted registry and can break the existing setup.\n\n"
+            "If you meant to use a different Modal environment, cancel and "
+            "re-run with --execution-modal-env <other-env>.",
+            title="⚠  Overwrite Modal secret?",
+            border_style="red",
+        )
+    )
+    typed = typer.prompt(
+        f"Type '{_OVERWRITE_CONFIRM_PHRASE}' to replace the secret "
+        "(anything else cancels)",
+        default="",
+        show_default=False,
+    )
+    if typed.strip() == _OVERWRITE_CONFIRM_PHRASE:
+        return True
+    console.print(
+        f"[yellow]Left the existing '{API_KEY_SECRET_NAME}' Modal secret "
+        f"in environment '{modal_env_display}' untouched.[/yellow] To point "
+        "DAG execution here later: stardag modal stardag-api-key create"
+        + (f" --modal-env {execution_modal_env}" if execution_modal_env else "")
+    )
+    return False
 
 
 def get_auth_config(
@@ -229,6 +330,9 @@ class ConnectOutcome:
     # None if key creation or the Modal-secret push failed (non-fatal)
     api_key_name: str | None
     modal_secret_name: str | None
+    # True when an existing stardag-api-key secret was deliberately left in
+    # place (the overwrite guard declined) rather than failing
+    api_key_secret_left_untouched: bool
     execution_modal_env: str | None  # None = Modal's default environment
     registry_name: str
     profile_name: str
@@ -289,15 +393,21 @@ def run_connect(
     no_target_root: bool = False,
     registry_name: str = DEFAULT_REGISTRY_NAME,
     profile_name: str = DEFAULT_PROFILE_NAME,
+    interactive: bool = True,
+    overwrite_api_key_secret: bool = False,
     push_modal_secret: Callable[[str, dict[str, str], str | None], None] | None = None,
+    secret_exists: Callable[[str, str | None], bool] | None = None,
     transport: httpx.BaseTransport | None = None,
 ) -> ConnectOutcome:
     """Idempotently wire up workspace, environment, API key, and SDK config.
 
     ``bearer_token`` is a session token (local auth mode) or OIDC token -
     both are accepted by the bootstrap endpoints and ``/auth/exchange``.
-    ``push_modal_secret`` is injectable for tests; defaults to the Modal
-    secret push used by ``stardag modal stardag-api-key create``.
+    ``push_modal_secret`` and ``secret_exists`` are injectable for tests;
+    they default to the Modal secret push / lookup used elsewhere in the CLI.
+    ``interactive`` and ``overwrite_api_key_secret`` gate whether a
+    pre-existing ``stardag-api-key`` Modal secret may be replaced (see
+    ``_confirm_overwrite_api_key_secret``).
     """
     from stardag._cli.auth import _sync_target_roots
     from stardag._cli.credentials import (
@@ -312,6 +422,8 @@ def run_connect(
 
     if push_modal_secret is None:
         push_modal_secret = _push_modal_secret
+    if secret_exists is None:
+        secret_exists = _default_modal_secret_exists
 
     api_url = api_url.rstrip("/")
     client = httpx.Client(
@@ -463,49 +575,70 @@ def run_connect(
         # Failures here are non-fatal by design: the local SDK config below
         # is still written, and re-running `stardag self-host connect`
         # retries this step (the rotate semantics keep that idempotent).
-        api_key_name: str | None = f"modal-{execution_modal_env or 'default'}"
+        key_name = f"modal-{execution_modal_env or 'default'}"
+        api_key_name: str | None = key_name
         modal_secret_name: str | None = API_KEY_SECRET_NAME
-        full_key: str | None = None
-        try:
-            full_key = _rotate_api_key(
-                ws_client,
-                f"{envs_url}/{environment_id}/api-keys",
-                api_key_name,
-            )
-        except Exception as e:
-            error_console.print(f"Could not create the Stardag API key: {e}")
-            console.print(
-                "[yellow]Modal DAG execution is not wired up yet - re-run "
-                "`stardag self-host connect` to retry (the rest of the "
-                "setup is completed below).[/yellow]"
-            )
+        api_key_secret_left_untouched = False
+
+        # Safety guard: never silently clobber a pre-existing
+        # ``stardag-api-key`` secret in the target execution Modal env. Such a
+        # secret means that env is likely already wired for Stardag DAG
+        # execution - possibly against a *different* registry - and
+        # overwriting it repoints all DAG execution in that env to this
+        # deployment. Require an explicit, deliberate confirmation first.
+        should_push = _confirm_overwrite_api_key_secret(
+            secret_exists,
+            execution_modal_env,
+            interactive=interactive,
+            overwrite=overwrite_api_key_secret,
+        )
+        if not should_push:
             api_key_name = None
             modal_secret_name = None
-        if full_key is not None:
+            api_key_secret_left_untouched = True
+
+        if should_push:
+            full_key: str | None = None
             try:
-                push_modal_secret(
-                    API_KEY_SECRET_NAME,
-                    {"STARDAG_API_KEY": full_key},
-                    execution_modal_env,
-                )
-                modal_env_display = execution_modal_env or "default"
-                console.print(
-                    f"Pushed Modal secret [bold]{API_KEY_SECRET_NAME}[/bold] "
-                    f"(Modal environment: {modal_env_display})"
+                full_key = _rotate_api_key(
+                    ws_client,
+                    f"{envs_url}/{environment_id}/api-keys",
+                    key_name,
                 )
             except Exception as e:
-                error_console.print(f"Could not push the Modal secret: {e}")
+                error_console.print(f"Could not create the Stardag API key: {e}")
                 console.print(
-                    "[yellow]Create it later with:[/yellow] "
-                    "stardag modal stardag-api-key create"
-                    + (
-                        f" --modal-env {execution_modal_env}"
-                        if execution_modal_env
-                        else ""
-                    )
+                    "[yellow]Modal DAG execution is not wired up yet - re-run "
+                    "`stardag self-host connect` to retry (the rest of the "
+                    "setup is completed below).[/yellow]"
                 )
                 api_key_name = None
                 modal_secret_name = None
+            if full_key is not None:
+                try:
+                    push_modal_secret(
+                        API_KEY_SECRET_NAME,
+                        {"STARDAG_API_KEY": full_key},
+                        execution_modal_env,
+                    )
+                    modal_env_display = execution_modal_env or "default"
+                    console.print(
+                        f"Pushed Modal secret [bold]{API_KEY_SECRET_NAME}[/bold] "
+                        f"(Modal environment: {modal_env_display})"
+                    )
+                except Exception as e:
+                    error_console.print(f"Could not push the Modal secret: {e}")
+                    console.print(
+                        "[yellow]Create it later with:[/yellow] "
+                        "stardag modal stardag-api-key create"
+                        + (
+                            f" --modal-env {execution_modal_env}"
+                            if execution_modal_env
+                            else ""
+                        )
+                    )
+                    api_key_name = None
+                    modal_secret_name = None
 
         # --- Local SDK config: registry + profile + caches ---
         add_registry(registry_name, api_url)
@@ -544,6 +677,7 @@ def run_connect(
         target_root=ensured_target_root,
         api_key_name=api_key_name,
         modal_secret_name=modal_secret_name,
+        api_key_secret_left_untouched=api_key_secret_left_untouched,
         execution_modal_env=execution_modal_env,
         registry_name=registry_name,
         profile_name=profile_name,
@@ -580,6 +714,12 @@ def print_summary(
         lines.append(
             f"  API key:      {outcome.api_key_name} -> Modal secret "
             f"'{outcome.modal_secret_name}' (Modal environment: {exec_env})"
+        )
+    elif outcome.api_key_secret_left_untouched:
+        lines.append(
+            f"  API key:      existing '{API_KEY_SECRET_NAME}' Modal secret "
+            f"(environment: {exec_env}) left untouched - wire this env up "
+            "with 'stardag modal stardag-api-key create' if intended"
         )
     lines += [
         "",

--- a/lib/stardag/src/stardag/_cli/modal.py
+++ b/lib/stardag/src/stardag/_cli/modal.py
@@ -236,6 +236,18 @@ def _create_stardag_api_key(
     raise typer.Exit(1)
 
 
+def _modal_secret_exists(secret_name: str, modal_env: str | None) -> bool:
+    """Whether a named Modal secret already exists in the target env."""
+    import modal
+    import modal.exception
+
+    try:
+        modal.Secret.from_name(secret_name, environment_name=modal_env or "").hydrate()
+        return True
+    except modal.exception.NotFoundError:
+        return False
+
+
 def _push_modal_secret(
     secret_name: str,
     env_dict: dict[str, str],
@@ -326,6 +338,14 @@ def stardag_api_key_create(
             f'[green]Created Stardag API key: "{api_key_name}" '
             f"(prefix: {key_prefix})[/green]"
         )
+
+        if _modal_secret_exists(secret_name, modal_env):
+            modal_env_display = f" in Modal env '{modal_env}'" if modal_env else ""
+            console.print(
+                f"[yellow]Replacing the existing '{secret_name}' Modal "
+                f"secret{modal_env_display} - DAG apps using it will pick up "
+                "the new key on their next run.[/yellow]"
+            )
 
         try:
             _push_modal_secret(secret_name, {"STARDAG_API_KEY": full_key}, modal_env)

--- a/lib/stardag/src/stardag/_cli/selfhost.py
+++ b/lib/stardag/src/stardag/_cli/selfhost.py
@@ -126,9 +126,14 @@ def _resolve_image_source(
 class ModalWorkspaceInfo:
     """The authenticated Modal account's workspace identity.
 
-    ``workspace_name`` is the shared workspace's display name and is None
-    for personal Modal workspaces; ``username`` is the account slug (always
-    present).
+    ``username`` is the Modal workspace's name/identity and is always
+    present - it is the same field for both personal and team/org
+    workspaces, and is what we mirror the primary Stardag workspace after.
+
+    ``workspace_name`` is kept for reference but is NOT a reliable
+    personal-vs-team signal: Modal's token lookup returns it empty for both
+    personal and shared/org workspaces, so it must not be used to classify
+    the workspace.
     """
 
     username: str
@@ -155,7 +160,9 @@ def _check_modal_auth() -> ModalWorkspaceInfo:
         workspace = asyncio.run(
             modal.config._lookup_workspace(server_url, token_id, token_secret)
         )
-        # workspace_name is empty for personal Modal workspaces
+        # ``username`` is the Modal workspace identity (always set) for both
+        # personal and team/org workspaces; ``workspace_name`` comes back
+        # empty in both cases, so it is not a usable personal-vs-team signal.
         return ModalWorkspaceInfo(
             username=workspace.username,
             workspace_name=workspace.workspace_name or None,
@@ -708,13 +715,14 @@ def up(
         None,
         "--primary-workspace",
         help="Name of the primary (shared) Stardag workspace to create. "
-        "Default: your shared Modal workspace's name; skipped for personal "
-        "Modal workspaces (your personal Stardag workspace is used instead).",
+        "Default: your Modal workspace's name (a shared workspace mirroring "
+        "your Modal workspace, with you as owner).",
     ),
     no_primary_workspace: bool = typer.Option(
         False,
         "--no-primary-workspace",
-        help="Do not create/map a shared primary workspace.",
+        help="Do not create a shared workspace; use your personal Stardag "
+        "workspace instead (solo/individual use).",
     ),
     skip_connect: bool = typer.Option(
         False,
@@ -728,6 +736,13 @@ def up(
         help="Modal environment where your DAG apps run - the stardag-api-key "
         "secret is pushed there (default: your Modal account's default "
         "environment, typically 'main'). NOT the server's environment.",
+    ),
+    overwrite_api_key_secret: bool = typer.Option(
+        False,
+        "--overwrite-api-key-secret",
+        help="With --yes, replace an existing 'stardag-api-key' Modal secret "
+        "in the execution environment (otherwise it is left untouched to "
+        "protect DAG apps already wired to another registry).",
     ),
     target_root: str = typer.Option(
         None,
@@ -770,13 +785,7 @@ def up(
     target_root_override = parse_target_root_flag(target_root) if target_root else None
 
     modal_info = _check_modal_auth()
-    if modal_info.workspace_name:
-        console.print(
-            f"Modal workspace: [bold]{modal_info.workspace_name}[/bold] "
-            f"(shared, signed in as {modal_info.username})"
-        )
-    else:
-        console.print(f"Modal workspace: [bold]{modal_info.username}[/bold] (personal)")
+    console.print(f"Modal workspace: [bold]{modal_info.username}[/bold]")
 
     server_env = server_modal_env or None
     if server_env:
@@ -900,7 +909,7 @@ def up(
             primary_ws_name = resolve_primary_workspace(
                 primary_workspace,
                 no_primary_workspace,
-                modal_info.workspace_name,
+                modal_info.username,
                 interactive,
             )
         else:
@@ -993,7 +1002,7 @@ def up(
         primary_ws_name = resolve_primary_workspace(
             primary_workspace,
             no_primary_workspace,
-            modal_info.workspace_name,
+            modal_info.username,
             interactive,
         )
 
@@ -1009,6 +1018,8 @@ def up(
         no_target_root=no_target_root,
         registry_name=registry_name,
         profile_name=profile_name,
+        interactive=interactive,
+        overwrite_api_key_secret=overwrite_api_key_secret,
     )
     console.print()
     print_summary(outcome, name, server_env)
@@ -1141,13 +1152,14 @@ def connect(
         None,
         "--primary-workspace",
         help="Name of the primary (shared) Stardag workspace. Default: your "
-        "shared Modal workspace's name; skipped for personal Modal "
-        "workspaces (your personal Stardag workspace is used instead).",
+        "Modal workspace's name (a shared workspace mirroring your Modal "
+        "workspace, with you as owner).",
     ),
     no_primary_workspace: bool = typer.Option(
         False,
         "--no-primary-workspace",
-        help="Do not create/map a shared primary workspace.",
+        help="Do not create a shared workspace; use your personal Stardag "
+        "workspace instead (solo/individual use).",
     ),
     execution_modal_env: str = typer.Option(
         None,
@@ -1155,6 +1167,13 @@ def connect(
         help="Modal environment where your DAG apps run - the stardag-api-key "
         "secret is pushed there (default: your Modal account's default "
         "environment, typically 'main').",
+    ),
+    overwrite_api_key_secret: bool = typer.Option(
+        False,
+        "--overwrite-api-key-secret",
+        help="With --yes, replace an existing 'stardag-api-key' Modal secret "
+        "in the execution environment (otherwise it is left untouched to "
+        "protect DAG apps already wired to another registry).",
     ),
     target_root: str = typer.Option(
         None,
@@ -1253,7 +1272,7 @@ def connect(
     primary_ws_name = resolve_primary_workspace(
         primary_workspace,
         no_primary_workspace,
-        modal_info.workspace_name,
+        modal_info.username,
         interactive,
     )
 
@@ -1268,6 +1287,8 @@ def connect(
         no_target_root=no_target_root,
         registry_name=registry_name,
         profile_name=profile_name,
+        interactive=interactive,
+        overwrite_api_key_secret=overwrite_api_key_secret,
     )
     console.print()
     print_summary(outcome, name, server_env)

--- a/lib/stardag/tests/test_selfhost/test_complete_setup.py
+++ b/lib/stardag/tests/test_selfhost/test_complete_setup.py
@@ -42,51 +42,52 @@ API_URL = "http://stardag.test"
 
 
 def test_modal_workspace_info_display():
-    shared = ModalWorkspaceInfo(username="alice", workspace_name="Acme Corp")
-    personal = ModalWorkspaceInfo(username="alice", workspace_name=None)
-    assert shared.display == "Acme Corp"
-    assert personal.display == "alice"
+    # ``workspace_name`` is unreliable (empty for both personal and team
+    # workspaces); ``display`` falls back to ``username`` when it is None.
+    with_name = ModalWorkspaceInfo(username="acme-corp", workspace_name="Acme Corp")
+    without_name = ModalWorkspaceInfo(username="acme-corp", workspace_name=None)
+    assert with_name.display == "Acme Corp"
+    assert without_name.display == "acme-corp"
 
 
-def test_resolve_primary_workspace_shared_modal_workspace():
-    # Non-interactive: the shared Modal workspace name is the default
+def test_resolve_primary_workspace_defaults_to_modal_username():
+    # Non-interactive (--yes): default to a shared workspace named after the
+    # Modal workspace's identity (username), which is always present.
     assert (
-        resolve_primary_workspace(None, False, "Acme Corp", interactive=False)
-        == "Acme Corp"
+        resolve_primary_workspace(None, False, "acme-corp", interactive=False)
+        == "acme-corp"
     )
-
-
-def test_resolve_primary_workspace_personal_modal_workspace():
-    # Personal Modal workspace: no shared Stardag workspace by default
-    assert resolve_primary_workspace(None, False, None, interactive=False) is None
 
 
 def test_resolve_primary_workspace_explicit_wins():
     assert (
-        resolve_primary_workspace("My Team", False, "Acme Corp", interactive=False)
+        resolve_primary_workspace("My Team", False, "acme-corp", interactive=False)
         == "My Team"
     )
-    # Explicit also works for personal Modal workspaces
+
+
+def test_resolve_primary_workspace_opt_out_uses_personal():
+    # --no-primary-workspace: no shared workspace (personal is used instead)
+    assert resolve_primary_workspace(None, True, "acme-corp", interactive=False) is None
+    # Opt-out beats an explicit name too
     assert (
-        resolve_primary_workspace("My Team", False, None, interactive=False)
-        == "My Team"
+        resolve_primary_workspace("My Team", True, "acme-corp", interactive=False)
+        is None
     )
-
-
-def test_resolve_primary_workspace_opt_out():
-    assert resolve_primary_workspace(None, True, "Acme Corp", interactive=False) is None
 
 
 def test_resolve_primary_workspace_interactive_confirm(
     monkeypatch: pytest.MonkeyPatch,
 ):
+    # Default answer Yes -> shared workspace named after the Modal workspace.
     monkeypatch.setattr(typer, "confirm", lambda *a, **k: True)
     assert (
-        resolve_primary_workspace(None, False, "Acme Corp", interactive=True)
-        == "Acme Corp"
+        resolve_primary_workspace(None, False, "acme-corp", interactive=True)
+        == "acme-corp"
     )
+    # Declining -> personal workspace (None).
     monkeypatch.setattr(typer, "confirm", lambda *a, **k: False)
-    assert resolve_primary_workspace(None, False, "Acme Corp", interactive=True) is None
+    assert resolve_primary_workspace(None, False, "acme-corp", interactive=True) is None
 
 
 def test_parse_target_root_flag():
@@ -144,6 +145,49 @@ def test_build_config_env_defaults_omit_primary_vars():
     env = _config_env()
     assert "AUTH_PRIMARY_WORKSPACE_NAME" not in env
     assert "AUTH_PRIMARY_WORKSPACE_ENVIRONMENT" not in env
+
+
+def test_modal_lookup_empty_workspace_name_still_bootstraps_shared_workspace(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Regression: Modal's token lookup returns an empty ``workspace_name``
+    for BOTH personal and team/org workspaces, so classification must key off
+    ``username`` (always present). The default flow must still resolve a
+    shared primary workspace named after ``username`` and bake
+    ``AUTH_PRIMARY_WORKSPACE_NAME`` into the config secret.
+    """
+    from types import SimpleNamespace
+
+    import modal.config
+
+    from stardag._cli.selfhost import _check_modal_auth
+
+    # A shared/org workspace comes back with a non-empty username but an
+    # empty workspace_name - identical shape to a personal workspace.
+    async def fake_lookup(server_url, token_id, token_secret):
+        return SimpleNamespace(username="acme-corp", workspace_name="")
+
+    monkeypatch.setattr(
+        modal.config,
+        "config",
+        {
+            "token_id": "ak-x",
+            "token_secret": "as-x",
+            "server_url": "https://api.modal.com",
+        },
+    )
+    monkeypatch.setattr(modal.config, "_lookup_workspace", fake_lookup)
+
+    info = _check_modal_auth()
+    assert info.username == "acme-corp"
+    assert info.workspace_name is None  # empty -> None, and NOT a signal
+
+    # Default (--yes / non-interactive) resolves to a shared workspace named
+    # after the Modal username, and that name lands in the config secret.
+    name = resolve_primary_workspace(None, False, info.username, interactive=False)
+    assert name == "acme-corp"
+    env = _config_env(primary_workspace_name=name, primary_workspace_environment="main")
+    assert env["AUTH_PRIMARY_WORKSPACE_NAME"] == "acme-corp"
 
 
 # ---------------------------------------------------------------------------
@@ -508,15 +552,24 @@ class _SecretPushRecorder:
         self.calls.append((secret_name, env_dict, modal_env))
 
 
+def _no_existing_secret(name, env):
+    """Default secret-existence probe for tests: nothing pre-exists."""
+    return False
+
+
 def _run_connect(
-    api: FakeRegistryApi, **kwargs
+    api: FakeRegistryApi, *, secret_exists=None, **kwargs
 ) -> tuple[ConnectOutcome, "_SecretPushRecorder"]:
     push = _SecretPushRecorder()
+    # Default: no pre-existing stardag-api-key secret (nothing to clobber).
+    resolved_secret_exists = secret_exists or _no_existing_secret
+
     outcome = run_connect(
         API_URL,
         "session-token",
         api.user_email,
         push_modal_secret=push,
+        secret_exists=resolved_secret_exists,
         transport=httpx.MockTransport(api.handler),
         **kwargs,
     )
@@ -590,6 +643,41 @@ def test_connect_creates_primary_workspace(isolated_home):
     assert outcome.api_key_name == "modal-staging"
     assert push.calls[0][2] == "staging"
     assert api.api_key_requests[0]["name"] == "modal-staging"
+
+
+def test_connect_wires_primary_not_personal_workspace(isolated_home):
+    """With both a personal and the shared primary workspace present, the
+    DAG-execution setup (API key, target root, local profile) must land on
+    the PRIMARY (shared) workspace's main env - not the personal one.
+    """
+    api = FakeRegistryApi()
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("local", "main")
+    )
+    api.add_workspace("Acme Corp", "acme-corp", env_slugs=("main",))
+
+    outcome, push = _run_connect(api, primary_workspace="Acme Corp")
+
+    # Everything is wired to the shared workspace, not the personal one.
+    assert outcome.workspace_slug == "acme-corp"
+    assert outcome.workspace_is_personal is False
+    assert outcome.workspace_created is False
+    assert outcome.target_root == (
+        "default",
+        "modalvol://stardag-targets-acme-corp-main/default",
+    )
+    assert len(push.calls) == 1
+
+    # The local SDK profile points at the shared workspace.
+    from stardag._cli.credentials import list_profiles
+
+    assert list_profiles()["selfhosted"]["workspace"] == "acme-corp"
+    # The env/API-key/target-root work happened under the shared workspace's
+    # id, never the personal workspace's.
+    personal_id = next(ws["id"] for ws in api.workspaces if ws["is_personal"])
+    shared_id = next(ws["id"] for ws in api.workspaces if ws["slug"] == "acme-corp")
+    assert any(f"/workspaces/{shared_id}/environments" in r for r in api.requests)
+    assert not any(f"/workspaces/{personal_id}/" in r for r in api.requests)
 
 
 def test_connect_existing_primary_workspace_idempotent(isolated_home):
@@ -718,6 +806,7 @@ def test_connect_modal_secret_push_failure_is_not_fatal(isolated_home):
         api.user_email,
         primary_workspace=None,
         push_modal_secret=failing_push,
+        secret_exists=lambda name, env: False,
         transport=httpx.MockTransport(api.handler),
     )
     assert outcome.api_key_name is None
@@ -726,3 +815,117 @@ def test_connect_modal_secret_push_failure_is_not_fatal(isolated_home):
     from stardag._cli.credentials import list_registries
 
     assert list_registries() == {"selfhosted": API_URL}
+
+
+# ---------------------------------------------------------------------------
+# Overwrite guard for a pre-existing stardag-api-key Modal secret
+# ---------------------------------------------------------------------------
+
+
+def test_connect_existing_secret_interactive_decline_leaves_it_untouched(
+    isolated_home, monkeypatch: pytest.MonkeyPatch
+):
+    """Interactive: an existing stardag-api-key secret + a non-matching typed
+    phrase -> the secret is left untouched (no push, no key minted), but the
+    rest of the setup (target root, local profile) is still written."""
+    import typer as typer_mod
+
+    # User types something other than the confirmation phrase -> cancel.
+    monkeypatch.setattr(typer_mod, "prompt", lambda *a, **k: "no")
+
+    api = FakeRegistryApi()
+    ws = api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("main",)
+    )
+    env = ws["envs"]["main"]
+
+    outcome, push = _run_connect(
+        api,
+        primary_workspace=None,
+        interactive=True,
+        secret_exists=lambda name, e: name == API_KEY_SECRET_NAME,
+    )
+
+    assert outcome.api_key_name is None
+    assert outcome.modal_secret_name is None
+    assert outcome.api_key_secret_left_untouched is True
+    # No key was minted on the registry and nothing was pushed to Modal.
+    assert push.calls == []
+    assert api.live_keys(env, "modal-default") == []
+    # The rest of the setup completed.
+    assert outcome.target_root == (
+        "default",
+        "modalvol://stardag-targets-admin-main/default",
+    )
+    from stardag._cli.credentials import list_profiles
+
+    assert "selfhosted" in list_profiles()
+
+
+def test_connect_existing_secret_interactive_typed_phrase_replaces(
+    isolated_home, monkeypatch: pytest.MonkeyPatch
+):
+    """Interactive: typing the exact confirmation phrase replaces the secret."""
+    import typer as typer_mod
+
+    monkeypatch.setattr(typer_mod, "prompt", lambda *a, **k: "replace key")
+
+    api = FakeRegistryApi()
+    ws = api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("main",)
+    )
+    env = ws["envs"]["main"]
+
+    outcome, push = _run_connect(
+        api,
+        primary_workspace=None,
+        interactive=True,
+        secret_exists=lambda name, e: name == API_KEY_SECRET_NAME,
+    )
+
+    assert outcome.api_key_name == "modal-default"
+    assert outcome.modal_secret_name == API_KEY_SECRET_NAME
+    assert outcome.api_key_secret_left_untouched is False
+    assert len(push.calls) == 1
+    assert len(api.live_keys(env, "modal-default")) == 1
+
+
+def test_connect_existing_secret_noninteractive_skips_without_flag(isolated_home):
+    """Non-interactive (--yes) without the flag: never silently overwrite."""
+    api = FakeRegistryApi()
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("main",)
+    )
+
+    outcome, push = _run_connect(
+        api,
+        primary_workspace=None,
+        interactive=False,
+        secret_exists=lambda name, e: name == API_KEY_SECRET_NAME,
+    )
+
+    assert outcome.api_key_name is None
+    assert outcome.api_key_secret_left_untouched is True
+    assert push.calls == []
+
+
+def test_connect_existing_secret_noninteractive_overwrite_flag_replaces(
+    isolated_home,
+):
+    """Non-interactive with --overwrite-api-key-secret: replace the secret."""
+    api = FakeRegistryApi()
+    api.add_workspace(
+        "Admin's Workspace", "admin", is_personal=True, env_slugs=("main",)
+    )
+
+    outcome, push = _run_connect(
+        api,
+        primary_workspace=None,
+        interactive=False,
+        overwrite_api_key_secret=True,
+        secret_exists=lambda name, e: name == API_KEY_SECRET_NAME,
+    )
+
+    assert outcome.api_key_name == "modal-default"
+    assert outcome.api_key_secret_left_untouched is False
+    assert len(push.calls) == 1


### PR DESCRIPTION
## Summary

Two `stardag self-host` connect-flow fixes, released as **v0.16.1**. Both are **CLI-only** — no server image change, `DEFAULT_SERVER_VERSION` stays `0.1.1`. The server already handles `AUTH_PRIMARY_WORKSPACE_NAME` correctly.

### 1. Primary-workspace detection (root cause)

Modal's token lookup (`modal.config._lookup_workspace`) returns an **empty `workspace_name` for BOTH personal and team/org workspaces** — only `username` differs (verified: a personal account and a shared org both come back with `workspace_name = ''`, distinguished only by `username`). The CLI classified shared-vs-personal on `workspace_name` being non-empty, so it *always* saw "personal": an org workspace was misclassified, the CLI never set `AUTH_PRIMARY_WORKSPACE_NAME`, and the server bootstrapped a `main` environment in the admin's **personal** workspace instead of creating a shared workspace named after the Modal workspace with the admin as owner.

Since Modal exposes no reliable personal-vs-team signal, auto-detection is impossible. This makes the primary workspace an **explicit, well-defaulted choice keyed off `username`** (always present, and the Modal workspace's identity):

- **Default** (`--yes` / non-interactive, or accepting the interactive prompt): create a **shared** Stardag workspace named after the Modal `username`, with the admin as owner.
- Interactive prompt (default **Yes**): *"Create a shared Stardag workspace '<username>' mirroring your Modal workspace? (No = use your personal workspace for solo/individual use.)"*
- `--primary-workspace NAME` → explicit name; `--no-primary-workspace` → personal workspace (solo/individual use).
- The connect flow wires the target root, API key, and local SDK profile to the **primary (shared)** workspace's `main` env when one is configured — not the admin's personal workspace.

`workspace_name` is kept on `ModalWorkspaceInfo` for reference but is no longer used to classify. The misleading `(personal)`/`(shared)` print is gone — it now just reports the Modal workspace name.

### 2. API-key secret overwrite guard (related safety bug)

The connect flow pushed the `stardag-api-key` Modal secret into the DAG-execution Modal env via an unconditional delete+create. If that env was **already** used for DAG execution against another registry (e.g. an existing cloud/app.stardag.com setup), the pre-existing secret was silently overwritten, repointing all DAG execution in that env to the self-hosted registry — especially dangerous in a shared/org Modal env.

Now, when a `stardag-api-key` secret already exists in the target execution env:

- **Interactive**: a prominent warning panel, then the user must type the exact phrase `replace key` to proceed; anything else skips the secret push (but still writes the target root + local profile, and the summary notes the secret was left untouched, with the `stardag modal stardag-api-key create` hint).
- **Non-interactive (`--yes`)**: never silently overwrites — requires the new `--overwrite-api-key-secret` flag; otherwise skips with a clear warning.
- **No existing secret**: unchanged (creates it).

The standalone `stardag modal stardag-api-key create` (whose purpose *is* to (re)push the secret) is unchanged except for a brief warning line when it replaces an existing secret.

## Tests

- Rewrote/extended `tests/test_selfhost/test_complete_setup.py`: username-based default name; `--yes` defaults to shared-named-after-username; `--no-primary-workspace` → personal; `--primary-workspace X` → X; a regression test mocking the Modal lookup (username set, `workspace_name` empty) asserting `AUTH_PRIMARY_WORKSPACE_NAME` is set; a connect-flow test asserting the primary (shared) workspace — not the personal one — is wired.
- Overwrite-guard coverage: interactive typed-phrase accept/decline, non-interactive skip-without-flag, and `--overwrite-api-key-secret` replace.
- `uv run pytest tests/test_selfhost -q` → **67 passed**. `pre-commit` (ruff, ruff-format, pyright, prettier) green. `mkdocs build` clean.

## Docs / release

- `docs/docs/how-to/self-host-modal.md`: shared-by-default workspace wording + the overwrite guard / `--overwrite-api-key-secret` flag.
- `CHANGELOG.md` `## [0.16.1]` "Fixed" and `RELEASE_NOTES.md` `## v0.16.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ARrhAGii9mMcpyVNTbSMEf