### PR TITLE
fix(reactive): scope the watchdog sweep server-side and fail trigger cleanly (#208 A3/A4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### Fixed
+
+- **The reactive watchdog now asks the registry only for the RUNNING builds
+  its own app owns** (`GET /builds?status=running&reactive_app_name=...`,
+  filters the API has supported since the reactive-metadata release but the
+  SDK never used). Previously each sweep paged the whole build listing,
+  filtered the derived status client-side, and then spent a full `tick`
+  invocation on every RUNNING build in the environment just to discover
+  most were not reactive. Worse, the sweep's per-period cap was consumed by
+  those irrelevant builds: an environment holding more stale RUNNING builds
+  than the cap could stop reaching genuine reactive builds entirely, and
+  silently — disabling the safety net exactly when it was needed. The
+  truncation warning now says how many _reactive_ builds owned by _which
+  app_ it truncated, and what to do about it. `build_list_running` gained an
+  optional `reactive_app_name` argument; the client-side status re-check is
+  retained so a server predating the filters degrades to a wider listing
+  rather than to ticking terminal builds. Note that scoping removes the
+  incidental cross-app coverage a sweep used to provide: a build owned by
+  an app deployed without a watchdog is no longer swept by another app's
+  watchdog. ([#208](https://github.com/stardag-dev/stardag/issues/208) A3)
+- **A reactive trigger that fails part-way no longer leaves a build stuck
+  in RUNNING forever.** `build_trigger(reactive=True)` mints the build
+  before running discovery and persisting the task store, and a build's
+  status is derived from its events — so a failure in between (most often a
+  target-root permission or storage error on the task-store write) left a
+  RUNNING build that nothing would ever terminate and that carried no
+  reactive owner, so it was invisible to its own app's sweep and pure
+  overhead for every other one. All post-mint trigger work is now wrapped:
+  any failure emits a terminal `BUILD_FAILED` naming the stage that failed
+  before the original exception propagates (a failure to record that event
+  is logged, never allowed to mask the root cause).
+  ([#208](https://github.com/stardag-dev/stardag/issues/208) A4)
+
 ## [0.17.0] — 2026-08-06
 
 ### SDK

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -145,10 +145,12 @@ DAG-defining code) spawns work.
 
 Each reactive build is **owned by the app that triggered it** (the owning
 app name is stored in the registry with the build's reactive metadata):
-ticks from any other deployed app in the environment — typically another
-app's watchdog sweep — forward the wake-up to the owner's tick instead of
-driving the build with the wrong code. Ownership moves only by an explicit
-re-trigger from the new app, which also updates the tick config.
+each app's watchdog sweeps only its own builds, and a tick that reaches
+any other deployed app in the environment — typically a wake-up from a
+worker still running under a previous owner — forwards the wake-up to the
+owner's tick instead of driving the build with the wrong code. Ownership
+moves only by an explicit re-trigger from the new app, which also updates
+the tick config.
 
 Reactive scheduling is experimental and currently Modal-first — see
 [Integrate with Modal](../how-to/integrate-modal.md#reactive-scheduling-no-resident-build-function-experimental)

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -484,9 +484,16 @@ Two operational notes:
   still importable and its fields are compatible (nested task fields
   must use `sd.TaskLoads`/`sd.SubClass` annotations). Only if both paths
   fail is the task failed by the next tick (never a silent stall).
-- **The watchdog sweep runs one quick scheduling pass per running build**
-  (it skips the linger), so its per-period cost is one short function
-  invocation plus a frontier query per running build.
+- **The watchdog sweep runs one quick scheduling pass per running build
+  that this app owns** (it skips the linger), so its per-period cost is
+  one short function invocation plus a frontier query per such build.
+  The sweep asks the registry only for RUNNING builds whose reactive
+  owner is this app, so unrelated builds in the environment — resident
+  builds, and builds left RUNNING by an orchestrator that died without
+  emitting a terminal event — cost nothing and cannot crowd out the
+  sweep's per-period cap. A build owned by an app deployed _without_
+  `watchdog_period_minutes` therefore has no watchdog covering it, even
+  if another app in the environment has one.
 - **Define the callables you pass to `StardagApp` in an importable
   module.** `worker_selector`, `limit_key_selector`, and any custom
   build/run functions are captured by the serialized Modal functions
@@ -553,15 +560,16 @@ server before relying on limits.
 **App ownership.** Each reactive build is owned by the `StardagApp`
 that triggered it (`app_name` recorded in the build's reactive metadata in
 the registry, read by every tick from the build frontier). With
-several apps deployed in one environment, every watchdog sweeps all
-running reactive builds — but a tick from a non-owning app never drives
-the build with its own commit's code and selectors (or unpickles the
-owner's task store, which may not match its code). Instead it
-**forwards**: it spawns the owner app's tick (best-effort) and returns
-`outcome="foreign_app"` — so wake-ups that land on the wrong app are
-not lost, and every app's watchdog doubles as cross-app coverage (the
-owner-side scheduler lease collapses duplicate forwards). Redeploying
-the **same** app name is the normal upgrade path and unaffected.
+several apps deployed in one environment, each app's watchdog sweeps only
+the builds that app owns. A tick from a non-owning app can still be
+triggered — typically a wake-up from a worker still running under a
+previous owner — and it never drives the build with its own commit's code
+and selectors (or unpickles the owner's task store, which may not match
+its code). Instead it **forwards**: it spawns the owner app's tick
+(best-effort) and returns `outcome="foreign_app"` — so wake-ups that land
+on the wrong app are not lost (the owner-side scheduler lease collapses
+duplicate forwards). Redeploying the **same** app name is the normal
+upgrade path and unaffected.
 
 To migrate a build to a different app, re-trigger it from that app
 (`build_trigger(tasks, reactive=True, build_id=<existing id>)`): the

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -73,6 +73,7 @@ from stardag.integration.modal._target import (
 from stardag.registry._base import (
     NoOpRegistry,
     accepts_executor_metadata_kwarg,
+    accepts_reactive_app_name_kwarg,
     get_git_commit_hash,
     registry_provider,
 )
@@ -288,6 +289,7 @@ def _run_watchdog_sweep(
     registry: typing.Any,
     tick: typing.Callable[..., typing.Any],
     sweep_limit: int = 100,
+    reactive_app_name: str | None = None,
 ) -> None:
     """One watchdog pass: tick every running build, without lingering.
 
@@ -295,21 +297,94 @@ def _run_watchdog_sweep(
     sweep runs ticks sequentially in one function call — persisted linger
     settings (default 120 s) would blow through the function timeout after
     a couple of builds and starve the rest of the safety-net tick.
+
+    ``reactive_app_name`` scopes the listing to the builds this app owns.
+    Without it, ``sweep_limit`` is spent on whatever RUNNING builds happen
+    to be most recently active in the environment — including builds no
+    tick can ever advance (resident-orchestrator builds, and builds whose
+    orchestrator died without emitting a terminal event, which stay RUNNING
+    forever). Once those exceed the limit the safety net stops reaching
+    genuine reactive builds entirely, and silently.
+
+    Trade-off: scoping drops the incidental cross-app coverage a sweep used
+    to provide, where app A's watchdog would tick app B's builds and the
+    tick would forward the wake-up to B. That coverage was accidental and
+    unreliable (it competed for the same limit); the owner app's own
+    watchdog is the supported mechanism, and forwarding still handles
+    wake-ups from workers of a previous owner. The one case that regresses
+    is a build owned by an app deployed WITHOUT a watchdog, which
+    build_trigger already warns about at trigger time.
     """
     if type(registry) is NoOpRegistry:
         logger.warning("Tick watchdog: no registry configured; nothing to do.")
         return
-    running_builds = registry.build_list_running(limit=sweep_limit)
+    # Old custom RegistryABC implementations predate the kwarg; degrade to
+    # an unscoped listing rather than breaking the sweep entirely.
+    if reactive_app_name is not None and accepts_reactive_app_name_kwarg(
+        registry.build_list_running
+    ):
+        running_builds = registry.build_list_running(
+            limit=sweep_limit, reactive_app_name=reactive_app_name
+        )
+        scope = f"reactive builds owned by {reactive_app_name!r}"
+    else:
+        running_builds = registry.build_list_running(limit=sweep_limit)
+        scope = "running builds"
     if len(running_builds) >= sweep_limit:
         logger.warning(
-            f"Tick watchdog: {sweep_limit}+ running builds; only the "
-            f"{sweep_limit} most recently active are swept."
+            f"Tick watchdog: {sweep_limit}+ {scope}; only the {sweep_limit} "
+            "most recently active are swept, so a less-recently-active build "
+            "may not be ticked this period. Cancel or clean up builds that "
+            "are RUNNING but abandoned, or reduce the number of concurrent "
+            "reactive builds per app."
         )
+    # Each tick re-reads the build's reactive metadata (GET /builds/{id}) to
+    # resolve the owner app and the stored tick_kwargs, so that probe is not
+    # redundant with the server-side filter — but it is now paid only for
+    # builds that survived the filter, instead of once per RUNNING build in
+    # the environment. It also stays the correctness backstop: a tick on a
+    # non-reactive build (which a degraded, unfiltered listing can still
+    # yield) no-ops on that gate.
     for running_build_id in running_builds:
         try:
             tick(str(running_build_id), tick_kwargs={"linger_seconds": 0})
         except Exception:
             logger.exception(f"Watchdog tick failed for build {running_build_id}")
+
+
+def _fail_build_on_trigger_error(
+    registry: typing.Any,
+    build_id: UUID,
+    stage: str,
+    error: BaseException,
+) -> None:
+    """Emit a terminal BUILD_FAILED for a trigger that died mid-way.
+
+    A build's status is derived from its events: once ``build_start`` has
+    happened, only a terminal event can move the build out of RUNNING. If
+    the trigger raises before it is finished, nobody else will ever emit
+    one — no orchestrator was ever spawned — so the trigger must do it.
+
+    Best-effort by construction: the caller re-raises the original error
+    unconditionally, and a failure to record the terminal event is logged
+    rather than raised, so a secondary registry error can never mask the
+    root cause the user needs to see.
+    """
+    try:
+        registry.build_fail(
+            build_id,
+            f"Reactive trigger failed during {stage}: {type(error).__name__}: {error}",
+        )
+        logger.info(
+            f"Reactive trigger failed during {stage}; marked build "
+            f"{build_id} as failed."
+        )
+    except Exception:
+        logger.exception(
+            f"Reactive trigger failed during {stage}, and marking build "
+            f"{build_id} as failed ALSO failed; the build may be left in "
+            "RUNNING status and should be cancelled manually."
+        )
 
 
 _TICK_KWARGS_ALLOWED = ("linger_seconds", "poll_interval_seconds", "fail_mode")
@@ -2328,7 +2403,14 @@ class StardagApp:
 
             def _modal_tick_watchdog() -> None:
                 _setup_logging()
-                _run_watchdog_sweep(registry_provider.get(), _modal_tick)
+                # Scoped to this app's own reactive builds: see
+                # _run_watchdog_sweep for why sweeping the environment's
+                # whole RUNNING set is both wasteful and unsafe at scale.
+                _run_watchdog_sweep(
+                    registry_provider.get(),
+                    _modal_tick,
+                    reactive_app_name=app_name,
+                )
 
             self.modal_app.function(
                 **{
@@ -2591,37 +2673,70 @@ class StardagApp:
         same configuration.
         """
         root_ids = [str(t.id) for t in task_list]
-        if is_retrigger:
-            # Un-terminal the build (no-op on a fresh/running build) and
-            # register the (possibly new) roots BEFORE discovery, so a
-            # concurrent tick can't complete-and-terminal the build on the
-            # old root set while we're adding to it.
-            if executor_metadata is not None and accepts_executor_metadata_kwarg(
-                registry.build_resume
-            ):
-                registry.build_resume(build_id, executor_metadata=executor_metadata)
-            else:
-                registry.build_resume(build_id)
-            registry.build_add_roots(build_id, root_ids)
-        discovery = asyncio.run(
-            discover_and_register_aio(
-                registry, build_id, tuple(task_list), retry_failed=True
+        # Everything up to and including build_set_reactive_meta runs AFTER
+        # the build row exists and is RUNNING (build status is derived from
+        # events, so nothing else will ever move it). A failure in here —
+        # most likely a target-root permission/storage error on the task
+        # store write, but discovery can raise too — used to leave the build
+        # RUNNING forever, and, because the reactive marker is written last,
+        # not even attributable to an app: invisible to the owner's scoped
+        # watchdog sweep and swept fruitlessly by everything else.
+        #
+        # Writing the marker earlier would make such a build discoverable,
+        # but it would also expose a partially-discovered DAG to a tick,
+        # which treats the registry frontier as ground truth and can
+        # terminal a build whose tasks are not registered yet. So the
+        # ordering stays and the terminal event is the fix: any failure
+        # emits BUILD_FAILED naming the stage, then re-raises.
+        stage = "build resume / root registration"
+        try:
+            if is_retrigger:
+                # Un-terminal the build (no-op on a fresh/running build) and
+                # register the (possibly new) roots BEFORE discovery, so a
+                # concurrent tick can't complete-and-terminal the build on
+                # the old root set while we're adding to it.
+                if executor_metadata is not None and accepts_executor_metadata_kwarg(
+                    registry.build_resume
+                ):
+                    registry.build_resume(build_id, executor_metadata=executor_metadata)
+                else:
+                    registry.build_resume(build_id)
+                registry.build_add_roots(build_id, root_ids)
+            stage = "task discovery and registration"
+            discovery = asyncio.run(
+                discover_and_register_aio(
+                    registry, build_id, tuple(task_list), retry_failed=True
+                )
             )
-        )
-        store = BuildTaskStore(build_id)
-        store.save_tasks(discovery.incomplete.values())
-        # Persist the reactive marker/owner/config in the registry
-        # (``reactive_app_name`` is the "this build is reactively scheduled"
-        # marker read by every tick). This is an upsert: because the registry
-        # is mutable — unlike a possibly-immutable target root — a re-trigger
-        # MAY update tick_kwargs. tick_kwargs is passed through as-is: None
-        # (a bare re-trigger) preserves the stored config server-side rather
-        # than wiping it, so the 0.10.1 merge-semantics guarantee holds.
-        # Build roots are tracked in the registry too (build_add_roots above
-        # — the scheduler reads them from the frontier).
-        registry.build_set_reactive_meta(
-            build_id, app_name=self.name, tick_kwargs=tick_kwargs
-        )
+            stage = "task store write"
+            store = BuildTaskStore(build_id)
+            store.save_tasks(discovery.incomplete.values())
+            stage = "reactive metadata write"
+            # Persist the reactive marker/owner/config in the registry
+            # (``reactive_app_name`` is the "this build is reactively
+            # scheduled" marker read by every tick). This is an upsert:
+            # because the registry is mutable — unlike a possibly-immutable
+            # target root — a re-trigger MAY update tick_kwargs. tick_kwargs
+            # is passed through as-is: None (a bare re-trigger) preserves the
+            # stored config server-side rather than wiping it, so the 0.10.1
+            # merge-semantics guarantee holds. Build roots are tracked in the
+            # registry too (build_add_roots above — the scheduler reads them
+            # from the frontier).
+            registry.build_set_reactive_meta(
+                build_id, app_name=self.name, tick_kwargs=tick_kwargs
+            )
+        except BaseException as error:
+            # BaseException, not Exception: a Ctrl-C during discovery is one
+            # of the likelier ways to abandon a trigger, and it wedges the
+            # build exactly the same way. The original error always
+            # propagates — _fail_build_on_trigger_error never masks it.
+            _fail_build_on_trigger_error(registry, build_id, stage, error)
+            raise
+        # The spawn is deliberately OUTSIDE the wrapper: by this point the
+        # durable state is complete and consistent, and the build carries the
+        # reactive marker, so a failed spawn is recovered by the app's next
+        # watchdog sweep (or a re-trigger). Failing the build here would take
+        # it out of the watchdog's RUNNING listing and remove that recovery.
         tick_function = modal.Function.from_name(app_name=self.name, name="tick")
         function_call = tick_function.spawn(build_id=str(build_id))
         return BuildTriggerResult(build_id=build_id, function_call=function_call)

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -320,9 +320,10 @@ def _run_watchdog_sweep(
         return
     # Old custom RegistryABC implementations predate the kwarg; degrade to
     # an unscoped listing rather than breaking the sweep entirely.
-    if reactive_app_name is not None and accepts_reactive_app_name_kwarg(
+    scoped = reactive_app_name is not None and accepts_reactive_app_name_kwarg(
         registry.build_list_running
-    ):
+    )
+    if scoped:
         running_builds = registry.build_list_running(
             limit=sweep_limit, reactive_app_name=reactive_app_name
         )
@@ -331,12 +332,24 @@ def _run_watchdog_sweep(
         running_builds = registry.build_list_running(limit=sweep_limit)
         scope = "running builds"
     if len(running_builds) >= sweep_limit:
+        # The remedy follows `scoped`, not whether a name was *asked* for:
+        # a scoping request the registry cannot honour still yields a
+        # listing capped by RUNNING builds of every kind, and "run fewer
+        # reactive builds per app" would then be advice about the wrong
+        # population.
+        remedy = (
+            "Cancel or clean up builds that are RUNNING but abandoned, or "
+            "reduce the number of concurrent reactive builds for this app."
+            if scoped
+            else "This listing was not scoped to a reactive app, so the cap "
+            "was consumed by RUNNING builds of every kind — most likely "
+            "abandoned ones. Clean those up (`stardag builds cleanup`); an "
+            "upgraded registry would also scope this listing."
+        )
         logger.warning(
             f"Tick watchdog: {sweep_limit}+ {scope}; only the {sweep_limit} "
             "most recently active are swept, so a less-recently-active build "
-            "may not be ticked this period. Cancel or clean up builds that "
-            "are RUNNING but abandoned, or reduce the number of concurrent "
-            "reactive builds per app."
+            f"may not be ticked this period. {remedy}"
         )
     # Each tick re-reads the build's reactive metadata (GET /builds/{id}) to
     # resolve the owner app and the stored tick_kwargs, so that probe is not

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -2689,6 +2689,16 @@ class StardagApp:
         # ordering stays and the terminal event is the fix: any failure
         # emits BUILD_FAILED naming the stage, then re-raises.
         stage = "build resume / root registration"
+        # Emitting the terminal event is only correct once THIS trigger has
+        # put the build into RUNNING. A fresh build was minted and started by
+        # the caller, so it already is. A re-trigger's build may still be
+        # terminal until build_resume succeeds — and a transient error on
+        # that very call would otherwise flip a COMPLETED build to FAILED,
+        # which is strictly worse than the orphan this wrapper exists to
+        # prevent. A re-trigger of an already-RUNNING build is the same case
+        # seen from the other side: it was RUNNING before we touched it, so
+        # it is not an orphan of ours to terminate.
+        build_is_running = not is_retrigger
         try:
             if is_retrigger:
                 # Un-terminal the build (no-op on a fresh/running build) and
@@ -2701,6 +2711,7 @@ class StardagApp:
                     registry.build_resume(build_id, executor_metadata=executor_metadata)
                 else:
                     registry.build_resume(build_id)
+                build_is_running = True
                 registry.build_add_roots(build_id, root_ids)
             stage = "task discovery and registration"
             discovery = asyncio.run(
@@ -2730,7 +2741,8 @@ class StardagApp:
             # of the likelier ways to abandon a trigger, and it wedges the
             # build exactly the same way. The original error always
             # propagates — _fail_build_on_trigger_error never masks it.
-            _fail_build_on_trigger_error(registry, build_id, stage, error)
+            if build_is_running:
+                _fail_build_on_trigger_error(registry, build_id, stage, error)
             raise
         # The spawn is deliberately OUTSIDE the wrapper: by this point the
         # durable state is complete and consistent, and the build carries the

--- a/lib/stardag/src/stardag/registry/_api_registry.py
+++ b/lib/stardag/src/stardag/registry/_api_registry.py
@@ -1105,11 +1105,23 @@ class APIRegistry(RegistryABC):
         )
         logger.info(f"Build exited early: {build_id}")
 
-    def build_list_running(self, limit: int = 100) -> list[UUID]:
+    def build_list_running(
+        self, limit: int = 100, reactive_app_name: str | None = None
+    ) -> list[UUID]:
         """List ids of running builds (most recently active first).
 
-        Pages through ``GET /builds`` (ordered by last_active_at desc) and
-        filters client-side on the derived status.
+        Pages through ``GET /builds``, narrowing server-side with
+        ``status=running`` and (when given) ``reactive_app_name`` — the
+        watchdog's real question is "RUNNING reactive builds owned by app
+        X", and an unnarrowed listing lets unrelated builds consume
+        ``limit`` (an environment that accumulates stale RUNNING builds
+        would silently stop reaching the reactive ones).
+
+        The derived status is re-checked client-side because a server
+        predating either filter ignores unknown query params and answers
+        with the unfiltered listing; the re-check keeps that degradation to
+        "wider than asked for" rather than "wrong". A wider listing is
+        harmless for the caller: a tick no-ops on a non-reactive build.
         """
         running: list[UUID] = []
         page = 1
@@ -1119,12 +1131,16 @@ class APIRegistry(RegistryABC):
         # stragglers would make the watchdog cost grow with total build
         # count. Truncation is logged.
         max_pages = 10
+        filter_params = {"status": "running"}
+        if reactive_app_name is not None:
+            filter_params["reactive_app_name"] = reactive_app_name
         while len(running) < limit:
             response = self._request(
                 "GET",
                 f"{self.api_url}/api/v1/builds",
                 params={
                     **self._get_params(),
+                    **filter_params,
                     "page": str(page),
                     "page_size": str(page_size),
                 },
@@ -1133,6 +1149,9 @@ class APIRegistry(RegistryABC):
             payload = response.json()
             builds = payload.get("builds", [])
             for build in builds:
+                # Redundant against a server that honours ``status``, and
+                # the only thing standing between a server that doesn't and
+                # a watchdog ticking terminal builds — keep it.
                 if build.get("status") == "running":
                     running.append(UUID(build["id"]))
                     if len(running) >= limit:

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -386,11 +386,17 @@ class RegistryABC(metaclass=abc.ABCMeta):
         self, limit: int = 100, reactive_app_name: str | None = None
     ) -> list[UUID]:
         """Async version of build_list_running."""
-        if reactive_app_name is not None and not accepts_reactive_app_name_kwarg(
+        # Only forward the kwarg when there is something to forward *and*
+        # the implementation takes it. An unscoped sweep must reach a
+        # pre-kwarg implementation unchanged — passing `None` positionally
+        # would raise TypeError on the very call that needs no scoping.
+        # Keyword, not positional: an implementation is free to make it
+        # keyword-only.
+        if reactive_app_name is None or not accepts_reactive_app_name_kwarg(
             self.build_list_running
         ):
             return self.build_list_running(limit)
-        return self.build_list_running(limit, reactive_app_name)
+        return self.build_list_running(limit, reactive_app_name=reactive_app_name)
 
     def build_add_roots(self, build_id: UUID, root_task_ids: list[str]) -> None:
         """Append root task ids to a build (reactive re-trigger with new roots).

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -79,6 +79,21 @@ def accepts_executor_metadata_kwarg(fn: Any) -> bool:
     return has_var_keyword or "executor_metadata" in params
 
 
+def accepts_reactive_app_name_kwarg(fn: Any) -> bool:
+    """Whether a ``build_list_running[_aio]`` impl accepts ``reactive_app_name``.
+
+    Same signature-inspection rationale as :func:`accepts_executor_kwargs`.
+    The watchdog degrades to an unscoped listing for older implementations
+    rather than raising: a tick no-ops on a non-reactive build, so a wider
+    listing only costs invocations, it does not misbehave.
+    """
+    info = _param_info(fn)
+    if info is None:
+        return False
+    params, has_var_keyword = info
+    return has_var_keyword or "reactive_app_name" in params
+
+
 class FrontierTaskRef(StardagBaseModel):
     """A task in a build's scheduling frontier (see :class:`BuildFrontier`)."""
 
@@ -354,17 +369,28 @@ class RegistryABC(metaclass=abc.ABCMeta):
             self.task_register(build_id, task)
         return None
 
-    def build_list_running(self, limit: int = 100) -> list[UUID]:
+    def build_list_running(
+        self, limit: int = 100, reactive_app_name: str | None = None
+    ) -> list[UUID]:
         """List ids of builds currently in RUNNING status (most recent first).
 
         Used by the reactive scheduler watchdog to sweep for builds that
-        may need a tick. Default: empty (no reactive-scheduling support).
+        may need a tick. ``reactive_app_name`` narrows the listing to builds
+        reactively scheduled by that app — the watchdog's actual question,
+        and what keeps ``limit`` from being consumed by unrelated builds.
+        Default: empty (no reactive-scheduling support).
         """
         return []
 
-    async def build_list_running_aio(self, limit: int = 100) -> list[UUID]:
+    async def build_list_running_aio(
+        self, limit: int = 100, reactive_app_name: str | None = None
+    ) -> list[UUID]:
         """Async version of build_list_running."""
-        return self.build_list_running(limit)
+        if reactive_app_name is not None and not accepts_reactive_app_name_kwarg(
+            self.build_list_running
+        ):
+            return self.build_list_running(limit)
+        return self.build_list_running(limit, reactive_app_name)
 
     def build_add_roots(self, build_id: UUID, root_task_ids: list[str]) -> None:
         """Append root task ids to a build (reactive re-trigger with new roots).

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -795,6 +795,112 @@ class TestStardagAppReactiveTrigger:
                 )
 
 
+class TestReactiveTriggerFailureLeavesNoOrphanBuild:
+    """A build minted by ``build_start`` is RUNNING until a terminal EVENT
+    says otherwise — and no orchestrator exists yet to emit one. So a
+    trigger that dies after minting must emit ``BUILD_FAILED`` itself, or
+    it leaves a build that is RUNNING forever and (because the reactive
+    marker is written last) not even attributable to an app.
+    """
+
+    def _make_app(self):
+        return StardagApp(
+            "test-reactive-app",
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={"default": FunctionSettings(image=_make_image())},
+        )
+
+    def _make_registry(self, build_id):
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_start.return_value = build_id
+        return registry
+
+    def _root(self):
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        return SyncOnlyTask(name="reactive-root")
+
+    def test_task_store_write_failure_fails_the_build(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        app = self._make_app()
+        build_id = uuid4()
+        registry = self._make_registry(build_id)
+
+        with patch(
+            "stardag.integration.modal._app.BuildTaskStore.save_tasks",
+            side_effect=PermissionError("read-only target root"),
+        ):
+            with registry_provider.override(registry):
+                with pytest.raises(PermissionError, match="read-only target root"):
+                    app.build_trigger(self._root(), reactive=True)
+
+        registry.build_fail.assert_called_once()
+        message = registry.build_fail.call_args.args[1]
+        assert "task store write" in message
+        assert "read-only target root" in message
+        # The marker is written after the store, so this build would have
+        # been an unattributable orphan; it must not be left RUNNING.
+        registry.build_set_reactive_meta.assert_not_called()
+
+    def test_discovery_failure_fails_the_build(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        """Reordering the store write ahead of ``build_start`` would not
+        cover this: discovery runs against the build id too."""
+        app = self._make_app()
+        build_id = uuid4()
+        registry = self._make_registry(build_id)
+        registry.task_register_bulk_aio.side_effect = RuntimeError("registry down")
+
+        with registry_provider.override(registry):
+            with pytest.raises(RuntimeError, match="registry down"):
+                app.build_trigger(self._root(), reactive=True)
+
+        assert (
+            "task discovery and registration" in registry.build_fail.call_args.args[1]
+        )
+
+    def test_secondary_build_fail_error_never_masks_the_root_cause(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        app = self._make_app()
+        build_id = uuid4()
+        registry = self._make_registry(build_id)
+        registry.build_fail.side_effect = RuntimeError("registry unreachable too")
+
+        with patch(
+            "stardag.integration.modal._app.BuildTaskStore.save_tasks",
+            side_effect=PermissionError("read-only target root"),
+        ):
+            with registry_provider.override(registry):
+                # The ORIGINAL error propagates, not the bookkeeping one.
+                with pytest.raises(PermissionError, match="read-only target root"):
+                    app.build_trigger(self._root(), reactive=True)
+
+    def test_spawn_failure_leaves_the_build_recoverable(
+        self, modal_function_stub, default_in_memory_fs_target, monkeypatch
+    ):
+        """The spawn is outside the wrapper on purpose: the durable state is
+        complete and the build carries the reactive marker, so the app's
+        watchdog recovers it. Failing it would remove that recovery path."""
+        app = self._make_app()
+        build_id = uuid4()
+        registry = self._make_registry(build_id)
+
+        def _boom(*args, **kwargs):
+            raise RuntimeError("modal spawn failed")
+
+        with registry_provider.override(registry):
+            with patch("modal.Function.from_name") as from_name:
+                from_name.return_value.spawn = _boom
+                with pytest.raises(RuntimeError, match="modal spawn failed"):
+                    app.build_trigger(self._root(), reactive=True)
+
+        registry.build_set_reactive_meta.assert_called_once()
+        registry.build_fail.assert_not_called()
+
+
 @pytest.fixture(autouse=True)
 def _mock_secret_hydrate(monkeypatch):
     """StardagApp.finalize() validates a by-name api-key secret via
@@ -1242,6 +1348,60 @@ class TestWatchdogSweep:
         from stardag.integration.modal._app import _run_watchdog_sweep
 
         _run_watchdog_sweep(NoOpRegistry(), lambda *a, **k: 1 / 0)  # no raise
+
+    def test_sweep_scopes_listing_to_this_apps_reactive_builds(self):
+        """The listing — not the tick — is where irrelevant builds must be
+        dropped: a tick on a non-reactive build is a whole (wasted) function
+        invocation, and unrelated builds otherwise consume the sweep limit."""
+        from stardag.integration.modal._app import _run_watchdog_sweep
+
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_list_running.return_value = []
+
+        _run_watchdog_sweep(registry, lambda *a, **k: None, reactive_app_name="an-app")
+
+        registry.build_list_running.assert_called_once_with(
+            limit=100, reactive_app_name="an-app"
+        )
+
+    def test_sweep_degrades_to_unscoped_listing_on_old_registry(self):
+        """A custom RegistryABC implementation predating the kwarg must not
+        break the sweep — it just gets the wider listing it always got."""
+        from stardag.integration.modal._app import _run_watchdog_sweep
+
+        calls: list = []
+
+        class OldRegistry(NoOpRegistry):
+            def build_list_running(self, limit: int = 100):  # type: ignore[override]
+                calls.append(limit)
+                return []
+
+        _run_watchdog_sweep(
+            OldRegistry(), lambda *a, **k: None, reactive_app_name="an-app"
+        )
+
+        assert calls == [100]
+
+    def test_truncation_warning_names_the_scope_and_the_remedy(self, caplog):
+        import logging
+
+        from stardag.integration.modal._app import _run_watchdog_sweep
+
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_list_running.return_value = [uuid4(), uuid4()]
+
+        with caplog.at_level(logging.WARNING):
+            _run_watchdog_sweep(
+                registry,
+                lambda *a, **k: None,
+                sweep_limit=2,
+                reactive_app_name="an-app",
+            )
+
+        # "2+ reactive builds owned by X", not "2+ running builds": the
+        # operator needs to know the cap was hit on RELEVANT builds.
+        assert "2+ reactive builds owned by 'an-app'" in caplog.text
+        assert "Cancel or clean up builds" in caplog.text
 
 
 class TestBuildTickConfig:

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -878,6 +878,44 @@ class TestReactiveTriggerFailureLeavesNoOrphanBuild:
                 with pytest.raises(PermissionError, match="read-only target root"):
                     app.build_trigger(self._root(), reactive=True)
 
+    def test_resume_failure_on_retrigger_does_not_terminate_the_build(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        """A re-trigger's build may still be TERMINAL on entry — nothing has
+        started it. Emitting BUILD_FAILED when the resume itself fails would
+        flip a COMPLETED build to FAILED over a transient registry error,
+        which is strictly worse than the orphan this wrapper prevents.
+        """
+        app = self._make_app()
+        build_id = uuid4()
+        registry = self._make_registry(build_id)
+        registry.build_resume.side_effect = RuntimeError("registry down")
+
+        with registry_provider.override(registry):
+            with pytest.raises(RuntimeError, match="registry down"):
+                app.build_trigger(self._root(), reactive=True, build_id=build_id)
+
+        registry.build_fail.assert_not_called()
+
+    def test_failure_after_a_successful_resume_does_terminate_the_build(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        """The other side of the same coin: once resume has put the build
+        back into RUNNING, this trigger owns it and must not abandon it."""
+        app = self._make_app()
+        build_id = uuid4()
+        registry = self._make_registry(build_id)
+        registry.task_register_bulk_aio.side_effect = RuntimeError("registry down")
+
+        with registry_provider.override(registry):
+            with pytest.raises(RuntimeError, match="registry down"):
+                app.build_trigger(self._root(), reactive=True, build_id=build_id)
+
+        registry.build_resume.assert_called_once()
+        assert (
+            "task discovery and registration" in registry.build_fail.call_args.args[1]
+        )
+
     def test_spawn_failure_leaves_the_build_recoverable(
         self, modal_function_stub, default_in_memory_fs_target, monkeypatch
     ):

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1439,7 +1439,33 @@ class TestWatchdogSweep:
         # "2+ reactive builds owned by X", not "2+ running builds": the
         # operator needs to know the cap was hit on RELEVANT builds.
         assert "2+ reactive builds owned by 'an-app'" in caplog.text
-        assert "Cancel or clean up builds" in caplog.text
+        assert "reduce the number of concurrent reactive builds" in caplog.text
+
+    def test_truncation_warning_remedy_differs_when_the_listing_is_unscoped(
+        self, caplog
+    ):
+        """An unscoped listing hit its cap on RUNNING builds of every kind,
+        so "run fewer reactive builds per app" is advice about the wrong
+        population — and the real remedy includes upgrading the registry."""
+        import logging
+
+        from stardag.integration.modal._app import _run_watchdog_sweep
+
+        class OldRegistry(NoOpRegistry):
+            def build_list_running(self, limit: int = 100):  # type: ignore[override]
+                return [uuid4(), uuid4()]
+
+        with caplog.at_level(logging.WARNING):
+            _run_watchdog_sweep(
+                OldRegistry(),
+                lambda *a, **k: None,
+                sweep_limit=2,
+                reactive_app_name="an-app",
+            )
+
+        assert "2+ running builds" in caplog.text
+        assert "not scoped to a reactive app" in caplog.text
+        assert "reduce the number of concurrent reactive builds" not in caplog.text
 
 
 class TestBuildTickConfig:

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -594,3 +594,73 @@ class TestConcurrencyLimitPathEncoding:
             self._encoded_path(captured[0])
             == "/api/v1/concurrency-limits/a%2Fb/holders/id%2F1/evict"
         )
+
+
+class TestBuildListRunningFilters:
+    """``build_list_running`` narrows ``GET /builds`` server-side.
+
+    The watchdog's question is "RUNNING reactive builds owned by app X".
+    Asking it unfiltered and answering it client-side lets unrelated builds
+    consume ``limit`` — an environment that accumulates stale RUNNING builds
+    then silently starves the reactive ones. The client-side status re-check
+    stays as the graceful-degradation guard for servers predating the
+    filters (unknown query params are ignored, not rejected).
+    """
+
+    def _make_registry_and_capture(self, pages):
+        import httpx
+
+        from stardag.registry._api_registry import APIRegistry
+
+        captured: list[httpx.Request] = []
+        remaining = list(pages)
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured.append(request)
+            builds = remaining.pop(0) if remaining else []
+            return httpx.Response(200, json={"builds": builds})
+
+        registry = APIRegistry(api_url="http://test.invalid", api_key="test-key")
+        registry._client = httpx.Client(
+            transport=httpx.MockTransport(handler),
+            auth=registry._auth,
+        )
+        return registry, captured
+
+    @staticmethod
+    def _build(status: str) -> dict:
+        from uuid import uuid4
+
+        return {"id": str(uuid4()), "status": status}
+
+    def test_status_filter_always_sent(self):
+        registry, captured = self._make_registry_and_capture([[self._build("running")]])
+        assert len(registry.build_list_running()) == 1
+        assert captured[0].url.params["status"] == "running"
+        assert "reactive_app_name" not in captured[0].url.params
+
+    def test_reactive_app_name_forwarded_when_given(self):
+        registry, captured = self._make_registry_and_capture([[self._build("running")]])
+        registry.build_list_running(limit=10, reactive_app_name="an-app")
+        assert captured[0].url.params["reactive_app_name"] == "an-app"
+        assert captured[0].url.params["status"] == "running"
+
+    def test_old_server_ignoring_filters_still_yields_only_running(self):
+        """Graceful degradation: a server that ignores the query params
+        answers with the unfiltered listing — the client-side re-check must
+        keep terminal builds out of the result."""
+        page = [
+            self._build("completed"),
+            self._build("running"),
+            self._build("failed"),
+        ]
+        registry, _ = self._make_registry_and_capture([page])
+        result = registry.build_list_running()
+        assert [str(b) for b in result] == [page[1]["id"]]
+
+    def test_limit_stops_paging(self):
+        registry, captured = self._make_registry_and_capture(
+            [[self._build("running") for _ in range(100)]]
+        )
+        assert len(registry.build_list_running(limit=2)) == 2
+        assert len(captured) == 1  # limit reached mid-page: no second request

--- a/lib/stardag/tests/test_registry/test_api_registry.py
+++ b/lib/stardag/tests/test_registry/test_api_registry.py
@@ -664,3 +664,64 @@ class TestBuildListRunningFilters:
         )
         assert len(registry.build_list_running(limit=2)) == 2
         assert len(captured) == 1  # limit reached mid-page: no second request
+
+
+class TestBuildListRunningAioDelegate:
+    """`RegistryABC.build_list_running_aio` forwards to the sync method.
+
+    How it forwards is a compatibility surface: `reactive_app_name` was
+    added to the ABC after implementations existed, so the delegate must
+    still reach an implementation that predates it.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unscoped_call_reaches_an_implementation_without_the_kwarg(self):
+        """An unscoped sweep has nothing to forward, so it must not try.
+
+        Passing `reactive_app_name=None` through anyway raises TypeError on
+        a pre-kwarg implementation — on precisely the call that asked for
+        no scoping and therefore needs no new parameter.
+        """
+        from stardag.registry import NoOpRegistry
+
+        seen: list[int] = []
+
+        class OldRegistry(NoOpRegistry):
+            def build_list_running(self, limit: int = 100):  # type: ignore[override]
+                seen.append(limit)
+                return []
+
+        assert await OldRegistry().build_list_running_aio(limit=7) == []
+        assert seen == [7]
+
+    @pytest.mark.asyncio
+    async def test_scoped_call_forwards_by_keyword(self):
+        """Keyword, not positional: an implementation may make it
+        keyword-only, and a positional forward would then fail."""
+        from stardag.registry import NoOpRegistry
+
+        seen: list[tuple] = []
+
+        class NewRegistry(NoOpRegistry):
+            def build_list_running(  # type: ignore[override]
+                self, limit: int = 100, *, reactive_app_name: str | None = None
+            ):
+                seen.append((limit, reactive_app_name))
+                return []
+
+        await NewRegistry().build_list_running_aio(limit=3, reactive_app_name="an-app")
+        assert seen == [(3, "an-app")]
+
+    @pytest.mark.asyncio
+    async def test_scoped_call_degrades_when_the_kwarg_is_unsupported(self):
+        from stardag.registry import NoOpRegistry
+
+        seen: list[int] = []
+
+        class OldRegistry(NoOpRegistry):
+            def build_list_running(self, limit: int = 100):  # type: ignore[override]
+                seen.append(limit)
+                return []
+
+        await OldRegistry().build_list_running_aio(limit=5, reactive_app_name="an-app")
+        assert seen == [5]


### PR DESCRIPTION
Two independent reactive-scheduling fixes from #208 — sections **A3** and
**A4**. Both are small, and both matter more the longer an environment
lives. `lib/` only.

## A3 — the watchdog ignores the server-side filters that exist for it

`build_list_running` paged `GET /builds` **unfiltered** and filtered on
the derived status client-side, even though the API has supported
`status=` and `reactive_app_name=` since the reactive-metadata release —
`reactive_app_name` exists precisely because "RUNNING reactive builds
owned by app X" is the watchdog's actual question.

One correction to the issue's phrasing, worth stating because it changes
the cost model: `_run_watchdog_sweep` does not itself issue a per-build
`GET /builds/{id}`. It calls the tick **locally, in-process, sequentially**
with `linger_seconds=0`, and the tick's own pre-lease gate
(`registry.build_get`, returning `{"outcome": "not_reactive"}`) is what
discovers most builds aren't reactive. So an irrelevant RUNNING build cost
a whole tick invocation every sweep period, not just a listing row.

The cap is the sharper problem. Builds sort by `last_active_at desc`, so
once an environment holds more stale RUNNING builds than `sweep_limit`
(nothing terminates abandoned builds today — #208 B3), the sweep can stop
reaching genuine reactive builds **entirely and silently**, disabling the
safety net exactly when it's needed.

Changes:

- `RegistryABC.build_list_running` / `build_list_running_aio` /
  `APIRegistry.build_list_running` take an optional `reactive_app_name`,
  and the API implementation now sends `status=running` unconditionally
  plus `reactive_app_name` when given.
- `_run_watchdog_sweep` takes `reactive_app_name` and the deployed
  `tick_watchdog` passes this app's name.
- The tick's own gate is **untouched** — it's still needed for
  `reactive_tick_kwargs` and app-ownership forwarding, and it stays the
  correctness backstop. It's simply now paid only for builds that survived
  the server-side filter.
- The truncation warning distinguishes `N+ reactive builds owned by <app>`
  from `N+ running builds` and says what to do about it.

**Graceful degradation.** A server predating the filters ignores unknown
query params rather than rejecting them, so it answers with the unfiltered
listing. The client-side status re-check is deliberately kept: it bounds
that degradation to "wider than asked for" instead of "the watchdog ticks
terminal builds". A wider listing is otherwise harmless — a tick no-ops on
a non-reactive build. Custom `RegistryABC` implementations written before
the kwarg are detected by signature inspection (the existing `accepts_*`
pattern in `registry/_base.py`) and called the old way.

**Behaviour change a reviewer should weigh.** Scoping drops the incidental
cross-app coverage a sweep used to provide, where app A's watchdog ticked
app B's builds and the tick forwarded to B. That coverage was accidental
and competed for the same cap; the owner app's own watchdog is the
supported mechanism, and forwarding still handles wake-ups from a previous
owner's still-running workers. The one case that regresses is a build
owned by an app deployed **without** `watchdog_period_minutes` — which
`build_trigger` already warns about at trigger time. Documented in both
`integrate-modal.md` and `build-execution.md`.

## A4 — a failed reactive trigger left an orphan RUNNING build forever

`_trigger_reactive` mints the build first, then discovers, then writes the
task store, then writes the reactive marker, then spawns. Build status is
derived from events, so a failure anywhere in that window left a build
`RUNNING` forever with no orchestrator that could ever emit a terminal
event — and, because the marker is written **last**, not even attributable
to an app: invisible to its own app's now-scoped sweep and pure overhead
for every other one.

All post-`build_start` work is wrapped so **any** exception emits a
terminal `BUILD_FAILED` naming the stage that failed
(`"Reactive trigger failed during task store write: PermissionError: …"`)
before the original exception propagates. If emitting that event also
fails, it's logged and the original error still propagates — the root
cause is never masked.

Two deliberate choices:

- **Ordering left alone.** Writing the reactive marker earlier would make
  a wedged build discoverable, but it would also expose a
  partially-discovered DAG to a tick, which treats the registry frontier
  as ground truth. Preferring the terminal-event wrapper also covers
  discovery, which reordering the task-store write alone would not.
- **The spawn is outside the wrapper.** By then the durable state is
  complete and the build carries the reactive marker, so a failed spawn is
  recovered by the next watchdog sweep or a re-trigger. Failing the build
  there would take it out of the watchdog's RUNNING listing and remove
  that recovery path.

`except BaseException` rather than `except Exception`: a Ctrl-C during
discovery is one of the likelier ways to abandon a trigger and wedges the
build identically. The original exception is always re-raised.

#208 B1 will later remove the target-root write from this path for most
users; A4 is worth having independently — discovery can raise too.

## Tests

- `tests/test_registry/test_api_registry.py::TestBuildListRunningFilters` —
  `status=running` always sent; `reactive_app_name` forwarded when given;
  an old server that ignores both filters still yields only RUNNING builds;
  `limit` stops paging mid-page.
- `tests/test_integration/test_modal/test_stardag_app.py::TestWatchdogSweep`
  — the listing is scoped to the app; an implementation predating the
  kwarg degrades to the unscoped call instead of raising; the truncation
  warning names the scope and the remedy.
- `…::TestReactiveTriggerFailureLeavesNoOrphanBuild` — a task-store write
  failure and a discovery failure each emit `BUILD_FAILED` with the right
  stage; a secondary `build_fail` error never masks the original; a spawn
  failure leaves the build marked and recoverable rather than failed.

`uv run pytest tests -m "not modal_live" -q` → **956 passed, 29
deselected**. No live/integration tests were run.

`pre-commit run --files <changed>` → `prettier`, `ruff`, `ruff-format`,
`pyright-stardag` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NyR9Kc9ZP5Ko7dVndhi3Y
