### PR TITLE
feat(api): persist reactive scheduler tick summaries per build (#208 B6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### Registry API
 
+- **Reactive scheduler tick summaries are now persisted per build**
+  (`POST`/`GET /builds/{build_id}/tick-summaries`). A reactive build is
+  driven by many short-lived scheduler ticks, each in its own container,
+  and each tick's `TickSummary` — the scheduler's own account of what it
+  did and why it did nothing — previously reached nothing but that
+  container's log. Reconstructing why a build stalled meant correlating
+  logs across dozens of containers; it is now a single request. The
+  summary is stored verbatim in a JSONB blob (with `outcome` promoted to
+  an indexed column), so the SDK can add fields without a server release
+  or a migration. Retention is bounded per build (newest 50 by default,
+  `STARDAG_API_MAX_TICK_SUMMARIES_PER_BUILD`), pruned on insert.
+  Additive: nothing writes to these endpoints yet.
 - **`GET /builds/{id}/frontier` now reports why a build is waiting on work
   it does not own** ([#208](https://github.com/stardag-dev/stardag/issues/208)).
   Dependency gating is environment-global (task rows and edges are shared

--- a/app/stardag-api/migrations/versions/20260807_205110_add_build_tick_summaries.py
+++ b/app/stardag-api/migrations/versions/20260807_205110_add_build_tick_summaries.py
@@ -1,0 +1,60 @@
+"""add build tick summaries
+
+Revision ID: 0807aacc230e
+Revises: 792fb8ab3c3c
+Create Date: 2026-08-07 20:51:10.251057
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0807aacc230e"
+down_revision: Union[str, Sequence[str], None] = "792fb8ab3c3c"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Per-build trail of reactive scheduler tick outcomes. ``outcome`` is
+    # promoted out of the payload (small closed-ish vocabulary, worth
+    # filtering on); ``summary`` keeps the SDK-owned dict verbatim so new
+    # fields need no migration. New table, no backfill.
+    op.create_table(
+        "build_tick_summaries",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("build_id", sa.Uuid(), nullable=False),
+        sa.Column("outcome", sa.String(length=32), nullable=False),
+        sa.Column(
+            "summary",
+            sa.JSON().with_variant(
+                postgresql.JSONB(astext_type=sa.Text()), "postgresql"
+            ),
+            nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["build_id"], ["builds.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    # The only query is "newest N for this build" (read endpoint and the
+    # insert-time retention prune); also serves plain build_id lookups and
+    # the FK cascade, so there is no separate index on build_id.
+    op.create_index(
+        "ix_build_tick_summaries_build_created",
+        "build_tick_summaries",
+        ["build_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(
+        "ix_build_tick_summaries_build_created", table_name="build_tick_summaries"
+    )
+    op.drop_table("build_tick_summaries")

--- a/app/stardag-api/src/stardag_api/config.py
+++ b/app/stardag-api/src/stardag_api/config.py
@@ -1,5 +1,6 @@
-from typing import Literal
+from typing import Annotated, Literal
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from stardag_api.limits import LimitsSettings
@@ -28,6 +29,14 @@ class Settings(BaseSettings):
 
     # CORS origins (comma-separated)
     cors_origins: str = "http://localhost:5173,http://localhost:3000"
+
+    # How many reactive scheduler tick summaries to retain per build.
+    # Older ones are pruned on insert (see routes/tick_summaries.py). Not
+    # a SaaS guardrail (those live in LimitsSettings and default to
+    # "unlimited") — an always-on retention window, since the point of
+    # the table is a bounded trail, and the useful window is the recent
+    # past: a stalled build repeats the same outcome forever.
+    max_tick_summaries_per_build: Annotated[int, Field(ge=1)] = 50
 
     model_config = SettingsConfigDict(env_prefix="STARDAG_API_")
 

--- a/app/stardag-api/src/stardag_api/main.py
+++ b/app/stardag-api/src/stardag_api/main.py
@@ -18,6 +18,7 @@ from stardag_api.routes import (
     search_router,
     target_roots_router,
     tasks_router,
+    tick_summaries_router,
     ui_router,
 )
 
@@ -82,6 +83,9 @@ app.include_router(workspaces_router, prefix="/api/v1")
 
 # SDK routes (API key or internal JWT auth)
 app.include_router(builds_router, prefix="/api/v1")
+# Build sub-resource, same /builds prefix — its own module only because
+# routes/builds.py is already large.
+app.include_router(tick_summaries_router, prefix="/api/v1")
 app.include_router(locks_router, prefix="/api/v1")
 app.include_router(concurrency_limits_router, prefix="/api/v1")
 # search_router must come before tasks_router because tasks_router has /{task_id}

--- a/app/stardag-api/src/stardag_api/models/__init__.py
+++ b/app/stardag-api/src/stardag_api/models/__init__.py
@@ -3,6 +3,7 @@
 from stardag_api.models.api_key import ApiKey
 from stardag_api.models.base import Base, TimestampMixin
 from stardag_api.models.build import Build
+from stardag_api.models.build_tick_summary import BuildTickSummary
 from stardag_api.models.enums import (
     BuildStatus,
     EventType,
@@ -31,6 +32,7 @@ __all__ = [
     "Base",
     "Build",
     "BuildStatus",
+    "BuildTickSummary",
     "DistributedLock",
     "EnvironmentConcurrencyLimit",
     "TaskLimitKey",

--- a/app/stardag-api/src/stardag_api/models/build_tick_summary.py
+++ b/app/stardag-api/src/stardag_api/models/build_tick_summary.py
@@ -1,0 +1,86 @@
+"""Reactive scheduler tick summaries retained per build."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Index, JSON, String, Uuid
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from stardag_api.models.base import Base, TimestampMixin, generate_uuid7
+
+if TYPE_CHECKING:
+    from stardag_api.models.build import Build
+
+
+class BuildTickSummary(Base, TimestampMixin):
+    """Outcome of one reactive scheduler tick, kept as a per-build trail.
+
+    A tick's ``TickSummary`` is otherwise written only to the log of the
+    (short-lived, one-per-tick) container that produced it, so answering
+    "why is this build not progressing?" means correlating logs across
+    dozens of containers. Persisting the last N summaries against the
+    build turns that into a single query.
+
+    Shape: one promoted column plus an opaque blob.
+
+    - ``summary`` is the whole summary dict *verbatim*. The dataclass is
+      SDK-owned and still growing (e.g. counts/details for tasks blocked
+      by another build), and this table is a write-mostly observability
+      trail, not a queried entity — so new fields must not cost a
+      migration, and unknown keys are stored rather than rejected.
+    - ``outcome`` is lifted out of the blob into a typed column because
+      it is the one field with a small closed-ish vocabulary that is
+      worth filtering and indexing on ("show me the ticks where this
+      build did nothing"), and the UI reads it on every row. It is
+      *also* still present inside ``summary``; the duplication is
+      deliberate — the blob stays a faithful copy of what the SDK sent.
+
+    Rows are pruned to the newest N per build on insert (see
+    ``routes/tick_summaries.py``), so this table's growth is bounded by
+    the number of builds, not by tick rate.
+    """
+
+    __tablename__ = "build_tick_summaries"
+    __table_args__ = (
+        # The only query is "newest N summaries for this build", for both
+        # the read endpoint and the retention prune. This composite also
+        # serves the plain ``build_id`` lookups (leading column) and the
+        # FK's cascade delete, so no separate index on ``build_id``: the
+        # write path is one insert + one delete per tick, and every extra
+        # index is paid on both.
+        Index(
+            "ix_build_tick_summaries_build_created",
+            "build_id",
+            "created_at",
+        ),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        Uuid,
+        primary_key=True,
+        default=generate_uuid7,
+    )
+    build_id: Mapped[UUID] = mapped_column(
+        Uuid,
+        ForeignKey("builds.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    # "not_reactive" | "lease_held" | "terminal" | "lingered_out" | ... —
+    # SDK-owned and open-ended (the Modal wrapper adds its own), hence a
+    # plain string rather than an enum: an unrecognised outcome must
+    # round-trip, not 500.
+    outcome: Mapped[str] = mapped_column(String(32), nullable=False)
+
+    # The tick summary as sent, unknown keys included. JSONB on Postgres
+    # for consistency with the other JSON columns; SQLite keeps JSON.
+    summary: Mapped[dict] = mapped_column(
+        JSON().with_variant(JSONB(), "postgresql"),
+        nullable=False,
+    )
+
+    # Relationships
+    build: Mapped[Build] = relationship()

--- a/app/stardag-api/src/stardag_api/routes/__init__.py
+++ b/app/stardag-api/src/stardag_api/routes/__init__.py
@@ -8,6 +8,7 @@ from stardag_api.routes.workspaces import router as workspaces_router
 from stardag_api.routes.search import router as search_router
 from stardag_api.routes.target_roots import router as target_roots_router
 from stardag_api.routes.tasks import router as tasks_router
+from stardag_api.routes.tick_summaries import router as tick_summaries_router
 from stardag_api.routes.ui import router as ui_router
 
 __all__ = [
@@ -19,5 +20,6 @@ __all__ = [
     "search_router",
     "target_roots_router",
     "tasks_router",
+    "tick_summaries_router",
     "ui_router",
 ]

--- a/app/stardag-api/src/stardag_api/routes/tick_summaries.py
+++ b/app/stardag-api/src/stardag_api/routes/tick_summaries.py
@@ -98,9 +98,18 @@ async def create_build_tick_summary(
     # Retention is enforced on insert rather than by a background job:
     # this service has no scheduler, and the property we actually need is
     # "a build's trail is bounded", which insert-time pruning gives
-    # exactly and immediately. The delete is bounded by construction —
-    # steady state removes one row per insert — and rides the same
-    # transaction, so a build never observes an over-long trail.
+    # immediately. The delete is bounded by construction — steady state
+    # removes one row per insert — and rides the same transaction.
+    #
+    # The bound is eventual, not absolute, and deliberately so. Two
+    # concurrent inserts for the same build each compute `retained_ids`
+    # without seeing the other's uncommitted row, so the trail can briefly
+    # hold a few rows more than the cap; the next insert prunes them. The
+    # alternative is locking the build row on every tick report, which puts
+    # a serialisation point on the scheduler's hot path to defend a
+    # retention limit whose violation nobody can observe except by counting
+    # rows. Not worth it — and the window is already narrow, since the
+    # scheduler lease single-flights ticks per build.
     retained_ids = (
         select(BuildTickSummary.id)
         .where(BuildTickSummary.build_id == build.id)

--- a/app/stardag-api/src/stardag_api/routes/tick_summaries.py
+++ b/app/stardag-api/src/stardag_api/routes/tick_summaries.py
@@ -1,0 +1,169 @@
+"""Reactive scheduler tick summary routes.
+
+A reactive build is driven by many short-lived scheduler ticks, each in
+its own container. The per-tick ``TickSummary`` the SDK computes is the
+scheduler's own account of what it did and why — and it used to reach
+nobody but that container's log. These endpoints keep the last N per
+build so "why is this build not progressing?" is one request.
+"""
+
+import json
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from stardag_api.auth import SdkAuth, require_sdk_auth
+from stardag_api.config import limits_settings, settings
+from stardag_api.db import get_db
+from stardag_api.limits import check_rate_limit
+from stardag_api.models import BuildTickSummary
+
+# Reused rather than reimplemented: _get_build_checked is the
+# build-belongs-to-this-environment check every build sub-resource must
+# apply identically (a second copy is a second thing to get wrong), and
+# _raise_if_limit_exceeded defines the 429 body/Retry-After contract.
+from stardag_api.routes.builds import _get_build_checked, _raise_if_limit_exceeded
+from stardag_api.schemas import (
+    BuildTickSummaryCreate,
+    BuildTickSummaryListResponse,
+    BuildTickSummaryResponse,
+)
+
+# Same prefix/tag as the builds router: these are build sub-resources and
+# belong next to the rest in the OpenAPI schema. They live in their own
+# module only because routes/builds.py is already 2.8k lines.
+router = APIRouter(prefix="/builds", tags=["builds"])
+
+
+# Size cap on a single tick summary (compact-JSON byte size), mirroring
+# _MAX_REACTIVE_TICK_KWARGS_BYTES / _MAX_EXECUTOR_METADATA_BYTES in
+# routes/builds.py. Roomier than those two because the summary is
+# growing towards per-blocker detail (task ids of what a tick was
+# waiting on) rather than a handful of scalars. Worst case retained per
+# build is this times the retention window (~400 KB at the defaults),
+# and a tick that would exceed it is reporting something pathological.
+_MAX_TICK_SUMMARY_BYTES = 8192
+
+
+@router.post(
+    "/{build_id}/tick-summaries",
+    response_model=BuildTickSummaryResponse,
+    status_code=201,
+)
+async def create_build_tick_summary(
+    build_id: UUID,
+    payload: BuildTickSummaryCreate,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
+):
+    """Record one reactive scheduler tick's summary against a build.
+
+    Called at the end of every tick, so it sits on a hot path and is
+    best-effort by contract: callers report and move on, and must not
+    fail a tick because this failed. Kept to one insert plus one bounded
+    delete for that reason.
+
+    The body is stored verbatim. ``outcome`` is required (and promoted
+    to a column); every other key — including ones this server has never
+    seen — is preserved, which is what lets the SDK grow the summary
+    without a server release.
+    """
+    _raise_if_limit_exceeded(check_rate_limit(auth.workspace_id, limits_settings))
+
+    summary = payload.model_dump(mode="json")
+    encoded = json.dumps(summary, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > _MAX_TICK_SUMMARY_BYTES:
+        raise HTTPException(
+            status_code=422,
+            detail=(
+                f"tick summary must be at most {_MAX_TICK_SUMMARY_BYTES} bytes "
+                f"as compact JSON (got {len(encoded)})"
+            ),
+        )
+
+    build = await _get_build_checked(build_id, db, auth)
+
+    row = BuildTickSummary(
+        build_id=build.id,
+        outcome=payload.outcome,
+        summary=summary,
+    )
+    db.add(row)
+    # Flush so the new row is visible to (and counted by) the prune below.
+    await db.flush()
+
+    # Retention is enforced on insert rather than by a background job:
+    # this service has no scheduler, and the property we actually need is
+    # "a build's trail is bounded", which insert-time pruning gives
+    # exactly and immediately. The delete is bounded by construction —
+    # steady state removes one row per insert — and rides the same
+    # transaction, so a build never observes an over-long trail.
+    retained_ids = (
+        select(BuildTickSummary.id)
+        .where(BuildTickSummary.build_id == build.id)
+        # id (UUID7, so insertion-ordered) breaks created_at ties, and
+        # must agree with the read endpoint's ordering — otherwise "keep
+        # the newest" and "list the newest" could disagree about which
+        # of two same-instant rows survives.
+        .order_by(BuildTickSummary.created_at.desc(), BuildTickSummary.id.desc())
+        .limit(settings.max_tick_summaries_per_build)
+        .scalar_subquery()
+    )
+    await db.execute(
+        delete(BuildTickSummary)
+        .where(BuildTickSummary.build_id == build.id)
+        .where(BuildTickSummary.id.not_in(retained_ids))
+        .execution_options(synchronize_session=False)
+    )
+    await db.commit()
+
+    return BuildTickSummaryResponse(
+        id=row.id,
+        build_id=row.build_id,
+        outcome=row.outcome,
+        summary=row.summary,
+        created_at=row.created_at,
+    )
+
+
+@router.get(
+    "/{build_id}/tick-summaries",
+    response_model=BuildTickSummaryListResponse,
+)
+async def list_build_tick_summaries(
+    build_id: UUID,
+    db: Annotated[AsyncSession, Depends(get_db)],
+    auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
+    limit: Annotated[int, Query(ge=1, le=200)] = 20,
+):
+    """List a build's retained tick summaries, newest first.
+
+    The default window is what a "why is this build not progressing?"
+    panel wants: the recent past, where a stalled build is repeating the
+    same outcome. ``limit`` is capped above the default retention window
+    so asking for everything retained is always possible.
+    """
+    build = await _get_build_checked(build_id, db, auth)
+
+    result = await db.execute(
+        select(BuildTickSummary)
+        .where(BuildTickSummary.build_id == build.id)
+        .order_by(BuildTickSummary.created_at.desc(), BuildTickSummary.id.desc())
+        .limit(limit)
+    )
+    return BuildTickSummaryListResponse(
+        build_id=build.id,
+        summaries=[
+            BuildTickSummaryResponse(
+                id=row.id,
+                build_id=row.build_id,
+                outcome=row.outcome,
+                summary=row.summary,
+                created_at=row.created_at,
+            )
+            for row in result.scalars()
+        ],
+    )

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -849,3 +849,41 @@ class TaskMetadataResponse(BaseModel):
     started_at: datetime | None
     completed_at: datetime | None
     error_message: str | None
+
+
+# --- Build Tick Summary Schemas ---
+
+
+class BuildTickSummaryCreate(BaseModel):
+    """One reactive scheduler tick's summary, as reported by the SDK.
+
+    Deliberately open (``extra="allow"``): the summary is an SDK-owned
+    dataclass that keeps growing, and the server stores it verbatim so a
+    new field needs no server release and no migration. ``outcome`` is
+    the only required key — it is promoted to a typed column.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    outcome: str = Field(max_length=32)
+
+
+class BuildTickSummaryResponse(BaseModel):
+    """A persisted tick summary.
+
+    ``summary`` is the reported dict verbatim (``outcome`` included), so
+    a client can render fields this server has never heard of.
+    """
+
+    id: UUID
+    build_id: UUID
+    outcome: str
+    summary: dict
+    created_at: datetime
+
+
+class BuildTickSummaryListResponse(BaseModel):
+    """Retained tick summaries for a build, newest first."""
+
+    build_id: UUID
+    summaries: list[BuildTickSummaryResponse]

--- a/app/stardag-api/tests/test_tick_summaries.py
+++ b/app/stardag-api/tests/test_tick_summaries.py
@@ -1,0 +1,342 @@
+"""Tests for the per-build reactive scheduler tick summary endpoints."""
+
+import contextlib
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+
+from stardag_api.config import settings
+
+FAKE_BUILD_ID = "00000000-0000-0000-0000-000000000099"
+
+
+async def _create_build(client: AsyncClient) -> str:
+    response = await client.post("/api/v1/builds", json={})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+def _summary(outcome: str = "lingered_out", **fields) -> dict:
+    """A representative TickSummary payload."""
+    return {
+        "outcome": outcome,
+        "terminal_status": None,
+        "spawned": 0,
+        "self_healed": 0,
+        "failed_recorded": 0,
+        "cancelled_refs": 0,
+        "iterations": 1,
+        "limit_denied": 0,
+        "claim_denied": 0,
+        "skipped": 0,
+        **fields,
+    }
+
+
+@pytest.fixture
+async def as_environment_b(async_engine):
+    """Context manager switching the app's auth override to a SECOND
+    environment in the same workspace (the tenancy boundary is the
+    environment)."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from stardag_api.auth import SdkAuth, require_sdk_auth
+    from stardag_api.main import app
+    from stardag_api.models import Environment, User
+    from tests.conftest import DEFAULT_USER_ID, DEFAULT_WORKSPACE_ID
+
+    env_b_id = UUID("00000000-0000-0000-0000-00000000000b")
+    session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+    async with session_maker() as session:
+        session.add(
+            Environment(
+                id=env_b_id,
+                workspace_id=DEFAULT_WORKSPACE_ID,
+                name="Environment B",
+                slug="env-b",
+            )
+        )
+        await session.commit()
+
+    auth_b = SdkAuth(
+        environment=Environment(
+            id=env_b_id, workspace_id=DEFAULT_WORKSPACE_ID, name="Environment B"
+        ),
+        workspace_id=DEFAULT_WORKSPACE_ID,
+        user=User(
+            id=DEFAULT_USER_ID,
+            external_id="default-local-user",
+            email="default@localhost",
+            display_name="Default User",
+        ),
+    )
+
+    async def override_require_sdk_auth_b() -> SdkAuth:
+        return auth_b
+
+    @contextlib.contextmanager
+    def _switch():
+        previous = app.dependency_overrides[require_sdk_auth]
+        app.dependency_overrides[require_sdk_auth] = override_require_sdk_auth_b
+        try:
+            yield
+        finally:
+            app.dependency_overrides[require_sdk_auth] = previous
+
+    return _switch
+
+
+@pytest.mark.asyncio
+async def test_post_and_list_round_trip(client: AsyncClient):
+    """A reported summary comes back verbatim, newest first."""
+    build_id = await _create_build(client)
+
+    for outcome in ("lease_held", "lingered_out", "terminal"):
+        response = await client.post(
+            f"/api/v1/builds/{build_id}/tick-summaries",
+            json=_summary(outcome, spawned=2),
+        )
+        assert response.status_code == 201
+        created = response.json()
+        assert created["build_id"] == build_id
+        assert created["outcome"] == outcome
+        assert created["summary"]["spawned"] == 2
+        # The blob is a faithful copy, outcome included.
+        assert created["summary"]["outcome"] == outcome
+        assert created["created_at"] is not None
+
+    response = await client.get(f"/api/v1/builds/{build_id}/tick-summaries")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["build_id"] == build_id
+    assert [s["outcome"] for s in data["summaries"]] == [
+        "terminal",
+        "lingered_out",
+        "lease_held",
+    ]
+    assert data["summaries"][0]["summary"] == _summary("terminal", spawned=2)
+
+
+@pytest.mark.asyncio
+async def test_unknown_fields_are_preserved(client: AsyncClient):
+    """Fields this server has never heard of survive the round trip —
+    the SDK must be able to grow TickSummary without a server release."""
+    build_id = await _create_build(client)
+    payload = _summary(
+        "lingered_out",
+        blocked_by_other_build=3,
+        blocked_details=[{"task_id": "abc", "build_id": "def"}],
+        some_future_flag=True,
+    )
+
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tick-summaries", json=payload
+    )
+    assert response.status_code == 201
+    assert response.json()["summary"] == payload
+
+    listed = (await client.get(f"/api/v1/builds/{build_id}/tick-summaries")).json()[
+        "summaries"
+    ]
+    assert listed[0]["summary"] == payload
+
+
+@pytest.mark.asyncio
+async def test_outcome_is_required(client: AsyncClient):
+    """outcome is the one promoted field, so it is the one required key."""
+    build_id = await _create_build(client)
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tick-summaries", json={"spawned": 1}
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_retention_prunes_at_the_boundary(client: AsyncClient, monkeypatch):
+    """Insert-time pruning keeps exactly the newest N, and the (N+1)th
+    insert evicts the oldest — not the newest, and not more than one."""
+    monkeypatch.setattr(settings, "max_tick_summaries_per_build", 5)
+    build_id = await _create_build(client)
+
+    # Exactly at the limit: nothing pruned yet.
+    for i in range(5):
+        response = await client.post(
+            f"/api/v1/builds/{build_id}/tick-summaries",
+            json=_summary("lease_held", iterations=i),
+        )
+        assert response.status_code == 201
+
+    listed = (
+        await client.get(
+            f"/api/v1/builds/{build_id}/tick-summaries", params={"limit": 100}
+        )
+    ).json()["summaries"]
+    assert [s["summary"]["iterations"] for s in listed] == [4, 3, 2, 1, 0]
+
+    # One over: the oldest goes, the window stays at N.
+    await client.post(
+        f"/api/v1/builds/{build_id}/tick-summaries",
+        json=_summary("lease_held", iterations=5),
+    )
+    listed = (
+        await client.get(
+            f"/api/v1/builds/{build_id}/tick-summaries", params={"limit": 100}
+        )
+    ).json()["summaries"]
+    assert [s["summary"]["iterations"] for s in listed] == [5, 4, 3, 2, 1]
+
+    # Well past the limit: still exactly N.
+    for i in range(6, 20):
+        await client.post(
+            f"/api/v1/builds/{build_id}/tick-summaries",
+            json=_summary("lease_held", iterations=i),
+        )
+    listed = (
+        await client.get(
+            f"/api/v1/builds/{build_id}/tick-summaries", params={"limit": 100}
+        )
+    ).json()["summaries"]
+    assert [s["summary"]["iterations"] for s in listed] == [19, 18, 17, 16, 15]
+
+
+@pytest.mark.asyncio
+async def test_retention_is_scoped_per_build(client: AsyncClient, monkeypatch):
+    """Pruning one build's trail never touches another's."""
+    monkeypatch.setattr(settings, "max_tick_summaries_per_build", 2)
+    build_a = await _create_build(client)
+    build_b = await _create_build(client)
+
+    await client.post(
+        f"/api/v1/builds/{build_b}/tick-summaries", json=_summary("terminal")
+    )
+    for _ in range(5):
+        await client.post(
+            f"/api/v1/builds/{build_a}/tick-summaries", json=_summary("lease_held")
+        )
+
+    a_listed = (await client.get(f"/api/v1/builds/{build_a}/tick-summaries")).json()
+    b_listed = (await client.get(f"/api/v1/builds/{build_b}/tick-summaries")).json()
+    assert len(a_listed["summaries"]) == 2
+    assert len(b_listed["summaries"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_oversized_summary_rejected(client: AsyncClient):
+    """A pathological summary is refused rather than stored."""
+    build_id = await _create_build(client)
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tick-summaries",
+        json=_summary("lingered_out", blocked_task_ids=["x" * 64] * 200),
+    )
+    assert response.status_code == 422
+    assert "at most" in response.json()["detail"]
+
+    # Nothing was persisted.
+    listed = (await client.get(f"/api/v1/builds/{build_id}/tick-summaries")).json()
+    assert listed["summaries"] == []
+
+
+@pytest.mark.asyncio
+async def test_long_outcome_rejected(client: AsyncClient):
+    """outcome is a String(32) column — over-long values 422 rather than
+    blowing up in the database."""
+    build_id = await _create_build(client)
+    response = await client.post(
+        f"/api/v1/builds/{build_id}/tick-summaries", json=_summary("x" * 33)
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_limit_query_param(client: AsyncClient):
+    """The read window is caller-controlled and hard-capped."""
+    build_id = await _create_build(client)
+    for i in range(5):
+        await client.post(
+            f"/api/v1/builds/{build_id}/tick-summaries",
+            json=_summary("lease_held", iterations=i),
+        )
+
+    listed = (
+        await client.get(
+            f"/api/v1/builds/{build_id}/tick-summaries", params={"limit": 2}
+        )
+    ).json()["summaries"]
+    assert [s["summary"]["iterations"] for s in listed] == [4, 3]
+
+    assert (
+        await client.get(
+            f"/api/v1/builds/{build_id}/tick-summaries", params={"limit": 201}
+        )
+    ).status_code == 422
+    assert (
+        await client.get(
+            f"/api/v1/builds/{build_id}/tick-summaries", params={"limit": 0}
+        )
+    ).status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_unknown_build_is_404(client: AsyncClient):
+    assert (
+        await client.post(
+            f"/api/v1/builds/{FAKE_BUILD_ID}/tick-summaries", json=_summary()
+        )
+    ).status_code == 404
+    assert (
+        await client.get(f"/api/v1/builds/{FAKE_BUILD_ID}/tick-summaries")
+    ).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_environment_isolation(client: AsyncClient, as_environment_b):
+    """Tick summaries are environment-scoped: another environment's auth
+    can neither write nor read this build's trail."""
+    build_id = await _create_build(client)
+    await client.post(
+        f"/api/v1/builds/{build_id}/tick-summaries", json=_summary("terminal")
+    )
+
+    with as_environment_b():
+        assert (
+            await client.post(
+                f"/api/v1/builds/{build_id}/tick-summaries", json=_summary("lease_held")
+            )
+        ).status_code == 403
+        assert (
+            await client.get(f"/api/v1/builds/{build_id}/tick-summaries")
+        ).status_code == 403
+
+    # Untouched in the owning environment.
+    listed = (await client.get(f"/api/v1/builds/{build_id}/tick-summaries")).json()
+    assert [s["outcome"] for s in listed["summaries"]] == ["terminal"]
+
+
+@pytest.mark.asyncio
+async def test_empty_trail(client: AsyncClient):
+    """A build that has never been ticked lists empty, not 404."""
+    build_id = await _create_build(client)
+    response = await client.get(f"/api/v1/builds/{build_id}/tick-summaries")
+    assert response.status_code == 200
+    assert response.json() == {"build_id": build_id, "summaries": []}
+
+
+@pytest.mark.asyncio
+async def test_round_trip_on_postgres(pg_client: AsyncClient):
+    """Same round trip against real Postgres: exercises the JSONB column
+    and the NOT IN (subquery LIMIT) prune on the production dialect."""
+    build_id = await _create_build(pg_client)
+    payload = _summary("lingered_out", blocked_by_other_build=2)
+    for _ in range(3):
+        assert (
+            await pg_client.post(
+                f"/api/v1/builds/{build_id}/tick-summaries", json=payload
+            )
+        ).status_code == 201
+
+    listed = (await pg_client.get(f"/api/v1/builds/{build_id}/tick-summaries")).json()[
+        "summaries"
+    ]
+    assert len(listed) == 3
+    assert listed[0]["summary"] == payload


### PR DESCRIPTION
Implements **B6** of #208 ("Tick outcomes are not persisted"), server side only.

A reactive build is driven by many short-lived scheduler ticks, each in its own container. Each tick's `TickSummary` — the scheduler's own account of what it did, and of why it did nothing — reached nothing but that container's log, so reconstructing why a build stalled meant correlating logs across dozens of containers. This persists the last N summaries against the build and exposes them.

Scope is `app/stardag-api/` only. Nothing writes to these endpoints yet: SDK-side reporting and the UI panel (B5) land separately, and both depend on the shapes below **verbatim**.

## Request / response shapes

### `POST /api/v1/builds/{build_id}/tick-summaries`

Auth: SDK (API key or internal JWT), scoped to the build's environment.

Request body — an **open object**. `outcome` is the only required key (`maxLength: 32`); everything else is accepted as-is and stored unchanged, including keys this server has never heard of. Today's `TickSummary` serialises to:

```json
{
  "outcome": "lingered_out",
  "terminal_status": null,
  "spawned": 0,
  "self_healed": 0,
  "failed_recorded": 0,
  "cancelled_refs": 0,
  "iterations": 1,
  "limit_denied": 0,
  "claim_denied": 0,
  "skipped": 0
}
```

`201` response body:

```json
{
  "id": "0198f0a1-...",
  "build_id": "0198f09c-...",
  "outcome": "lingered_out",
  "summary": {
    "outcome": "lingered_out",
    "terminal_status": null,
    "spawned": 0,
    "self_healed": 0,
    "failed_recorded": 0,
    "cancelled_refs": 0,
    "iterations": 1,
    "limit_denied": 0,
    "claim_denied": 0,
    "skipped": 0
  },
  "created_at": "2026-08-07T20:51:10.251057Z"
}
```

`summary` is the request body verbatim, `outcome` included — the top-level `outcome` is a duplicate of it, promoted for indexing.

Errors: `404` unknown build, `403` build in another environment, `422` missing/over-long `outcome` or a body over 8192 bytes as compact JSON, `429` workspace rate limit.

### `GET /api/v1/builds/{build_id}/tick-summaries?limit=<n>`

`limit` defaults to `20`, `ge=1`, `le=200`. Newest first.

```json
{
  "build_id": "0198f09c-...",
  "summaries": [
    {
      "id": "0198f0a1-...",
      "build_id": "0198f09c-...",
      "outcome": "lingered_out",
      "summary": { "...": "as posted" },
      "created_at": "2026-08-07T20:51:10.251057Z"
    }
  ]
}
```

A build that has never been ticked returns `200` with `"summaries": []`. Errors: `404` unknown build, `403` cross-environment.

## Design notes

**One promoted column plus a blob.** `outcome` is lifted into an indexed `String(32)`: it is the one field with a small, closed-ish vocabulary worth filtering on, and the UI reads it on every row. Everything else lives in a JSON/JSONB blob stored as sent. `TickSummary` is SDK-owned and still growing (per-blocker detail is coming), this table is a write-mostly observability trail rather than a queried entity, and unknown keys must be preserved rather than rejected — so a new field must cost neither a server release nor a migration. `outcome` stays a plain string, not an enum: the Modal wrapper already emits an outcome the core doesn't, and an unrecognised one must round-trip rather than 500.

**Retention pruned on insert**, to the newest N per build (default 50, `STARDAG_API_MAX_TICK_SUMMARIES_PER_BUILD`), inside the insert's transaction. This service has no scheduler to run a background reaper, and the property actually needed is "a build's trail is bounded" — insert-time pruning gives that exactly and immediately. The delete is bounded by construction: steady state removes one row per insert.

**Cheap by contract.** The write sits on a hot path and is best-effort — a caller reports and moves on, and must never fail a tick because this failed. It is one insert plus one bounded delete, nothing more.

**Indexing.** One composite index `(build_id, created_at)` and nothing else. "Newest N for this build" is the only query — for both the read endpoint and the prune — and the composite's leading column also serves plain `build_id` lookups and the FK cascade. Deviates slightly from a separate `build_id` index: the write path pays for every index twice per tick, and a redundant one buys nothing. Direction is left ASC rather than `DESC`; a btree is scanned backwards at no cost, and an expression-based index would make Alembic's autogenerate emit a spurious drop/create on every future run.

**Route module.** New `routes/tick_summaries.py` rather than more of `routes/builds.py` (already 2.8k lines). Same `/builds` prefix and `builds` tag, so it groups with the rest in the OpenAPI schema. It reuses `_get_build_checked` and `_raise_if_limit_exceeded` from `routes/builds.py` rather than copying them — the environment-scoping check in particular should have exactly one implementation.

## Migration

`0807aacc230e` (`20260807_205110_add_build_tick_summaries.py`), autogenerated, revising `792fb8ab3c3c`. New table, no backfill, no changes to existing tables. Verified against a real Postgres 16: `alembic upgrade head && alembic downgrade -1 && alembic upgrade head`, plus `alembic check` reporting no drift afterwards.

## Tests

`app/stardag-api/tests/test_tick_summaries.py` — write/read round trip, unknown-field preservation, retention at the boundary (at N, N+1, and well past), retention scoped per build, size-cap and over-long-`outcome` rejection, `limit` bounds, unknown build → 404, cross-environment write and read → 403, empty trail, and a Postgres round trip via `pg_client` exercising JSONB and the `NOT IN (… LIMIT n)` prune on the production dialect.

```
uv run pytest                                        372 passed, 19 skipped
STARDAG_API_TEST_DATABASE_URL=… uv run pytest        390 passed,  1 skipped
pre-commit run --files <changed files>               all hooks passed (ruff, ruff-format, pyright-stardag-api, prettier)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NyR9Kc9ZP5Ko7dVndhi3Y
