### PR TITLE
feat(reactive): declare task modules so scheduler ticks can reconstruct tasks without pickles (#208 B1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,14 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   about classes the patterns don't cover, naming the pattern to add;
   `require_pickle_free=True` turns that fallback into a hard error.
 
-  Resident (non-reactive) builds are unaffected, and `task_modules=[]`
-  behaves exactly as before. **Upgrade note for reactive users:** because
-  the default _infers_ patterns, a reactive trigger from the upgraded SDK
-  may skip pickles that the currently _deployed_ tick cannot compensate
-  for — redeploy the app before triggering (reactive mode already requires
-  the deployed app and the SDK to match), or pass `task_modules=[]`.
+  Skipping pickles requires declaring `task_modules` explicitly; the
+  inferred default only drives the coverage warning. Upgrading stardag
+  therefore changes nothing on its own — a newer SDK triggering against an
+  app deployed by an older one still writes pickles, because eliding them
+  would depend on a baked-in module list that deployment does not have.
+  Resident (non-reactive) builds are unaffected either way, and
+  `task_modules=[]` behaves exactly as before. **Redeploy the app whenever
+  you change `task_modules`**, before triggering.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+- **`StardagApp(task_modules=[...])`: declare the modules whose import
+  registers your task classes, so reactive scheduler ticks can rebuild
+  tasks from registry data instead of pickles.** A tick reconstructs task
+  objects from the registry's stored payload, which resolves a class
+  through the polymorphic registry — populated only as a side effect of
+  importing the defining module. Without a declaration, whatever a tick
+  container happens to import is arbitrary, so the build task store's
+  pickles were load-bearing (and needed target-root write access at
+  trigger time, and were invalidated by every redeploy).
+
+  Patterns are exact modules (`"my_pkg.tasks.ingest"`) or trailing
+  recursive wildcards (`"my_pkg.tasks.*"`); the default infers the root
+  package of the module defining the app, and `[]` opts out. They are
+  expanded to a concrete module list at deploy time (without importing
+  submodules) and baked into the deployed tick, so **adding or moving task
+  classes requires a redeploy**; `stardag modal deploy` reports the
+  expansion (`--no-check-task-modules` skips the warn-only local import
+  check). Task modules are imported in every tick container, so keep heavy
+  runtime dependencies inside `run()` rather than at module scope.
+
+  With the declaration in place, a reactive trigger writes **no pickle**
+  for any task whose class is covered and whose payload round-trips to the
+  same task id — a fully covered build needs no target-root write access
+  at all. Everything else keeps its pickle exactly as before, including
+  `AliasTask` payloads (pickled `loads_type`, never auto-unpickled from
+  registry data by design) and non-importable classes. The trigger warns
+  about classes the patterns don't cover, naming the pattern to add;
+  `require_pickle_free=True` turns that fallback into a hard error.
+
+  Resident (non-reactive) builds are unaffected, and `task_modules=[]`
+  behaves exactly as before. **Upgrade note for reactive users:** because
+  the default _infers_ patterns, a reactive trigger from the upgraded SDK
+  may skip pickles that the currently _deployed_ tick cannot compensate
+  for — redeploy the app before triggering (reactive mode already requires
+  the deployed app and the SDK to match), or pass `task_modules=[]`.
+
 ### Fixed
 
 - **The reactive watchdog now asks the registry only for the RUNNING builds

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -584,12 +584,24 @@ by default but **warn-only** — your deploy environment may lack extras the
 image has, so a local import failure never fails the deploy. Pass
 `--no-check-task-modules` to skip the check and report names only.
 
-**What you get.** At trigger time, every discovered task whose class is
-covered _and_ whose payload round-trips to the same task id is persisted
-**without a pickle**. A build whose classes are all covered writes nothing
-to the target root, so reactive triggering stops needing target-root write
-access at all. Set `require_pickle_free=True` to turn the fallback into a
-hard error that names every task that would have needed a pickle and why.
+**What you get.** Once you declare `task_modules` explicitly, every
+discovered task whose class is covered _and_ whose payload round-trips to
+the same task id is persisted **without a pickle**. A build whose classes
+are all covered writes nothing to the target root, so reactive triggering
+stops needing target-root write access at all. Set
+`require_pickle_free=True` to turn the fallback into a hard error that
+names every task that would have needed a pickle and why.
+
+**Skipping pickles requires the explicit declaration** — the inferred
+default never elides on its own. Inference happens for every app,
+including apps written before this feature existed, and the trigger runs
+from your _local_ app definition while the tick runs from the _deployed_
+one. If inference alone skipped pickles, upgrading stardag would silently
+start dropping pickles that an app deployed by an older version has no
+baked-in module list to compensate for. Requiring you to write the
+argument is what puts the redeploy requirement in front of you at the
+moment it matters. Inference still drives the coverage warning below,
+which only observes.
 
 Some payloads stay pickle-bound by design, and always will:
 
@@ -615,16 +627,16 @@ Two caveats worth designing around:
   it directly buys tick cold-start latency.
 - **Stale-deploy blind spot.** The trigger-time coverage check reads your
   _local_ app definition, so it cannot tell that the _deployed_ app was
-  built from an older `task_modules` — or from a stardag version that
-  predates the feature entirely. If you add a pattern (or upgrade stardag)
-  and trigger without redeploying, the pre-flight is silent while the tick
-  still can't resolve the class, and because the trigger already skipped
-  the pickle there is no fallback left. **Redeploy the app whenever you
-  change `task_modules` or upgrade stardag**, before triggering — which
-  the reactive mode already requires for other reasons (see the
-  requirements above). Passing `task_modules=[]` restores the pre-feature
-  behaviour unconditionally if you need to trigger against an older
-  deployment.
+  built from an older `task_modules`. If you add a pattern and trigger
+  without redeploying, the pre-flight is silent while the tick still can't
+  resolve the class — and because the trigger already skipped the pickle,
+  there is no fallback left. **Redeploy the app whenever you change
+  `task_modules`**, before triggering — which reactive mode already
+  requires for other reasons (see the requirements above). Upgrading
+  stardag alone is safe: elision only follows an explicit declaration, so
+  a newer SDK triggering against an app deployed by an older one still
+  writes pickles. Passing `task_modules=[]` restores the pre-feature
+  behaviour unconditionally.
 
 Named concurrency limits are enforced registry-side in reactive mode —
 across builds, not just within one. Configure caps per environment

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -466,7 +466,10 @@ access to the default target root (task _objects_ are persisted there as
 pickles for the ticks — the reactive marker, owning app, and tick config
 live in the registry, not on the target root, so re-triggering works even
 when the target root is immutable/append-only and a re-trigger may update
-`tick_kwargs`); the global concurrency lock and build-local
+`tick_kwargs`; declaring
+[`task_modules`](#declaring-your-task-modules-recommended) removes the
+target-root write from this path entirely for most builds); the global
+concurrency lock and build-local
 `ConcurrencyConfig` limits are not applied by ticks (use the
 registry-backed named limits above; Modal's per-function
 `concurrency_limit` also still applies). Builds cancelled from the
@@ -484,6 +487,9 @@ Two operational notes:
   still importable and its fields are compatible (nested task fields
   must use `sd.TaskLoads`/`sd.SubClass` annotations). Only if both paths
   fail is the task failed by the next tick (never a silent stall).
+  Declaring [`task_modules`](#declaring-your-task-modules-recommended) is
+  what makes "still importable" true by construction — and lets stardag
+  skip the pickle in the first place.
 - **The watchdog sweep runs one quick scheduling pass per running build
   that this app owns** (it skips the linger), so its per-period cost is
   one short function invocation plus a frontier query per such build.
@@ -520,6 +526,105 @@ Two operational notes:
   on the default and don't declare a registry secret at all. (On stardag
   ≤ 0.10.1 you instead had to put the secret on the builder — 0.10.1 —
   or on every worker — 0.10.0.)
+
+#### Declaring your task modules (recommended)
+
+A scheduler tick is a fresh, short-lived process. It learns _which_ tasks
+are actionable from the registry, but to spawn a worker it needs the actual
+task _object_ — and it has two ways to get one:
+
+1. unpickle it from the build task store (needs target-root access, and is
+   only valid for the deployment that wrote it), or
+2. rebuild it from the payload the registry already stores.
+
+The second path is the good one, but it has a catch: rebuilding a task
+resolves its class through stardag's polymorphic registry, and classes land
+in that registry **as a side effect of importing the module that defines
+them**. A pickle carries `module.QualName` and self-imports; the registry
+payload carries no module locator at all. So the tick can only rebuild
+classes whose modules its container happened to import — which, without
+help, is essentially arbitrary.
+
+`task_modules` is that help:
+
+```{.python notest}
+app = sd_modal.StardagApp(
+    "stardag-poc",
+    builder_settings=sd_modal.FunctionSettings(image=image),
+    worker_settings={"default": sd_modal.FunctionSettings(image=image)},
+    watchdog_period_minutes=5,
+    # Modules whose import registers the task classes this app may
+    # schedule. Default: the root package of the module defining the app.
+    # Pass [] to opt out (resident builds never need this).
+    task_modules=["my_pkg.tasks.*", "my_pkg.pipelines.*"],
+)
+```
+
+**Pattern grammar.** Each entry is either an exact module
+(`"my_pkg.tasks.ingest"`) or a package followed by a trailing recursive
+wildcard (`"my_pkg.tasks.*"`, matching `my_pkg.tasks` and everything below
+it). A `*` anywhere but the final component, or a malformed path, raises
+from `StardagApp(...)` — a typo must not degrade into a silent no-match.
+Left unset, the default is `"<root package of the module defining the
+app>.*"`; if the app lives in `__main__` or a loose script (no importable
+package), inference is impossible and stardag warns and falls back to the
+pickle path.
+
+**A redeploy is required** when you add or move task classes. The patterns
+are expanded to a concrete module list at deploy time and baked into the
+deployed tick, so the deployed set is explicit and auditable and container
+startup does no filesystem walking. `stardag modal deploy` reports it:
+
+```text
+Task modules: 37 discovered from "my_pkg.*"  ->  128 task classes registered
+```
+
+The class count requires importing the modules locally, which the CLI does
+by default but **warn-only** — your deploy environment may lack extras the
+image has, so a local import failure never fails the deploy. Pass
+`--no-check-task-modules` to skip the check and report names only.
+
+**What you get.** At trigger time, every discovered task whose class is
+covered _and_ whose payload round-trips to the same task id is persisted
+**without a pickle**. A build whose classes are all covered writes nothing
+to the target root, so reactive triggering stops needing target-root write
+access at all. Set `require_pickle_free=True` to turn the fallback into a
+hard error that names every task that would have needed a pickle and why.
+
+Some payloads stay pickle-bound by design, and always will:
+
+- **`AliasTask`**, whose `loads_type` is pickled bytes — auto-unpickling
+  registry-supplied bytes inside a scheduler tick would be a remote code
+  execution vector, so rehydration refuses those payloads outright;
+- **dynamically generated or otherwise non-importable classes**;
+- **anything whose serialization is not losslessly round-trippable** (in
+  particular, nested task fields must use `sd.TaskLoads` / `sd.SubClass`
+  annotations — a plain task-typed annotation validates children into the
+  abstract base class).
+
+The trigger warns — naming the class, the pattern to add, and the redeploy
+requirement — for any discovered class the patterns don't cover. It is a
+warning rather than an error because an uncovered class still works via the
+pickle path, exactly as before this feature existed.
+
+Two caveats worth designing around:
+
+- **Task modules become import-hot.** They are imported in every tick
+  container, on every cold start. Keep heavy runtime dependencies inside
+  `run()` rather than at module scope — good practice regardless, but here
+  it directly buys tick cold-start latency.
+- **Stale-deploy blind spot.** The trigger-time coverage check reads your
+  _local_ app definition, so it cannot tell that the _deployed_ app was
+  built from an older `task_modules` — or from a stardag version that
+  predates the feature entirely. If you add a pattern (or upgrade stardag)
+  and trigger without redeploying, the pre-flight is silent while the tick
+  still can't resolve the class, and because the trigger already skipped
+  the pickle there is no fallback left. **Redeploy the app whenever you
+  change `task_modules` or upgrade stardag**, before triggering — which
+  the reactive mode already requires for other reasons (see the
+  requirements above). Passing `task_modules=[]` restores the pre-feature
+  behaviour unconditionally if you need to trigger against an older
+  deployment.
 
 Named concurrency limits are enforced registry-side in reactive mode —
 across builds, not just within one. Configure caps per environment

--- a/lib/stardag/src/stardag/_cli/modal.py
+++ b/lib/stardag/src/stardag/_cli/modal.py
@@ -36,7 +36,7 @@ from stardag._cli.credentials import (
 )
 from stardag.config.cache import get_cached_slugs
 from stardag.config.loader import clear_config_cache, get_config
-from stardag.integration.modal import StardagApp
+from stardag.integration.modal import FinalizeResult, StardagApp
 
 # Check if modal is available
 try:
@@ -488,6 +488,61 @@ def _parse_app_ref(app_ref: str) -> tuple[str, str]:
     return app_ref, ""
 
 
+def _report_task_modules(
+    stardag_app_instance: StardagApp,
+    finalize_result: FinalizeResult,
+    *,
+    check: bool,
+) -> None:
+    """Report the task-module expansion baked into the deployed tick.
+
+    The class count is the genuinely useful number — "37 modules" says
+    nothing about whether the DAG's classes are among them — but getting it
+    requires actually importing the modules *here*, in the deploy
+    environment, which is not the image: it may lack extras, GPU libraries,
+    or credentials the containers have. So the import check is default-on
+    and strictly **warn-only**; it can never fail a deploy, and
+    ``--no-check-task-modules`` skips it entirely. It also stays in the CLI
+    rather than in ``finalize()``, so programmatic callers pay only for
+    name expansion.
+    """
+    task_modules = list(finalize_result.task_modules)
+    patterns = list(stardag_app_instance.task_modules)
+    if not task_modules:
+        if not patterns:
+            console.print(
+                "[dim]  task modules: none declared — reactive scheduler "
+                "ticks will rely on task-store pickles[/dim]"
+            )
+        return
+
+    from_patterns = ", ".join(f'"{p}"' for p in patterns)
+    summary = f"{len(task_modules)} discovered from {from_patterns}"
+    if not check:
+        console.print(f"[cyan]Task modules:[/cyan] [dim]{summary}[/dim]")
+        return
+
+    from stardag.build import import_task_modules
+
+    report = import_task_modules(task_modules)
+    console.print(
+        f"[cyan]Task modules:[/cyan] [dim]{summary}  ->  "
+        f"{report.task_classes_registered} task classes registered[/dim]"
+    )
+    if report.failures:
+        console.print(
+            f"[yellow]  {len(report.failures)} task module(s) failed to "
+            "import locally. This does NOT fail the deploy — the image may "
+            "have dependencies this environment lacks — but if the failure "
+            "reproduces in the container, task classes defined in these "
+            "modules will not be reconstructable by scheduler ticks:[/yellow]"
+        )
+        for module_name in sorted(report.failures):
+            console.print(
+                f"[yellow]    {module_name}: {report.failures[module_name]}[/yellow]"
+            )
+
+
 @app.command("deploy")
 def deploy(
     app_ref: str = typer.Argument(
@@ -531,6 +586,16 @@ def deploy(
         False,
         "-m",
         help="Interpret argument as a Python module path instead of a file/script path",
+    ),
+    check_task_modules: bool = typer.Option(
+        True,
+        "--check-task-modules/--no-check-task-modules",
+        help=(
+            "Import the app's expanded task_modules locally to report how "
+            "many task classes they register. Warn-only — a local import "
+            "failure never fails the deploy (the deploy environment may "
+            "lack extras the image has)."
+        ),
     ),
 ) -> None:
     """Deploy a Stardag Modal application.
@@ -632,6 +697,10 @@ def deploy(
         console.print("[cyan]Functions:[/cyan]")
         for func_name in finalize_result.functions:
             console.print(f"[dim]  {func_name}[/dim]")
+
+        _report_task_modules(
+            stardag_app_instance, finalize_result, check=check_task_modules
+        )
 
     # Get the underlying Modal app
     modal_app = stardag_app_instance.modal_app

--- a/lib/stardag/src/stardag/build/__init__.py
+++ b/lib/stardag/src/stardag/build/__init__.py
@@ -24,6 +24,12 @@ Global concurrency locking:
 Granular concurrency limiting:
 - ConcurrencyConfig: Overall and named limits on concurrently executing tasks
 - ConcurrencyLimiter: Protocol for custom/distributed limiters
+
+Task-module declaration (reactive scheduling only):
+- expand_task_module_patterns()/import_task_modules(): make a scheduler
+    process able to reconstruct a build's task classes from registry data
+- plan_pickle_elision(): decide which tasks still need a build-task-store
+    pickle (see stardag.build._task_modules for the full rationale)
 """
 
 from stardag.build._base import (
@@ -57,6 +63,20 @@ from stardag.build._reactive import (
     run_tick_aio,
 )
 from stardag.build._task_store import BuildTaskStore
+from stardag.build._task_modules import (
+    PickleElisionPlan,
+    TaskModuleImportReport,
+    TaskModulesError,
+    declared_task_module_patterns,
+    expand_task_module_patterns,
+    import_task_modules,
+    last_import_failures,
+    module_is_covered,
+    plan_pickle_elision,
+    set_declared_task_module_patterns,
+    uncovered_task_classes,
+    validate_task_module_patterns,
+)
 from stardag.build._concurrency import (
     ConcurrencyConfig,
     ConcurrencyKeySelector,
@@ -108,6 +128,19 @@ __all__ = [
     "RoutedTaskExecutor",
     "TaskExecutionError",
     "BuildTaskStore",
+    # Task-module declaration (reactive scheduling)
+    "PickleElisionPlan",
+    "TaskModuleImportReport",
+    "TaskModulesError",
+    "declared_task_module_patterns",
+    "expand_task_module_patterns",
+    "import_task_modules",
+    "last_import_failures",
+    "module_is_covered",
+    "plan_pickle_elision",
+    "set_declared_task_module_patterns",
+    "uncovered_task_classes",
+    "validate_task_module_patterns",
     "ClaimConfig",
     "DetachedExecutionStatus",
     "DiscoveryResult",

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -23,7 +23,11 @@ with detached support. Requirements and current limitations:
 - A real registry (frontier computation is registry-backed; the reactive
   marker/owner live in the frontier's ``reactive_app_name``).
 - Task objects are rehydrated from the :class:`BuildTaskStore` — written by
-  the trigger (initial discovery) and by workers (dynamic deps).
+  the trigger (initial discovery) and by workers (dynamic deps) — or, when
+  the pickle is absent, reconstructed from the registry's stored task data.
+  The latter resolves only *registered* classes, i.e. classes whose
+  defining module the tick process has imported; see
+  ``stardag.build._task_modules`` for how an app declares those.
 - The global concurrency lock and build-local ``ConcurrencyConfig`` limits
   are not applied by ticks (infra-level limits, e.g. Modal per-function
   ``concurrency_limit``, still apply). Registry-backed named limits *are*
@@ -56,6 +60,7 @@ from stardag.build._base import (
     TaskExecutorABC,
     current_build_id_var,
 )
+from stardag.build._task_modules import import_failure_note
 from stardag.build._task_store import BuildTaskStore
 from stardag.exceptions import NotFoundError, is_missing_route_error
 from stardag.registry._api_registry import _is_route_not_found
@@ -360,6 +365,15 @@ async def _load_task(
     the stack trace — for callers where a missing object is tolerated (a
     RUNNING task resolves via its worker's self-reporting), the repeated
     per-tick ``logger.exception`` would be noise.
+
+    A rehydration failure is annotated with any declared task modules that
+    failed to import in this process (see
+    ``stardag.build._task_modules``): "no task class registered for X" and
+    "the module defining X blew up on import" are the same incident seen
+    from two ends, and only the annotation connects them. The annotation is
+    read from the task-module registry rather than plumbed through
+    ``rehydrate.py``, which stays a pure reconstruction primitive with no
+    notion of how its classes got imported.
     """
     task = task_store.load_task(task_id)
     if task is not None:
@@ -372,10 +386,11 @@ async def _load_task(
             f"Task {task_id} is missing from the task store and could not "
             f"be rehydrated from registry data"
         )
+        note = import_failure_note()
         if quiet:
-            logger.warning(f"{message}: {e}")
+            logger.warning(f"{message}: {e}{note}")
         else:
-            logger.exception(f"{message}.")
+            logger.exception(f"{message}.{note}")
         return None
     logger.info(f"Rehydrated task {task_id} from registry data.")
     try:

--- a/lib/stardag/src/stardag/build/_task_modules.py
+++ b/lib/stardag/src/stardag/build/_task_modules.py
@@ -358,9 +358,18 @@ def count_registered_task_classes(modules: typing.Iterable[str]) -> int:
 
 
 def _reset_import_state_for_tests() -> None:
-    """Clear the per-process import cache/failure record (tests only)."""
+    """Reset **all** module-level state (tests only).
+
+    Every piece of ambient state this module keeps, not just the import
+    cache: a declaration or a one-shot warning surviving into the next test
+    makes results depend on execution order, and `only_unwarned=True` in
+    particular is silently order-sensitive.
+    """
     _import_cache.clear()
     _last_failures.clear()
+    _warned_classes.clear()
+    global _declared_patterns
+    _declared_patterns = ()
 
 
 # =============================================================================
@@ -379,7 +388,20 @@ def set_declared_task_module_patterns(patterns: typing.Sequence[str]) -> None:
     several frames below any reference to the app object.
     """
     global _declared_patterns
-    _declared_patterns = tuple(patterns)
+    # Normalised, not stored verbatim: these patterns drive coverage checks
+    # and the pickle-elision decision, and a stray space makes a pattern
+    # match nothing while still reading as a declaration at the call site.
+    # A silently-inert declaration is the worst outcome here — it turns
+    # "ticks reconstruct tasks by import" back into "ticks need the
+    # pickles" with no signal.
+    cleaned = tuple(p.strip() for p in patterns)
+    if any(not p for p in cleaned):
+        raise ValueError(
+            f"task-module patterns must be non-empty: {list(patterns)!r}. "
+            "An empty or whitespace-only pattern matches no module, so the "
+            "declaration would be silently inert."
+        )
+    _declared_patterns = cleaned
 
 
 def declared_task_module_patterns() -> tuple[str, ...]:

--- a/lib/stardag/src/stardag/build/_task_modules.py
+++ b/lib/stardag/src/stardag/build/_task_modules.py
@@ -1,0 +1,541 @@
+"""Declaring the modules whose import registers a build's task classes.
+
+Reactive scheduling reconstructs task *objects* from data, and the two
+available paths have disjoint failure modes:
+
+======================================  ====================================
+path                                    fails when
+======================================  ====================================
+pickle from the ``BuildTaskStore``      the app was redeployed (pickles are
+                                        same-deployment only), or the target
+                                        root is not writable
+``task_from_registry_data``             the module defining the task class
+                                        was never imported in the
+                                        reconstructing process
+======================================  ====================================
+
+The second failure mode is easy to miss. A pickle embeds
+``module.QualName`` and ``pickle.loads`` **self-imports**, so it resolves
+its class regardless of what the container happened to import. Polymorphic
+JSON carries only ``__namespace`` / ``__name``; ``get_class()`` is a plain
+dict lookup that raises ``KeyError`` and **never attempts an import**.
+Since the default namespace is ``""`` (the module path is consulted only to
+resolve an explicitly registered namespace), the stored payload generally
+contains no module locator at all. Task classes register at *class
+definition* time, so the only way to make a class resolvable is to import
+its defining module.
+
+Meanwhile the deployed scheduler tick is defined inside stardag itself and
+drags in user modules only incidentally — whatever the app's selector
+callables transitively import. That is arbitrary, and usually does not
+cover a DAG's task classes: DAGs are typically assembled in scripts and
+entrypoints rather than in the module defining the app.
+
+Hence this module: a way for an app to *declare* the modules whose import
+registers the task classes it may schedule, so a scheduler process can make
+itself able to reconstruct them. Nothing here is Modal-specific, and
+nothing here is needed by a resident (non-reactive) build — a resident
+orchestrator holds the real task objects, and workers receive tasks by
+value (self-importing, like any unpickle).
+
+Three pieces, used at three different times:
+
+1. **Deploy time** — :func:`expand_task_module_patterns` turns the declared
+   patterns into a concrete, sorted module list *without importing the
+   submodules*, so the deployed set is explicit and auditable and container
+   startup does no filesystem walking.
+2. **Container startup** — :func:`import_task_modules` imports that baked
+   list once per container. A module that fails to import warns rather than
+   aborting the tick, but the failure is retained
+   (:func:`last_import_failures`) so a later rehydration error can point at
+   it.
+3. **Trigger time** — :func:`uncovered_task_classes` and
+   :func:`plan_pickle_elision` answer "will a tick be able to rebuild this
+   task from registry data alone?" for a concrete task set, which is what
+   lets the trigger skip writing pickles (and warn about the classes it
+   cannot skip).
+
+Pattern grammar
+---------------
+
+A pattern is either an exact module (``"a.b.c"``) or a trailing recursive
+wildcard (``"a.b.*"``, matching ``a.b`` and everything below it). A ``*``
+anywhere but the final component, an empty pattern, or a component that is
+not a valid identifier is a :class:`TaskModulesError` — a malformed pattern
+must never degrade into a silent no-match, because the symptom would be a
+scheduler tick failing to rebuild a task hours later.
+
+Two deliberate expansion choices, both about what a wildcard sweeps up:
+
+- ``__main__`` submodules are **skipped**. They are CLI entrypoints, run
+  for their side effects; importing one in every scheduler container is at
+  best wasted work and at worst an unwanted execution.
+- ``_``-prefixed modules are **not** skipped. A user's ``_tasks.py`` is a
+  perfectly ordinary place to define task classes, and the leading
+  underscore is a statement about *their* API, not about ours.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import pkgutil
+import typing
+from dataclasses import dataclass, field
+
+from stardag._core.base_task import BaseTask
+from stardag._core.rehydrate import task_from_registry_data
+from stardag.exceptions import StardagError
+
+logger = logging.getLogger(__name__)
+
+_WILDCARD_SUFFIX = ".*"
+
+
+class TaskModulesError(StardagError):
+    """A task-module declaration is malformed, unexpandable, or unsatisfied."""
+
+
+# =============================================================================
+# Patterns: validation, expansion, coverage
+# =============================================================================
+
+
+def validate_task_module_patterns(
+    patterns: typing.Iterable[str],
+) -> tuple[str, ...]:
+    """Validate task-module patterns; return them deduped and sorted.
+
+    Raises:
+        TaskModulesError: For anything that is not an exact dotted module
+            path or such a path followed by a trailing ``.*``.
+    """
+    validated: set[str] = set()
+    for pattern in patterns:
+        if not isinstance(pattern, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TaskModulesError(
+                f"task_modules entries must be strings, got {pattern!r} "
+                f"({type(pattern).__name__})."
+            )
+        _validate_one(pattern)
+        validated.add(pattern)
+    return tuple(sorted(validated))
+
+
+def _validate_one(pattern: str) -> None:
+    problem = _pattern_problem(pattern)
+    if problem is None:
+        return
+    raise TaskModulesError(
+        f"Invalid task_modules pattern {pattern!r}: {problem}. A pattern is "
+        'either an exact module ("my_pkg.tasks.ingest") or a package '
+        'followed by a trailing recursive wildcard ("my_pkg.tasks.*").'
+    )
+
+
+def _pattern_problem(pattern: str) -> str | None:
+    if not pattern or pattern.strip() != pattern:
+        return "it is empty or has surrounding whitespace"
+    if pattern in ("*", _WILDCARD_SUFFIX):
+        return (
+            "a bare wildcard would match every importable module; name at "
+            "least the root package"
+        )
+    components = pattern.split(".")
+    if pattern.endswith(_WILDCARD_SUFFIX):
+        components = components[:-1]
+    for component in components:
+        if component == "*":
+            return "'*' is only allowed as the final component"
+        if not component.isidentifier():
+            return f"component {component!r} is not a valid Python identifier"
+    return None
+
+
+def module_is_covered(module_name: str, patterns: typing.Sequence[str]) -> bool:
+    """Whether importing the declared ``patterns`` reaches ``module_name``.
+
+    Mirrors :func:`expand_task_module_patterns`, including its ``__main__``
+    exclusion — a class defined in a ``__main__`` module is never
+    reconstructable in a scheduler container, wildcard or not.
+    """
+    if module_name == "__main__" or module_name.endswith(".__main__"):
+        return False
+    for pattern in patterns:
+        if pattern.endswith(_WILDCARD_SUFFIX):
+            root = pattern[: -len(_WILDCARD_SUFFIX)]
+            if module_name == root or module_name.startswith(root + "."):
+                return True
+        elif module_name == pattern:
+            return True
+    return False
+
+
+def suggested_pattern_for(module_name: str) -> str:
+    """The narrowest pattern that would cover ``module_name``.
+
+    The module's own package plus a recursive wildcard (or the module
+    itself when it is top-level) — precise enough to paste into
+    ``task_modules`` without dragging in half the source tree.
+    """
+    package, _, _ = module_name.rpartition(".")
+    return f"{package}{_WILDCARD_SUFFIX}" if package else module_name
+
+
+def expand_task_module_patterns(
+    patterns: typing.Iterable[str],
+) -> list[str]:
+    """Expand patterns to the concrete, sorted, deduped module list.
+
+    **Importing is avoided wherever it can be.** ``pkgutil.walk_packages``
+    is deliberately not used: it imports each package to reach its
+    ``__path__``, which would run every ``__init__.py`` in the tree just to
+    *list* names. Only the root package of a ``"pkg.*"`` pattern is
+    imported (unavoidable — its ``__path__`` is the entry point to the
+    tree); everything below it is discovered from the filesystem with
+    ``pkgutil.iter_modules``.
+
+    Raises:
+        TaskModulesError: If a pattern is malformed, or the root package of
+            a wildcard pattern cannot be imported (a typo'd pattern must
+            fail loudly at deploy time rather than expand to nothing).
+    """
+    modules: set[str] = set()
+    for pattern in validate_task_module_patterns(patterns):
+        if not pattern.endswith(_WILDCARD_SUFFIX):
+            modules.add(pattern)
+            continue
+        root = pattern[: -len(_WILDCARD_SUFFIX)]
+        modules.add(root)
+        modules.update(_iter_submodules(root, pattern))
+    return sorted(modules)
+
+
+def _iter_submodules(root: str, pattern: str) -> typing.Iterator[str]:
+    try:
+        package = importlib.import_module(root)
+    except Exception as e:
+        raise TaskModulesError(
+            f"Cannot expand task_modules pattern {pattern!r}: the root "
+            f"package {root!r} could not be imported ({type(e).__name__}: "
+            f"{e}). Expansion needs the package's __path__; check the "
+            "pattern for typos and make sure the package is importable "
+            "from the process running the deploy."
+        ) from e
+    search_paths = list(getattr(package, "__path__", []))
+    if not search_paths:
+        # A plain module, not a package: the wildcard has nothing below it
+        # to recurse into. The root itself is already included by the
+        # caller, so this is a harmless (if pointless) pattern.
+        return
+    # Guard against symlink loops in the source tree: a directory is walked
+    # at most once, by its resolved path.
+    seen_dirs: set[str] = set()
+    stack: list[tuple[str, list[str]]] = [(root, search_paths)]
+    while stack:
+        prefix, paths = stack.pop()
+        for path in paths:
+            real = os.path.realpath(path)
+            if real in seen_dirs:
+                continue
+            seen_dirs.add(real)
+            for module_info in pkgutil.iter_modules([path]):
+                if module_info.name == "__main__":
+                    # Entrypoints: usually side-effectful, never a place to
+                    # define task classes (see the module docstring).
+                    continue
+                qualified = f"{prefix}.{module_info.name}"
+                yield qualified
+                if module_info.ispkg:
+                    stack.append((qualified, [os.path.join(path, module_info.name)]))
+
+
+# =============================================================================
+# Importing (in the reconstructing process)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class TaskModuleImportReport:
+    """Outcome of :func:`import_task_modules`."""
+
+    imported: tuple[str, ...] = ()
+    # module name -> "ExceptionType: message"
+    failures: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def task_classes_registered(self) -> int:
+        """Task classes registered from the imported modules.
+
+        Counted after the fact from the polymorphic registry rather than as
+        a delta, so it is stable when some modules were already imported.
+        """
+        return count_registered_task_classes(self.imported)
+
+
+_import_cache: dict[tuple[str, ...], TaskModuleImportReport] = {}
+_last_failures: dict[str, str] = {}
+
+
+def import_task_modules(
+    modules: typing.Sequence[str],
+) -> TaskModuleImportReport:
+    """Import ``modules`` so their task classes register; never raise.
+
+    Idempotent and cached on the exact module list: a container that serves
+    many scheduler ticks pays the walk once, and re-importing an
+    already-imported module is a ``sys.modules`` hit anyway.
+
+    A module that fails to import is **warned about, not fatal** — one bad
+    module (a missing optional dependency, a syntax error in a module
+    nobody schedules) must not take the whole scheduler down. The failures
+    are retained in the report and in :func:`last_import_failures` so that
+    a downstream "no task class registered for …" error can name the likely
+    cause instead of leaving the user to guess.
+    """
+    global _last_failures
+    key = tuple(modules)
+    cached = _import_cache.get(key)
+    if cached is not None:
+        _last_failures = dict(cached.failures)
+        return cached
+
+    imported: list[str] = []
+    failures: dict[str, str] = {}
+    for module in modules:
+        try:
+            importlib.import_module(module)
+        except Exception as e:
+            failures[module] = f"{type(e).__name__}: {e}"
+            logger.warning(
+                f"Declared task module {module!r} failed to import: "
+                f"{type(e).__name__}: {e}. Task classes defined there will "
+                "not be reconstructable from registry data."
+            )
+            continue
+        imported.append(module)
+    report = TaskModuleImportReport(imported=tuple(imported), failures=failures)
+    _import_cache[key] = report
+    _last_failures = dict(failures)
+    logger.info(
+        f"Imported {len(imported)}/{len(key)} declared task module(s)"
+        + (f"; {len(failures)} failed: {sorted(failures)}" if failures else ".")
+    )
+    return report
+
+
+def last_import_failures() -> dict[str, str]:
+    """Task modules that failed to import in this process, most recent call.
+
+    Diagnostics hook: a ``TaskRehydrationError`` naming an unresolved class
+    is far more actionable when it can add "…and by the way, these declared
+    task modules failed to import".
+    """
+    return dict(_last_failures)
+
+
+def import_failure_note(max_listed: int = 5) -> str:
+    """A one-line addendum naming import failures, or ``""`` if there were none."""
+    failures = _last_failures
+    if not failures:
+        return ""
+    listed = sorted(failures)[:max_listed]
+    rendered = "; ".join(f"{name} ({failures[name]})" for name in listed)
+    more = len(failures) - len(listed)
+    return (
+        f" Note: {len(failures)} declared task module(s) failed to import in "
+        f"this process, which is a likely cause: {rendered}"
+        + (f" (+{more} more)" if more else "")
+        + "."
+    )
+
+
+def count_registered_task_classes(modules: typing.Iterable[str]) -> int:
+    """How many registered task classes are defined in ``modules``."""
+    wanted = set(modules)
+    return sum(1 for cls in BaseTask._registry().classes() if cls.__module__ in wanted)
+
+
+def _reset_import_state_for_tests() -> None:
+    """Clear the per-process import cache/failure record (tests only)."""
+    _import_cache.clear()
+    _last_failures.clear()
+
+
+# =============================================================================
+# The ambient declaration (for code far from the app object)
+# =============================================================================
+
+_declared_patterns: tuple[str, ...] = ()
+
+
+def set_declared_task_module_patterns(patterns: typing.Sequence[str]) -> None:
+    """Record the executing app's task-module patterns for this process.
+
+    Deployed worker/scheduler entrypoints bake the app's patterns into
+    their closure and publish them here, because the code that needs them
+    — dynamic-dependency registration inside a worker, for instance — sits
+    several frames below any reference to the app object.
+    """
+    global _declared_patterns
+    _declared_patterns = tuple(patterns)
+
+
+def declared_task_module_patterns() -> tuple[str, ...]:
+    """The patterns published by :func:`set_declared_task_module_patterns`."""
+    return _declared_patterns
+
+
+# =============================================================================
+# Coverage of a concrete task set
+# =============================================================================
+
+_warned_classes: set[str] = set()
+
+
+def uncovered_task_classes(
+    tasks: typing.Iterable[BaseTask],
+    patterns: typing.Sequence[str],
+    *,
+    only_unwarned: bool = False,
+) -> list[type[BaseTask]]:
+    """Distinct classes in ``tasks`` that ``patterns`` does not reach.
+
+    Args:
+        tasks: The tasks to check. At trigger time this should be the
+            *incomplete* discovered set — the only tasks a tick ever
+            rehydrates.
+        patterns: The app's declared task-module patterns.
+        only_unwarned: Report each class at most once per process, and
+            record the ones reported. For hot paths (every worker
+            registering dynamic deps) where the same class would otherwise
+            produce the same warning on every invocation.
+    """
+    seen: dict[str, type[BaseTask]] = {}
+    for task in tasks:
+        cls = type(task)
+        key = f"{cls.__module__}.{cls.__qualname__}"
+        if key in seen or module_is_covered(cls.__module__, patterns):
+            continue
+        if only_unwarned:
+            if key in _warned_classes:
+                continue
+            _warned_classes.add(key)
+        seen[key] = cls
+    return [seen[key] for key in sorted(seen)]
+
+
+def format_uncovered_message(
+    uncovered: typing.Sequence[type[BaseTask]],
+    patterns: typing.Sequence[str],
+    *,
+    remedy: str = "",
+) -> str:
+    """Render the actionable "these classes are not covered" message."""
+    names = [f"{cls.__module__}.{cls.__qualname__}" for cls in uncovered]
+    suggestions = sorted({suggested_pattern_for(cls.__module__) for cls in uncovered})
+    head = (
+        f"Task class {names[0]} is"
+        if len(names) == 1
+        else f"{len(names)} task classes ({', '.join(names)}) are"
+    )
+    declared = list(patterns) if patterns else "not declared"
+    return (
+        f"{head} not covered by this app's task_modules ({declared}). A "
+        "reactive scheduler tick will not be able to reconstruct them from "
+        "registry data, so they stay dependent on the build task store's "
+        f"pickles. Add {suggestions} to task_modules and redeploy the app."
+        + (f" {remedy}" if remedy else "")
+    )
+
+
+# =============================================================================
+# Conditional pickle elision
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class PickleElisionPlan:
+    """Which tasks still need a pickle in the build task store, and why.
+
+    A task needs no pickle when its class is covered by the declared
+    patterns *and* its registration payload round-trips back to the same
+    task id. Everything else keeps the pickle it would have gotten anyway,
+    so the feature is purely subtractive — nothing that works today stops
+    working because a task did not qualify.
+    """
+
+    pickle_free: tuple[BaseTask, ...] = ()
+    # (task, reason) for the tasks that must still be pickled
+    pickled: tuple[tuple[BaseTask, str], ...] = ()
+
+    def summary(self) -> str:
+        """One-line log summary: counts, plus the distinct reasons."""
+        line = (
+            f"{len(self.pickle_free)} task(s) pickle-free, {len(self.pickled)} pickled"
+        )
+        if not self.pickled:
+            return line + "."
+        reasons: dict[str, int] = {}
+        for _, reason in self.pickled:
+            reasons[reason] = reasons.get(reason, 0) + 1
+        rendered = "; ".join(
+            f"{reason} (x{count})" if count > 1 else reason
+            for reason, count in sorted(reasons.items())
+        )
+        return f"{line} — {rendered}."
+
+    def require_pickle_free_error(self) -> str | None:
+        """Message for ``require_pickle_free``, or None if everything qualified."""
+        if not self.pickled:
+            return None
+        lines = [
+            f"  - {type(task).__module__}.{type(task).__qualname__} "
+            f"(task {task.id}): {reason}"
+            for task, reason in self.pickled
+        ]
+        return (
+            f"require_pickle_free=True, but {len(self.pickled)} task(s) "
+            "cannot be reconstructed from registry data alone and would "
+            "need a pickle in the build task store:\n" + "\n".join(lines)
+        )
+
+
+_UNCOVERED_REASON = "task class not covered by task_modules"
+
+
+def plan_pickle_elision(
+    tasks: typing.Iterable[BaseTask],
+    patterns: typing.Sequence[str],
+) -> PickleElisionPlan:
+    """Decide, per task, whether the build task store still needs its pickle.
+
+    The self-check reconstructs the task from exactly the payload that
+    registration stores (``model_dump(mode="json")`` — see
+    ``_get_task_data_for_registration``), so it is a faithful dry run of
+    what a scheduler tick will do. Note this is *cheaper* than the write it
+    replaces: pure CPU, versus a per-task target-root existence check plus
+    a conditional upload.
+
+    ``AliasTask`` payloads fail the check by construction (rehydration
+    refuses ``__aliased`` data, whose pickled ``loads_type`` would be an
+    execution primitive in a scheduler process), as do dynamically
+    generated and otherwise non-importable classes. Those are exactly the
+    cases that keep their pickles.
+    """
+    pickle_free: list[BaseTask] = []
+    pickled: list[tuple[BaseTask, str]] = []
+    for task in tasks:
+        if not module_is_covered(type(task).__module__, patterns):
+            pickled.append((task, _UNCOVERED_REASON))
+            continue
+        try:
+            task_from_registry_data(
+                task.model_dump(mode="json"), expected_task_id=task.id
+            )
+        except Exception as e:
+            pickled.append((task, f"registry-data round-trip failed ({e})"))
+            continue
+        pickle_free.append(task)
+    return PickleElisionPlan(pickle_free=tuple(pickle_free), pickled=tuple(pickled))

--- a/lib/stardag/src/stardag/build/_task_store.py
+++ b/lib/stardag/src/stardag/build/_task_store.py
@@ -22,6 +22,16 @@ immutable object), so the store is compatible with immutable/append-only
 target roots. Same-deployment guarantee applies: a pickle is only loaded by
 containers of the same deployed app version that wrote it — the same
 constraint as passing tasks to workers by value.
+
+The store is a *fallback*, not the primary path. When the app declares its
+task modules (see ``stardag.build._task_modules``) the writer skips every
+task a scheduler tick can rebuild from the registry's stored data, and a
+fully covered build writes nothing here at all — no target-root write
+access needed, and no same-deployment constraint to trip over. What
+remains are the payloads that genuinely cannot be reconstructed:
+``AliasTask`` (pickled ``loads_type``, deliberately never auto-unpickled
+from registry data), dynamically generated classes, and anything whose
+serialization does not round-trip to the same task id.
 """
 
 from __future__ import annotations

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -65,8 +65,12 @@ from stardag.build import (
 from stardag.build._base import GlobalLockConfig
 from stardag.build._base import BuildSummary
 from stardag.build._task_modules import (
+    declared_task_module_patterns,
     expand_task_module_patterns,
+    format_uncovered_message,
     import_task_modules,
+    set_declared_task_module_patterns,
+    uncovered_task_classes,
     validate_task_module_patterns,
 )
 from stardag.config import clear_config_cache, config_provider, load_config
@@ -1592,6 +1596,27 @@ class _WorkerLifecycleReporter:
             discover_and_register_aio(self.registry, self.build_id, task_struct)
         )
         store = BuildTaskStore(self.build_id)
+        # The trigger's pre-flight structurally cannot see dynamically
+        # yielded deps — they don't exist until their parent runs — so the
+        # coverage check is re-run here, on the app's patterns as published
+        # by the deployed worker wrapper. Once per class per process: this
+        # runs on every suspending worker invocation.
+        patterns = declared_task_module_patterns()
+        if patterns:
+            uncovered = uncovered_task_classes(
+                result.incomplete.values(), patterns, only_unwarned=True
+            )
+            if uncovered:
+                logger.warning(
+                    format_uncovered_message(
+                        uncovered,
+                        patterns,
+                        remedy=(
+                            "These were registered as dynamic dependencies, "
+                            "so the trigger's pre-flight could not see them."
+                        ),
+                    )
+                )
         store.save_tasks(result.incomplete.values())
         deps = flatten_task_struct(task_struct)
         self.registry.task_add_dependencies(
@@ -2303,7 +2328,8 @@ class StardagApp:
         # tick — it needs a redeploy, which is also when the operator gets
         # to see the list change. Only name expansion happens here (no
         # submodule imports): the CLI does the optional local import check.
-        task_modules = expand_task_module_patterns(self.task_modules)
+        task_module_patterns = self.task_modules
+        task_modules = expand_task_module_patterns(task_module_patterns)
         # Wrap callables in real functions for Modal compatibility.
         # Modal's is_async() only accepts inspect.isfunction()-compatible objects,
         # not callable class instances. The wrappers delegate to the actual callable
@@ -2328,6 +2354,15 @@ class StardagApp:
         def _modal_run(
             task: BaseTask, *, env_overrides: dict[str, str] | None = None
         ) -> typing.Any:
+            # Publish the app's task-module patterns for the worker-side
+            # code that needs them but is nowhere near the app object:
+            # _WorkerLifecycleReporter._register_dynamic_deps checks the
+            # coverage of dynamically yielded deps, which the trigger's
+            # pre-flight cannot see. The worker does not IMPORT the
+            # modules: its task arrived by value (self-importing) and its
+            # dynamic deps were just constructed by user code, so their
+            # classes are registered by definition.
+            set_declared_task_module_patterns(task_module_patterns)
             if run_fn_accepts_env:
                 run_fn_with_env = typing.cast(_RunFunctionWithEnv, run_fn)
                 return run_fn_with_env(task, env_overrides=env_overrides)
@@ -2480,6 +2515,7 @@ class StardagApp:
             # Failures warn rather than abort — and are retained, so a
             # later "could not rehydrate" error can name them.
             if task_modules:
+                set_declared_task_module_patterns(task_module_patterns)
                 import_task_modules(task_modules)
 
             executor = ModalTaskExecutor(
@@ -2758,6 +2794,47 @@ class StardagApp:
             )
         return metadata
 
+    def _preflight_task_modules(self, tasks: typing.Iterable[BaseTask]) -> None:
+        """Warn about discovered task classes ``task_modules`` doesn't cover.
+
+        The trigger is the one place that holds both the real DAG and the
+        app, so it is the only place that can catch a class no scheduler
+        tick will be able to reconstruct — before a single container
+        starts, rather than as a mystifying tick failure hours later.
+
+        **Severity is a warning, not an error.** An uncovered class is not
+        broken: it falls back to the pickle path, which is exactly how
+        every reactive build worked before ``task_modules`` existed.
+        Failing the trigger would therefore break working setups the
+        moment they upgrade, which is precisely what "this feature is
+        additive" forbids.
+
+        Known limitation: this reads the *local* app definition, so it
+        cannot detect that the deployed app was built from an older
+        ``task_modules``. Closing that needs the deployed list exposed for
+        comparison.
+
+        Skipped entirely when the app opted out of ``task_modules`` — an
+        app that never declared any would otherwise warn about every class
+        in every DAG, on every trigger.
+        """
+        if not self.task_modules:
+            return
+        uncovered = uncovered_task_classes(tasks, self.task_modules)
+        if not uncovered:
+            return
+        logger.warning(
+            format_uncovered_message(
+                uncovered,
+                self.task_modules,
+                remedy=(
+                    "Until then these tasks stay dependent on their "
+                    "build-task-store pickles, which need target-root "
+                    "write access and are invalidated by a redeploy."
+                ),
+            )
+        )
+
     def _trigger_reactive(
         self,
         task_list: list[BaseTask],
@@ -2840,6 +2917,11 @@ class StardagApp:
                     registry, build_id, tuple(task_list), retry_failed=True
                 )
             )
+            stage = "task-module coverage pre-flight"
+            # Runs on the DISCOVERED incomplete set: those are exactly the
+            # tasks a tick may have to rehydrate, and reusing discovery's
+            # walk avoids a second local traversal of the DAG.
+            self._preflight_task_modules(discovery.incomplete.values())
             stage = "task store write"
             store = BuildTaskStore(build_id)
             store.save_tasks(discovery.incomplete.values())

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -64,6 +64,11 @@ from stardag.build import (
 )
 from stardag.build._base import GlobalLockConfig
 from stardag.build._base import BuildSummary
+from stardag.build._task_modules import (
+    expand_task_module_patterns,
+    import_task_modules,
+    validate_task_module_patterns,
+)
 from stardag.config import clear_config_cache, config_provider, load_config
 from stardag.integration.modal._target import (
     MODAL_VOLUME_URI_PREFIX,
@@ -255,12 +260,17 @@ class FinalizeResult(typing.NamedTuple):
         functions: List of created Modal function names.
         volume_mounts: Dict of mount_path -> volume_name for auto-mounted volumes.
         auto_volumes: Dict of mount_path -> Volume for auto-mounted volumes.
+        task_modules: The app's ``task_modules`` patterns expanded to the
+            concrete, sorted module list baked into the deployed scheduler
+            tick (empty when the app opted out). Surfaced so the CLI can
+            report what the deployment will import.
     """
 
     volumes: dict[str, modal.Volume]
     functions: list[str]
     volume_mounts: dict[str, str] = {}
     auto_volumes: dict[str, modal.Volume] = {}
+    task_modules: list[str] = []
 
 
 # --- Function settings ---
@@ -1900,6 +1910,46 @@ def _setup_logging():
 # --- Stardag App ---
 
 
+def _infer_task_module_patterns(_depth: int = 2) -> tuple[str, ...]:
+    """Infer ``task_modules`` from the module that constructs the app.
+
+    The default declaration is "the root package of the module defining
+    this app, recursively" — which is right far more often than not: an
+    app and the tasks it schedules almost always live in the same
+    distribution, and a whole-package wildcard costs only import time.
+
+    Inference is impossible for a module that is not part of a package —
+    ``__main__``, or a loose script that Modal loads as a top-level module.
+    Such a module isn't importable in a container under a stable name in
+    the first place, so a pattern derived from it would be a lie. We warn
+    and opt out (the pickle path still works), rather than baking in a
+    module list that would fail to import in every tick container.
+
+    Args:
+        _depth: Stack frames back to the user's call site (``__init__``'s
+            caller by default). Not part of the public contract.
+    """
+    frame = inspect.currentframe()
+    for _ in range(_depth):
+        frame = frame.f_back if frame is not None else None
+    module_name = frame.f_globals.get("__name__") if frame is not None else None
+    package = frame.f_globals.get("__package__") if frame is not None else None
+    if not module_name or module_name == "__main__" or not package:
+        logger.warning(
+            "Could not infer StardagApp(task_modules=...): the app is "
+            f"defined in {module_name or 'an unknown module'!r}, which is "
+            "not part of an importable package. Reactive scheduler ticks "
+            "will therefore fall back to the build task store's pickles "
+            "(which need target-root write access at trigger time and are "
+            "invalidated by a redeploy). Declare the modules explicitly — "
+            'e.g. task_modules=["my_pkg.tasks.*"] — to let ticks '
+            "reconstruct tasks from registry data instead, or pass "
+            "task_modules=[] to silence this warning."
+        )
+        return ()
+    return (f"{module_name.split('.')[0]}.*",)
+
+
 class StardagApp:
     """Wrapper around modal.App for Stardag task execution.
 
@@ -1940,6 +1990,8 @@ class StardagApp:
         modal_app: The underlying modal.App instance.
         name: The app name.
         is_finalized: Whether finalize() has been called.
+        task_modules: The validated task-module patterns (see the
+            ``task_modules`` argument); empty when opted out.
     """
 
     def __init__(
@@ -1955,6 +2007,7 @@ class StardagApp:
         watchdog_period_minutes: int | None = None,
         limit_key_selector: typing.Callable[[BaseTask], typing.Sequence[str]]
         | None = None,
+        task_modules: typing.Sequence[str] | None = None,
         modal_workspace: str | None = None,
         stardag_api_key_secret: "modal.Secret | str | None" = "stardag-api-key",
     ):
@@ -2003,6 +2056,26 @@ class StardagApp:
                 concurrency-limit keys it runs under in reactive scheduling
                 (deployed-app configuration applied by every tick). Default:
                 no limits.
+            task_modules: Modules whose import registers the task classes
+                this app may schedule. **Only reactive scheduling needs
+                this**: a scheduler tick reconstructs tasks from registry
+                data and can resolve only classes that are already
+                registered in its process (registration happens at class
+                definition time). Resident builds hold the real task
+                objects and are entirely unaffected.
+
+                Each entry is an exact module (``"my_pkg.tasks.ingest"``)
+                or a package with a trailing recursive wildcard
+                (``"my_pkg.tasks.*"``); anything else raises. The patterns
+                are expanded to a concrete module list at ``finalize()``
+                and baked into the deployed tick, so **adding or moving
+                task classes requires a redeploy**. Declared modules become
+                import-hot — they are imported in every tick container —
+                so keep heavy runtime dependencies inside ``run()`` rather
+                than at module scope.
+
+                Default (``None``): infer ``"<root package of the module
+                defining this app>.*"``. Pass ``[]`` to opt out.
             modal_workspace: Explicit Modal workspace name recorded in the
                 executor metadata of triggered builds and started tasks
                 (used by the UI for Modal dashboard deep links). Default:
@@ -2051,6 +2124,15 @@ class StardagApp:
         # consistently (callables can't be persisted in the JSON build
         # meta like the scalar tick_kwargs).
         self.limit_key_selector = limit_key_selector
+        # Task-module declaration for reactive scheduling: the patterns
+        # whose expansion is imported by every scheduler tick so it can
+        # rebuild task objects from registry data (see
+        # stardag.build._task_modules). Validated eagerly — a malformed
+        # pattern must fail here, not silently match nothing and surface
+        # hours later as a tick that cannot reconstruct a task.
+        if task_modules is None:
+            task_modules = _infer_task_module_patterns()
+        self.task_modules: tuple[str, ...] = validate_task_module_patterns(task_modules)
         # Explicit Modal workspace name for executor metadata (UI deep
         # links). Default: resolved from the Modal token, best-effort.
         # Used by build_trigger and by the tick's executor; the resident
@@ -2130,10 +2212,13 @@ class StardagApp:
                 target roots if they don't exist.
 
         Returns:
-            FinalizeResult with created volumes, function names, and mount info.
+            FinalizeResult with created volumes, function names, mount info,
+            and the expanded ``task_modules`` baked into the tick.
 
         Raises:
             RuntimeError: If finalize() has already been called.
+            TaskModulesError: If a ``task_modules`` pattern cannot be
+                expanded (e.g. its root package is not importable here).
         """
         if self._is_finalized:
             raise RuntimeError("StardagApp has already been finalized")
@@ -2209,6 +2294,16 @@ class StardagApp:
                         f"proceeding: {e}"
                     )
             extra_secrets.append(self.stardag_api_key_secret)
+        # Expand the declared task-module patterns to a concrete, sorted
+        # module list ONCE, here, and bake it into the deployed functions
+        # below. Deploy-time expansion (rather than in-container) keeps the
+        # deployed set explicit and auditable, keeps container startup off
+        # the filesystem, and makes the deployment reproducible: a module
+        # added after this deploy is not silently picked up by a running
+        # tick — it needs a redeploy, which is also when the operator gets
+        # to see the list change. Only name expansion happens here (no
+        # submodule imports): the CLI does the optional local import check.
+        task_modules = expand_task_module_patterns(self.task_modules)
         # Wrap callables in real functions for Modal compatibility.
         # Modal's is_async() only accepts inspect.isfunction()-compatible objects,
         # not callable class instances. The wrappers delegate to the actual callable
@@ -2375,6 +2470,18 @@ class StardagApp:
                 build_info.reactive_tick_kwargs, tick_kwargs, limit_key_selector
             )
 
+            # Register the app's task classes in THIS container before the
+            # tick reconstructs anything: rehydrating a task from registry
+            # data is a dict lookup in the polymorphic registry, which is
+            # populated only as a side effect of importing the defining
+            # modules (unlike pickle, which self-imports). The list was
+            # expanded and frozen at deploy time; the import is cached per
+            # module list, so a container serving many ticks pays it once.
+            # Failures warn rather than abort — and are retained, so a
+            # later "could not rehydrate" error can name them.
+            if task_modules:
+                import_task_modules(task_modules)
+
             executor = ModalTaskExecutor(
                 modal_app_name=app_name,
                 worker_selector=default_worker_selector,
@@ -2442,6 +2549,7 @@ class StardagApp:
             functions=function_names,
             volume_mounts=volume_mounts,
             auto_volumes=auto_volumes,
+            task_modules=task_modules,
         )
 
     def build_spawn(

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -2119,6 +2119,13 @@ class StardagApp:
 
                 Default (``None``): infer ``"<root package of the module
                 defining this app>.*"``. Pass ``[]`` to opt out.
+
+                **Declaring this explicitly is also the opt-in to skipping
+                pickles** — the inferred default only drives the coverage
+                warning. The trigger reads the local app definition while
+                the tick runs the deployed one, so if inference alone
+                elided, upgrading stardag would start dropping pickles that
+                an app deployed by an older version cannot compensate for.
             require_pickle_free: Turn the pickle fallback from a silent
                 safety net into a hard error. With ``task_modules``
                 covering a build's classes, a reactive trigger writes no
@@ -2187,6 +2194,12 @@ class StardagApp:
         # stardag.build._task_modules). Validated eagerly — a malformed
         # pattern must fail here, not silently match nothing and surface
         # hours later as a tick that cannot reconstruct a task.
+        #
+        # Whether the patterns were *declared* or merely inferred decides
+        # whether pickles may be elided — see _persist_discovered_tasks.
+        # Inference must stay observation-only: it happens on every app,
+        # including apps written before this feature existed.
+        self._task_modules_declared = task_modules is not None
         if task_modules is None:
             task_modules = _infer_task_module_patterns()
         self.task_modules: tuple[str, ...] = validate_task_module_patterns(task_modules)
@@ -2885,17 +2898,33 @@ class StardagApp:
     ) -> None:
         """Write the build task store, skipping pickles that aren't needed.
 
-        With no declared ``task_modules`` this is byte-for-byte the old
-        behaviour: pickle everything. With them, each task gets a local
+        Unless the app *opted in*, this is byte-for-byte the old
+        behaviour: pickle everything. With opt-in, each task gets a local
         dry run of what a tick will do — reconstruct it from exactly the
         payload registration stored — and only the ones that fail keep a
         pickle. A build whose classes are all covered writes nothing to
         the target root at all, so the trigger stops needing write access
         there (and stops being vulnerable to a storage error minting an
         orphan RUNNING build).
+
+        Opt-in means ``task_modules`` was passed explicitly (or
+        ``require_pickle_free`` was), NOT merely inferred. This matters:
+        the trigger runs from the local app definition while the tick runs
+        from the *deployed* one, and nothing lets the trigger see the
+        deployed app's task modules (the stale-deploy blind spot). If
+        inference alone enabled elision, then simply upgrading the SDK
+        would start eliding pickles that an app deployed by an older SDK
+        has no baked-in module list to compensate for — turning an upgrade
+        into a broken build. Elision therefore requires an act by the user,
+        which is also what makes the "redeploy after changing
+        ``task_modules``" requirement land at a moment they are paying
+        attention. Inference still drives the coverage warning, which is
+        pure observation and safe to do everywhere.
         """
         store = BuildTaskStore(build_id)
-        if not self.task_modules:
+        if not self.task_modules or not (
+            self._task_modules_declared or self.require_pickle_free
+        ):
             store.save_tasks(tasks)
             return
         plan: PickleElisionPlan = plan_pickle_elision(tasks, self.task_modules)

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -1969,11 +1969,18 @@ def _infer_task_module_patterns(_depth: int = 2) -> tuple[str, ...]:
         _depth: Stack frames back to the user's call site (``__init__``'s
             caller by default). Not part of the public contract.
     """
+    # Frames hold their locals and globals alive and participate in
+    # reference cycles, so the walk is scoped and the references dropped
+    # rather than left for the collector — this runs in long-lived
+    # scheduler containers.
     frame = inspect.currentframe()
-    for _ in range(_depth):
-        frame = frame.f_back if frame is not None else None
-    module_name = frame.f_globals.get("__name__") if frame is not None else None
-    package = frame.f_globals.get("__package__") if frame is not None else None
+    try:
+        for _ in range(_depth):
+            frame = frame.f_back if frame is not None else None
+        module_name = frame.f_globals.get("__name__") if frame is not None else None
+        package = frame.f_globals.get("__package__") if frame is not None else None
+    finally:
+        del frame
     if not module_name or module_name == "__main__" or not package:
         logger.warning(
             "Could not infer StardagApp(task_modules=...): the app is "

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -65,10 +65,13 @@ from stardag.build import (
 from stardag.build._base import GlobalLockConfig
 from stardag.build._base import BuildSummary
 from stardag.build._task_modules import (
+    PickleElisionPlan,
+    TaskModulesError,
     declared_task_module_patterns,
     expand_task_module_patterns,
     format_uncovered_message,
     import_task_modules,
+    plan_pickle_elision,
     set_declared_task_module_patterns,
     uncovered_task_classes,
     validate_task_module_patterns,
@@ -1601,6 +1604,11 @@ class _WorkerLifecycleReporter:
         # coverage check is re-run here, on the app's patterns as published
         # by the deployed worker wrapper. Once per class per process: this
         # runs on every suspending worker invocation.
+        #
+        # The same elision applies (see StardagApp._persist_discovered_tasks):
+        # without it the pickle-free property would hold only until a task
+        # yielded its first dynamic dependency, and a build with dynamic
+        # deps would still need target-root write access.
         patterns = declared_task_module_patterns()
         if patterns:
             uncovered = uncovered_task_classes(
@@ -1617,7 +1625,14 @@ class _WorkerLifecycleReporter:
                         ),
                     )
                 )
-        store.save_tasks(result.incomplete.values())
+            plan = plan_pickle_elision(result.incomplete.values(), patterns)
+            store.save_tasks(task for task, _ in plan.pickled)
+            logger.info(
+                f"Build {self.build_id} dynamic deps of task "
+                f"{self.task.id}: {plan.summary()}"
+            )
+        else:
+            store.save_tasks(result.incomplete.values())
         deps = flatten_task_struct(task_struct)
         self.registry.task_add_dependencies(
             self.build_id, self.task, deps, is_dynamic=True
@@ -2017,6 +2032,8 @@ class StardagApp:
         is_finalized: Whether finalize() has been called.
         task_modules: The validated task-module patterns (see the
             ``task_modules`` argument); empty when opted out.
+        require_pickle_free: Whether a reactive trigger refuses to fall
+            back to writing task pickles.
     """
 
     def __init__(
@@ -2033,6 +2050,7 @@ class StardagApp:
         limit_key_selector: typing.Callable[[BaseTask], typing.Sequence[str]]
         | None = None,
         task_modules: typing.Sequence[str] | None = None,
+        require_pickle_free: bool = False,
         modal_workspace: str | None = None,
         stardag_api_key_secret: "modal.Secret | str | None" = "stardag-api-key",
     ):
@@ -2101,6 +2119,20 @@ class StardagApp:
 
                 Default (``None``): infer ``"<root package of the module
                 defining this app>.*"``. Pass ``[]`` to opt out.
+            require_pickle_free: Turn the pickle fallback from a silent
+                safety net into a hard error. With ``task_modules``
+                covering a build's classes, a reactive trigger writes no
+                task pickles at all and therefore needs no target-root
+                *write* access; with this flag, a trigger that *would* have
+                fallen back to pickling raises instead, naming every task
+                and why. Off by default (the fallback is what keeps the
+                feature additive).
+
+                Enforced at the trigger only. Dynamic dependencies
+                registered from inside a worker apply the same elision but
+                never raise: their task has already run, and failing its
+                bookkeeping to enforce a storage preference would be a
+                strictly worse outcome than one extra pickle.
             modal_workspace: Explicit Modal workspace name recorded in the
                 executor metadata of triggered builds and started tasks
                 (used by the UI for Modal dashboard deep links). Default:
@@ -2158,6 +2190,16 @@ class StardagApp:
         if task_modules is None:
             task_modules = _infer_task_module_patterns()
         self.task_modules: tuple[str, ...] = validate_task_module_patterns(task_modules)
+        if require_pickle_free and not self.task_modules:
+            raise TaskModulesError(
+                "require_pickle_free=True is meaningless without "
+                "task_modules: with no declared modules, no task can be "
+                "reconstructed from registry data and every task would "
+                "need a pickle. Declare task_modules explicitly (if you "
+                "left it at the default, inference was not possible — see "
+                "the warning above), or drop require_pickle_free."
+            )
+        self.require_pickle_free = require_pickle_free
         # Explicit Modal workspace name for executor metadata (UI deep
         # links). Default: resolved from the Modal token, best-effort.
         # Used by build_trigger and by the tick's executor; the resident
@@ -2802,12 +2844,15 @@ class StardagApp:
         tick will be able to reconstruct — before a single container
         starts, rather than as a mystifying tick failure hours later.
 
-        **Severity is a warning, not an error.** An uncovered class is not
-        broken: it falls back to the pickle path, which is exactly how
-        every reactive build worked before ``task_modules`` existed.
-        Failing the trigger would therefore break working setups the
-        moment they upgrade, which is precisely what "this feature is
-        additive" forbids.
+        **Severity is a warning, not an error** (unless
+        ``require_pickle_free``). An uncovered class is not broken: it
+        falls back to the pickle path, which is exactly how every reactive
+        build worked before ``task_modules`` existed. Failing the trigger
+        would therefore break working setups the moment they upgrade,
+        which is precisely what "this feature is additive" forbids. The
+        hard failure lives behind ``require_pickle_free=True``, raised
+        from the persistence step below (which additionally knows about
+        round-trip failures, not just coverage).
 
         Known limitation: this reads the *local* app definition, so it
         cannot detect that the deployed app was built from an older
@@ -2834,6 +2879,32 @@ class StardagApp:
                 ),
             )
         )
+
+    def _persist_discovered_tasks(
+        self, build_id: UUID, tasks: typing.Iterable[BaseTask]
+    ) -> None:
+        """Write the build task store, skipping pickles that aren't needed.
+
+        With no declared ``task_modules`` this is byte-for-byte the old
+        behaviour: pickle everything. With them, each task gets a local
+        dry run of what a tick will do — reconstruct it from exactly the
+        payload registration stored — and only the ones that fail keep a
+        pickle. A build whose classes are all covered writes nothing to
+        the target root at all, so the trigger stops needing write access
+        there (and stops being vulnerable to a storage error minting an
+        orphan RUNNING build).
+        """
+        store = BuildTaskStore(build_id)
+        if not self.task_modules:
+            store.save_tasks(tasks)
+            return
+        plan: PickleElisionPlan = plan_pickle_elision(tasks, self.task_modules)
+        if self.require_pickle_free:
+            error = plan.require_pickle_free_error()
+            if error is not None:
+                raise TaskModulesError(error)
+        store.save_tasks(task for task, _ in plan.pickled)
+        logger.info(f"Build {build_id} task store: {plan.summary()}")
 
     def _trigger_reactive(
         self,
@@ -2923,8 +2994,7 @@ class StardagApp:
             # walk avoids a second local traversal of the DAG.
             self._preflight_task_modules(discovery.incomplete.values())
             stage = "task store write"
-            store = BuildTaskStore(build_id)
-            store.save_tasks(discovery.incomplete.values())
+            self._persist_discovered_tasks(build_id, discovery.incomplete.values())
             stage = "reactive metadata write"
             # Persist the reactive marker/owner/config in the registry
             # (``reactive_app_name`` is the "this build is reactively

--- a/lib/stardag/src/stardag/polymorphic.py
+++ b/lib/stardag/src/stardag/polymorphic.py
@@ -214,6 +214,16 @@ class _TypeRegistry:
             raise KeyError(f"No class registered for type id: {type_id}")
         return cls
 
+    def classes(self) -> tuple[Type[BaseModel], ...]:
+        """Snapshot of every registered class.
+
+        Read-only introspection (e.g. "how many task classes did importing
+        these modules register?"). A tuple rather than a view: registration
+        happens at class-definition time, so an import triggered while
+        iterating would otherwise mutate the mapping mid-loop.
+        """
+        return tuple(self._type_id_to_class.values())
+
     def get_type_id(self, cls: Type[BaseModel]) -> TypeId:
         """Get registered type id for a model class."""
         type_id = self._class_to_type_id.get(cls)

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -1225,6 +1225,74 @@ class TestRehydrationFallback:
         assert summary.terminal_status == "failed"
 
 
+class TestRehydrationDiagnostics:
+    """A rehydration failure names the declared task modules that failed to
+    import — "class X unresolved" and "the module defining X blew up on
+    import" are the same incident seen from two ends, and only the
+    annotation connects them."""
+
+    @pytest.fixture
+    def failed_task_module_import(self):
+        from stardag.build._task_modules import (
+            _reset_import_state_for_tests,
+            import_task_modules,
+        )
+
+        _reset_import_state_for_tests()
+        import_task_modules(["stardag_no_such_declared_task_module"])
+        yield
+        _reset_import_state_for_tests()
+
+    async def test_failure_note_is_appended_to_the_rehydration_error(
+        self,
+        caplog,
+        failed_task_module_import,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        (root,) = _chain("diagnostic-root")
+        registry, locks, executor, store = _setup([root], auto_complete=False)
+        store._tasks.clear()  # neither a pickle nor rehydratable metadata
+
+        with caplog.at_level("WARNING"):
+            await run_tick_aio(
+                uuid4(),
+                registry=registry,
+                task_executor=executor,
+                lock_manager=locks,
+                task_store=store,
+                config=FAST_TICK,
+            )
+
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert "could not be rehydrated from registry data" in messages
+        assert "stardag_no_such_declared_task_module" in messages
+        assert "likely cause" in messages
+
+    async def test_no_note_when_every_task_module_imported(
+        self, caplog, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        from stardag.build._task_modules import _reset_import_state_for_tests
+
+        _reset_import_state_for_tests()
+        (root,) = _chain("diagnostic-clean-root")
+        registry, locks, executor, store = _setup([root], auto_complete=False)
+        store._tasks.clear()
+
+        with caplog.at_level("WARNING"):
+            await run_tick_aio(
+                uuid4(),
+                registry=registry,
+                task_executor=executor,
+                lock_manager=locks,
+                task_store=store,
+                config=FAST_TICK,
+            )
+
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert "could not be rehydrated from registry data" in messages
+        assert "failed to import" not in messages
+
+
 class TestExecutorMetadataRecording:
     """The post-spawn ref-recording start carries the handle's
     executor_metadata (and drops it for pre-metadata registries)."""

--- a/lib/stardag/tests/test_build/test_task_modules.py
+++ b/lib/stardag/tests/test_build/test_task_modules.py
@@ -1,0 +1,473 @@
+"""Unit tests for task-module declaration (stardag.build._task_modules).
+
+Expansion is exercised against a *real* package tree written to disk and
+put on ``sys.path``, because the property that matters most — expansion
+lists module names without importing them — cannot be observed with mocks.
+Each generated module appends its name to a marker file at import time, so
+the tests can assert exactly which modules were imported and when.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import typing
+from pathlib import Path
+
+import pytest
+
+from stardag import BaseTask, auto_namespace
+from stardag.build._task_modules import (
+    TaskModulesError,
+    _reset_import_state_for_tests,
+    count_registered_task_classes,
+    declared_task_module_patterns,
+    expand_task_module_patterns,
+    format_uncovered_message,
+    import_failure_note,
+    import_task_modules,
+    last_import_failures,
+    module_is_covered,
+    plan_pickle_elision,
+    set_declared_task_module_patterns,
+    suggested_pattern_for,
+    uncovered_task_classes,
+    validate_task_module_patterns,
+)
+from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+auto_namespace(__name__)
+
+
+# =============================================================================
+# A real package tree on disk
+# =============================================================================
+
+_PACKAGE_COUNTER = itertools.count()
+
+# Prepended to every generated module: records the import in a marker file
+# whose path is baked in, so imports are observable from the test process
+# without importing anything itself.
+_IMPORT_MARKER_SOURCE = """\
+import pathlib
+
+pathlib.Path({marker!r}).open("a").write(__name__ + "\\n")
+"""
+
+
+class GeneratedPackage(typing.NamedTuple):
+    """A package tree written to disk and importable from ``sys.path``."""
+
+    name: str
+    root: Path
+    marker: Path
+
+    def imported(self) -> list[str]:
+        """Modules of this package imported so far, in import order."""
+        if not self.marker.exists():
+            return []
+        return [line for line in self.marker.read_text().splitlines() if line]
+
+    def reset_imports(self) -> None:
+        self.marker.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def make_package(tmp_path: Path):
+    """Factory writing a uniquely-named package tree and cleaning up after.
+
+    Layout (``<pkg>`` is unique per call so ``sys.modules`` can't leak
+    between tests)::
+
+        <pkg>/__init__.py
+        <pkg>/_tasks.py          underscore-prefixed: must NOT be skipped
+        <pkg>/__main__.py        entrypoint: MUST be skipped
+        <pkg>/ingest/__init__.py
+        <pkg>/ingest/raw.py
+        <pkg>/reporting/__init__.py
+        <pkg>/reporting/nested/__init__.py
+        <pkg>/reporting/nested/deep.py
+    """
+    created: list[str] = []
+
+    def _make(*, broken_module: bool = False) -> GeneratedPackage:
+        name = f"generated_pkg_{next(_PACKAGE_COUNTER)}"
+        root = tmp_path / name
+        marker = tmp_path / f"{name}.imports"
+        header = _IMPORT_MARKER_SOURCE.format(marker=str(marker))
+
+        def write(relpath: str, extra: str = "") -> None:
+            path = root / relpath
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(header + extra)
+
+        write("__init__.py")
+        write("_tasks.py")
+        write("__main__.py")
+        write("ingest/__init__.py")
+        write("ingest/raw.py")
+        write("reporting/__init__.py")
+        write("reporting/nested/__init__.py")
+        write("reporting/nested/deep.py")
+        if broken_module:
+            write("broken.py", "raise RuntimeError('missing optional dep')\n")
+
+        created.append(name)
+        return GeneratedPackage(name=name, root=root, marker=marker)
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        yield _make
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in created:
+            for module in [
+                m for m in sys.modules if m == name or m.startswith(name + ".")
+            ]:
+                del sys.modules[module]
+        _reset_import_state_for_tests()
+
+
+# =============================================================================
+# Pattern validation
+# =============================================================================
+
+
+class TestPatternValidation:
+    def test_accepts_exact_and_wildcard_patterns(self):
+        assert validate_task_module_patterns(
+            ["my_pkg.tasks.ingest", "my_pkg.pipelines.*", "my_pkg"]
+        ) == ("my_pkg", "my_pkg.pipelines.*", "my_pkg.tasks.ingest")
+
+    def test_dedupes_and_sorts(self):
+        assert validate_task_module_patterns(["b.*", "a.*", "b.*"]) == ("a.*", "b.*")
+
+    def test_empty_is_allowed_as_opt_out(self):
+        assert validate_task_module_patterns([]) == ()
+
+    @pytest.mark.parametrize(
+        "pattern,expected_problem",
+        [
+            ("", "empty"),
+            ("  my_pkg.*", "whitespace"),
+            ("my_pkg.* ", "whitespace"),
+            ("my_pkg.*.tasks", "only allowed as the final component"),
+            ("*.tasks", "only allowed as the final component"),
+            ("*", "at least the root package"),
+            ("my_pkg.", "not a valid Python identifier"),
+            ("my_pkg..tasks", "not a valid Python identifier"),
+            ("1st_pkg.tasks", "not a valid Python identifier"),
+            ("my-pkg.tasks", "not a valid Python identifier"),
+            ("my_pkg.ta*sks", "not a valid Python identifier"),
+        ],
+    )
+    def test_rejects_malformed(self, pattern: str, expected_problem: str):
+        with pytest.raises(TaskModulesError) as exc:
+            validate_task_module_patterns([pattern])
+        assert expected_problem in str(exc.value)
+        # Always actionable: the message shows the accepted grammar.
+        assert "trailing recursive wildcard" in str(exc.value)
+
+    def test_rejects_non_string(self):
+        with pytest.raises(TaskModulesError, match="must be strings"):
+            validate_task_module_patterns([typing.cast(str, 42)])
+
+
+# =============================================================================
+# Expansion
+# =============================================================================
+
+
+class TestExpansion:
+    def test_wildcard_lists_the_whole_tree_without_importing_submodules(
+        self, make_package
+    ):
+        pkg: GeneratedPackage = make_package()
+
+        expanded = expand_task_module_patterns([f"{pkg.name}.*"])
+
+        assert expanded == [
+            pkg.name,
+            f"{pkg.name}._tasks",  # underscore modules are NOT skipped
+            f"{pkg.name}.ingest",
+            f"{pkg.name}.ingest.raw",
+            f"{pkg.name}.reporting",
+            f"{pkg.name}.reporting.nested",
+            f"{pkg.name}.reporting.nested.deep",
+        ]
+        # __main__ submodules are skipped (entrypoints, run for side effects).
+        assert f"{pkg.name}.__main__" not in expanded
+        # The heart of the matter: only the ROOT package was imported — its
+        # __path__ is the unavoidable entry point to the tree. Everything
+        # below it came from the filesystem.
+        assert pkg.imported() == [pkg.name]
+        assert not [m for m in sys.modules if m.startswith(pkg.name + ".")]
+
+    def test_exact_pattern_imports_nothing_at_all(self, make_package):
+        pkg: GeneratedPackage = make_package()
+
+        expanded = expand_task_module_patterns([f"{pkg.name}.ingest.raw"])
+
+        assert expanded == [f"{pkg.name}.ingest.raw"]
+        assert pkg.imported() == []
+
+    def test_narrower_wildcard_scopes_the_walk(self, make_package):
+        pkg: GeneratedPackage = make_package()
+
+        expanded = expand_task_module_patterns([f"{pkg.name}.reporting.*"])
+
+        assert expanded == [
+            f"{pkg.name}.reporting",
+            f"{pkg.name}.reporting.nested",
+            f"{pkg.name}.reporting.nested.deep",
+        ]
+
+    def test_overlapping_patterns_dedupe(self, make_package):
+        pkg: GeneratedPackage = make_package()
+
+        expanded = expand_task_module_patterns(
+            [f"{pkg.name}.*", f"{pkg.name}.ingest.*", f"{pkg.name}.ingest.raw"]
+        )
+
+        assert len(expanded) == len(set(expanded))
+        assert expanded == sorted(expanded)
+
+    def test_unimportable_root_raises_rather_than_expanding_to_nothing(self):
+        with pytest.raises(TaskModulesError) as exc:
+            expand_task_module_patterns(["no_such_package_anywhere.*"])
+        assert "could not be imported" in str(exc.value)
+        assert "typos" in str(exc.value)
+
+    def test_malformed_pattern_raises_from_expansion_too(self):
+        with pytest.raises(TaskModulesError):
+            expand_task_module_patterns(["my_pkg.*.tasks"])
+
+
+# =============================================================================
+# Importing
+# =============================================================================
+
+
+class TestImportTaskModules:
+    def test_imports_every_module_and_counts_classes(self, make_package):
+        pkg: GeneratedPackage = make_package()
+        modules = expand_task_module_patterns([f"{pkg.name}.*"])
+        pkg.reset_imports()
+        del sys.modules[pkg.name]
+
+        report = import_task_modules(modules)
+
+        assert report.failures == {}
+        assert sorted(report.imported) == sorted(modules)
+        assert sorted(pkg.imported()) == sorted(modules)
+        # The generated modules define no task classes.
+        assert report.task_classes_registered == 0
+
+    def test_failures_are_warned_about_and_retained(self, make_package):
+        pkg: GeneratedPackage = make_package(broken_module=True)
+        modules = expand_task_module_patterns([f"{pkg.name}.*"])
+        broken = f"{pkg.name}.broken"
+        assert broken in modules
+
+        report = import_task_modules(modules)
+
+        # One bad module does not abort the rest.
+        assert broken not in report.imported
+        assert f"{pkg.name}.ingest.raw" in report.imported
+        assert "RuntimeError: missing optional dep" in report.failures[broken]
+        # Retained process-wide for the rehydration-failure diagnostic.
+        assert last_import_failures() == report.failures
+        note = import_failure_note()
+        assert broken in note and "likely cause" in note
+
+    def test_no_failures_means_no_diagnostic_note(self, make_package):
+        pkg: GeneratedPackage = make_package()
+        import_task_modules(expand_task_module_patterns([f"{pkg.name}.*"]))
+        assert import_failure_note() == ""
+
+    def test_repeated_calls_are_cached_per_module_list(self, make_package):
+        pkg: GeneratedPackage = make_package()
+        modules = expand_task_module_patterns([f"{pkg.name}.*"])
+        first = import_task_modules(modules)
+        pkg.reset_imports()
+
+        second = import_task_modules(list(modules))
+
+        assert second is first
+        # Nothing re-executed: a container serving many ticks pays once.
+        assert pkg.imported() == []
+
+    def test_counts_only_classes_from_the_named_modules(self):
+        class _CountedTask(SyncOnlyTask):
+            pass
+
+        assert count_registered_task_classes([__name__]) >= 1
+        assert count_registered_task_classes(["definitely.not.a.module"]) == 0
+        assert _CountedTask  # referenced so the definition isn't flagged unused
+
+
+# =============================================================================
+# Coverage
+# =============================================================================
+
+
+class TestCoverage:
+    @pytest.mark.parametrize(
+        "module_name,covered",
+        [
+            ("my_pkg.tasks", True),
+            ("my_pkg.tasks.ingest", True),
+            ("my_pkg.tasks.ingest.deep", True),
+            ("my_pkg", False),
+            ("my_pkg.tasksomething", False),  # prefix, not a package boundary
+            ("my_pkg.experiments", False),
+            ("other.tasks", False),
+            ("my_pkg.exact", True),
+            ("my_pkg.exactly", False),
+        ],
+    )
+    def test_wildcard_and_exact_matching(self, module_name: str, covered: bool):
+        patterns = ["my_pkg.tasks.*", "my_pkg.exact"]
+        assert module_is_covered(module_name, patterns) is covered
+
+    def test_main_modules_are_never_covered(self):
+        # Consistent with expansion, which skips them: a class defined in a
+        # __main__ module can never be registered in a scheduler container.
+        assert module_is_covered("my_pkg.__main__", ["my_pkg.*"]) is False
+        assert module_is_covered("__main__", ["__main__"]) is False
+
+    def test_no_patterns_covers_nothing(self):
+        assert module_is_covered("my_pkg.tasks", []) is False
+
+    def test_suggested_pattern_is_the_defining_package(self):
+        assert suggested_pattern_for("my_pkg.experiments.scratch") == (
+            "my_pkg.experiments.*"
+        )
+        assert suggested_pattern_for("toplevel") == "toplevel"
+
+    def test_uncovered_task_classes_dedupes_and_sorts(self):
+        tasks = [
+            SyncOnlyTask(name="a"),
+            SyncOnlyTask(name="b"),  # same class, reported once
+        ]
+        uncovered = uncovered_task_classes(tasks, ["nothing_matching.*"])
+        assert uncovered == [SyncOnlyTask]
+
+    def test_covered_classes_are_not_reported(self):
+        tasks = [SyncOnlyTask(name="a")]
+        patterns = [f"{SyncOnlyTask.__module__}"]
+        assert uncovered_task_classes(tasks, patterns) == []
+
+    def test_only_unwarned_reports_each_class_once_per_process(self):
+        tasks = [SyncOnlyTask(name="once")]
+        first = uncovered_task_classes(tasks, ["nope.*"], only_unwarned=True)
+        second = uncovered_task_classes(tasks, ["nope.*"], only_unwarned=True)
+        assert first == [SyncOnlyTask]
+        assert second == []
+
+    def test_message_names_class_patterns_and_the_fix(self):
+        message = format_uncovered_message(
+            [SyncOnlyTask], ["my_pkg.tasks.*"], remedy="Then redeploy."
+        )
+        assert f"{SyncOnlyTask.__module__}.{SyncOnlyTask.__qualname__}" in message
+        assert "['my_pkg.tasks.*']" in message
+        assert suggested_pattern_for(SyncOnlyTask.__module__) in message
+        assert "redeploy" in message
+        assert "Then redeploy." in message
+
+    def test_message_without_declared_patterns(self):
+        message = format_uncovered_message([SyncOnlyTask], [])
+        assert "not declared" in message
+
+
+# =============================================================================
+# The ambient declaration
+# =============================================================================
+
+
+class TestDeclaredPatterns:
+    def test_set_and_read_back(self):
+        previous = declared_task_module_patterns()
+        try:
+            set_declared_task_module_patterns(["my_pkg.*"])
+            assert declared_task_module_patterns() == ("my_pkg.*",)
+        finally:
+            set_declared_task_module_patterns(previous)
+
+    def test_defaults_to_empty(self):
+        previous = declared_task_module_patterns()
+        try:
+            set_declared_task_module_patterns([])
+            assert declared_task_module_patterns() == ()
+        finally:
+            set_declared_task_module_patterns(previous)
+
+
+# =============================================================================
+# Pickle elision planning
+# =============================================================================
+
+
+class TestPlanPickleElision:
+    def test_covered_and_round_tripping_task_needs_no_pickle(self):
+        task = SyncOnlyTask(name="elide-me")
+        plan = plan_pickle_elision([task], [SyncOnlyTask.__module__])
+        assert plan.pickle_free == (task,)
+        assert plan.pickled == ()
+        assert plan.require_pickle_free_error() is None
+        assert "1 task(s) pickle-free, 0 pickled" in plan.summary()
+
+    def test_uncovered_class_keeps_its_pickle(self):
+        task = SyncOnlyTask(name="keep-me")
+        plan = plan_pickle_elision([task], ["unrelated_pkg.*"])
+        assert plan.pickle_free == ()
+        assert [reason for _, reason in plan.pickled] == [
+            "task class not covered by task_modules"
+        ]
+        assert "not covered" in plan.summary()
+
+    def test_alias_task_payload_stays_pickle_bound(self, default_in_memory_fs_target):
+        """AliasTask embeds a pickled ``loads_type``; rehydration refuses it
+        (auto-unpickling registry bytes in a scheduler is an RCE vector), so
+        the self-check fails and the pickle is written — by design."""
+        import stardag as sd
+
+        class ElisionAliasSource(sd.Task[int]):
+            def run(self) -> None:
+                self._save(42)
+
+        source = ElisionAliasSource()
+        alias = sd.AliasTask[int](aliased=sd.AliasedMetadata.from_task(source))
+        plan = plan_pickle_elision([alias], [type(alias).__module__, __name__])
+
+        assert plan.pickle_free == ()
+        assert len(plan.pickled) == 1
+        assert "round-trip failed" in plan.pickled[0][1]
+        assert "__aliased" in plan.pickled[0][1]
+
+    def test_require_pickle_free_error_names_every_task_and_reason(self):
+        tasks = [SyncOnlyTask(name="x"), SyncOnlyTask(name="y")]
+        plan = plan_pickle_elision(tasks, ["unrelated_pkg.*"])
+        error = plan.require_pickle_free_error()
+        assert error is not None
+        assert "2 task(s)" in error
+        for task in tasks:
+            assert str(task.id) in error
+        assert "not covered by task_modules" in error
+
+    def test_summary_aggregates_repeated_reasons(self):
+        tasks = [SyncOnlyTask(name=f"t{i}") for i in range(3)]
+        plan = plan_pickle_elision(tasks, ["unrelated_pkg.*"])
+        assert "(x3)" in plan.summary()
+
+    def test_no_patterns_means_everything_pickled(self):
+        task = SyncOnlyTask(name="no-patterns")
+        plan = plan_pickle_elision([task], [])
+        assert plan.pickle_free == ()
+        assert len(plan.pickled) == 1
+
+
+def test_base_task_registry_exposes_registered_classes():
+    """``count_registered_task_classes`` relies on this accessor."""
+    classes = BaseTask._registry().classes()
+    assert SyncOnlyTask in classes

--- a/lib/stardag/tests/test_build/test_task_modules.py
+++ b/lib/stardag/tests/test_build/test_task_modules.py
@@ -471,3 +471,50 @@ def test_base_task_registry_exposes_registered_classes():
     """``count_registered_task_classes`` relies on this accessor."""
     classes = BaseTask._registry().classes()
     assert SyncOnlyTask in classes
+
+
+class TestDeclarationHygiene:
+    def test_a_whitespace_padded_pattern_is_normalised(self):
+        from stardag.build._task_modules import (
+            _reset_import_state_for_tests,
+            declared_task_module_patterns,
+            set_declared_task_module_patterns,
+        )
+
+        _reset_import_state_for_tests()
+        set_declared_task_module_patterns([" pkg.tasks ", "pkg.more"])
+        assert declared_task_module_patterns() == ("pkg.tasks", "pkg.more")
+        _reset_import_state_for_tests()
+
+    def test_an_empty_pattern_is_refused_rather_than_stored(self):
+        """It would match no module while still reading as a declaration,
+        quietly returning ticks to the pickle path."""
+        import pytest
+
+        from stardag.build._task_modules import (
+            _reset_import_state_for_tests,
+            set_declared_task_module_patterns,
+        )
+
+        _reset_import_state_for_tests()
+        with pytest.raises(ValueError, match="non-empty"):
+            set_declared_task_module_patterns(["pkg.tasks", "   "])
+        _reset_import_state_for_tests()
+
+    def test_the_test_reset_hook_clears_every_piece_of_ambient_state(self):
+        """Otherwise a declaration or a one-shot warning leaks into the next
+        test and results depend on execution order."""
+        from stardag.build._task_modules import (
+            _reset_import_state_for_tests,
+            _warned_classes,
+            declared_task_module_patterns,
+            set_declared_task_module_patterns,
+        )
+
+        set_declared_task_module_patterns(["pkg.tasks"])
+        _warned_classes.add("some.Class")
+
+        _reset_import_state_for_tests()
+
+        assert declared_task_module_patterns() == ()
+        assert _warned_classes == set()

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -795,6 +795,182 @@ class TestStardagAppReactiveTrigger:
                 )
 
 
+# ---------------------------------------------------------------------------
+# task_modules: declaration, deploy-time expansion, pre-flight, pickle elision
+# ---------------------------------------------------------------------------
+
+
+def _app_with_task_modules(name: str, **kwargs) -> StardagApp:
+    return StardagApp(
+        name,
+        builder_settings=FunctionSettings(image=_make_image()),
+        worker_settings={"default": FunctionSettings(image=_make_image())},
+        **kwargs,
+    )
+
+
+class TestTaskModulesDeclaration:
+    """`StardagApp(task_modules=...)` validation and inference."""
+
+    def test_patterns_are_validated_eagerly(self):
+        from stardag.build import TaskModulesError
+
+        with pytest.raises(TaskModulesError, match="only allowed as the final"):
+            _app_with_task_modules("tm-bad", task_modules=["my_pkg.*.tasks"])
+
+    def test_empty_list_opts_out_silently(self, caplog):
+        with caplog.at_level("WARNING"):
+            app = _app_with_task_modules("tm-optout", task_modules=[])
+        assert app.task_modules == ()
+        assert "task_modules" not in caplog.text
+
+    def test_declared_patterns_are_deduped_and_sorted(self):
+        app = _app_with_task_modules(
+            "tm-declared", task_modules=["b_pkg.*", "a_pkg.tasks", "b_pkg.*"]
+        )
+        assert app.task_modules == ("a_pkg.tasks", "b_pkg.*")
+
+    def test_default_infers_from_the_defining_module(self):
+        """The default is "the root package of the module defining the app,
+        recursively" — resolved from the caller's frame, so it matches what
+        inference sees from this very test function."""
+        from stardag.integration.modal._app import _infer_task_module_patterns
+
+        expected = _infer_task_module_patterns(_depth=1)
+        app = _app_with_task_modules("tm-inferred")
+        assert app.task_modules == expected
+
+    def test_inference_uses_the_callers_root_package(self):
+        from stardag.integration.modal._app import _infer_task_module_patterns
+
+        namespace = {
+            "__name__": "acme_pipelines.deploy.app",
+            "__package__": "acme_pipelines.deploy",
+            "_infer": _infer_task_module_patterns,
+        }
+        exec("result = _infer(_depth=1)", namespace)  # noqa: S102
+        assert namespace["result"] == ("acme_pipelines.*",)
+
+    @pytest.mark.parametrize(
+        "module_name,package",
+        [("__main__", None), ("loose_deploy_script", ""), ("__main__", "")],
+    )
+    def test_inference_opts_out_with_a_warning_for_unpackaged_modules(
+        self, caplog, module_name, package
+    ):
+        """A module that isn't part of a package has no importable name in a
+        container, so a pattern derived from it would be a lie: warn (naming
+        the fallback and the fix) and opt out."""
+        from stardag.integration.modal._app import _infer_task_module_patterns
+
+        namespace = {
+            "__name__": module_name,
+            "__package__": package,
+            "_infer": _infer_task_module_patterns,
+        }
+        with caplog.at_level("WARNING"):
+            exec("result = _infer(_depth=1)", namespace)  # noqa: S102
+
+        assert namespace["result"] == ()
+        assert "Could not infer StardagApp(task_modules=...)" in caplog.text
+        assert "fall back to the build task store's pickles" in caplog.text
+        assert 'task_modules=["my_pkg.tasks.*"]' in caplog.text
+
+
+class TestFinalizeBakesTaskModules:
+    """finalize() expands the patterns once and freezes the result into the
+    deployed tick — so the deployed set is explicit, auditable, and only
+    changes on redeploy."""
+
+    def _finalize(self, **app_kwargs):
+        app = _app_with_task_modules("tm-finalize", **app_kwargs)
+        captured: dict = {}
+
+        def capture_function(**kwargs):
+            def decorator(fn):
+                captured[kwargs.get("name", "unknown")] = fn
+                return fn
+
+            return decorator
+
+        app.modal_app.function = capture_function  # type: ignore[assignment]
+        with patch("stardag.integration.modal._app.get_target_roots_volumes") as mv:
+            mv.return_value = MagicMock(by_volume_name={}, by_root_key={})
+            result = app.finalize()
+        return app, result, captured
+
+    def test_expansion_is_surfaced_on_the_finalize_result(self):
+        _, result, _ = self._finalize(task_modules=["stardag.utils.*"])
+
+        assert "stardag.utils" in result.task_modules
+        assert "stardag.utils.testing.helper_tasks" in result.task_modules
+        assert result.task_modules == sorted(set(result.task_modules))
+
+    def test_opted_out_app_bakes_nothing(self):
+        _, result, _ = self._finalize(task_modules=[])
+        assert result.task_modules == []
+
+    def test_tick_imports_the_baked_list(self, default_in_memory_fs_target):
+        from stardag.build import TickSummary
+        from stardag.registry import BuildInfo
+
+        _, result, captured = self._finalize(task_modules=["stardag.utils.*"])
+        build_id = uuid4()
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_get.return_value = BuildInfo(
+            id=build_id, reactive_app_name="tm-finalize", reactive_tick_kwargs=None
+        )
+
+        async def stub_tick_aio(build_uuid, **kwargs):
+            return TickSummary(outcome="noop")
+
+        with (
+            patch("stardag.integration.modal._app.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch(
+                "stardag.integration.modal._app.RegistryGlobalConcurrencyLockManager"
+            ),
+            patch(
+                "stardag.integration.modal._app.import_task_modules"
+            ) as import_modules,
+        ):
+            rp.get.return_value = registry
+            captured["tick"](str(build_id))
+
+        # Exactly the list frozen at deploy time — not re-derived in the
+        # container, where the filesystem walk would cost cold-start time.
+        import_modules.assert_called_once_with(result.task_modules)
+
+    def test_opted_out_tick_imports_nothing(self, default_in_memory_fs_target):
+        from stardag.build import TickSummary
+        from stardag.registry import BuildInfo
+
+        _, _, captured = self._finalize(task_modules=[])
+        build_id = uuid4()
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_get.return_value = BuildInfo(
+            id=build_id, reactive_app_name="tm-finalize", reactive_tick_kwargs=None
+        )
+
+        async def stub_tick_aio(build_uuid, **kwargs):
+            return TickSummary(outcome="noop")
+
+        with (
+            patch("stardag.integration.modal._app.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch(
+                "stardag.integration.modal._app.RegistryGlobalConcurrencyLockManager"
+            ),
+            patch(
+                "stardag.integration.modal._app.import_task_modules"
+            ) as import_modules,
+        ):
+            rp.get.return_value = registry
+            captured["tick"](str(build_id))
+
+        import_modules.assert_not_called()
+
+
 class TestReactiveTriggerFailureLeavesNoOrphanBuild:
     """A build minted by ``build_start`` is RUNNING until a terminal EVENT
     says otherwise — and no orchestrator exists yet to emit one. So a

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -10,6 +10,7 @@ except ImportError:
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import stardag as _sd
 from stardag import BaseTask
 from stardag.build._base import BuildSummary
 from stardag.integration.modal import (
@@ -876,6 +877,14 @@ class TestTaskModulesDeclaration:
         assert "fall back to the build task store's pickles" in caplog.text
         assert 'task_modules=["my_pkg.tasks.*"]' in caplog.text
 
+    def test_require_pickle_free_without_task_modules_is_rejected(self):
+        from stardag.build import TaskModulesError
+
+        with pytest.raises(TaskModulesError, match="meaningless without"):
+            _app_with_task_modules(
+                "tm-contradiction", task_modules=[], require_pickle_free=True
+            )
+
 
 class TestFinalizeBakesTaskModules:
     """finalize() expands the patterns once and freezes the result into the
@@ -973,8 +982,7 @@ class TestFinalizeBakesTaskModules:
     def test_worker_publishes_the_patterns_for_dynamic_dep_registration(self):
         """The worker doesn't import the modules (its task arrived by value,
         self-importing) but it does need the patterns: dynamic deps are
-        coverage-checked there, where the trigger's pre-flight can't see
-        them."""
+        persisted with the same elision as the trigger's discovered set."""
         from stardag.build import declared_task_module_patterns
         from stardag.utils.testing.helper_tasks import SyncOnlyTask
 
@@ -1069,6 +1077,243 @@ class TestReactiveTriggerCoveragePreflight:
         # class is reported once regardless, but the point is the completed
         # dep never entered the checked set.
         assert caplog.text.count("not covered by this app's task_modules") == 1
+
+
+class _ElisionAliasedSource(_sd.Task[int]):
+    """Module-level (pickle-able) source for the AliasTask elision test."""
+
+    def run(self) -> None:
+        self._save(7)
+
+
+class _ElisionIntAlias(_sd.AliasTask[int]):
+    """Concrete alias class (module-level so the store can pickle it)."""
+
+
+class _ElisionAliasConsumer(_sd.Task[int]):
+    """Consumes an aliased upstream — its payload therefore embeds the
+    ``__aliased`` marker that rehydration refuses."""
+
+    loads_int: _sd.TaskLoads[int]
+
+    def run(self) -> None:
+        self._save(self.loads_int.load() + 1)
+
+
+class TestReactivePickleElision:
+    """With task_modules covering the classes, the trigger writes no
+    pickles: a scheduler tick rebuilds the tasks from registry data."""
+
+    def _trigger(self, app, root, build_id=None):
+        build_id = build_id or uuid4()
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_start.return_value = build_id
+        registry.task_register_bulk_aio.return_value = None
+        with registry_provider.override(registry):
+            result = app.build_trigger(root, reactive=True)
+        return result, registry
+
+    def test_covered_round_tripping_tasks_get_no_pickle(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules("tm-elide", task_modules=[SyncOnlyTask.__module__])
+        dep = SyncOnlyTask(name="elide-dep")
+        root = SyncOnlyTask(name="elide-root", deps=(dep,))
+
+        with caplog.at_level("INFO"):
+            result, _ = self._trigger(app, root)
+
+        store = BuildTaskStore(result.build_id)
+        assert store.load_task(root.id) is None
+        assert store.load_task(dep.id) is None
+        assert "2 task(s) pickle-free, 0 pickled" in caplog.text
+
+    def test_uncovered_tasks_still_get_their_pickle(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-elide-uncovered", task_modules=["acme_pipelines.*"]
+        )
+        root = SyncOnlyTask(name="elide-uncovered-root")
+
+        result, _ = self._trigger(app, root)
+
+        store = BuildTaskStore(result.build_id)
+        loaded = store.load_task(root.id)
+        assert loaded is not None and loaded.id == root.id
+
+    def test_opted_out_app_pickles_everything_exactly_as_before(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules("tm-elide-optout", task_modules=[])
+        root = SyncOnlyTask(name="elide-optout-root")
+
+        result, _ = self._trigger(app, root)
+
+        assert BuildTaskStore(result.build_id).load_task(root.id) is not None
+
+    def test_alias_task_dag_keeps_its_pickle(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        """AliasTask is pickle-bound by design: its ``loads_type`` is pickled
+        bytes that a scheduler tick must never auto-unpickle from registry
+        data. The self-check fails, so the pickle is written."""
+        from stardag.build import BuildTaskStore
+
+        source = _ElisionAliasedSource()
+        source.run()
+        alias = _ElisionIntAlias(aliased=_sd.AliasedMetadata.from_task(source))
+        root = _ElisionAliasConsumer(loads_int=alias)
+        app = _app_with_task_modules("tm-elide-alias", task_modules=[__name__])
+
+        result, _ = self._trigger(app, root)
+
+        store = BuildTaskStore(result.build_id)
+        # The consumer embeds the alias payload, so it too fails the
+        # round-trip and keeps its pickle.
+        assert store.load_task(root.id) is not None
+
+    def test_require_pickle_free_raises_naming_every_task(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import TaskModulesError
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-require-pickle-free",
+            task_modules=["acme_pipelines.*"],
+            require_pickle_free=True,
+        )
+        dep = SyncOnlyTask(name="require-dep")
+        root = SyncOnlyTask(name="require-root", deps=(dep,))
+
+        with pytest.raises(TaskModulesError) as exc:
+            self._trigger(app, root)
+
+        message = str(exc.value)
+        assert "require_pickle_free=True" in message
+        assert "2 task(s)" in message
+        assert str(root.id) in message and str(dep.id) in message
+        assert "not covered by task_modules" in message
+
+    def test_require_pickle_free_passes_when_everything_is_covered(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-require-ok",
+            task_modules=[SyncOnlyTask.__module__],
+            require_pickle_free=True,
+        )
+        root = SyncOnlyTask(name="require-ok-root")
+
+        result, _ = self._trigger(app, root)
+
+        assert BuildTaskStore(result.build_id).load_task(root.id) is None
+
+
+class TestDynamicDepPickleElision:
+    """Dynamic deps registered from inside a worker get the same treatment —
+    without it, ``require_pickle_free`` would hold only until a task yielded
+    its first dynamic dependency."""
+
+    def _reporter(self, build_id):
+        from stardag.integration.modal._app import _WorkerLifecycleReporter
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        registry = MagicMock(spec=RegistryABC)
+        registry.task_register_bulk_aio.return_value = None
+        return (
+            _WorkerLifecycleReporter(
+                registry,
+                build_id,
+                SyncOnlyTask(name="dyn-parent"),
+                reactive=True,
+                app_name="tm-dynamic",
+            ),
+            registry,
+        )
+
+    def test_covered_dynamic_deps_are_not_pickled(self, default_in_memory_fs_target):
+        from stardag.build import (
+            BuildTaskStore,
+            set_declared_task_module_patterns,
+        )
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        build_id = uuid4()
+        reporter, _ = self._reporter(build_id)
+        dyn = SyncOnlyTask(name="dyn-dep-covered")
+
+        set_declared_task_module_patterns([SyncOnlyTask.__module__])
+        try:
+            reporter._register_dynamic_deps((dyn,))
+        finally:
+            set_declared_task_module_patterns([])
+
+        assert BuildTaskStore(build_id).load_task(dyn.id) is None
+
+    def test_uncovered_dynamic_deps_are_pickled_and_warned_once(
+        self, caplog, default_in_memory_fs_target
+    ):
+        from stardag.build import (
+            BuildTaskStore,
+            set_declared_task_module_patterns,
+        )
+        from stardag.build._task_modules import _warned_classes
+        from stardag.utils.testing.helper_tasks import AsyncOnlyTask
+
+        build_id = uuid4()
+        reporter, _ = self._reporter(build_id)
+        first = AsyncOnlyTask(name="dyn-dep-uncovered-1")
+        second = AsyncOnlyTask(name="dyn-dep-uncovered-2")
+
+        _warned_classes.discard(
+            f"{AsyncOnlyTask.__module__}.{AsyncOnlyTask.__qualname__}"
+        )
+        set_declared_task_module_patterns(["acme_pipelines.*"])
+        try:
+            with caplog.at_level("WARNING"):
+                reporter._register_dynamic_deps((first,))
+                reporter._register_dynamic_deps((second,))
+        finally:
+            set_declared_task_module_patterns([])
+
+        store = BuildTaskStore(build_id)
+        assert store.load_task(first.id) is not None
+        assert store.load_task(second.id) is not None
+        # Once per class per process — this runs on every suspending worker.
+        assert caplog.text.count("not covered by this app's task_modules") == 1
+        assert "the trigger's pre-flight could not see them" in caplog.text
+
+    def test_without_declared_patterns_behaviour_is_unchanged(
+        self, default_in_memory_fs_target
+    ):
+        from stardag.build import (
+            BuildTaskStore,
+            set_declared_task_module_patterns,
+        )
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        build_id = uuid4()
+        reporter, _ = self._reporter(build_id)
+        dyn = SyncOnlyTask(name="dyn-dep-no-patterns")
+
+        set_declared_task_module_patterns([])
+        reporter._register_dynamic_deps((dyn,))
+
+        assert BuildTaskStore(build_id).load_task(dyn.id) is not None
 
 
 class TestReactiveTriggerFailureLeavesNoOrphanBuild:

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -970,6 +970,106 @@ class TestFinalizeBakesTaskModules:
 
         import_modules.assert_not_called()
 
+    def test_worker_publishes_the_patterns_for_dynamic_dep_registration(self):
+        """The worker doesn't import the modules (its task arrived by value,
+        self-importing) but it does need the patterns: dynamic deps are
+        coverage-checked there, where the trigger's pre-flight can't see
+        them."""
+        from stardag.build import declared_task_module_patterns
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app, _, captured = self._finalize(task_modules=["stardag.utils.*"])
+        from stardag.build import set_declared_task_module_patterns
+
+        set_declared_task_module_patterns([])
+        try:
+            with patch.object(Runner, "run", return_value=None):
+                captured["worker_default"](SyncOnlyTask(name="publishes"))
+            assert declared_task_module_patterns() == app.task_modules
+        finally:
+            set_declared_task_module_patterns([])
+
+
+class TestReactiveTriggerCoveragePreflight:
+    """The trigger holds both the real DAG and the app, so it is the only
+    place that can tell the user a scheduler tick won't be able to rebuild
+    one of their task classes — before a single container starts."""
+
+    def _trigger(self, app, root):
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_start.return_value = uuid4()
+        registry.task_register_bulk_aio.return_value = None
+        with registry_provider.override(registry):
+            return app.build_trigger(root, reactive=True), registry
+
+    def test_uncovered_class_warns_with_the_pattern_to_add(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-preflight", task_modules=["acme_pipelines.tasks.*"]
+        )
+        root = SyncOnlyTask(name="preflight-uncovered")
+
+        with caplog.at_level("WARNING"):
+            self._trigger(app, root)
+
+        assert "not covered by this app's task_modules" in caplog.text
+        assert "['acme_pipelines.tasks.*']" in caplog.text
+        # The exact pattern that would fix it, and the redeploy requirement.
+        assert f"{SyncOnlyTask.__module__.rsplit('.', 1)[0]}.*" in caplog.text
+        assert "redeploy" in caplog.text
+
+    def test_covered_class_does_not_warn(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-preflight-ok", task_modules=[SyncOnlyTask.__module__]
+        )
+        with caplog.at_level("WARNING"):
+            self._trigger(app, SyncOnlyTask(name="preflight-covered"))
+
+        assert "not covered" not in caplog.text
+
+    def test_opted_out_app_never_warns(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        """An app that declared nothing would otherwise warn about every
+        class in every DAG, on every trigger."""
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules("tm-preflight-optout", task_modules=[])
+        with caplog.at_level("WARNING"):
+            self._trigger(app, SyncOnlyTask(name="preflight-optout"))
+
+        assert "not covered" not in caplog.text
+
+    def test_only_incomplete_tasks_are_checked(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        """Discovery stops at complete tasks and only incomplete ones are
+        ever rehydrated by a tick — so a completed dep's class is
+        irrelevant, and checking it would be a false alarm."""
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        dep = SyncOnlyTask(name="preflight-complete-dep")
+        dep.run()  # writes its target -> discovery treats it as complete
+        root = SyncOnlyTask(name="preflight-root", deps=(dep,))
+        app = _app_with_task_modules(
+            "tm-preflight-incomplete", task_modules=["acme_pipelines.*"]
+        )
+
+        with caplog.at_level("WARNING"):
+            _, registry = self._trigger(app, root)
+
+        # One warning for the class, naming only the root's occurrence: the
+        # class is reported once regardless, but the point is the completed
+        # dep never entered the checked set.
+        assert caplog.text.count("not covered by this app's task_modules") == 1
+
 
 class TestReactiveTriggerFailureLeavesNoOrphanBuild:
     """A build minted by ``build_start`` is RUNNING until a terminal EVENT

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1148,6 +1148,49 @@ class TestReactivePickleElision:
         loaded = store.load_task(root.id)
         assert loaded is not None and loaded.id == root.id
 
+    def test_inferred_task_modules_do_not_elide(
+        self, monkeypatch, modal_function_stub, default_in_memory_fs_target
+    ):
+        """Inference is observation-only; only an explicit declaration elides.
+
+        The trigger reads the LOCAL app definition while the tick runs the
+        DEPLOYED one, and nothing lets the trigger see the deployed app's
+        baked module list. If inference alone enabled elision, merely
+        upgrading the SDK would start dropping pickles that an app deployed
+        by an older SDK has no module list to compensate for — an upgrade
+        that breaks builds.
+        """
+        from stardag.build import BuildTaskStore
+        from stardag.integration.modal import _app as app_module
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        monkeypatch.setattr(
+            app_module, "_infer_task_module_patterns", lambda *a, **k: ("stardag.*",)
+        )
+        app = _app_with_task_modules("tm-elide-inferred")
+        # The inferred patterns DO cover the task class — coverage is not
+        # what is being withheld here, the opt-in is.
+        assert app.task_modules == ("stardag.*",)
+        root = SyncOnlyTask(name="elide-inferred-root")
+
+        result, _ = self._trigger(app, root)
+
+        assert BuildTaskStore(result.build_id).load_task(root.id) is not None
+
+    def test_the_same_patterns_declared_explicitly_do_elide(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        """The opt-in is the user's act, not the patterns' content."""
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules("tm-elide-explicit", task_modules=["stardag.*"])
+        root = SyncOnlyTask(name="elide-explicit-root")
+
+        result, _ = self._trigger(app, root)
+
+        assert BuildTaskStore(result.build_id).load_task(root.id) is None
+
     def test_opted_out_app_pickles_everything_exactly_as_before(
         self, modal_function_stub, default_in_memory_fs_target
     ):


### PR DESCRIPTION
Implements **#208 B1** — task registration for reactive scheduling — in three
reviewable steps plus docs.

## The problem

A reactive scheduler tick is a fresh, short-lived process. It learns *which*
tasks are actionable from the registry, but to spawn a worker it needs the
actual task *object*, and it has two ways to get one:

| path | fails when |
| --- | --- |
| pickle from the `BuildTaskStore` | the app was redeployed (pickles are same-deployment only), or the target root isn't writable |
| `task_from_registry_data` | the module defining the task class was never imported in the reconstructing process |

The second failure mode is easy to miss and hard to diagnose. A pickle embeds
`module.QualName` and `pickle.loads` **self-imports**, so it resolves its class
regardless of what the container imported. Polymorphic JSON carries only
`__namespace` / `__name`; `get_class()` is a plain dict lookup that raises
`KeyError` and **never attempts an import** — and since the default namespace is
`""`, the payload generally contains no module locator at all. Classes register
at *class-definition* time, so the only way to make one resolvable is to import
its defining module.

Meanwhile the deployed tick is defined inside stardag and drags in user modules
only incidentally (whatever the app's selector callables transitively import).
That's arbitrary, and usually doesn't cover a DAG's task classes — DAGs are
typically assembled in scripts and entrypoints, not in the module defining the
app. So today the pickle path is load-bearing.

## The three steps

### (i) Declaration and deploy-time expansion — `449d8ca`

New executor-agnostic module `stardag/build/_task_modules.py` holding the whole
concept, plus `StardagApp(task_modules=[...])`.

- **Pattern grammar**: an exact module (`"my_pkg.tasks.ingest"`) or a package
  with a trailing recursive wildcard (`"my_pkg.tasks.*"`). A `*` anywhere but
  the final component, an empty/whitespace-padded pattern, a bare `*`, or a
  component that isn't an identifier is a `TaskModulesError` raised eagerly from
  `StardagApp.__init__` — a typo must never degrade into a silent no-match,
  because the symptom would surface hours later as a tick that can't rebuild a
  task.
- **Default** (`None`): infer `"<root package of the module defining the app>.*"`
  from the calling frame. A module with no package (`__main__`, a loose deploy
  script) has no importable name in a container, so inference **warns and opts
  out** rather than baking a list that would fail to import everywhere. `[]`
  opts out silently.
- **Expansion imports nothing it doesn't have to.** `pkgutil.walk_packages` is
  deliberately avoided — it imports each package to reach its `__path__`. Only
  the root package of a `"pkg.*"` pattern is imported (unavoidable); the rest is
  a filesystem walk with `pkgutil.iter_modules`, guarded against symlink loops.
  `__main__` submodules are skipped (side-effectful entrypoints);
  `_`-prefixed modules are **not** (a user's `_tasks.py` is legitimate).
- `finalize()` expands once and bakes the concrete sorted list into the tick
  closure — the same freeze-into-locals pattern already used for `app_name` and
  the selectors — and surfaces it on `FinalizeResult`. In the container the tick
  imports that list before `run_tick_aio`, cached per module list so a container
  serving many ticks pays once. **A module that fails to import warns rather
  than aborting**, and the failures are retained so `_load_task` can append them
  to a rehydration failure ("class X unresolved; note these modules failed to
  import: …"). That annotation is read from the task-module registry rather than
  plumbed through `rehydrate.py`, which stays a pure reconstruction primitive.
- `stardag modal deploy` reports the expansion
  (`task modules: 37 discovered from "my_pkg.*"  ->  128 task classes
  registered`). The class count needs a local import and the deploy environment
  may lack extras the image has, so the check is default-on but **strictly
  warn-only** and can never fail a deploy (`--no-check-task-modules` skips it).
  It lives in the CLI so programmatic `finalize()` callers pay only for name
  expansion.

Also adds `_TypeRegistry.classes()`, the read-only snapshot the class count uses.

### (ii) Trigger-time coverage pre-flight — `c325897`

The trigger is the one place holding both the real DAG and the app, so it's the
only place that can catch a class no tick will be able to reconstruct — before a
container starts. It runs on the **discovered incomplete** set straight after
`discover_and_register_aio`: those are exactly the tasks a tick ever rehydrates,
and reusing discovery's walk avoids a second local DAG traversal. The message
names the class, the app's current patterns, and the narrowest pattern that
would fix it, plus the redeploy requirement.

**Deviation from #208, deliberate: this is a warning, not an error.** #208 frames
it as a hard failure, but an uncovered class isn't broken — it falls back to the
pickle path, which is exactly how every reactive build worked before this
feature. Failing the trigger would break working setups the moment they upgrade,
and "additive" is the premise here. The hard failure is opt-in via
`require_pickle_free=True`. (The middle ground of "error only if the pickle write
failed" is deliberately *not* implemented: it couples error reporting to
storage-failure ordering.)

Dynamically yielded deps don't exist until their parent runs, so the trigger's
pre-flight structurally cannot see them. The deployed worker wrapper therefore
publishes the app's patterns into the process and
`_WorkerLifecycleReporter._register_dynamic_deps` re-runs the check there — once
per class per process, since it runs on every suspending worker invocation.

### (iii) Conditional pickle elision — `f2a988a`

For each task the trigger would persist:

- covered by the patterns **and**
  `task_from_registry_data(task.model_dump(mode="json"), expected_task_id=task.id)`
  round-trips → **write no pickle**;
- otherwise → write the pickle exactly as today.

The self-check is faithful because registration stores exactly
`model_dump(mode="json")` (`_get_task_data_for_registration`), so it's a local
dry run of what the tick will do. It's also *cheaper* than the write it
replaces: pure CPU, versus a per-task target-root existence check plus a
conditional upload. A build whose classes are all covered writes nothing to the
target root, so reactive triggering stops needing write access there — which
also removes the storage-error path that can mint an orphan RUNNING build
(#208 A4). One summary line is logged: how many were pickle-free, how many
pickled, and why.

**What stays pickle-bound, by design** (all of it falls out of the self-check —
no special-casing):

- `AliasTask` payloads — their `loads_type` is pickled bytes, and rehydration
  refuses `__aliased` data because auto-unpickling registry-supplied bytes in a
  scheduler tick is an execution primitive;
- dynamically generated or otherwise non-importable classes;
- anything whose serialization doesn't round-trip to the same task id (notably
  nested task fields with plain task-typed annotations rather than
  `sd.TaskLoads` / `sd.SubClass`).

`require_pickle_free=True` raises naming every task that would have needed a
pickle and why. It's rejected up front alongside `task_modules=[]` (nothing could
ever qualify), and it's enforced **at the trigger only**: a worker registering
dynamic deps applies the same elision but never raises — its task has already
run, and failing the bookkeeping to enforce a storage preference would be
strictly worse than one extra pickle. Dynamic deps do get the elision, so a build
with dynamic dependencies is pickle-free end to end rather than only until the
first `yield`.

Nothing is added to hash-mode serialization — a new top-level key in
`model_dump(mode="json", context={"mode": "hash"})` would silently repartition
every task identity in existence. (The `__module` hint alternative rejected in
the #208 appendix is not implemented.)

### Docs — `f6768e8`

A "Declaring your task modules" section in the Modal how-to, with two caveats
called out explicitly:

- **Task modules become import-hot** — imported in every tick container on every
  cold start, so heavy runtime dependencies belong inside `run()` rather than at
  module scope.
- **Stale-deploy blind spot** — the pre-flight reads the *local* app definition
  and cannot see that the deployed app was built from an older `task_modules`,
  or from a stardag version predating the feature. Since the default *infers*
  patterns, an upgraded SDK triggering against a not-yet-redeployed app can skip
  a pickle the deployed tick can't compensate for. Redeploy before triggering
  (reactive mode already requires the deployed app and SDK to match), or pass
  `task_modules=[]`. Flagged in the CHANGELOG as an upgrade note.

## Scope and compatibility

`lib/` and `docs/` only; nothing under `app/`. Resident (non-reactive) builds
never touch any of this: they hold the real task objects, and workers receive
tasks by value. `task_modules=[]` reproduces the old behaviour byte for byte.
The registry/server needs no knowledge of the feature — `task_data` stays an
opaque blob server-side.

## Test coverage

- `tests/test_build/test_task_modules.py` (new, 52 tests): pattern validation
  including every rejected form; expansion against a **real package tree written
  to disk** and put on `sys.path`, whose modules record their own import to a
  marker file — so the tests can assert that expanding `"pkg.*"` imported the
  root package **and nothing else**, that `__main__` is skipped and `_tasks` is
  not, and that an exact pattern imports nothing at all; import-failure
  retention and the diagnostic note; per-module-list import caching; coverage
  matching (including package-boundary vs. prefix); elision planning, with
  `AliasTask` verified to fail the self-check.
- `tests/test_build/test_reactive.py`: `_load_task`'s diagnostic augmentation,
  with and without recorded import failures, using the existing
  `FakeReactiveRegistry` / `InMemoryTaskStore` / `FakeTickExecutor` fakes.
- `tests/test_integration/test_modal/test_stardag_app.py`: `StardagApp`
  validation and inference (both branches, via controlled frame globals),
  `finalize()` expansion surfaced on `FinalizeResult`, the tick importing exactly
  the baked list (and nothing when opted out), the worker publishing the
  patterns, the pre-flight (warns / doesn't warn / opted out / only-incomplete),
  pickle elision (covered, uncovered, opted out, `AliasTask` DAG),
  `require_pickle_free` raising with every task named, and dynamic-dep elision
  with the once-per-class warning.

`uv run pytest tests -q -m "not modal_live"` → 1026 passed, 29 deselected.
`uv run pyright src tests` → 0 errors. `pre-commit` (ruff, ruff-format,
pyright-stardag, prettier) clean on every changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NyR9Kc9ZP5Ko7dVndhi3Y
