### PR TITLE
fix(api): surface externally-blocked tasks in the build frontier; allow retry from suspended (#208 A1/A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   was declared and documented as the input to scheduler staleness bounds
   but never populated, so it always serialised as `null` and those guards
   silently did nothing.
+- **`POST /builds/{id}/tasks/{task_id}/retry` accepts `suspended`.** A task
+  suspended for dynamic dependencies and then abandoned (orchestrator died,
+  build cancelled) was permanently unschedulable — the only escape was an
+  undocumented cancel-then-retry. `running` remains non-retryable on
+  purpose: it holds a live execution claim, and releasing that is
+  cancellation, not retry.
 
 ### SDK
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### Registry API
+
+- **`GET /builds/{id}/frontier` now reports why a build is waiting on work
+  it does not own** ([#208](https://github.com/stardag-dev/stardag/issues/208)).
+  Dependency gating is environment-global (task rows and edges are shared
+  across builds) while `running`/`status_counts` cover only the tasks a
+  build has events for, so an upstream left non-COMPLETED by another build
+  could gate a build's tasks while contributing nothing it could see — a
+  scheduler then read "nothing actionable, nothing running" as "cannot
+  progress" and failed the build. The new `blocked_by_external` list pairs
+  each such blocked task with its blocker (identity, status, the owning
+  build id and status timestamp, and whether the blocker is in this build's
+  task set), capped with an explicit `blocked_by_external_truncated` flag.
+  Purely additive: every existing field keeps its exact semantics.
+- **Frontier task refs now actually carry `latest_status_at`.** The field
+  was declared and documented as the input to scheduler staleness bounds
+  but never populated, so it always serialised as `null` and those guards
+  silently did nothing.
+
 ### SDK
 
 - **Reactive builds now discover the DAG inside Modal, not on the machine

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -2524,14 +2524,25 @@ async def retry_task(
     auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
     commit_hash: str | None = None,
 ):
-    """Reset a failed/cancelled/skipped task to pending (retry).
+    """Reset a failed/cancelled/skipped/suspended task to pending (retry).
 
-    Emits TASK_RETRIED; status derivation flips only terminal-but-
-    retryable statuses back to PENDING — completed and running tasks are
-    unaffected (the event is still recorded, making concurrent
-    trigger/retry races benign). Used by reactive triggers so a
-    re-triggered failed build (or a new build referencing a previously
-    failed task) becomes schedulable again.
+    Emits TASK_RETRIED; status derivation flips only retryable statuses
+    back to PENDING. Used by reactive triggers so a re-triggered failed
+    build (or a new build referencing a previously failed task) becomes
+    schedulable again.
+
+    **Suspended tasks are retryable.** A task suspended for dynamic
+    dependencies is not executing — the execution yielded and returned —
+    so a task whose orchestrator then died has no path forward except
+    running again from scratch, which is what a retry means. Without this
+    it would be permanently unschedulable.
+
+    **Completed and running tasks are unaffected.** COMPLETED is sticky.
+    RUNNING is excluded on purpose: it holds a live execution claim, and
+    releasing that claim is cancellation (POST .../cancel), not retry —
+    resetting it to PENDING would invite a second, concurrent execution of
+    the same task. The event is recorded either way, which is what makes
+    concurrent trigger/retry races benign.
     """
     return await _create_task_event(
         build_id, task_id, EventType.TASK_RETRIED, db, auth, commit_hash=commit_hash

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -52,6 +52,7 @@ from stardag_api.schemas import (
     BuildListResponse,
     BuildNotifyResponse,
     BuildResponse,
+    FrontierExternalBlocker,
     FrontierTaskRef,
     EventResponse,
     SetReactiveMetaRequest,
@@ -104,6 +105,22 @@ def _raise_if_limit_exceeded(error: LimitExceededError | None) -> None:
 # every read. Enforced consistently on the query-param paths (task start,
 # build resume) and the build-create body path.
 _MAX_EXECUTOR_METADATA_BYTES = 2048
+
+# Task statuses the build frontier considers still in play: neither
+# COMPLETED nor a failure terminal, so the build either can act on them or
+# is waiting for someone who can.
+_FRONTIER_NON_TERMINAL_STATUSES = (
+    TaskStatus.PENDING,
+    TaskStatus.SUSPENDED,
+    TaskStatus.RUNNING,
+)
+
+# Cap on BuildFrontierResponse.blocked_by_external. A wide DAG stalled
+# behind another build can produce one entry per blocked edge; the list is
+# a diagnostic ("you are waiting, and here is on what"), so a bounded
+# sample plus the truncation flag carries the same signal at a fixed
+# payload size. Deliberately not silent — see blocked_by_external_truncated.
+_MAX_FRONTIER_EXTERNAL_BLOCKERS = 50
 
 
 def _validate_executor_metadata_size(metadata: dict) -> None:
@@ -1323,6 +1340,11 @@ async def get_build_frontier(
     denormalised statuses — a task completed or running in another build
     counts as such here too (which is exactly what a scheduler wants:
     don't re-run what's done, re-attach to what's running).
+
+    ``blocked_by_external`` reconciles the two scopes this endpoint mixes:
+    dependency gating is environment-global, while ``running`` and
+    ``status_counts`` cover only tasks this build has events for. See
+    :class:`FrontierExternalBlocker`.
     """
     _raise_if_limit_exceeded(check_rate_limit(auth.workspace_id, limits_settings))
     build = await _get_build_checked(build_id, db, auth)
@@ -1367,13 +1389,7 @@ async def get_build_frontier(
                 select(Task)
                 .where(
                     Task.id.in_(build_task_ids),
-                    Task.latest_status.in_(
-                        [
-                            TaskStatus.PENDING,
-                            TaskStatus.SUSPENDED,
-                            TaskStatus.RUNNING,
-                        ]
-                    ),
+                    Task.latest_status.in_(_FRONTIER_NON_TERMINAL_STATUSES),
                     ~has_incomplete_upstream,
                 )
                 .order_by(Task.created_at)
@@ -1400,6 +1416,80 @@ async def get_build_frontier(
         .all()
     )
 
+    # Why a build with nothing actionable and nothing running can still be
+    # perfectly healthy: `has_incomplete_upstream` above joins Task
+    # *globally* (task rows and dependency edges are per-environment), while
+    # `running` / `status_counts` are scoped to this build's task set. An
+    # upstream that some other build left RUNNING therefore gates this
+    # build's downstream tasks while contributing nothing this build can
+    # see — and it need not be in this build's task set at all (a dynamic
+    # dependency registered under an earlier build is the usual case).
+    # Reported explicitly rather than folded into `running`, which must keep
+    # meaning "RUNNING tasks of *this* build" (it is the cancellation
+    # target list).
+    #
+    # One flat (blocked, blocker) query — resolving blockers per blocked
+    # task would be N+1 on an endpoint polled every tick. It mirrors the
+    # join `actionable` already performs, so the added cost is ~one more
+    # pass over this build's dependency edges (ix_task_dep_downstream),
+    # bounded by LIMIT.
+    blocked = aliased(Task)
+    blocker = aliased(Task)
+    blocker_rows = (
+        await db.execute(
+            select(
+                blocked.task_id,
+                blocker.task_id,
+                blocker.task_namespace,
+                blocker.task_name,
+                blocker.latest_status,
+                blocker.latest_status_at,
+                blocker.latest_status_build_id,
+                blocker.id.in_(build_task_ids),
+            )
+            .select_from(TaskDependency)
+            .join(blocked, TaskDependency.downstream_task_id == blocked.id)
+            .join(blocker, TaskDependency.upstream_task_id == blocker.id)
+            .where(
+                blocked.id.in_(build_task_ids),
+                blocked.latest_status.in_(_FRONTIER_NON_TERMINAL_STATUSES),
+                blocker.latest_status != TaskStatus.COMPLETED,
+                # Null-safe inequality (renders IS DISTINCT FROM on
+                # Postgres, IS NOT on SQLite): a blocker with no recorded
+                # status build — a pre-denormalisation row — is likewise not
+                # something this build put there.
+                blocker.latest_status_build_id.is_distinct_from(build_id),
+            )
+            # Registration order, matching `actionable`. Deterministic, so a
+            # truncated list is stable across the polls of one tick.
+            .order_by(blocked.created_at, blocker.created_at)
+            .limit(_MAX_FRONTIER_EXTERNAL_BLOCKERS + 1)
+        )
+    ).all()
+    blocked_by_external_truncated = len(blocker_rows) > _MAX_FRONTIER_EXTERNAL_BLOCKERS
+    blocked_by_external = [
+        FrontierExternalBlocker(
+            task_id=blocked_task_id,
+            blocking_task_id=blocking_task_id,
+            blocking_task_namespace=blocking_namespace,
+            blocking_task_name=blocking_name,
+            blocking_status=blocking_status,
+            blocking_status_at=blocking_status_at,
+            blocking_status_build_id=blocking_status_build_id,
+            blocking_in_build=bool(blocking_in_build),
+        )
+        for (
+            blocked_task_id,
+            blocking_task_id,
+            blocking_namespace,
+            blocking_name,
+            blocking_status,
+            blocking_status_at,
+            blocking_status_build_id,
+            blocking_in_build,
+        ) in blocker_rows[:_MAX_FRONTIER_EXTERNAL_BLOCKERS]
+    ]
+
     root_task_ids: list[str] = list(build.root_task_ids or [])
     roots: list[Task] = []
     if root_task_ids:
@@ -1425,6 +1515,10 @@ async def get_build_frontier(
             latest_executor=t.latest_executor,
             latest_executor_ref=t.latest_executor_ref,
             latest_executor_metadata=t.latest_executor_metadata,
+            # Schedulers bound staleness with this (e.g. "RUNNING for too
+            # long with no executor ref"); omitting it silently disabled
+            # those guards, since the field defaults to None.
+            latest_status_at=t.latest_status_at,
         )
 
     return BuildFrontierResponse(
@@ -1436,6 +1530,8 @@ async def get_build_frontier(
         status_counts=status_counts,
         actionable=[_ref(t) for t in actionable_tasks],
         running=[_ref(t) for t in running_tasks],
+        blocked_by_external=blocked_by_external,
+        blocked_by_external_truncated=blocked_by_external_truncated,
         reactive_app_name=build.reactive_app_name,
         reactive_tick_kwargs=build.reactive_tick_kwargs,
     )

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1428,67 +1428,86 @@ async def get_build_frontier(
     # meaning "RUNNING tasks of *this* build" (it is the cancellation
     # target list).
     #
+    # Computed ONLY when this build has nothing actionable and nothing
+    # running — i.e. exactly when it looks stuck, which is the only state in
+    # which either consumer asks the question. That is not an optimisation
+    # detail to gloss over: the frontier is re-read on every linger poll
+    # (~3 s per active build), and this query sorts over the build's
+    # dependency edges, so computing it unconditionally would put a
+    # per-edge sort on the hot path of every healthy build. A build that is
+    # visibly progressing does not need to be told what it is waiting on.
+    #
+    # The gate mirrors the SDK's own stuck check (`not actionable and
+    # running == 0`) so the two cannot disagree about when the diagnostic
+    # is meaningful. Consequence for consumers: an EMPTY list means "not
+    # blocked externally, or not stalled" — never read it as proof that no
+    # external blocker exists while the build is still making progress.
+    #
     # One flat (blocked, blocker) query — resolving blockers per blocked
-    # task would be N+1 on an endpoint polled every tick. It mirrors the
-    # join `actionable` already performs, so the added cost is ~one more
-    # pass over this build's dependency edges (ix_task_dep_downstream),
-    # bounded by LIMIT.
-    blocked = aliased(Task)
-    blocker = aliased(Task)
-    blocker_rows = (
-        await db.execute(
-            select(
-                blocked.task_id,
-                blocker.task_id,
-                blocker.task_namespace,
-                blocker.task_name,
-                blocker.latest_status,
-                blocker.latest_status_at,
-                blocker.latest_status_build_id,
-                blocker.id.in_(build_task_ids),
+    # task would be N+1. It mirrors the join `actionable` already performs,
+    # so the added cost is ~one more pass over this build's dependency
+    # edges (ix_task_dep_downstream), bounded by LIMIT.
+    blocked_by_external: list[FrontierExternalBlocker] = []
+    blocked_by_external_truncated = False
+    if not actionable_tasks and not running_tasks:
+        blocked = aliased(Task)
+        blocker = aliased(Task)
+        blocker_rows = (
+            await db.execute(
+                select(
+                    blocked.task_id,
+                    blocker.task_id,
+                    blocker.task_namespace,
+                    blocker.task_name,
+                    blocker.latest_status,
+                    blocker.latest_status_at,
+                    blocker.latest_status_build_id,
+                    blocker.id.in_(build_task_ids),
+                )
+                .select_from(TaskDependency)
+                .join(blocked, TaskDependency.downstream_task_id == blocked.id)
+                .join(blocker, TaskDependency.upstream_task_id == blocker.id)
+                .where(
+                    blocked.id.in_(build_task_ids),
+                    blocked.latest_status.in_(_FRONTIER_NON_TERMINAL_STATUSES),
+                    blocker.latest_status != TaskStatus.COMPLETED,
+                    # Null-safe inequality (renders IS DISTINCT FROM on
+                    # Postgres, IS NOT on SQLite): a blocker with no recorded
+                    # status build — a pre-denormalisation row — is likewise
+                    # not something this build put there.
+                    blocker.latest_status_build_id.is_distinct_from(build_id),
+                )
+                # Registration order, matching `actionable`. Deterministic,
+                # so a truncated list is stable across the polls of one tick.
+                .order_by(blocked.created_at, blocker.created_at)
+                .limit(_MAX_FRONTIER_EXTERNAL_BLOCKERS + 1)
             )
-            .select_from(TaskDependency)
-            .join(blocked, TaskDependency.downstream_task_id == blocked.id)
-            .join(blocker, TaskDependency.upstream_task_id == blocker.id)
-            .where(
-                blocked.id.in_(build_task_ids),
-                blocked.latest_status.in_(_FRONTIER_NON_TERMINAL_STATUSES),
-                blocker.latest_status != TaskStatus.COMPLETED,
-                # Null-safe inequality (renders IS DISTINCT FROM on
-                # Postgres, IS NOT on SQLite): a blocker with no recorded
-                # status build — a pre-denormalisation row — is likewise not
-                # something this build put there.
-                blocker.latest_status_build_id.is_distinct_from(build_id),
+        ).all()
+        blocked_by_external_truncated = (
+            len(blocker_rows) > _MAX_FRONTIER_EXTERNAL_BLOCKERS
+        )
+        blocked_by_external = [
+            FrontierExternalBlocker(
+                task_id=blocked_task_id,
+                blocking_task_id=blocking_task_id,
+                blocking_task_namespace=blocking_namespace,
+                blocking_task_name=blocking_name,
+                blocking_status=blocking_status,
+                blocking_status_at=blocking_status_at,
+                blocking_status_build_id=blocking_status_build_id,
+                blocking_in_build=bool(blocking_in_build),
             )
-            # Registration order, matching `actionable`. Deterministic, so a
-            # truncated list is stable across the polls of one tick.
-            .order_by(blocked.created_at, blocker.created_at)
-            .limit(_MAX_FRONTIER_EXTERNAL_BLOCKERS + 1)
-        )
-    ).all()
-    blocked_by_external_truncated = len(blocker_rows) > _MAX_FRONTIER_EXTERNAL_BLOCKERS
-    blocked_by_external = [
-        FrontierExternalBlocker(
-            task_id=blocked_task_id,
-            blocking_task_id=blocking_task_id,
-            blocking_task_namespace=blocking_namespace,
-            blocking_task_name=blocking_name,
-            blocking_status=blocking_status,
-            blocking_status_at=blocking_status_at,
-            blocking_status_build_id=blocking_status_build_id,
-            blocking_in_build=bool(blocking_in_build),
-        )
-        for (
-            blocked_task_id,
-            blocking_task_id,
-            blocking_namespace,
-            blocking_name,
-            blocking_status,
-            blocking_status_at,
-            blocking_status_build_id,
-            blocking_in_build,
-        ) in blocker_rows[:_MAX_FRONTIER_EXTERNAL_BLOCKERS]
-    ]
+            for (
+                blocked_task_id,
+                blocking_task_id,
+                blocking_namespace,
+                blocking_name,
+                blocking_status,
+                blocking_status_at,
+                blocking_status_build_id,
+                blocking_in_build,
+            ) in blocker_rows[:_MAX_FRONTIER_EXTERNAL_BLOCKERS]
+        ]
 
     root_task_ids: list[str] = list(build.root_task_ids or [])
     roots: list[Task] = []

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -251,6 +251,47 @@ class FrontierTaskRef(BaseModel):
     latest_status_at: datetime | None = None
 
 
+class FrontierExternalBlocker(BaseModel):
+    """An upstream outside this build that holds one of its tasks back.
+
+    Task rows (and their dependency edges) are per *environment*, not per
+    build, so an upstream left non-COMPLETED by some *other* build still
+    gates this build's downstream tasks — silently, since such an upstream
+    need not be part of this build's task set at all (a dynamic dependency
+    registered under an earlier build is the common case). Each entry pairs
+    one blocked task of this build with one such blocker.
+
+    "Not this build's doing" is decided by ``blocking_status_build_id``:
+    the build whose event produced the blocker's current status. If that is
+    not this build, this build did not put the blocker in that state and
+    cannot generally get it out of it.
+
+    The blocked side carries only ``task_id`` (the caller registered it, and
+    every other frontier field is task_id-keyed too); the *blocking* side
+    carries name/namespace because it may be entirely unknown to the caller,
+    and a diagnostic is useless without something human-readable.
+    """
+
+    # Blocked task — always a member of this build's task set.
+    task_id: str
+    # The blocking upstream. Identity is spelled out because the caller may
+    # never have seen this task.
+    blocking_task_id: str
+    blocking_task_namespace: str
+    blocking_task_name: str
+    blocking_status: TaskStatus
+    # When the blocker entered its current status, and the build whose event
+    # put it there ("running under build Z since T"). The build id is null
+    # only for rows predating status denormalisation.
+    blocking_status_at: datetime | None = None
+    blocking_status_build_id: UUID | None = None
+    # Whether the blocker is also part of *this* build's task set. False is
+    # the pathological case: this build will never schedule it, so it can
+    # only wait for whoever owns it. True still blocks, but the blocker
+    # shows up in this build's own ``actionable``/``running`` as well.
+    blocking_in_build: bool
+
+
 class BuildFrontierResponse(BaseModel):
     """Scheduling state of a build, for reactive scheduler ticks.
 
@@ -263,6 +304,12 @@ class BuildFrontierResponse(BaseModel):
     ``status_counts`` covers *all* tasks referenced by the build, keyed by
     global status value — used for terminal detection (e.g. nothing running
     and nothing actionable).
+
+    ``blocked_by_external`` explains the gap between the two: dependency
+    gating is environment-global while ``running``/``status_counts`` are
+    scoped to this build, so a build can have nothing actionable and
+    nothing running yet still be legitimately waiting. See
+    :class:`FrontierExternalBlocker`.
     """
 
     build_id: UUID
@@ -275,6 +322,12 @@ class BuildFrontierResponse(BaseModel):
     # All RUNNING tasks in the build, including non-actionable ones (e.g.
     # inside the dynamic-dep registration window) — cancellation targets.
     running: list[FrontierTaskRef] = []
+    # Non-terminal tasks of this build held back by an upstream this build
+    # doesn't own. Empty for the overwhelming majority of builds; capped, in
+    # which case blocked_by_external_truncated is set (it is a diagnostic,
+    # not a work queue — a truncated list still proves "waiting, not stuck").
+    blocked_by_external: list[FrontierExternalBlocker] = []
+    blocked_by_external_truncated: bool = False
     # Reactive-scheduling owner: the app whose ticks drive this build. None
     # for non-reactive builds — its presence is the marker a tick reads to
     # decide whether to drive the build (and which app owns it).

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -323,9 +323,16 @@ class BuildFrontierResponse(BaseModel):
     # inside the dynamic-dep registration window) — cancellation targets.
     running: list[FrontierTaskRef] = []
     # Non-terminal tasks of this build held back by an upstream this build
-    # doesn't own. Empty for the overwhelming majority of builds; capped, in
-    # which case blocked_by_external_truncated is set (it is a diagnostic,
-    # not a work queue — a truncated list still proves "waiting, not stuck").
+    # doesn't own. Capped, in which case blocked_by_external_truncated is set
+    # (it is a diagnostic, not a work queue — a truncated list still proves
+    # "waiting, not stuck").
+    #
+    # Populated ONLY when the build has nothing actionable and nothing
+    # running, i.e. when it looks stuck — which is the only state in which
+    # the answer matters, and keeps a per-edge sort off the hot path of
+    # every healthy build's linger polls. So an EMPTY list means "not
+    # externally blocked, OR not stalled"; do not read it as proof that no
+    # external blocker exists while the build is still progressing.
     blocked_by_external: list[FrontierExternalBlocker] = []
     blocked_by_external_truncated: bool = False
     # Reactive-scheduling owner: the app whose ticks drive this build. None

--- a/app/stardag-api/src/stardag_api/services/status.py
+++ b/app/stardag-api/src/stardag_api/services/status.py
@@ -8,6 +8,29 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from stardag_api.models import BuildStatus, Event, EventType, Task, TaskStatus
 
+# Statuses TASK_RETRIED resets to PENDING. Shared by the denormalised path
+# (apply_event_to_task) and the two per-build event replays below, which
+# must agree — they answer the same question for different readers.
+#
+# SUSPENDED is in the set because it is a dead end otherwise: a task
+# suspended for dynamic dependencies whose orchestrator then died stays
+# suspended forever, and no supported operation makes it schedulable again
+# (the only escape was to cancel it first, purely to reach a status that
+# *was* retryable). Nothing is running at that point — the suspension
+# itself means the execution yielded and returned — so resetting it cannot
+# orphan an execution.
+#
+# RUNNING is deliberately NOT retryable: it holds a live execution claim,
+# and releasing that is cancellation, not retry. Flipping it to PENDING
+# would let a scheduler spawn a second execution of a task that is still
+# running. COMPLETED is excluded by stickiness.
+_RETRYABLE_STATUSES = (
+    TaskStatus.FAILED,
+    TaskStatus.CANCELLED,
+    TaskStatus.SKIPPED,
+    TaskStatus.SUSPENDED,
+)
+
 
 def apply_event_to_task(task: Task, event: Event) -> None:
     """Mutate a Task's denormalised latest_* columns to reflect a new event.
@@ -68,20 +91,21 @@ def apply_event_to_task(task: Task, event: Event) -> None:
         task.latest_executor_ref = metadata.get("executor_ref")
         task.latest_executor_metadata = metadata.get("executor_metadata")
     elif et == EventType.TASK_RETRIED:
-        # Reset terminal-but-retryable statuses to PENDING (see the event
-        # scan above); sticky-COMPLETED is already handled by the early
-        # return, and RUNNING is never downgraded by a retry.
-        if task.latest_status in (
-            TaskStatus.FAILED,
-            TaskStatus.CANCELLED,
-            TaskStatus.SKIPPED,
-        ):
+        # Reset a retryable status to PENDING (see _RETRYABLE_STATUSES);
+        # sticky-COMPLETED is already handled by the early return, and
+        # RUNNING is never downgraded by a retry.
+        if task.latest_status in _RETRYABLE_STATUSES:
             task.latest_status = TaskStatus.PENDING
             task.latest_status_at = event.created_at
             task.latest_status_event_id = event.id
             task.latest_status_build_id = event.build_id
             task.latest_completed_at = None
             task.latest_error_message = None
+            # The executor fields describe the run that reached the
+            # retryable status — including a suspended one, which keeps the
+            # ref of the execution that yielded. A retry re-runs from
+            # scratch, so clearing them is what stops a scheduler from
+            # re-attaching to an execution that will never resume.
             task.latest_executor = None
             task.latest_executor_ref = None
             task.latest_executor_metadata = None
@@ -262,15 +286,12 @@ async def get_task_status_in_build(
         elif event.event_type == EventType.TASK_RESUMED:
             status = TaskStatus.RUNNING
         elif event.event_type == EventType.TASK_RETRIED:
-            # Retry: reset a terminal-but-retryable status back to PENDING so
-            # the task is schedulable again (a re-trigger of a failed build,
-            # or a new build referencing a previously-failed task). No-op for
-            # completed/running — a retry never downgrades those.
-            if status in (
-                TaskStatus.FAILED,
-                TaskStatus.CANCELLED,
-                TaskStatus.SKIPPED,
-            ):
+            # Retry: reset a retryable status back to PENDING so the task is
+            # schedulable again (a re-trigger of a failed build, a new build
+            # referencing a previously-failed task, or an abandoned
+            # suspension). No-op for completed/running — a retry never
+            # downgrades those. See _RETRYABLE_STATUSES.
+            if status in _RETRYABLE_STATUSES:
                 status = TaskStatus.PENDING
                 completed_at = None
                 error_message = None
@@ -336,15 +357,12 @@ async def get_all_task_statuses_in_build(
         elif event.event_type == EventType.TASK_RESUMED:
             status = TaskStatus.RUNNING
         elif event.event_type == EventType.TASK_RETRIED:
-            # Retry: reset a terminal-but-retryable status back to PENDING so
-            # the task is schedulable again (a re-trigger of a failed build,
-            # or a new build referencing a previously-failed task). No-op for
-            # completed/running — a retry never downgrades those.
-            if status in (
-                TaskStatus.FAILED,
-                TaskStatus.CANCELLED,
-                TaskStatus.SKIPPED,
-            ):
+            # Retry: reset a retryable status back to PENDING so the task is
+            # schedulable again (a re-trigger of a failed build, a new build
+            # referencing a previously-failed task, or an abandoned
+            # suspension). No-op for completed/running — a retry never
+            # downgrades those. See _RETRYABLE_STATUSES.
+            if status in _RETRYABLE_STATUSES:
                 status = TaskStatus.PENDING
                 completed_at = None
                 error_message = None

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -1882,7 +1882,44 @@ async def test_retry_task_never_downgrades_completed_or_running(client: AsyncCli
     r1 = await client.post(f"/api/v1/builds/{build_id}/tasks/retry-done/retry")
     r2 = await client.post(f"/api/v1/builds/{build_id}/tasks/retry-running/retry")
     assert r1.json()["status"] == "completed"
+    # A running task holds a live execution claim: releasing it is
+    # cancellation, not retry — a reset here would invite a second execution.
     assert r2.json()["status"] == "running"
+
+
+@pytest.mark.asyncio
+async def test_retry_task_resets_suspended_to_pending(client: AsyncClient):
+    """A task suspended for dynamic dependencies and then abandoned is
+    recoverable by retry — otherwise it is permanently unschedulable."""
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks", json=_register_payload("susp-t")
+    )
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks/susp-t/start",
+        params={"executor": "modal", "executor_ref": "fc-suspended"},
+    )
+    await client.post(f"/api/v1/builds/{build_id}/tasks/susp-t/suspend")
+
+    frontier = (await client.get(f"/api/v1/builds/{build_id}/frontier")).json()
+    assert frontier["status_counts"] == {"suspended": 1}
+
+    response = await client.post(f"/api/v1/builds/{build_id}/tasks/susp-t/retry")
+    assert response.status_code == 200
+    assert response.json()["status"] == "pending"
+
+    frontier = (await client.get(f"/api/v1/builds/{build_id}/frontier")).json()
+    assert frontier["status_counts"] == {"pending": 1}
+    assert [t["task_id"] for t in frontier["actionable"]] == ["susp-t"]
+    # The suspended run's executor ref is cleared with the retry, so no
+    # scheduler re-attaches to an execution that already returned.
+    assert frontier["actionable"][0]["latest_executor"] is None
+    assert frontier["actionable"][0]["latest_executor_ref"] is None
+
+    # Per-build derived status (the event replay) agrees with the
+    # denormalised global one.
+    tasks = (await client.get(f"/api/v1/builds/{build_id}/tasks")).json()
+    assert [t["status"] for t in tasks] == ["pending"]
 
 
 @pytest.mark.asyncio

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -1956,6 +1956,165 @@ async def test_frontier_reflects_cross_build_running(client: AsyncClient):
     assert actionable["shared-task"]["latest_executor_ref"] == "fc-other-build"
 
 
+async def _assert_frontier_reports_cross_build_blocker(client: AsyncClient) -> None:
+    """A build whose only remaining task is gated by an upstream that another
+    build left RUNNING has nothing actionable and nothing running — the
+    frontier must say so explicitly instead of looking terminal."""
+    build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks",
+        json={
+            "task_id": "ext-up",
+            "task_namespace": "pipelines.ingest",
+            "task_name": "Upstream",
+            "task_data": {},
+        },
+    )
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks",
+        json=_register_payload("ext-down", ["ext-up"]),
+    )
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks/ext-up/start",
+        params={"executor": "modal", "executor_ref": "fc-build-a"},
+    )
+
+    # Build B references only the downstream task; the upstream (and the
+    # edge, which is environment-global) belongs to build A entirely.
+    build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_b}/tasks", json=_register_payload("ext-down")
+    )
+
+    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    # The shape that used to read as "this build cannot progress".
+    assert frontier_b["actionable"] == []
+    assert frontier_b["running"] == []
+    assert frontier_b["status_counts"] == {"pending": 1}
+
+    assert frontier_b["blocked_by_external_truncated"] is False
+    assert frontier_b["blocked_by_external"] == [
+        {
+            "task_id": "ext-down",
+            "blocking_task_id": "ext-up",
+            "blocking_task_namespace": "pipelines.ingest",
+            "blocking_task_name": "Upstream",
+            "blocking_status": "running",
+            "blocking_status_at": frontier_b["blocked_by_external"][0][
+                "blocking_status_at"
+            ],
+            "blocking_status_build_id": build_a,
+            "blocking_in_build": False,
+        }
+    ]
+    assert frontier_b["blocked_by_external"][0]["blocking_status_at"] is not None
+
+    # Build A owns the blocker, so from its side nothing is external — and
+    # its own liveness signal (`running`) covers the same task.
+    frontier_a = (await client.get(f"/api/v1/builds/{build_a}/frontier")).json()
+    assert frontier_a["blocked_by_external"] == []
+    assert [t["task_id"] for t in frontier_a["running"]] == ["ext-up"]
+
+    # Once the blocker completes, the downstream is this build's to run.
+    await client.post(f"/api/v1/builds/{build_a}/tasks/ext-up/complete")
+    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    assert frontier_b["blocked_by_external"] == []
+    assert [t["task_id"] for t in frontier_b["actionable"]] == ["ext-down"]
+
+
+@pytest.mark.asyncio
+async def test_frontier_reports_blocker_owned_by_another_build(client: AsyncClient):
+    await _assert_frontier_reports_cross_build_blocker(client)
+
+
+@pytest.mark.asyncio
+async def test_frontier_reports_blocker_owned_by_another_build_postgres(pg_client):
+    """Same scenario on Postgres: the "not this build's status" predicate is
+    a null-safe inequality, which the two dialects render differently
+    (IS DISTINCT FROM vs IS NOT)."""
+    await _assert_frontier_reports_cross_build_blocker(pg_client)
+
+
+@pytest.mark.asyncio
+async def test_frontier_external_blocker_reports_in_build_membership(
+    client: AsyncClient,
+):
+    """A blocker this build *does* know about is still reported when another
+    build owns its status — but flagged as in-build, since it also shows up
+    in this build's own running/actionable lists."""
+    build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
+    for build_id in (build_a, build_b):
+        await client.post(
+            f"/api/v1/builds/{build_id}/tasks", json=_register_payload("shared-up")
+        )
+    await client.post(f"/api/v1/builds/{build_a}/tasks/shared-up/start")
+    await client.post(
+        f"/api/v1/builds/{build_b}/tasks",
+        json=_register_payload("shared-down", ["shared-up"]),
+    )
+
+    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    entry = frontier_b["blocked_by_external"][0]
+    assert entry["task_id"] == "shared-down"
+    assert entry["blocking_task_id"] == "shared-up"
+    assert entry["blocking_status_build_id"] == build_a
+    assert entry["blocking_in_build"] is True
+    # This build can see the blocker itself, so it is not actually stuck.
+    assert [t["task_id"] for t in frontier_b["running"]] == ["shared-up"]
+
+
+@pytest.mark.asyncio
+async def test_frontier_external_blockers_are_capped_and_flagged(
+    client: AsyncClient, monkeypatch: pytest.MonkeyPatch
+):
+    """The blocker list is a bounded diagnostic; truncation is reported
+    rather than silent."""
+    from stardag_api.routes import builds as builds_routes
+
+    monkeypatch.setattr(builds_routes, "_MAX_FRONTIER_EXTERNAL_BLOCKERS", 1)
+
+    build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks", json=_register_payload("cap-up")
+    )
+    for tid in ("cap-down-1", "cap-down-2"):
+        await client.post(
+            f"/api/v1/builds/{build_a}/tasks", json=_register_payload(tid, ["cap-up"])
+        )
+    await client.post(f"/api/v1/builds/{build_a}/tasks/cap-up/start")
+
+    build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
+    for tid in ("cap-down-1", "cap-down-2"):
+        await client.post(
+            f"/api/v1/builds/{build_b}/tasks", json=_register_payload(tid)
+        )
+
+    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    assert len(frontier_b["blocked_by_external"]) == 1
+    assert frontier_b["blocked_by_external_truncated"] is True
+    # Registration order, so the cap keeps a stable prefix across polls.
+    assert frontier_b["blocked_by_external"][0]["task_id"] == "cap-down-1"
+
+
+@pytest.mark.asyncio
+async def test_frontier_refs_carry_status_timestamp(client: AsyncClient):
+    """`latest_status_at` is the input to scheduler staleness bounds (e.g.
+    'RUNNING too long with no executor ref'); it must actually be sent."""
+    build_id = (
+        await client.post("/api/v1/builds", json={"root_task_ids": ["ts-task"]})
+    ).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks", json=_register_payload("ts-task")
+    )
+    await client.post(f"/api/v1/builds/{build_id}/tasks/ts-task/start")
+
+    frontier = (await client.get(f"/api/v1/builds/{build_id}/frontier")).json()
+    for key in ("actionable", "running", "roots"):
+        assert frontier[key], key
+        assert frontier[key][0]["latest_status_at"] is not None, key
+
+
 @pytest.mark.asyncio
 async def test_concurrency_limit_crud(client: AsyncClient):
     response = await client.get("/api/v1/concurrency-limits")

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -2076,29 +2076,97 @@ async def test_frontier_reports_blocker_owned_by_another_build_postgres(pg_clien
 async def test_frontier_external_blocker_reports_in_build_membership(
     client: AsyncClient,
 ):
-    """A blocker this build *does* know about is still reported when another
-    build owns its status — but flagged as in-build, since it also shows up
-    in this build's own running/actionable lists."""
+    """`blocking_in_build` separates the two ways a stalled build is held up.
+
+    Chain top -> mid -> down, where `top` runs under another build and `mid`
+    is registered here but was last touched there (registration is
+    status-neutral, so ownership does not move). This build is stalled on
+    both: one blocker it has never heard of, one it can see but cannot
+    advance.
+    """
     build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks", json=_register_payload("chain-top")
+    )
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks",
+        json=_register_payload("chain-mid", ["chain-top"]),
+    )
+    await client.post(f"/api/v1/builds/{build_a}/tasks/chain-top/start")
+
     build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
-    for build_id in (build_a, build_b):
-        await client.post(
-            f"/api/v1/builds/{build_id}/tasks", json=_register_payload("shared-up")
-        )
-    await client.post(f"/api/v1/builds/{build_a}/tasks/shared-up/start")
+    await client.post(
+        f"/api/v1/builds/{build_b}/tasks", json=_register_payload("chain-mid")
+    )
     await client.post(
         f"/api/v1/builds/{build_b}/tasks",
-        json=_register_payload("shared-down", ["shared-up"]),
+        json=_register_payload("chain-down", ["chain-mid"]),
     )
 
     frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
-    entry = frontier_b["blocked_by_external"][0]
-    assert entry["task_id"] == "shared-down"
-    assert entry["blocking_task_id"] == "shared-up"
-    assert entry["blocking_status_build_id"] == build_a
-    assert entry["blocking_in_build"] is True
-    # This build can see the blocker itself, so it is not actually stuck.
-    assert [t["task_id"] for t in frontier_b["running"]] == ["shared-up"]
+    assert frontier_b["actionable"] == []
+    assert frontier_b["running"] == []
+
+    entries = {e["task_id"]: e for e in frontier_b["blocked_by_external"]}
+    # Never registered here: this build can only wait for whoever owns it.
+    assert entries["chain-mid"]["blocking_task_id"] == "chain-top"
+    assert entries["chain-mid"]["blocking_in_build"] is False
+    assert entries["chain-mid"]["blocking_status"] == "running"
+    assert entries["chain-mid"]["blocking_status_build_id"] == build_a
+    # Registered here, but held back by the above — visible, not advanceable.
+    assert entries["chain-down"]["blocking_task_id"] == "chain-mid"
+    assert entries["chain-down"]["blocking_in_build"] is True
+
+
+@pytest.mark.asyncio
+async def test_frontier_omits_external_blockers_while_the_build_progresses(
+    client: AsyncClient,
+):
+    """The blocker list is computed only when the build has nothing
+    actionable and nothing running.
+
+    That is the single state in which "why is this not progressing?" is a
+    real question, and the gate keeps a per-edge sort off the hot path: the
+    frontier is re-read on every linger poll of every healthy build.
+    """
+    build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks", json=_register_payload("gate-up")
+    )
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks",
+        json=_register_payload("gate-down", ["gate-up"]),
+    )
+    await client.post(f"/api/v1/builds/{build_a}/tasks/gate-up/start")
+
+    build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_b}/tasks", json=_register_payload("gate-down")
+    )
+    await client.post(
+        f"/api/v1/builds/{build_b}/tasks", json=_register_payload("gate-free")
+    )
+
+    # Something to run: not stalled, so no diagnostic even though the
+    # external blocker is present and gating `gate-down`.
+    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    assert [t["task_id"] for t in frontier_b["actionable"]] == ["gate-free"]
+    assert frontier_b["blocked_by_external"] == []
+
+    # Running counts as progress too. (A RUNNING task stays in `actionable`
+    # — that is the scheduler's probe partition — so this also pins down
+    # that the gate is an OR, not a check on `actionable` alone.)
+    await client.post(f"/api/v1/builds/{build_b}/tasks/gate-free/start")
+    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    assert [t["task_id"] for t in frontier_b["running"]] == ["gate-free"]
+    assert frontier_b["blocked_by_external"] == []
+
+    # Out of work: now the build looks stuck, and the answer appears.
+    await client.post(f"/api/v1/builds/{build_b}/tasks/gate-free/complete")
+    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    assert frontier_b["actionable"] == []
+    assert frontier_b["running"] == []
+    assert [e["task_id"] for e in frontier_b["blocked_by_external"]] == ["gate-down"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Server side of **A1** and **A2** from #208. Registry API only — no SDK or
UI changes. Both changes are purely additive and backward compatible:
existing frontier fields keep their exact semantics and values, and a
client that ignores the new fields behaves exactly as before.

## A1 — scope-consistent liveness in the build frontier

`GET /builds/{id}/frontier` mixes two scopes:

- `has_incomplete_upstream` joins `Task` **globally** — task rows are
  unique on `(environment_id, task_id)` with denormalised `latest_status*`,
  and `TaskDependency` edges are global too — so an upstream left
  non-COMPLETED by *any* build removes a downstream task from `actionable`.
- `running` and `status_counts` are scoped to `Task.id.in_(build_task_ids)`,
  i.e. only tasks this build has events for.

So a task running in another build is fully effective as a blocker while
contributing nothing to this build's `running` count. A scheduler reads
"nothing actionable and `running == 0`" as "this build cannot progress"
and fails it, with an error naming only status counts. The blocker need
not even be in this build's task set — a dynamic dependency registered
under an earlier build is the common case.

This PR does not change the liveness rule; it gives the client the
information the rule was missing, as an explicit `blocked_by_external`
list on the frontier response.

### Response shape (new fields)

```jsonc
{
  // ... all existing BuildFrontierResponse fields, unchanged ...
  "blocked_by_external": [
    {
      "task_id": "…",                     // string  — blocked task, always a member of this build
      "blocking_task_id": "…",            // string
      "blocking_task_namespace": "…",     // string  ("" for the default namespace)
      "blocking_task_name": "…",          // string
      "blocking_status": "running",       // TaskStatus enum value; never "completed"
      "blocking_status_at": "2026-01-01T00:00:00Z", // string|null (ISO-8601 datetime)
      "blocking_status_build_id": "…",    // string|null (UUID) — the build that owns the status
      "blocking_in_build": false          // bool
    }
  ],
  "blocked_by_external_truncated": false  // bool
}
```

Both fields default to `[]` / `false`, so nothing changes for builds with
no external blockers (the overwhelming majority).

Semantics of an entry: `task_id` is a task of this build with global
status PENDING / SUSPENDED / RUNNING, held back by `blocking_task_id`,
which is not COMPLETED and whose current status was **not** produced by
this build (`blocking_status_build_id` is not this build's id, null-safe —
a null, i.e. a row predating status denormalisation, also counts as "not
this build's doing").

`blocking_in_build` says whether the blocker is also in this build's task
set. `false` is the pathological case behind the spurious failures: this
build will never schedule the blocker, so it can only wait for whoever
owns it. `true` still blocks, but the blocker also appears in this build's
own `actionable` / `running`.

### Design notes

- **Name/namespace of the blocker are included**; of the blocked task they
  are not. The blocked task was registered by the caller and every other
  frontier field is `task_id`-keyed, whereas the blocker may be entirely
  unknown to the caller — a diagnostic that only says "blocked by
  `9f3a…`" is not actionable. Both come from the same join, so there is no
  extra round-trip either way.
- **Capped at 50 entries, with `blocked_by_external_truncated`** rather
  than a silent cut. A wide DAG stalled behind another build can produce
  one entry per blocked edge; the list is a diagnostic ("you are waiting,
  and here is on what"), so a bounded, deterministically-ordered sample
  plus an explicit flag carries the same signal at a fixed payload size. A
  total count was considered and dropped: it needs a second aggregate over
  the same predicate, and the flag already distinguishes "this is all of
  them" from "there are more".
- **Ordering** is registration order (blocked task, then blocker), matching
  `actionable`, so the truncated prefix is stable across the polls of a
  single tick.
- **Reported separately rather than folded into `running`.** `running` must
  keep meaning "RUNNING tasks of *this* build" — it is the list a tick
  cancels through.
- **A PENDING upstream this build merely referenced also qualifies**, since
  its PENDING was recorded by an earlier build. That is accurate (this
  build did not put it there) but is not a stall — such a blocker is
  in-build and actionable. Consumers can discriminate on
  `blocking_status` + `blocking_in_build`.

### Cost

One additional query per frontier read. It is a flat
`task_dependencies ⋈ tasks ⋈ tasks` join restricted to this build's task
set (`ix_task_dep_downstream`, then the tasks PK) with a `LIMIT` —
essentially the same join `actionable` already performs per row as a
correlated `EXISTS`, done once and non-correlated. Resolving blockers per
blocked task instead would be N+1 on an endpoint polled on every tick and
every linger poll, which is why it is one statement. The endpoint already
issues five queries; this makes six, and the new one touches no rows the
others do not.

### Also fixed here: `latest_status_at` was always null

`FrontierTaskRef` declares `latest_status_at` and documents it as the
input to scheduler staleness bounds ("RUNNING too long with no executor
ref"), but the frontier never populated it — the field defaults to `None`,
so it silently serialised as `null` on every ref and those guards were
dead. Now populated from `Task.latest_status_at` for `actionable`,
`running` and `roots`. Same area, same class of bug (declared signal,
never sent), so it rides along.

## A2 — `suspended` is recoverable

A task left `SUSPENDED` — suspended for dynamic dependencies, then
abandoned because the orchestrator died or the build was cancelled — was
permanently unschedulable. `TASK_RETRIED` reset only FAILED / CANCELLED /
SKIPPED, so the retry endpoint was a no-op on it. The only escape was to
cancel the task purely to reach a status that *was* retryable and then
retry — undocumented and non-obvious.

`suspended` now resets to `PENDING`. A suspended task is not executing —
the suspension means the execution yielded and returned — so resetting it
cannot orphan a live execution, and re-running from scratch is exactly
what a retry expresses. The retry also clears the executor ref of the run
that suspended, which is what stops a scheduler from re-attaching to an
execution that will never resume.

**`running` remains non-retryable, deliberately.** It holds a live
execution claim; releasing that claim is cancellation, not retry, and
conflating them risks a second concurrent execution of the same task. This
is stated in the endpoint docstring (and therefore the OpenAPI
description) and beside the constant.

The retryable set lived in three hard-coded tuples — the denormalised
`apply_event_to_task` path and the two per-build event replays, which must
agree — now hoisted into one `_RETRYABLE_STATUSES` so they cannot drift.

Note this is the *server* half. The SDK's own `_RETRYABLE_STATUSES`, used
by `discover_and_register_aio(..., retry_failed=True)` to decide which
tasks to retry, is unchanged and lands separately.

## Tests

Added to `app/stardag-api/tests/test_builds.py`:

- `test_frontier_reports_blocker_owned_by_another_build` — the end-to-end
  A1 repro: build A registers `up → down` and starts `up`; build B
  references only `down`. Build B's frontier has empty `actionable`, empty
  `running` and `status_counts == {"pending": 1}` (the shape that used to
  read as terminal) and now reports the blocker with build A's id and
  `blocking_in_build: false`. Build A's own frontier reports no external
  blockers. Completing `up` clears the list and makes `down` actionable.
- `test_frontier_reports_blocker_owned_by_another_build_postgres` — the
  same scenario against Postgres via the `pg_client` fixture, because the
  "not this build's status" predicate is a null-safe inequality that the
  two dialects render differently (`IS DISTINCT FROM` vs `IS NOT`).
- `test_frontier_external_blocker_reports_in_build_membership` — a blocker
  the build does know about is still reported, flagged `blocking_in_build:
  true`.
- `test_frontier_external_blockers_are_capped_and_flagged` — cap and
  truncation flag, with a stable prefix.
- `test_frontier_refs_carry_status_timestamp` — regression test for the
  always-null `latest_status_at`.
- `test_retry_task_resets_suspended_to_pending` — suspended → pending
  through the endpoint, executor fields cleared, and the per-build event
  replay agreeing with the denormalised global status.

Existing `test_retry_task_never_downgrades_completed_or_running` still
covers the completed/running no-ops.

No migration: query-only, no model change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NyR9Kc9ZP5Ko7dVndhi3Y
