### PR TITLE
Add PEP 561 `py.typed` marker so consumers get stardag's types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.17.0] — 2026-08-06
+
+### SDK
+
+- **The published distribution now ships a [PEP 561](https://peps.python.org/pep-0561/)
+  `py.typed` marker** (plus the `Typing :: Typed` classifier), so type
+  checkers use stardag's inline annotations instead of discarding them. No
+  API change — the minor bump reflects the downstream effect below.
+
+  **Downstream:** mypy previously skipped the package entirely —
+  `module is installed, but missing library stubs or py.typed marker` —
+  and treated every stardag symbol as `Any`, so genuine mismatches in
+  consumer code went unreported. They are now flagged, which means a
+  previously green mypy run can surface new — real — errors after
+  upgrading. Two workarounds also go stale and should be removed:
+  `# type: ignore[import-untyped]` comments on stardag imports, and any
+  `ignore_missing_imports` override for `stardag.*` (`warn_unused_ignores`
+  will report them as unused). Pyright already resolved stardag's types
+  from the installed package; the only change there is that strict mode
+  no longer emits `reportMissingTypeStubs`.
+
 ## [0.16.1] — 2026-07-17
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,45 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.17.0 — stardag ships its type information (PEP 561)
+
+The published distribution now includes a
+[PEP 561](https://peps.python.org/pep-0561/) `py.typed` marker, so type
+checkers honour stardag's inline annotations instead of discarding them.
+There are no API or runtime changes.
+
+**What this means if you use mypy.** Without the marker, mypy ignored
+stardag's annotations altogether:
+
+```
+error: Skipping analyzing "stardag": module is installed, but missing
+library stubs or py.typed marker  [import-untyped]
+```
+
+Every stardag symbol was `Any`, so mistakes in your own code — a wrong
+argument type, a misspelled attribute on a `Task` — passed silently. After
+upgrading they are checked, so **a mypy run that was green may now report
+new errors**. Those errors were always there; they were just invisible.
+
+Two workarounds you may have in place become unnecessary, and will be
+reported as unused once `warn_unused_ignores` is on:
+
+```python
+from stardag import Task  # type: ignore[import-untyped]  # <- remove
+```
+
+```toml
+[[tool.mypy.overrides]]           # <- remove
+module = ["stardag.*"]
+ignore_missing_imports = true
+```
+
+**If you use pyright**, nothing changes in practice — it already resolved
+stardag's types from the installed package. Strict mode simply stops
+emitting `reportMissingTypeStubs: Stub file not found for "stardag"`.
+
+---
+
 ## v0.16.1 — Self-host: shared-workspace default + API-key secret safety
 
 Two `stardag self-host` fixes:

--- a/lib/stardag/pyproject.toml
+++ b/lib/stardag/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 dependencies = [
     "aiofiles>=23.1.0",


### PR DESCRIPTION
## Why

`stardag` is type-checked with pyright in CI, but the published distribution ships no `py.typed` marker. [PEP 561](https://peps.python.org/pep-0561/) requires one:

> Package maintainers who wish to support type checking of their code MUST add a marker file named `py.typed` to their package supporting typing.

(Same wording in the [typing spec](https://typing.python.org/en/latest/spec/distributing.html).)

Without it, mypy discards the package's type information entirely. Checked against a locally built wheel of the current source:

| | Without `py.typed` | With `py.typed` |
|---|---|---|
| mypy | `Skipping analyzing "stardag": module is installed, but missing library stubs or py.typed marker [import-untyped]`; package treated as `Any`, and a deliberate bad attribute access goes **undetected** | Attribute access correctly flagged: `"Task[Any]" has no attribute ... [attr-defined]` |
| pyright (strict) | `reportMissingTypeStubs: Stub file not found for "stardag"` | Diagnostic gone |

Pyright resolves `stardag`'s types in both cases and caught the bad attribute access either way; the marker removes the strict-mode diagnostic. The dropped type information is mypy-specific.

## What this does

- Adds an empty `lib/stardag/src/stardag/py.typed`. Hatchling's existing `packages = ["src/stardag"]` picks it up with no build-config change — verified present in both the built wheel (`stardag/py.typed`) and sdist (`src/stardag/py.typed`).
- Adds the `Typing :: Typed` trove classifier — verified as `Classifier: Typing :: Typed` in the built wheel `METADATA`.

Scoped to `lib/stardag`, the only package this repository publishes to PyPI (`publish.yml` builds `lib/stardag` alone).

## Checks performed

- **Re-export behavior.** `py.typed` can change how checkers treat re-exported symbols, so I checked the submodules imported across docs and examples (`stardag.config`, `stardag.registry`, `stardag.target`, `stardag.build`) under pyright `typeCheckingMode: strict` and mypy `--no-implicit-reexport`. Both clean.
- `uv run pyright src tests` in `lib/stardag`: 0 errors.
- pre-commit hooks pass on the changed files.
