### PR TITLE
fix(reactive): wait for cross-build blockers instead of failing the build (#208 A1/A2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,12 +37,14 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   about classes the patterns don't cover, naming the pattern to add;
   `require_pickle_free=True` turns that fallback into a hard error.
 
-  Resident (non-reactive) builds are unaffected, and `task_modules=[]`
-  behaves exactly as before. **Upgrade note for reactive users:** because
-  the default _infers_ patterns, a reactive trigger from the upgraded SDK
-  may skip pickles that the currently _deployed_ tick cannot compensate
-  for — redeploy the app before triggering (reactive mode already requires
-  the deployed app and the SDK to match), or pass `task_modules=[]`.
+  Skipping pickles requires declaring `task_modules` explicitly; the
+  inferred default only drives the coverage warning. Upgrading stardag
+  therefore changes nothing on its own — a newer SDK triggering against an
+  app deployed by an older one still writes pickles, because eliding them
+  would depend on a baked-in module list that deployment does not have.
+  Resident (non-reactive) builds are unaffected either way, and
+  `task_modules=[]` behaves exactly as before. **Redeploy the app whenever
+  you change `task_modules`**, before triggering.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### SDK
+
+- **`StardagApp(task_modules=[...])`: declare the modules whose import
+  registers your task classes, so reactive scheduler ticks can rebuild
+  tasks from registry data instead of pickles.** A tick reconstructs task
+  objects from the registry's stored payload, which resolves a class
+  through the polymorphic registry — populated only as a side effect of
+  importing the defining module. Without a declaration, whatever a tick
+  container happens to import is arbitrary, so the build task store's
+  pickles were load-bearing (and needed target-root write access at
+  trigger time, and were invalidated by every redeploy).
+
+  Patterns are exact modules (`"my_pkg.tasks.ingest"`) or trailing
+  recursive wildcards (`"my_pkg.tasks.*"`); the default infers the root
+  package of the module defining the app, and `[]` opts out. They are
+  expanded to a concrete module list at deploy time (without importing
+  submodules) and baked into the deployed tick, so **adding or moving task
+  classes requires a redeploy**; `stardag modal deploy` reports the
+  expansion (`--no-check-task-modules` skips the warn-only local import
+  check). Task modules are imported in every tick container, so keep heavy
+  runtime dependencies inside `run()` rather than at module scope.
+
+  With the declaration in place, a reactive trigger writes **no pickle**
+  for any task whose class is covered and whose payload round-trips to the
+  same task id — a fully covered build needs no target-root write access
+  at all. Everything else keeps its pickle exactly as before, including
+  `AliasTask` payloads (pickled `loads_type`, never auto-unpickled from
+  registry data by design) and non-importable classes. The trigger warns
+  about classes the patterns don't cover, naming the pattern to add;
+  `require_pickle_free=True` turns that fallback into a hard error.
+
+  Resident (non-reactive) builds are unaffected, and `task_modules=[]`
+  behaves exactly as before. **Upgrade note for reactive users:** because
+  the default _infers_ patterns, a reactive trigger from the upgraded SDK
+  may skip pickles that the currently _deployed_ tick cannot compensate
+  for — redeploy the app before triggering (reactive mode already requires
+  the deployed app and the SDK to match), or pass `task_modules=[]`.
+
 ### Fixed
 
 - **The reactive watchdog now asks the registry only for the RUNNING builds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,23 +57,33 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   a dynamic dependency registered under an earlier build, so it is not in
   the new build's task set at all.
 
-  A tick now reads the frontier's blocking upstreams and acts on them: a
-  blocker **running under another build** is waited out (like a busy
-  concurrency-limit slot — its completion wakes this scheduler), while a
-  blocker **nobody is executing** fails the build immediately, naming the
-  task, its namespace/name, its status, how long it has been in it, the
-  build that owns it, and how to release it. A blocker inside this build's
-  own task set is unchanged: it is already visible in the counts, and still
-  fails the build when it can never run.
+  A tick now reads the frontier's blocking upstreams and asks, for each,
+  whether anyone is going to move it. A blocker **another build is
+  executing** is waited out (like a busy concurrency-limit slot — its
+  completion wakes this scheduler), and so is one **a still-live build has
+  yet to schedule**: that build is going to run it, and failing here would
+  only trade one spurious failure for another. A blocker **no live build is
+  going to run** — its owning build has gone terminal, no build owns its
+  status, or that status could not be resolved — fails the build
+  immediately, naming the task, its namespace/name, its status, how long it
+  has been in it, the build that owns it, why that owner will not move it,
+  and how to release it. A blocker inside this build's own task set is
+  unchanged: it is already visible in the counts, and still fails the build
+  when it can never run.
 
-  The wait is bounded by the new `TickConfig.stale_external_blocker_seconds`
-  (default 6 hours), measured on how long the blocker has been RUNNING
-  rather than on the tick, which is too short-lived to bound anything: past
-  the bound the claim is presumed abandoned and the build fails with the
-  full explanation instead of hanging silently. `None` waits indefinitely.
-  `TickSummary` gains `external_blockers`, `external_blockers_waited` and
-  `external_blockers_fatal`. Requires a stardag-api version matching this
-  SDK; against an older server the blocker list is always empty and
+  Both waits are bounded by the new
+  `TickConfig.stale_external_blocker_seconds` (default 6 hours), measured on
+  how long the blocker has sat in its status rather than on the tick, which
+  is too short-lived to bound anything: past the bound the blocker is
+  presumed abandoned and the build fails with the full explanation instead
+  of hanging silently. `None` waits indefinitely. `TickSummary` gains
+  `external_blockers`, `external_blockers_waited` and
+  `external_blockers_fatal`, and `BuildInfo` gains `status` (the build's
+  derived status, `None` when a server or custom registry does not report
+  it). Owner liveness is resolved only when a build actually looks stalled,
+  and once per owning build per pass, so a healthy build issues no extra
+  requests however often it polls. Requires a stardag-api version matching
+  this SDK; against an older server the blocker list is always empty and
   terminal detection behaves exactly as before.
 
 - **Fixed: re-triggering a reactive build now recovers tasks left

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,59 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   `task_modules=[]` behaves exactly as before. **Redeploy the app whenever
   you change `task_modules`**, before triggering.
 
+- **Fixed: a reactive build no longer fails because another build is
+  running one of its upstreams.** Task state is per environment, so an
+  upstream some other build left RUNNING gates this build's tasks — while
+  contributing nothing to the `running` count and status counts a tick
+  sees, which are scoped to this build. That shape read as "nothing
+  runnable, nothing running, so this build is dead", and the build was
+  failed within seconds of triggering with an error naming only status
+  counts. Common whenever DAGs overlap, and especially when the blocker is
+  a dynamic dependency registered under an earlier build, so it is not in
+  the new build's task set at all.
+
+  A tick now reads the frontier's blocking upstreams and acts on them: a
+  blocker **running under another build** is waited out (like a busy
+  concurrency-limit slot — its completion wakes this scheduler), while a
+  blocker **nobody is executing** fails the build immediately, naming the
+  task, its namespace/name, its status, how long it has been in it, the
+  build that owns it, and how to release it. A blocker inside this build's
+  own task set is unchanged: it is already visible in the counts, and still
+  fails the build when it can never run.
+
+  The wait is bounded by the new `TickConfig.stale_external_blocker_seconds`
+  (default 6 hours), measured on how long the blocker has been RUNNING
+  rather than on the tick, which is too short-lived to bound anything: past
+  the bound the claim is presumed abandoned and the build fails with the
+  full explanation instead of hanging silently. `None` waits indefinitely.
+  `TickSummary` gains `external_blockers`, `external_blockers_waited` and
+  `external_blockers_fatal`. Requires a stardag-api version matching this
+  SDK; against an older server the blocker list is always empty and
+  terminal detection behaves exactly as before.
+
+- **Fixed: re-triggering a reactive build now recovers tasks left
+  `SUSPENDED`.** A task that suspended for dynamic dependencies and was
+  then abandoned (its orchestrator died, or the build was cancelled) was
+  permanently unschedulable: the re-trigger's retry pass skipped it, and
+  the only escape was to cancel it purely to reach a status that _was_
+  retryable and then retry. `suspended` joins failed/cancelled/skipped in
+  the set a re-trigger resets to pending. Safe because a suspended task has
+  no live execution — the suspension means the execution yielded and
+  returned — so nothing can be orphaned. Workers registering dynamically
+  yielded dependencies do not retry at all and are unaffected. `running`
+  remains deliberately non-retryable: it holds a live execution claim, and
+  releasing that claim is cancellation, not retry.
+
+- **`TickConfig.stale_running_no_ref_seconds` takes effect for the first
+  time**, now that the frontier actually populates
+  `FrontierTaskRef.latest_status_at`. The field was declared and documented
+  as the input to that bound but never sent by the server — it silently
+  serialised as `null` on every ref, leaving the guard dead. Against a
+  matching server, a task stuck RUNNING without an executor ref for longer
+  than the bound (default 30 minutes) is now failed as intended. Raise the
+  bound if you run long ref-less tasks — e.g. a resident build sharing
+  tasks with a concurrently ticking reactive one.
+
 ### Fixed
 
 - **The reactive watchdog now asks the registry only for the RUNNING builds

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -168,16 +168,24 @@ not own:
 
 - **A blocker another build is running** — the build waits, exactly as it
   waits for a busy concurrency-limit slot. The blocker's completion wakes
-  this scheduler, and the watchdog covers a lost wake-up. The wait is
-  bounded by `TickConfig.stale_external_blocker_seconds` (default 6 hours,
-  measured on how long the blocker has been RUNNING, not on this tick):
-  past the bound the claim is presumed abandoned and the build fails rather
-  than hanging silently. Raise it if your tasks routinely run longer;
-  `None` waits indefinitely.
-- **A blocker nobody is running** (pending, suspended, failed, cancelled or
-  skipped, and not part of this build) — nothing is going to move it, so
-  the build fails immediately, naming the blocking task, its status, how
-  long it has been in it, and the build that owns it.
+  this scheduler, and the watchdog covers a lost wake-up.
+- **A blocker another build has yet to schedule** (pending or suspended,
+  under a build that is itself still live) — the build waits too. That
+  build is going to run it; failing here would just trade one spurious
+  failure for another.
+- **A blocker no live build is going to run** — its owning build has gone
+  terminal, no build owns its status at all, or that status could not be
+  resolved. Nothing is going to move it, so the build fails immediately,
+  naming the blocking task, its status, how long it has been in it, the
+  build that owns it, and why that owner will not move it.
+
+Both waits are bounded by `TickConfig.stale_external_blocker_seconds`
+(default 6 hours, measured on how long the blocker has sat in its status,
+not on this tick): past the bound the blocker is presumed abandoned and the
+build fails rather than hanging silently. Raise it if your tasks routinely
+run longer; `None` waits indefinitely. Owner liveness is resolved only when
+a build actually looks stalled, and once per owning build, so a healthy
+build never pays for it.
 
 **Recovering a build blocked on a task from another build.** Retry the
 blocking task (`POST /api/v1/builds/{build_id}/tasks/{task_id}/retry`,

--- a/docs/docs/concepts/build-execution.md
+++ b/docs/docs/concepts/build-execution.md
@@ -121,7 +121,8 @@ tick(build_id):
          probe running refs — leave live ones; self-heal completions
          (target existence is ground truth); record failures
     handle terminal states (all roots complete / failure — with blocked
-    tasks marked skipped / cancelled)
+    tasks marked skipped / cancelled; wait rather than fail when the
+    only thing missing is a task another build is executing)
     linger briefly on the wake-up flag; exit when quiet
 ```
 
@@ -151,6 +152,44 @@ worker still running under a previous owner — forwards the wake-up to the
 owner's tick instead of driving the build with the wrong code. Ownership
 moves only by an explicit re-trigger from the new app, which also updates
 the tick config.
+
+### Cross-build blocking
+
+Task state is **per environment**, not per build: a task id has one status,
+and its dependency edges are shared. Two builds over overlapping DAGs
+therefore see each other — which is what makes "don't re-run what another
+build already completed" work, and equally means an upstream some _other_
+build is executing holds this build's downstream tasks back.
+
+A build can consequently have nothing runnable and nothing running of its
+own and still be perfectly healthy. Terminal detection distinguishes the
+two cases from the frontier's list of blocking upstreams this build does
+not own:
+
+- **A blocker another build is running** — the build waits, exactly as it
+  waits for a busy concurrency-limit slot. The blocker's completion wakes
+  this scheduler, and the watchdog covers a lost wake-up. The wait is
+  bounded by `TickConfig.stale_external_blocker_seconds` (default 6 hours,
+  measured on how long the blocker has been RUNNING, not on this tick):
+  past the bound the claim is presumed abandoned and the build fails rather
+  than hanging silently. Raise it if your tasks routinely run longer;
+  `None` waits indefinitely.
+- **A blocker nobody is running** (pending, suspended, failed, cancelled or
+  skipped, and not part of this build) — nothing is going to move it, so
+  the build fails immediately, naming the blocking task, its status, how
+  long it has been in it, and the build that owns it.
+
+**Recovering a build blocked on a task from another build.** Retry the
+blocking task (`POST /api/v1/builds/{build_id}/tasks/{task_id}/retry`,
+using the owning build's id) to reset it to PENDING, then re-trigger your
+build — a re-trigger resets blocking tasks in any retryable status for you.
+Retry covers **suspended** as well as failed/cancelled/skipped: a task left
+SUSPENDED (its execution registered dynamic dependencies, yielded and
+returned, and then its build was abandoned) used to have no supported way
+back, and needed an undocumented cancel-then-retry dance. A task stuck
+RUNNING is the one exception — it holds a live execution claim, so
+**cancel** it (`.../cancel`) to release the claim; retry deliberately does
+not, since that would risk a second concurrent execution.
 
 Reactive scheduling is experimental and currently Modal-first — see
 [Integrate with Modal](../how-to/integrate-modal.md#reactive-scheduling-no-resident-build-function-experimental)

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -712,6 +712,18 @@ can be force-failed by that build's `stale_running_no_ref_seconds`
 escape hatch — raise the bound if you mix modes over the same long
 tasks.
 
+**Builds that overlap.** Task state is per environment, so a task another
+build is executing blocks yours. A tick waits that out instead of failing
+the build (bounded by `TickConfig.stale_external_blocker_seconds`, default
+6 hours); a blocker nobody is executing fails the build with a message
+naming the task and the build that owns it. Symptom worth knowing: a tick
+log line saying the build is _"blocked by N task(s) running in other
+build(s); waiting rather than failing"_ means your build is fine and
+waiting on a neighbour. See
+[Cross-build blocking](../concepts/build-execution.md#cross-build-blocking)
+for the recovery path when the blocker is abandoned — including a task left
+SUSPENDED, which a retry (and therefore a re-trigger) now resets.
+
 Requirements and current limitations: the app must be deployed with this
 stardag version (scheduler `tick` function + self-reporting workers); the
 triggering process needs registry credentials and access to the default

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -584,12 +584,24 @@ by default but **warn-only** — your deploy environment may lack extras the
 image has, so a local import failure never fails the deploy. Pass
 `--no-check-task-modules` to skip the check and report names only.
 
-**What you get.** At trigger time, every discovered task whose class is
-covered _and_ whose payload round-trips to the same task id is persisted
-**without a pickle**. A build whose classes are all covered writes nothing
-to the target root, so reactive triggering stops needing target-root write
-access at all. Set `require_pickle_free=True` to turn the fallback into a
-hard error that names every task that would have needed a pickle and why.
+**What you get.** Once you declare `task_modules` explicitly, every
+discovered task whose class is covered _and_ whose payload round-trips to
+the same task id is persisted **without a pickle**. A build whose classes
+are all covered writes nothing to the target root, so reactive triggering
+stops needing target-root write access at all. Set
+`require_pickle_free=True` to turn the fallback into a hard error that
+names every task that would have needed a pickle and why.
+
+**Skipping pickles requires the explicit declaration** — the inferred
+default never elides on its own. Inference happens for every app,
+including apps written before this feature existed, and the trigger runs
+from your _local_ app definition while the tick runs from the _deployed_
+one. If inference alone skipped pickles, upgrading stardag would silently
+start dropping pickles that an app deployed by an older version has no
+baked-in module list to compensate for. Requiring you to write the
+argument is what puts the redeploy requirement in front of you at the
+moment it matters. Inference still drives the coverage warning below,
+which only observes.
 
 Some payloads stay pickle-bound by design, and always will:
 
@@ -615,16 +627,16 @@ Two caveats worth designing around:
   it directly buys tick cold-start latency.
 - **Stale-deploy blind spot.** The trigger-time coverage check reads your
   _local_ app definition, so it cannot tell that the _deployed_ app was
-  built from an older `task_modules` — or from a stardag version that
-  predates the feature entirely. If you add a pattern (or upgrade stardag)
-  and trigger without redeploying, the pre-flight is silent while the tick
-  still can't resolve the class, and because the trigger already skipped
-  the pickle there is no fallback left. **Redeploy the app whenever you
-  change `task_modules` or upgrade stardag**, before triggering — which
-  the reactive mode already requires for other reasons (see the
-  requirements above). Passing `task_modules=[]` restores the pre-feature
-  behaviour unconditionally if you need to trigger against an older
-  deployment.
+  built from an older `task_modules`. If you add a pattern and trigger
+  without redeploying, the pre-flight is silent while the tick still can't
+  resolve the class — and because the trigger already skipped the pickle,
+  there is no fallback left. **Redeploy the app whenever you change
+  `task_modules`**, before triggering — which reactive mode already
+  requires for other reasons (see the requirements above). Upgrading
+  stardag alone is safe: elision only follows an explicit declaration, so
+  a newer SDK triggering against an app deployed by an older one still
+  writes pickles. Passing `task_modules=[]` restores the pre-feature
+  behaviour unconditionally.
 
 Named concurrency limits are enforced registry-side in reactive mode —
 across builds, not just within one. Configure caps per environment

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -713,13 +713,14 @@ escape hatch — raise the bound if you mix modes over the same long
 tasks.
 
 **Builds that overlap.** Task state is per environment, so a task another
-build is executing blocks yours. A tick waits that out instead of failing
-the build (bounded by `TickConfig.stale_external_blocker_seconds`, default
-6 hours); a blocker nobody is executing fails the build with a message
-naming the task and the build that owns it. Symptom worth knowing: a tick
-log line saying the build is _"blocked by N task(s) running in other
-build(s); waiting rather than failing"_ means your build is fine and
-waiting on a neighbour. See
+build owns blocks yours. A tick waits that out — whether the other build is
+executing the task or has yet to schedule it — instead of failing the build
+(bounded by `TickConfig.stale_external_blocker_seconds`, default 6 hours);
+a blocker no _live_ build is going to run fails the build with a message
+naming the task, the build that owns it and why that owner will not move
+it. Symptom worth knowing: a tick log line saying the build is _"waiting on
+N upstream task(s) owned by other builds … waiting rather than failing"_
+means your build is fine and waiting on a neighbour. See
 [Cross-build blocking](../concepts/build-execution.md#cross-build-blocking)
 for the recovery path when the blocker is abandoned — including a task left
 SUSPENDED, which a retry (and therefore a re-trigger) now resets.

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -466,7 +466,10 @@ access to the default target root (task _objects_ are persisted there as
 pickles for the ticks — the reactive marker, owning app, and tick config
 live in the registry, not on the target root, so re-triggering works even
 when the target root is immutable/append-only and a re-trigger may update
-`tick_kwargs`); the global concurrency lock and build-local
+`tick_kwargs`; declaring
+[`task_modules`](#declaring-your-task-modules-recommended) removes the
+target-root write from this path entirely for most builds); the global
+concurrency lock and build-local
 `ConcurrencyConfig` limits are not applied by ticks (use the
 registry-backed named limits above; Modal's per-function
 `concurrency_limit` also still applies). Builds cancelled from the
@@ -484,6 +487,9 @@ Two operational notes:
   still importable and its fields are compatible (nested task fields
   must use `sd.TaskLoads`/`sd.SubClass` annotations). Only if both paths
   fail is the task failed by the next tick (never a silent stall).
+  Declaring [`task_modules`](#declaring-your-task-modules-recommended) is
+  what makes "still importable" true by construction — and lets stardag
+  skip the pickle in the first place.
 - **The watchdog sweep runs one quick scheduling pass per running build
   that this app owns** (it skips the linger), so its per-period cost is
   one short function invocation plus a frontier query per such build.
@@ -520,6 +526,105 @@ Two operational notes:
   on the default and don't declare a registry secret at all. (On stardag
   ≤ 0.10.1 you instead had to put the secret on the builder — 0.10.1 —
   or on every worker — 0.10.0.)
+
+#### Declaring your task modules (recommended)
+
+A scheduler tick is a fresh, short-lived process. It learns _which_ tasks
+are actionable from the registry, but to spawn a worker it needs the actual
+task _object_ — and it has two ways to get one:
+
+1. unpickle it from the build task store (needs target-root access, and is
+   only valid for the deployment that wrote it), or
+2. rebuild it from the payload the registry already stores.
+
+The second path is the good one, but it has a catch: rebuilding a task
+resolves its class through stardag's polymorphic registry, and classes land
+in that registry **as a side effect of importing the module that defines
+them**. A pickle carries `module.QualName` and self-imports; the registry
+payload carries no module locator at all. So the tick can only rebuild
+classes whose modules its container happened to import — which, without
+help, is essentially arbitrary.
+
+`task_modules` is that help:
+
+```{.python notest}
+app = sd_modal.StardagApp(
+    "stardag-poc",
+    builder_settings=sd_modal.FunctionSettings(image=image),
+    worker_settings={"default": sd_modal.FunctionSettings(image=image)},
+    watchdog_period_minutes=5,
+    # Modules whose import registers the task classes this app may
+    # schedule. Default: the root package of the module defining the app.
+    # Pass [] to opt out (resident builds never need this).
+    task_modules=["my_pkg.tasks.*", "my_pkg.pipelines.*"],
+)
+```
+
+**Pattern grammar.** Each entry is either an exact module
+(`"my_pkg.tasks.ingest"`) or a package followed by a trailing recursive
+wildcard (`"my_pkg.tasks.*"`, matching `my_pkg.tasks` and everything below
+it). A `*` anywhere but the final component, or a malformed path, raises
+from `StardagApp(...)` — a typo must not degrade into a silent no-match.
+Left unset, the default is `"<root package of the module defining the
+app>.*"`; if the app lives in `__main__` or a loose script (no importable
+package), inference is impossible and stardag warns and falls back to the
+pickle path.
+
+**A redeploy is required** when you add or move task classes. The patterns
+are expanded to a concrete module list at deploy time and baked into the
+deployed tick, so the deployed set is explicit and auditable and container
+startup does no filesystem walking. `stardag modal deploy` reports it:
+
+```text
+Task modules: 37 discovered from "my_pkg.*"  ->  128 task classes registered
+```
+
+The class count requires importing the modules locally, which the CLI does
+by default but **warn-only** — your deploy environment may lack extras the
+image has, so a local import failure never fails the deploy. Pass
+`--no-check-task-modules` to skip the check and report names only.
+
+**What you get.** At trigger time, every discovered task whose class is
+covered _and_ whose payload round-trips to the same task id is persisted
+**without a pickle**. A build whose classes are all covered writes nothing
+to the target root, so reactive triggering stops needing target-root write
+access at all. Set `require_pickle_free=True` to turn the fallback into a
+hard error that names every task that would have needed a pickle and why.
+
+Some payloads stay pickle-bound by design, and always will:
+
+- **`AliasTask`**, whose `loads_type` is pickled bytes — auto-unpickling
+  registry-supplied bytes inside a scheduler tick would be a remote code
+  execution vector, so rehydration refuses those payloads outright;
+- **dynamically generated or otherwise non-importable classes**;
+- **anything whose serialization is not losslessly round-trippable** (in
+  particular, nested task fields must use `sd.TaskLoads` / `sd.SubClass`
+  annotations — a plain task-typed annotation validates children into the
+  abstract base class).
+
+The trigger warns — naming the class, the pattern to add, and the redeploy
+requirement — for any discovered class the patterns don't cover. It is a
+warning rather than an error because an uncovered class still works via the
+pickle path, exactly as before this feature existed.
+
+Two caveats worth designing around:
+
+- **Task modules become import-hot.** They are imported in every tick
+  container, on every cold start. Keep heavy runtime dependencies inside
+  `run()` rather than at module scope — good practice regardless, but here
+  it directly buys tick cold-start latency.
+- **Stale-deploy blind spot.** The trigger-time coverage check reads your
+  _local_ app definition, so it cannot tell that the _deployed_ app was
+  built from an older `task_modules` — or from a stardag version that
+  predates the feature entirely. If you add a pattern (or upgrade stardag)
+  and trigger without redeploying, the pre-flight is silent while the tick
+  still can't resolve the class, and because the trigger already skipped
+  the pickle there is no fallback left. **Redeploy the app whenever you
+  change `task_modules` or upgrade stardag**, before triggering — which
+  the reactive mode already requires for other reasons (see the
+  requirements above). Passing `task_modules=[]` restores the pre-feature
+  behaviour unconditionally if you need to trigger against an older
+  deployment.
 
 Named concurrency limits are enforced registry-side in reactive mode —
 across builds, not just within one. Configure caps per environment

--- a/lib/stardag/src/stardag/_cli/modal.py
+++ b/lib/stardag/src/stardag/_cli/modal.py
@@ -36,7 +36,7 @@ from stardag._cli.credentials import (
 )
 from stardag.config.cache import get_cached_slugs
 from stardag.config.loader import clear_config_cache, get_config
-from stardag.integration.modal import StardagApp
+from stardag.integration.modal import FinalizeResult, StardagApp
 
 # Check if modal is available
 try:
@@ -488,6 +488,61 @@ def _parse_app_ref(app_ref: str) -> tuple[str, str]:
     return app_ref, ""
 
 
+def _report_task_modules(
+    stardag_app_instance: StardagApp,
+    finalize_result: FinalizeResult,
+    *,
+    check: bool,
+) -> None:
+    """Report the task-module expansion baked into the deployed tick.
+
+    The class count is the genuinely useful number — "37 modules" says
+    nothing about whether the DAG's classes are among them — but getting it
+    requires actually importing the modules *here*, in the deploy
+    environment, which is not the image: it may lack extras, GPU libraries,
+    or credentials the containers have. So the import check is default-on
+    and strictly **warn-only**; it can never fail a deploy, and
+    ``--no-check-task-modules`` skips it entirely. It also stays in the CLI
+    rather than in ``finalize()``, so programmatic callers pay only for
+    name expansion.
+    """
+    task_modules = list(finalize_result.task_modules)
+    patterns = list(stardag_app_instance.task_modules)
+    if not task_modules:
+        if not patterns:
+            console.print(
+                "[dim]  task modules: none declared — reactive scheduler "
+                "ticks will rely on task-store pickles[/dim]"
+            )
+        return
+
+    from_patterns = ", ".join(f'"{p}"' for p in patterns)
+    summary = f"{len(task_modules)} discovered from {from_patterns}"
+    if not check:
+        console.print(f"[cyan]Task modules:[/cyan] [dim]{summary}[/dim]")
+        return
+
+    from stardag.build import import_task_modules
+
+    report = import_task_modules(task_modules)
+    console.print(
+        f"[cyan]Task modules:[/cyan] [dim]{summary}  ->  "
+        f"{report.task_classes_registered} task classes registered[/dim]"
+    )
+    if report.failures:
+        console.print(
+            f"[yellow]  {len(report.failures)} task module(s) failed to "
+            "import locally. This does NOT fail the deploy — the image may "
+            "have dependencies this environment lacks — but if the failure "
+            "reproduces in the container, task classes defined in these "
+            "modules will not be reconstructable by scheduler ticks:[/yellow]"
+        )
+        for module_name in sorted(report.failures):
+            console.print(
+                f"[yellow]    {module_name}: {report.failures[module_name]}[/yellow]"
+            )
+
+
 @app.command("deploy")
 def deploy(
     app_ref: str = typer.Argument(
@@ -531,6 +586,16 @@ def deploy(
         False,
         "-m",
         help="Interpret argument as a Python module path instead of a file/script path",
+    ),
+    check_task_modules: bool = typer.Option(
+        True,
+        "--check-task-modules/--no-check-task-modules",
+        help=(
+            "Import the app's expanded task_modules locally to report how "
+            "many task classes they register. Warn-only — a local import "
+            "failure never fails the deploy (the deploy environment may "
+            "lack extras the image has)."
+        ),
     ),
 ) -> None:
     """Deploy a Stardag Modal application.
@@ -632,6 +697,10 @@ def deploy(
         console.print("[cyan]Functions:[/cyan]")
         for func_name in finalize_result.functions:
             console.print(f"[dim]  {func_name}[/dim]")
+
+        _report_task_modules(
+            stardag_app_instance, finalize_result, check=check_task_modules
+        )
 
     # Get the underlying Modal app
     modal_app = stardag_app_instance.modal_app

--- a/lib/stardag/src/stardag/build/__init__.py
+++ b/lib/stardag/src/stardag/build/__init__.py
@@ -24,6 +24,12 @@ Global concurrency locking:
 Granular concurrency limiting:
 - ConcurrencyConfig: Overall and named limits on concurrently executing tasks
 - ConcurrencyLimiter: Protocol for custom/distributed limiters
+
+Task-module declaration (reactive scheduling only):
+- expand_task_module_patterns()/import_task_modules(): make a scheduler
+    process able to reconstruct a build's task classes from registry data
+- plan_pickle_elision(): decide which tasks still need a build-task-store
+    pickle (see stardag.build._task_modules for the full rationale)
 """
 
 from stardag.build._base import (
@@ -57,6 +63,20 @@ from stardag.build._reactive import (
     run_tick_aio,
 )
 from stardag.build._task_store import BuildTaskStore
+from stardag.build._task_modules import (
+    PickleElisionPlan,
+    TaskModuleImportReport,
+    TaskModulesError,
+    declared_task_module_patterns,
+    expand_task_module_patterns,
+    import_task_modules,
+    last_import_failures,
+    module_is_covered,
+    plan_pickle_elision,
+    set_declared_task_module_patterns,
+    uncovered_task_classes,
+    validate_task_module_patterns,
+)
 from stardag.build._concurrency import (
     ConcurrencyConfig,
     ConcurrencyKeySelector,
@@ -108,6 +128,19 @@ __all__ = [
     "RoutedTaskExecutor",
     "TaskExecutionError",
     "BuildTaskStore",
+    # Task-module declaration (reactive scheduling)
+    "PickleElisionPlan",
+    "TaskModuleImportReport",
+    "TaskModulesError",
+    "declared_task_module_patterns",
+    "expand_task_module_patterns",
+    "import_task_modules",
+    "last_import_failures",
+    "module_is_covered",
+    "plan_pickle_elision",
+    "set_declared_task_module_patterns",
+    "uncovered_task_classes",
+    "validate_task_module_patterns",
     "ClaimConfig",
     "DetachedExecutionStatus",
     "DiscoveryResult",

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -1003,22 +1003,53 @@ def _describe_blockers(
 
 
 def _blocker_remediation(verdicts: Sequence[_BlockerVerdict]) -> str:
-    """How to get out of it — the part #208 says today's error lacks."""
-    remedy = (
-        "Retry the blocking task under the build that owns it "
-        "(POST /api/v1/builds/{build_id}/tasks/{task_id}/retry) to reset it "
-        "to pending — this now works from suspended as well as from "
-        "failed/cancelled/skipped — then re-trigger this build"
-    )
-    if any(
-        verdict.blocker.blocking_status in _RUNNING_STATUSES for verdict in verdicts
-    ):
-        remedy += (
-            ". A blocker stuck RUNNING holds an execution claim no retry can "
-            "take: cancel it (POST /api/v1/builds/{build_id}/tasks/{task_id}"
-            "/cancel) to release the claim first"
+    """How to get out of it — the part the error used to lack.
+
+    Both documented endpoints are addressed to a *build*, so a blocker
+    whose owning build was never recorded has no build id to substitute
+    into them. Telling that reader to "retry it under the build that owns
+    it" is not a remedy, it is the shape of one — and this function exists
+    precisely for the reader who is stuck.
+    """
+    unowned = [
+        verdict
+        for verdict in verdicts
+        if verdict.blocker.blocking_status_build_id is None
+    ]
+    owned = [
+        verdict
+        for verdict in verdicts
+        if verdict.blocker.blocking_status_build_id is not None
+    ]
+
+    parts: list[str] = []
+    if owned:
+        remedy = (
+            "Retry the blocking task under the build that owns it "
+            "(POST /api/v1/builds/{build_id}/tasks/{task_id}/retry) to reset "
+            "it to pending — this now works from suspended as well as from "
+            "failed/cancelled/skipped — then re-trigger this build"
         )
-    return remedy + "."
+        if any(
+            verdict.blocker.blocking_status in _RUNNING_STATUSES for verdict in owned
+        ):
+            remedy += (
+                ". A blocker stuck RUNNING holds an execution claim no retry "
+                "can take: cancel it (POST /api/v1/builds/{build_id}/tasks/"
+                "{task_id}/cancel) to release the claim first"
+            )
+        parts.append(remedy + ".")
+    if unowned:
+        parts.append(
+            "No build is recorded as having set the status of "
+            f"{'some of these blockers' if owned else 'this blocker'}, so "
+            "there is no build id to address a retry or cancel to. Find the "
+            "task in the registry UI (or `stardag tasks list`), which names "
+            "the build that owns each claim; if nothing owns it, the status "
+            "predates claim recording and the task has to be re-run under a "
+            "new build."
+        )
+    return " ".join(parts)
 
 
 async def _handle_terminal(

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -41,11 +41,13 @@ stuck. Task rows and dependency edges are per environment, so an upstream
 that some other build left non-COMPLETED gates this build's tasks while
 contributing nothing to the counts this build can see. Terminal detection
 therefore consults the frontier's ``blocked_by_external`` before declaring
-a build dead: a blocker RUNNING under another build is waited on (bounded
-by ``TickConfig.stale_external_blocker_seconds``), while a blocker nobody
-is executing fails the build immediately with a message naming the task
-and the build that owns it. Against servers predating those fields the
-list is always empty and detection degrades to its pre-fix behaviour.
+a build dead: a blocker another build is executing — or one a still-live
+build has yet to schedule — is waited on (bounded by
+``TickConfig.stale_external_blocker_seconds``), while a blocker no live
+build is going to run fails the build immediately, with a message naming
+the task, the build that owns it and why that owner will not move it.
+Against servers predating those fields the list is always empty and
+detection degrades to its pre-fix behaviour.
 """
 
 from __future__ import annotations
@@ -239,13 +241,14 @@ class TickConfig:
     # its actual execution is unaffected and its completion (sticky) still
     # lands; generous default accordingly.
     stale_running_no_ref_seconds: float | None = 1800.0
-    # How long this build will wait on a blocker that is RUNNING under
-    # ANOTHER build before giving up and failing (see
-    # ``_classify_external_blockers``). Measured on the blocker's status
-    # timestamp — how long it has been RUNNING — not on tick-local time: a
-    # tick is short-lived and the watchdog keeps re-ticking, so a tick-local
-    # bound would never expire and the build would hang silently forever,
-    # which is the failure mode this whole path exists to remove.
+    # How long this build will wait on a blocker owned by ANOTHER build —
+    # one that build is executing, or one it has yet to schedule — before
+    # giving up and failing (see ``_classify_external_blockers``). Measured
+    # on the blocker's status timestamp — how long it has sat in that status
+    # — not on tick-local time: a tick is short-lived and the watchdog keeps
+    # re-ticking, so a tick-local bound would never expire and the build
+    # would hang silently forever, which is the failure mode this whole path
+    # exists to remove.
     #
     # Deliberately generous (6 h). Waiting is the cheap direction: the
     # blocker's own build has far better information about it (a live
@@ -726,19 +729,39 @@ async def _resolve_running(
     return "leave"
 
 
+class _BlockerVerdict(typing.NamedTuple):
+    """A blocker paired with the reason it landed in its bucket.
+
+    The reason is carried rather than re-derived at rendering time so the
+    message can say *why* a blocker is fatal ("its owning build is failed")
+    without re-issuing the lookups the classification already made.
+    """
+
+    blocker: FrontierExternalBlocker
+    # Short why-clause appended to this blocker's description.
+    note: str
+
+
 class _ExternalBlockers(typing.NamedTuple):
     """Partition of a frontier's ``blocked_by_external`` (see below)."""
 
-    # Out-of-build and RUNNING within the staleness bound: someone else is
+    # Out-of-build, RUNNING, within the staleness bound: someone else is
     # executing it, and their completion frees this build. Wait.
-    waiting: list[FrontierExternalBlocker]
-    # Out-of-build and NOT going to run — either not RUNNING at all, or
-    # RUNNING for longer than ``stale_external_blocker_seconds``. Fail.
-    fatal: list[FrontierExternalBlocker]
+    executing: list[_BlockerVerdict]
+    # Out-of-build, not running, but owned by a build that is still live —
+    # that build is going to schedule it. Wait, on the same bound.
+    queued: list[_BlockerVerdict]
+    # Out-of-build and nothing is going to run it. Fail.
+    fatal: list[_BlockerVerdict]
     # In this build's own task set: already accounted for by actionable /
     # running / status_counts, so it must not influence the wait-or-fail
     # decision. Kept only to enrich the message.
-    in_build: list[FrontierExternalBlocker]
+    in_build: list[_BlockerVerdict]
+
+    @property
+    def waiting(self) -> list[_BlockerVerdict]:
+        """Every blocker this build should wait on rather than fail over."""
+        return self.executing + self.queued
 
 
 def _blocker_label(blocker: FrontierExternalBlocker) -> str:
@@ -765,53 +788,172 @@ def _blocker_status_age_seconds(
     return (now - status_at).total_seconds()
 
 
-def _classify_external_blockers(
-    frontier: BuildFrontier, config: TickConfig, now: datetime
+def _blocker_is_stale(
+    blocker: FrontierExternalBlocker, config: TickConfig, now: datetime
+) -> bool:
+    """Whether the blocker has sat in its status longer than the bound.
+
+    False when the bound is disabled or the blocker carries no status
+    timestamp: an unageable blocker is waited on rather than failed, since
+    failing on missing information would reintroduce exactly the spurious
+    failures this path removes (see
+    ``TickConfig.stale_external_blocker_seconds``).
+    """
+    stale_after = config.stale_external_blocker_seconds
+    if stale_after is None:
+        return False
+    age = _blocker_status_age_seconds(blocker, now)
+    return age is not None and age > stale_after
+
+
+async def _classify_external_blockers(
+    frontier: BuildFrontier,
+    config: TickConfig,
+    now: datetime,
+    *,
+    registry: RegistryABC,
 ) -> _ExternalBlockers:
     """Split the frontier's external blockers into wait / fail / ignore.
 
     The frontier reports these only when the build has nothing actionable
-    and nothing running — precisely the state the stuck-build check reads
-    as "this build is dead". The split decides whether it actually is:
+    and nothing running — precisely the state the stuck-build check reads as
+    "this build is dead". The split decides whether it actually is, on two
+    questions: is the blocker in this build's own task set, and is anyone
+    going to move it?
 
-    - ``blocking_in_build`` → ignored. The blocker is in this build's own
-      task set, so it is already visible in ``actionable``/``running``/
-      ``status_counts``; letting it also drive this decision would
-      double-count it (and a blocker that is genuinely stuck *in* this
-      build must still fail the build, exactly as before).
+    - ``blocking_in_build`` → **ignored**. The blocker is in this build's
+      own task set, so it is already visible in ``actionable`` /
+      ``running`` / ``status_counts``; letting it also drive this decision
+      would double-count it (and a blocker that is genuinely stuck *in*
+      this build must still fail the build, exactly as before).
     - out-of-build and RUNNING → **wait**. Another build is executing it;
       its completion unblocks this build and wakes this scheduler. Treated
-      like a concurrency-limit denial: return, don't fail. Bounded by
-      ``config.stale_external_blocker_seconds`` against the blocker's own
-      status timestamp, since a tick is too short-lived to bound anything
-      itself — see that field for the rationale and the None cases.
-    - out-of-build and anything else (pending/suspended/failed/cancelled/
-      skipped) → **fail now**. Nobody is executing it and this build will
-      never schedule it, so waiting would be waiting forever. (Narrow
-      exception this deliberately does not carve out: a PENDING blocker
-      belonging to another *live* build will be scheduled by that build.
-      It is rare — a build's discovery registers the whole static
-      dependency tree, so out-of-build blockers are dynamic dependencies
-      of an earlier build — and the failure now says exactly which task to
-      retry, unlike the silent hang it replaces.)
+      like a concurrency-limit denial: return, don't fail.
+    - out-of-build, not RUNNING, but its status-owning build is still live
+      → **wait**. That build is going to schedule it. Without this a
+      PENDING dynamic dependency of a healthy concurrent build would fail
+      this build — a *new* spurious failure, which is the very class of bug
+      being fixed here, so the liveness question is asked rather than
+      assumed.
+    - out-of-build with no live owner → **fail now**: its owning build has
+      gone terminal, no build owns its status at all, or the owner's status
+      could not be resolved. Nothing is going to run it and this build
+      never will, so waiting would be waiting forever.
+
+    Both waits are bounded by ``config.stale_external_blocker_seconds``
+    against the blocker's own status timestamp, since a tick is too
+    short-lived to bound anything itself — see that field for the rationale
+    and the unageable cases.
+
+    A blocker with ``blocking_status_build_id is None`` is fatal without a
+    lookup: no build owns its status, meaning no status-moving event was
+    ever recorded against it, so there is no evidence anyone intends to run
+    it — and a silent indefinite hang is the failure mode #208 exists to
+    kill. The same goes for an owner status of None, whether because the
+    lookup failed or because the server doesn't report the field: unknown
+    is not evidence of life. Every one of those still fails with the full
+    remediation, so the operator is never left without a next step.
     """
-    waiting: list[FrontierExternalBlocker] = []
-    fatal: list[FrontierExternalBlocker] = []
-    in_build: list[FrontierExternalBlocker] = []
-    stale_after = config.stale_external_blocker_seconds
+    executing: list[_BlockerVerdict] = []
+    queued: list[_BlockerVerdict] = []
+    fatal: list[_BlockerVerdict] = []
+    in_build: list[_BlockerVerdict] = []
+
+    # Owning-build statuses resolved during THIS classification only. A wide
+    # DAG stalled behind one build yields one blocker entry per blocked edge,
+    # every one naming the same owner, so without the memo this would be N
+    # requests for one answer. Deliberately not cached across calls: a later
+    # pass must be able to see the owner go terminal.
+    #
+    # The whole lookup only happens on the stalled path — the frontier
+    # populates blocked_by_external solely when the build has nothing
+    # actionable and nothing running — so a healthy build issues zero extra
+    # requests, however often it polls. Please don't "optimise" this away on
+    # the assumption that it runs per tick in steady state; it does not.
+    owner_statuses: dict[UUID, str | None] = {}
+
+    async def owner_status(owner_id: UUID) -> str | None:
+        if owner_id not in owner_statuses:
+            try:
+                info = await registry.build_get_aio(owner_id)
+                owner_statuses[owner_id] = info.status
+            except Exception as e:
+                # Swallowed on purpose: this is a diagnostic lookup on the
+                # path that decides a build's fate, and an unreachable or
+                # deleted owner must produce a precise failure, not an
+                # exception out of the tick.
+                logger.warning(
+                    f"Could not resolve the status of build {owner_id}, which "
+                    f"owns a task blocking this build: {e}"
+                )
+                owner_statuses[owner_id] = None
+        return owner_statuses[owner_id]
+
     for blocker in frontier.blocked_by_external:
         if blocker.blocking_in_build:
-            in_build.append(blocker)
+            in_build.append(_BlockerVerdict(blocker, "in this build's own task set"))
             continue
-        if blocker.blocking_status not in _RUNNING_STATUSES:
-            fatal.append(blocker)
+
+        if blocker.blocking_status in _RUNNING_STATUSES:
+            if _blocker_is_stale(blocker, config, now):
+                fatal.append(
+                    _BlockerVerdict(
+                        blocker,
+                        "RUNNING past the "
+                        f"{config.stale_external_blocker_seconds:.0f}s staleness "
+                        "bound, so its execution claim is presumed abandoned",
+                    )
+                )
+            else:
+                executing.append(
+                    _BlockerVerdict(blocker, "another build is executing it")
+                )
             continue
-        age = _blocker_status_age_seconds(blocker, now)
-        if stale_after is not None and age is not None and age > stale_after:
-            fatal.append(blocker)
+
+        # Not running: it moves only if the build owning its status is still
+        # going to schedule it.
+        owner_id = blocker.blocking_status_build_id
+        if owner_id is None:
+            fatal.append(
+                _BlockerVerdict(
+                    blocker,
+                    "no build owns its status, so nothing has ever moved it",
+                )
+            )
+            continue
+        status = await owner_status(owner_id)
+        if status is None:
+            fatal.append(
+                _BlockerVerdict(
+                    blocker,
+                    "its owning build's status is unknown (the lookup failed, "
+                    "or this registry does not report it), which is not "
+                    "evidence that anyone will run it",
+                )
+            )
+        elif status in _TERMINAL_BUILD_STATUSES:
+            fatal.append(_BlockerVerdict(blocker, f"its owning build is {status}"))
+        elif _blocker_is_stale(blocker, config, now):
+            fatal.append(
+                _BlockerVerdict(
+                    blocker,
+                    f"its owning build is still {status} but has left it in "
+                    "this status past the "
+                    f"{config.stale_external_blocker_seconds:.0f}s staleness "
+                    "bound",
+                )
+            )
         else:
-            waiting.append(blocker)
-    return _ExternalBlockers(waiting=waiting, fatal=fatal, in_build=in_build)
+            # Includes an owner still PENDING: a build that has not started
+            # yet may still start, and the staleness bound above is what
+            # stops that from being an unbounded wait.
+            queued.append(
+                _BlockerVerdict(blocker, f"its owning build is still {status}")
+            )
+
+    return _ExternalBlockers(
+        executing=executing, queued=queued, fatal=fatal, in_build=in_build
+    )
 
 
 # How many blockers a log line or build error names before summarising the
@@ -822,7 +964,7 @@ _MAX_REPORTED_BLOCKERS = 5
 
 
 def _describe_blockers(
-    blockers: Sequence[FrontierExternalBlocker], now: datetime, truncated: bool
+    verdicts: Sequence[_BlockerVerdict], now: datetime, truncated: bool
 ) -> str:
     """One-line, user-actionable rendering of blockers (names, not ids only).
 
@@ -831,22 +973,25 @@ def _describe_blockers(
     """
     described = "; ".join(
         (
-            f"task {blocker.task_id} is blocked by {_blocker_label(blocker)} "
-            f"({blocker.blocking_task_id}), {blocker.blocking_status.upper()}"
+            f"task {verdict.blocker.task_id} is blocked by "
+            f"{_blocker_label(verdict.blocker)} "
+            f"({verdict.blocker.blocking_task_id}), "
+            f"{verdict.blocker.blocking_status.upper()}"
             + (
                 ""
-                if (age := _blocker_status_age_seconds(blocker, now)) is None
+                if (age := _blocker_status_age_seconds(verdict.blocker, now)) is None
                 else f" for {age:.0f}s"
             )
             + (
-                f" under build {blocker.blocking_status_build_id}"
-                if blocker.blocking_status_build_id is not None
-                else " under an unrecorded build"
+                f" under build {verdict.blocker.blocking_status_build_id}"
+                if verdict.blocker.blocking_status_build_id is not None
+                else " under no recorded build"
             )
+            + f" — {verdict.note}"
         )
-        for blocker in blockers[:_MAX_REPORTED_BLOCKERS]
+        for verdict in verdicts[:_MAX_REPORTED_BLOCKERS]
     )
-    remaining = len(blockers) - _MAX_REPORTED_BLOCKERS
+    remaining = len(verdicts) - _MAX_REPORTED_BLOCKERS
     if remaining > 0:
         described += f"; and {remaining} more"
     if truncated:
@@ -857,7 +1002,7 @@ def _describe_blockers(
     return described
 
 
-def _blocker_remediation(blockers: Sequence[FrontierExternalBlocker]) -> str:
+def _blocker_remediation(verdicts: Sequence[_BlockerVerdict]) -> str:
     """How to get out of it — the part #208 says today's error lacks."""
     remedy = (
         "Retry the blocking task under the build that owns it "
@@ -865,7 +1010,9 @@ def _blocker_remediation(blockers: Sequence[FrontierExternalBlocker]) -> str:
         "to pending — this now works from suspended as well as from "
         "failed/cancelled/skipped — then re-trigger this build"
     )
-    if any(blocker.blocking_status in _RUNNING_STATUSES for blocker in blockers):
+    if any(
+        verdict.blocker.blocking_status in _RUNNING_STATUSES for verdict in verdicts
+    ):
         remedy += (
             ". A blocker stuck RUNNING holds an execution claim no retry can "
             "take: cancel it (POST /api/v1/builds/{build_id}/tasks/{task_id}"
@@ -942,50 +1089,67 @@ async def _handle_terminal(
         # failure.
         now = datetime.now(timezone.utc)
         truncated = frontier.blocked_by_external_truncated
-        blockers = _classify_external_blockers(frontier, config, now)
+        blockers = await _classify_external_blockers(
+            frontier, config, now, registry=registry
+        )
+        waiting = blockers.waiting
         summary.external_blockers += len(frontier.blocked_by_external)
-        summary.external_blockers_waited += len(blockers.waiting)
+        summary.external_blockers_waited += len(waiting)
         summary.external_blockers_fatal += len(blockers.fatal)
 
-        if blockers.waiting and not blockers.fatal:
-            # Waiting on work someone else is doing — the same call the
-            # denied_this_round branch above makes, and for the same reason:
-            # running == 0 here does not mean the environment is idle. The
-            # blocker's completion wakes this scheduler; a lost wake-up is
-            # covered by the watchdog. Logged every pass on purpose: a build
-            # that sits here needs to be diagnosable from the tick logs
-            # alone.
+        if waiting and not blockers.fatal:
+            # Waiting on work another build is doing or is about to do — the
+            # same call the denied_this_round branch above makes, and for the
+            # same reason: running == 0 here does not mean the environment is
+            # idle. The blocker's completion wakes this scheduler; a lost
+            # wake-up is covered by the watchdog. Logged every pass on
+            # purpose: a build that sits here needs to be diagnosable from
+            # the tick logs alone.
             if config.stale_external_blocker_seconds is None:
                 bound_note = " (staleness bound disabled — this wait is unbounded)"
-            elif any(
-                blocker.blocking_status_at is None for blocker in blockers.waiting
-            ):
+            elif any(verdict.blocker.blocking_status_at is None for verdict in waiting):
                 bound_note = (
                     " (a blocker carries no status timestamp, so its wait "
                     "cannot be bounded)"
                 )
             else:
                 bound_note = ""
+            # Spelled out as "executing" vs "queued in a live build" because
+            # the two are different operational situations: one is work in
+            # progress, the other is work another build has not started yet.
+            held_by = " and ".join(
+                part
+                for part in (
+                    f"{len(blockers.executing)} being executed elsewhere"
+                    if blockers.executing
+                    else "",
+                    f"{len(blockers.queued)} queued in a build that is still live"
+                    if blockers.queued
+                    else "",
+                )
+                if part
+            )
             logger.info(
-                f"Build {build_id} has nothing to schedule but is blocked by "
-                f"{len(blockers.waiting)} task(s) running in other build(s); "
-                f"waiting rather than failing{bound_note}: "
-                f"{_describe_blockers(blockers.waiting, now, truncated)}"
+                f"Build {build_id} has nothing runnable or running of its own "
+                f"but is waiting on {len(waiting)} upstream task(s) owned by "
+                f"other builds ({held_by}); waiting rather than failing"
+                f"{bound_note}: {_describe_blockers(waiting, now, truncated)}"
             )
             return None
 
         await _skip_blocked(registry, build_id, summary)
         if blockers.fatal:
             # Precise, actionable failure: which task, its name, its status,
-            # how long it has been in it, and which build owns it — plus how
-            # to release it. The status counts alone (the whole of the old
-            # message) point nowhere near the cause when the cause is not in
-            # this build's task set at all.
+            # how long it has been in it, which build owns it, why that owner
+            # is not going to move it — plus how to release it. The status
+            # counts alone (the whole of the old message) point nowhere near
+            # the cause when the cause is not in this build's task set at all.
             reason = (
-                f"Build is blocked by {len(blockers.fatal)} task(s) owned by "
-                "another build that nobody is executing, and has nothing "
-                f"runnable or running of its own (status counts: {counts}). "
-                f"Blocked by: {_describe_blockers(blockers.fatal, now, truncated)}"
+                f"Build cannot progress: it has nothing runnable or running "
+                f"of its own, and {len(blockers.fatal)} of its task(s) are "
+                "blocked by an upstream owned by another build that no live "
+                f"build is going to run (status counts: {counts}). Blocked "
+                f"by: {_describe_blockers(blockers.fatal, now, truncated)}"
                 f". {_blocker_remediation(blockers.fatal)}"
             )
         else:

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -23,7 +23,11 @@ with detached support. Requirements and current limitations:
 - A real registry (frontier computation is registry-backed; the reactive
   marker/owner live in the frontier's ``reactive_app_name``).
 - Task objects are rehydrated from the :class:`BuildTaskStore` — written by
-  the trigger (initial discovery) and by workers (dynamic deps).
+  the trigger (initial discovery) and by workers (dynamic deps) — or, when
+  the pickle is absent, reconstructed from the registry's stored task data.
+  The latter resolves only *registered* classes, i.e. classes whose
+  defining module the tick process has imported; see
+  ``stardag.build._task_modules`` for how an app declares those.
 - The global concurrency lock and build-local ``ConcurrencyConfig`` limits
   are not applied by ticks (infra-level limits, e.g. Modal per-function
   ``concurrency_limit``, still apply). Registry-backed named limits *are*
@@ -56,6 +60,7 @@ from stardag.build._base import (
     TaskExecutorABC,
     current_build_id_var,
 )
+from stardag.build._task_modules import import_failure_note
 from stardag.build._task_store import BuildTaskStore
 from stardag.exceptions import NotFoundError, is_missing_route_error
 from stardag.registry._api_registry import _is_route_not_found
@@ -360,6 +365,15 @@ async def _load_task(
     the stack trace — for callers where a missing object is tolerated (a
     RUNNING task resolves via its worker's self-reporting), the repeated
     per-tick ``logger.exception`` would be noise.
+
+    A rehydration failure is annotated with any declared task modules that
+    failed to import in this process (see
+    ``stardag.build._task_modules``): "no task class registered for X" and
+    "the module defining X blew up on import" are the same incident seen
+    from two ends, and only the annotation connects them. The annotation is
+    read from the task-module registry rather than plumbed through
+    ``rehydrate.py``, which stays a pure reconstruction primitive with no
+    notion of how its classes got imported.
     """
     task = task_store.load_task(task_id)
     if task is not None:
@@ -372,10 +386,11 @@ async def _load_task(
             f"Task {task_id} is missing from the task store and could not "
             f"be rehydrated from registry data"
         )
+        note = import_failure_note()
         if quiet:
-            logger.warning(f"{message}: {e}")
+            logger.warning(f"{message}: {e}{note}")
         else:
-            logger.exception(f"{message}.")
+            logger.exception(f"{message}.{note}")
         return None
     logger.info(f"Rehydrated task {task_id} from registry data.")
     try:

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -110,12 +110,26 @@ class DiscoveryResult:
     incomplete: dict[UUID, BaseTask] = field(default_factory=dict)
     # Tasks found already complete (registered + marked complete).
     previously_completed: list[BaseTask] = field(default_factory=list)
-    # Tasks whose failed/cancelled/skipped registry status was reset to
-    # pending (only when retry_failed=True).
+    # Tasks whose failed/cancelled/skipped/suspended registry status was
+    # reset to pending (only when retry_failed=True).
     retried: list[BaseTask] = field(default_factory=list)
 
 
-_RETRYABLE_STATUSES = ("failed", "cancelled", "skipped")
+# Statuses a re-trigger resets to PENDING (see discover_and_register_aio's
+# retry_failed). Mirrors the registry's own retryable set.
+#
+# SUSPENDED is in here — and is safe — because a suspended task has NO live
+# execution: suspension means the execution registered its dynamic
+# dependencies, yielded and *returned*. Resetting it therefore cannot orphan
+# a running worker; re-running from scratch is exactly what the retry
+# expresses. RUNNING is deliberately absent: it holds a live execution
+# claim, and releasing that claim is cancellation, not retry.
+#
+# Only the re-trigger path passes retry_failed=True. Workers registering
+# dynamically yielded deps call discover_and_register_aio with the default
+# (False), so a worker can never reset its own parent's SUSPENDED status
+# out from under itself.
+_RETRYABLE_STATUSES = ("failed", "cancelled", "skipped", "suspended")
 
 
 async def discover_and_register_aio(
@@ -137,9 +151,13 @@ async def discover_and_register_aio(
     registering dynamically yielded deps.
 
     With ``retry_failed=True``, incomplete tasks whose registry status is
-    failed/cancelled/skipped (from a previous build) are reset to pending
-    via ``task_retry`` — without it, a previously failed task would never
-    enter the frontier and would FAIL_FAST a new build on its first tick.
+    failed/cancelled/skipped/suspended (from a previous build) are reset to
+    pending via ``task_retry`` — without it, a previously failed task would
+    never enter the frontier and would FAIL_FAST a new build on its first
+    tick, and a task abandoned SUSPENDED (its orchestrator died, or its
+    build was cancelled mid dynamic-dependency yield) would stay
+    permanently unschedulable. See ``_RETRYABLE_STATUSES`` for why
+    resetting a SUSPENDED task cannot orphan a live execution.
     """
     result = DiscoveryResult()
     post_order: list[BaseTask] = []

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -35,6 +35,17 @@ with detached support. Requirements and current limitations:
 - On failure (FAIL_FAST) the build is failed, running executions are
   cancelled, and blocked descendants are marked SKIPPED (server-computed;
   older servers without the skip-blocked endpoint are tolerated).
+
+A build with nothing actionable and nothing running is *not* automatically
+stuck. Task rows and dependency edges are per environment, so an upstream
+that some other build left non-COMPLETED gates this build's tasks while
+contributing nothing to the counts this build can see. Terminal detection
+therefore consults the frontier's ``blocked_by_external`` before declaring
+a build dead: a blocker RUNNING under another build is waited on (bounded
+by ``TickConfig.stale_external_blocker_seconds``), while a blocker nobody
+is executing fails the build immediately with a message naming the task
+and the build that owns it. Against servers predating those fields the
+list is always empty and detection degrades to its pre-fix behaviour.
 """
 
 from __future__ import annotations
@@ -64,7 +75,12 @@ from stardag.build._task_modules import import_failure_note
 from stardag.build._task_store import BuildTaskStore
 from stardag.exceptions import NotFoundError, is_missing_route_error
 from stardag.registry._api_registry import _is_route_not_found
-from stardag.registry import BuildFrontier, FrontierTaskRef, RegistryABC
+from stardag.registry import (
+    BuildFrontier,
+    FrontierExternalBlocker,
+    FrontierTaskRef,
+    RegistryABC,
+)
 from stardag.registry._base import accepts_executor_metadata_kwarg
 
 logger = logging.getLogger(__name__)
@@ -205,6 +221,30 @@ class TickConfig:
     # its actual execution is unaffected and its completion (sticky) still
     # lands; generous default accordingly.
     stale_running_no_ref_seconds: float | None = 1800.0
+    # How long this build will wait on a blocker that is RUNNING under
+    # ANOTHER build before giving up and failing (see
+    # ``_classify_external_blockers``). Measured on the blocker's status
+    # timestamp — how long it has been RUNNING — not on tick-local time: a
+    # tick is short-lived and the watchdog keeps re-ticking, so a tick-local
+    # bound would never expire and the build would hang silently forever,
+    # which is the failure mode this whole path exists to remove.
+    #
+    # Deliberately generous (6 h). Waiting is the cheap direction: the
+    # blocker's own build has far better information about it (a live
+    # executor ref it can probe) and its completion wakes this build within
+    # a watchdog period, whereas failing a build whose blocker was merely
+    # slow is a regression of exactly the spurious-failure bug being fixed
+    # here. The bound is a backstop for a claim nobody will ever release —
+    # an abandoned RUNNING task whose owning build is gone — not a
+    # scheduling deadline. Raise it if your tasks routinely run longer than
+    # this; None waits indefinitely (pre-fix "hangs quietly" behaviour, with
+    # a per-tick warning naming the blocker).
+    #
+    # A blocker whose ``blocking_status_at`` is None (a task row predating
+    # server-side status denormalisation) cannot be aged, so it is waited on
+    # regardless of this bound — failing on missing information would
+    # reintroduce the spurious failures. The wait is logged as unbounded.
+    stale_external_blocker_seconds: float | None = 21600.0
 
 
 class _MissingTaskRef(typing.NamedTuple):
@@ -217,7 +257,11 @@ class _MissingTaskRef(typing.NamedTuple):
 
 @dataclass
 class TickSummary:
-    """Outcome of one scheduler tick, for logging/observability."""
+    """Outcome of one scheduler tick, for logging/observability.
+
+    Flat and JSON-friendly on purpose: the whole dataclass is serialized
+    with ``dataclasses.asdict`` and reported to the registry.
+    """
 
     outcome: str  # "not_reactive" | "lease_held" | "terminal" | "lingered_out"
     terminal_status: str | None = None
@@ -229,6 +273,20 @@ class TickSummary:
     limit_denied: int = 0
     claim_denied: int = 0
     skipped: int = 0
+    # Cross-build blocking, summed over the terminal evaluations of this
+    # tick (like limit_denied, these are counts of observations, not of
+    # distinct tasks — one blocker seen on three linger passes counts
+    # three times).
+    #
+    # ``external_blockers`` is every entry the frontier reported while the
+    # build looked stalled, including in-build ones; ``waited`` and
+    # ``fatal`` split only the out-of-build entries, so the three do not
+    # add up. A tick with waited > 0 and fatal == 0 is the healthy
+    # "waiting on another build" state; fatal > 0 always accompanies a
+    # failed build.
+    external_blockers: int = 0
+    external_blockers_waited: int = 0
+    external_blockers_fatal: int = 0
 
 
 async def run_tick_aio(
@@ -650,6 +708,154 @@ async def _resolve_running(
     return "leave"
 
 
+class _ExternalBlockers(typing.NamedTuple):
+    """Partition of a frontier's ``blocked_by_external`` (see below)."""
+
+    # Out-of-build and RUNNING within the staleness bound: someone else is
+    # executing it, and their completion frees this build. Wait.
+    waiting: list[FrontierExternalBlocker]
+    # Out-of-build and NOT going to run — either not RUNNING at all, or
+    # RUNNING for longer than ``stale_external_blocker_seconds``. Fail.
+    fatal: list[FrontierExternalBlocker]
+    # In this build's own task set: already accounted for by actionable /
+    # running / status_counts, so it must not influence the wait-or-fail
+    # decision. Kept only to enrich the message.
+    in_build: list[FrontierExternalBlocker]
+
+
+def _blocker_label(blocker: FrontierExternalBlocker) -> str:
+    """``namespace.Name`` of a blocker (namespace is "" by default)."""
+    if blocker.blocking_task_namespace:
+        return f"{blocker.blocking_task_namespace}.{blocker.blocking_task_name}"
+    return blocker.blocking_task_name
+
+
+def _blocker_status_age_seconds(
+    blocker: FrontierExternalBlocker, now: datetime
+) -> float | None:
+    """Seconds the blocker has been in its current status, None if unknown.
+
+    Naive timestamps (a custom registry that drops the offset) are read as
+    UTC rather than raising: this runs on the path that decides whether to
+    fail a build, so a formatting quirk must not become a tick crash.
+    """
+    if blocker.blocking_status_at is None:
+        return None
+    status_at = blocker.blocking_status_at
+    if status_at.tzinfo is None:
+        status_at = status_at.replace(tzinfo=timezone.utc)
+    return (now - status_at).total_seconds()
+
+
+def _classify_external_blockers(
+    frontier: BuildFrontier, config: TickConfig, now: datetime
+) -> _ExternalBlockers:
+    """Split the frontier's external blockers into wait / fail / ignore.
+
+    The frontier reports these only when the build has nothing actionable
+    and nothing running — precisely the state the stuck-build check reads
+    as "this build is dead". The split decides whether it actually is:
+
+    - ``blocking_in_build`` → ignored. The blocker is in this build's own
+      task set, so it is already visible in ``actionable``/``running``/
+      ``status_counts``; letting it also drive this decision would
+      double-count it (and a blocker that is genuinely stuck *in* this
+      build must still fail the build, exactly as before).
+    - out-of-build and RUNNING → **wait**. Another build is executing it;
+      its completion unblocks this build and wakes this scheduler. Treated
+      like a concurrency-limit denial: return, don't fail. Bounded by
+      ``config.stale_external_blocker_seconds`` against the blocker's own
+      status timestamp, since a tick is too short-lived to bound anything
+      itself — see that field for the rationale and the None cases.
+    - out-of-build and anything else (pending/suspended/failed/cancelled/
+      skipped) → **fail now**. Nobody is executing it and this build will
+      never schedule it, so waiting would be waiting forever. (Narrow
+      exception this deliberately does not carve out: a PENDING blocker
+      belonging to another *live* build will be scheduled by that build.
+      It is rare — a build's discovery registers the whole static
+      dependency tree, so out-of-build blockers are dynamic dependencies
+      of an earlier build — and the failure now says exactly which task to
+      retry, unlike the silent hang it replaces.)
+    """
+    waiting: list[FrontierExternalBlocker] = []
+    fatal: list[FrontierExternalBlocker] = []
+    in_build: list[FrontierExternalBlocker] = []
+    stale_after = config.stale_external_blocker_seconds
+    for blocker in frontier.blocked_by_external:
+        if blocker.blocking_in_build:
+            in_build.append(blocker)
+            continue
+        if blocker.blocking_status not in _RUNNING_STATUSES:
+            fatal.append(blocker)
+            continue
+        age = _blocker_status_age_seconds(blocker, now)
+        if stale_after is not None and age is not None and age > stale_after:
+            fatal.append(blocker)
+        else:
+            waiting.append(blocker)
+    return _ExternalBlockers(waiting=waiting, fatal=fatal, in_build=in_build)
+
+
+# How many blockers a log line or build error names before summarising the
+# rest. The server already caps its list (hence blocked_by_external_
+# truncated); this second cap keeps a build's error_message readable when a
+# wide DAG is stalled behind a single upstream.
+_MAX_REPORTED_BLOCKERS = 5
+
+
+def _describe_blockers(
+    blockers: Sequence[FrontierExternalBlocker], now: datetime, truncated: bool
+) -> str:
+    """One-line, user-actionable rendering of blockers (names, not ids only).
+
+    ``truncated`` is the frontier's ``blocked_by_external_truncated``: the
+    server capped its list, so this must not read as an exhaustive account.
+    """
+    described = "; ".join(
+        (
+            f"task {blocker.task_id} is blocked by {_blocker_label(blocker)} "
+            f"({blocker.blocking_task_id}), {blocker.blocking_status.upper()}"
+            + (
+                ""
+                if (age := _blocker_status_age_seconds(blocker, now)) is None
+                else f" for {age:.0f}s"
+            )
+            + (
+                f" under build {blocker.blocking_status_build_id}"
+                if blocker.blocking_status_build_id is not None
+                else " under an unrecorded build"
+            )
+        )
+        for blocker in blockers[:_MAX_REPORTED_BLOCKERS]
+    )
+    remaining = len(blockers) - _MAX_REPORTED_BLOCKERS
+    if remaining > 0:
+        described += f"; and {remaining} more"
+    if truncated:
+        described += (
+            "; the registry capped the blocker list, so there may be further "
+            "blockers not shown"
+        )
+    return described
+
+
+def _blocker_remediation(blockers: Sequence[FrontierExternalBlocker]) -> str:
+    """How to get out of it — the part #208 says today's error lacks."""
+    remedy = (
+        "Retry the blocking task under the build that owns it "
+        "(POST /api/v1/builds/{build_id}/tasks/{task_id}/retry) to reset it "
+        "to pending — this now works from suspended as well as from "
+        "failed/cancelled/skipped — then re-trigger this build"
+    )
+    if any(blocker.blocking_status in _RUNNING_STATUSES for blocker in blockers):
+        remedy += (
+            ". A blocker stuck RUNNING holds an execution claim no retry can "
+            "take: cancel it (POST /api/v1/builds/{build_id}/tasks/{task_id}"
+            "/cancel) to release the claim first"
+        )
+    return remedy + "."
+
+
 async def _handle_terminal(
     frontier: BuildFrontier,
     *,
@@ -661,7 +867,13 @@ async def _handle_terminal(
     summary: TickSummary,
     denied_this_round: int = 0,
 ) -> str | None:
-    """Evaluate terminal conditions; emit build events. Returns terminal status."""
+    """Evaluate terminal conditions; emit build events. Returns terminal status.
+
+    Returning ``None`` means "not terminal — keep waiting", which covers
+    both a build with work in flight and a build with nothing of its own to
+    do that is legitimately waiting on another build (see
+    :func:`_classify_external_blockers`).
+    """
     if frontier.build_status in _TERMINAL_BUILD_STATUSES:
         if frontier.build_status == "cancelled":
             # Cancelled externally (e.g. UI): stop the running work.
@@ -701,15 +913,79 @@ async def _handle_terminal(
     # Note: spawns within this iteration imply frontier.actionable was
     # non-empty, so this check can't misfire on the pre-spawn snapshot.
     if not frontier.actionable and running == 0:
-        # Nothing runnable and nothing running: the build can't progress
-        # (failed deps in CONTINUE mode, or a lost task pickle). Fail
-        # rather than idle forever.
+        # Nothing runnable and nothing *in this build* running. That is not
+        # the same as "the build can't progress": dependency gating is
+        # environment-global while these counts are build-scoped, so a task
+        # some other build is executing gates this build's tasks while
+        # showing up in neither. Ask the frontier which it is before
+        # declaring the build dead (#208 A1) — the list is populated only in
+        # this exact state, and is empty against servers predating it, in
+        # which case everything below degrades to the old unconditional
+        # failure.
+        now = datetime.now(timezone.utc)
+        truncated = frontier.blocked_by_external_truncated
+        blockers = _classify_external_blockers(frontier, config, now)
+        summary.external_blockers += len(frontier.blocked_by_external)
+        summary.external_blockers_waited += len(blockers.waiting)
+        summary.external_blockers_fatal += len(blockers.fatal)
+
+        if blockers.waiting and not blockers.fatal:
+            # Waiting on work someone else is doing — the same call the
+            # denied_this_round branch above makes, and for the same reason:
+            # running == 0 here does not mean the environment is idle. The
+            # blocker's completion wakes this scheduler; a lost wake-up is
+            # covered by the watchdog. Logged every pass on purpose: a build
+            # that sits here needs to be diagnosable from the tick logs
+            # alone.
+            if config.stale_external_blocker_seconds is None:
+                bound_note = " (staleness bound disabled — this wait is unbounded)"
+            elif any(
+                blocker.blocking_status_at is None for blocker in blockers.waiting
+            ):
+                bound_note = (
+                    " (a blocker carries no status timestamp, so its wait "
+                    "cannot be bounded)"
+                )
+            else:
+                bound_note = ""
+            logger.info(
+                f"Build {build_id} has nothing to schedule but is blocked by "
+                f"{len(blockers.waiting)} task(s) running in other build(s); "
+                f"waiting rather than failing{bound_note}: "
+                f"{_describe_blockers(blockers.waiting, now, truncated)}"
+            )
+            return None
+
         await _skip_blocked(registry, build_id, summary)
-        await registry.build_fail_aio(
-            build_id,
-            "No runnable or running tasks left but roots are not complete "
-            f"(status counts: {counts})",
-        )
+        if blockers.fatal:
+            # Precise, actionable failure: which task, its name, its status,
+            # how long it has been in it, and which build owns it — plus how
+            # to release it. The status counts alone (the whole of the old
+            # message) point nowhere near the cause when the cause is not in
+            # this build's task set at all.
+            reason = (
+                f"Build is blocked by {len(blockers.fatal)} task(s) owned by "
+                "another build that nobody is executing, and has nothing "
+                f"runnable or running of its own (status counts: {counts}). "
+                f"Blocked by: {_describe_blockers(blockers.fatal, now, truncated)}"
+                f". {_blocker_remediation(blockers.fatal)}"
+            )
+        else:
+            # No out-of-build blocker: genuinely stuck (failed deps in
+            # CONTINUE mode, a lost task pickle, or a blocker inside this
+            # build that will never run). Fail rather than idle forever —
+            # naming any in-build blockers, which are otherwise invisible in
+            # the status counts.
+            reason = (
+                "No runnable or running tasks left but roots are not "
+                f"complete (status counts: {counts})"
+            )
+            if blockers.in_build:
+                reason += ". Blocked within this build by: " + _describe_blockers(
+                    blockers.in_build, now, truncated
+                )
+        logger.error(f"Failing build {build_id}: {reason}")
+        await registry.build_fail_aio(build_id, reason)
         return "failed"
 
     return None

--- a/lib/stardag/src/stardag/build/_task_modules.py
+++ b/lib/stardag/src/stardag/build/_task_modules.py
@@ -358,9 +358,18 @@ def count_registered_task_classes(modules: typing.Iterable[str]) -> int:
 
 
 def _reset_import_state_for_tests() -> None:
-    """Clear the per-process import cache/failure record (tests only)."""
+    """Reset **all** module-level state (tests only).
+
+    Every piece of ambient state this module keeps, not just the import
+    cache: a declaration or a one-shot warning surviving into the next test
+    makes results depend on execution order, and `only_unwarned=True` in
+    particular is silently order-sensitive.
+    """
     _import_cache.clear()
     _last_failures.clear()
+    _warned_classes.clear()
+    global _declared_patterns
+    _declared_patterns = ()
 
 
 # =============================================================================
@@ -379,7 +388,20 @@ def set_declared_task_module_patterns(patterns: typing.Sequence[str]) -> None:
     several frames below any reference to the app object.
     """
     global _declared_patterns
-    _declared_patterns = tuple(patterns)
+    # Normalised, not stored verbatim: these patterns drive coverage checks
+    # and the pickle-elision decision, and a stray space makes a pattern
+    # match nothing while still reading as a declaration at the call site.
+    # A silently-inert declaration is the worst outcome here — it turns
+    # "ticks reconstruct tasks by import" back into "ticks need the
+    # pickles" with no signal.
+    cleaned = tuple(p.strip() for p in patterns)
+    if any(not p for p in cleaned):
+        raise ValueError(
+            f"task-module patterns must be non-empty: {list(patterns)!r}. "
+            "An empty or whitespace-only pattern matches no module, so the "
+            "declaration would be silently inert."
+        )
+    _declared_patterns = cleaned
 
 
 def declared_task_module_patterns() -> tuple[str, ...]:

--- a/lib/stardag/src/stardag/build/_task_modules.py
+++ b/lib/stardag/src/stardag/build/_task_modules.py
@@ -1,0 +1,541 @@
+"""Declaring the modules whose import registers a build's task classes.
+
+Reactive scheduling reconstructs task *objects* from data, and the two
+available paths have disjoint failure modes:
+
+======================================  ====================================
+path                                    fails when
+======================================  ====================================
+pickle from the ``BuildTaskStore``      the app was redeployed (pickles are
+                                        same-deployment only), or the target
+                                        root is not writable
+``task_from_registry_data``             the module defining the task class
+                                        was never imported in the
+                                        reconstructing process
+======================================  ====================================
+
+The second failure mode is easy to miss. A pickle embeds
+``module.QualName`` and ``pickle.loads`` **self-imports**, so it resolves
+its class regardless of what the container happened to import. Polymorphic
+JSON carries only ``__namespace`` / ``__name``; ``get_class()`` is a plain
+dict lookup that raises ``KeyError`` and **never attempts an import**.
+Since the default namespace is ``""`` (the module path is consulted only to
+resolve an explicitly registered namespace), the stored payload generally
+contains no module locator at all. Task classes register at *class
+definition* time, so the only way to make a class resolvable is to import
+its defining module.
+
+Meanwhile the deployed scheduler tick is defined inside stardag itself and
+drags in user modules only incidentally — whatever the app's selector
+callables transitively import. That is arbitrary, and usually does not
+cover a DAG's task classes: DAGs are typically assembled in scripts and
+entrypoints rather than in the module defining the app.
+
+Hence this module: a way for an app to *declare* the modules whose import
+registers the task classes it may schedule, so a scheduler process can make
+itself able to reconstruct them. Nothing here is Modal-specific, and
+nothing here is needed by a resident (non-reactive) build — a resident
+orchestrator holds the real task objects, and workers receive tasks by
+value (self-importing, like any unpickle).
+
+Three pieces, used at three different times:
+
+1. **Deploy time** — :func:`expand_task_module_patterns` turns the declared
+   patterns into a concrete, sorted module list *without importing the
+   submodules*, so the deployed set is explicit and auditable and container
+   startup does no filesystem walking.
+2. **Container startup** — :func:`import_task_modules` imports that baked
+   list once per container. A module that fails to import warns rather than
+   aborting the tick, but the failure is retained
+   (:func:`last_import_failures`) so a later rehydration error can point at
+   it.
+3. **Trigger time** — :func:`uncovered_task_classes` and
+   :func:`plan_pickle_elision` answer "will a tick be able to rebuild this
+   task from registry data alone?" for a concrete task set, which is what
+   lets the trigger skip writing pickles (and warn about the classes it
+   cannot skip).
+
+Pattern grammar
+---------------
+
+A pattern is either an exact module (``"a.b.c"``) or a trailing recursive
+wildcard (``"a.b.*"``, matching ``a.b`` and everything below it). A ``*``
+anywhere but the final component, an empty pattern, or a component that is
+not a valid identifier is a :class:`TaskModulesError` — a malformed pattern
+must never degrade into a silent no-match, because the symptom would be a
+scheduler tick failing to rebuild a task hours later.
+
+Two deliberate expansion choices, both about what a wildcard sweeps up:
+
+- ``__main__`` submodules are **skipped**. They are CLI entrypoints, run
+  for their side effects; importing one in every scheduler container is at
+  best wasted work and at worst an unwanted execution.
+- ``_``-prefixed modules are **not** skipped. A user's ``_tasks.py`` is a
+  perfectly ordinary place to define task classes, and the leading
+  underscore is a statement about *their* API, not about ours.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import pkgutil
+import typing
+from dataclasses import dataclass, field
+
+from stardag._core.base_task import BaseTask
+from stardag._core.rehydrate import task_from_registry_data
+from stardag.exceptions import StardagError
+
+logger = logging.getLogger(__name__)
+
+_WILDCARD_SUFFIX = ".*"
+
+
+class TaskModulesError(StardagError):
+    """A task-module declaration is malformed, unexpandable, or unsatisfied."""
+
+
+# =============================================================================
+# Patterns: validation, expansion, coverage
+# =============================================================================
+
+
+def validate_task_module_patterns(
+    patterns: typing.Iterable[str],
+) -> tuple[str, ...]:
+    """Validate task-module patterns; return them deduped and sorted.
+
+    Raises:
+        TaskModulesError: For anything that is not an exact dotted module
+            path or such a path followed by a trailing ``.*``.
+    """
+    validated: set[str] = set()
+    for pattern in patterns:
+        if not isinstance(pattern, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TaskModulesError(
+                f"task_modules entries must be strings, got {pattern!r} "
+                f"({type(pattern).__name__})."
+            )
+        _validate_one(pattern)
+        validated.add(pattern)
+    return tuple(sorted(validated))
+
+
+def _validate_one(pattern: str) -> None:
+    problem = _pattern_problem(pattern)
+    if problem is None:
+        return
+    raise TaskModulesError(
+        f"Invalid task_modules pattern {pattern!r}: {problem}. A pattern is "
+        'either an exact module ("my_pkg.tasks.ingest") or a package '
+        'followed by a trailing recursive wildcard ("my_pkg.tasks.*").'
+    )
+
+
+def _pattern_problem(pattern: str) -> str | None:
+    if not pattern or pattern.strip() != pattern:
+        return "it is empty or has surrounding whitespace"
+    if pattern in ("*", _WILDCARD_SUFFIX):
+        return (
+            "a bare wildcard would match every importable module; name at "
+            "least the root package"
+        )
+    components = pattern.split(".")
+    if pattern.endswith(_WILDCARD_SUFFIX):
+        components = components[:-1]
+    for component in components:
+        if component == "*":
+            return "'*' is only allowed as the final component"
+        if not component.isidentifier():
+            return f"component {component!r} is not a valid Python identifier"
+    return None
+
+
+def module_is_covered(module_name: str, patterns: typing.Sequence[str]) -> bool:
+    """Whether importing the declared ``patterns`` reaches ``module_name``.
+
+    Mirrors :func:`expand_task_module_patterns`, including its ``__main__``
+    exclusion — a class defined in a ``__main__`` module is never
+    reconstructable in a scheduler container, wildcard or not.
+    """
+    if module_name == "__main__" or module_name.endswith(".__main__"):
+        return False
+    for pattern in patterns:
+        if pattern.endswith(_WILDCARD_SUFFIX):
+            root = pattern[: -len(_WILDCARD_SUFFIX)]
+            if module_name == root or module_name.startswith(root + "."):
+                return True
+        elif module_name == pattern:
+            return True
+    return False
+
+
+def suggested_pattern_for(module_name: str) -> str:
+    """The narrowest pattern that would cover ``module_name``.
+
+    The module's own package plus a recursive wildcard (or the module
+    itself when it is top-level) — precise enough to paste into
+    ``task_modules`` without dragging in half the source tree.
+    """
+    package, _, _ = module_name.rpartition(".")
+    return f"{package}{_WILDCARD_SUFFIX}" if package else module_name
+
+
+def expand_task_module_patterns(
+    patterns: typing.Iterable[str],
+) -> list[str]:
+    """Expand patterns to the concrete, sorted, deduped module list.
+
+    **Importing is avoided wherever it can be.** ``pkgutil.walk_packages``
+    is deliberately not used: it imports each package to reach its
+    ``__path__``, which would run every ``__init__.py`` in the tree just to
+    *list* names. Only the root package of a ``"pkg.*"`` pattern is
+    imported (unavoidable — its ``__path__`` is the entry point to the
+    tree); everything below it is discovered from the filesystem with
+    ``pkgutil.iter_modules``.
+
+    Raises:
+        TaskModulesError: If a pattern is malformed, or the root package of
+            a wildcard pattern cannot be imported (a typo'd pattern must
+            fail loudly at deploy time rather than expand to nothing).
+    """
+    modules: set[str] = set()
+    for pattern in validate_task_module_patterns(patterns):
+        if not pattern.endswith(_WILDCARD_SUFFIX):
+            modules.add(pattern)
+            continue
+        root = pattern[: -len(_WILDCARD_SUFFIX)]
+        modules.add(root)
+        modules.update(_iter_submodules(root, pattern))
+    return sorted(modules)
+
+
+def _iter_submodules(root: str, pattern: str) -> typing.Iterator[str]:
+    try:
+        package = importlib.import_module(root)
+    except Exception as e:
+        raise TaskModulesError(
+            f"Cannot expand task_modules pattern {pattern!r}: the root "
+            f"package {root!r} could not be imported ({type(e).__name__}: "
+            f"{e}). Expansion needs the package's __path__; check the "
+            "pattern for typos and make sure the package is importable "
+            "from the process running the deploy."
+        ) from e
+    search_paths = list(getattr(package, "__path__", []))
+    if not search_paths:
+        # A plain module, not a package: the wildcard has nothing below it
+        # to recurse into. The root itself is already included by the
+        # caller, so this is a harmless (if pointless) pattern.
+        return
+    # Guard against symlink loops in the source tree: a directory is walked
+    # at most once, by its resolved path.
+    seen_dirs: set[str] = set()
+    stack: list[tuple[str, list[str]]] = [(root, search_paths)]
+    while stack:
+        prefix, paths = stack.pop()
+        for path in paths:
+            real = os.path.realpath(path)
+            if real in seen_dirs:
+                continue
+            seen_dirs.add(real)
+            for module_info in pkgutil.iter_modules([path]):
+                if module_info.name == "__main__":
+                    # Entrypoints: usually side-effectful, never a place to
+                    # define task classes (see the module docstring).
+                    continue
+                qualified = f"{prefix}.{module_info.name}"
+                yield qualified
+                if module_info.ispkg:
+                    stack.append((qualified, [os.path.join(path, module_info.name)]))
+
+
+# =============================================================================
+# Importing (in the reconstructing process)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class TaskModuleImportReport:
+    """Outcome of :func:`import_task_modules`."""
+
+    imported: tuple[str, ...] = ()
+    # module name -> "ExceptionType: message"
+    failures: dict[str, str] = field(default_factory=dict)
+
+    @property
+    def task_classes_registered(self) -> int:
+        """Task classes registered from the imported modules.
+
+        Counted after the fact from the polymorphic registry rather than as
+        a delta, so it is stable when some modules were already imported.
+        """
+        return count_registered_task_classes(self.imported)
+
+
+_import_cache: dict[tuple[str, ...], TaskModuleImportReport] = {}
+_last_failures: dict[str, str] = {}
+
+
+def import_task_modules(
+    modules: typing.Sequence[str],
+) -> TaskModuleImportReport:
+    """Import ``modules`` so their task classes register; never raise.
+
+    Idempotent and cached on the exact module list: a container that serves
+    many scheduler ticks pays the walk once, and re-importing an
+    already-imported module is a ``sys.modules`` hit anyway.
+
+    A module that fails to import is **warned about, not fatal** — one bad
+    module (a missing optional dependency, a syntax error in a module
+    nobody schedules) must not take the whole scheduler down. The failures
+    are retained in the report and in :func:`last_import_failures` so that
+    a downstream "no task class registered for …" error can name the likely
+    cause instead of leaving the user to guess.
+    """
+    global _last_failures
+    key = tuple(modules)
+    cached = _import_cache.get(key)
+    if cached is not None:
+        _last_failures = dict(cached.failures)
+        return cached
+
+    imported: list[str] = []
+    failures: dict[str, str] = {}
+    for module in modules:
+        try:
+            importlib.import_module(module)
+        except Exception as e:
+            failures[module] = f"{type(e).__name__}: {e}"
+            logger.warning(
+                f"Declared task module {module!r} failed to import: "
+                f"{type(e).__name__}: {e}. Task classes defined there will "
+                "not be reconstructable from registry data."
+            )
+            continue
+        imported.append(module)
+    report = TaskModuleImportReport(imported=tuple(imported), failures=failures)
+    _import_cache[key] = report
+    _last_failures = dict(failures)
+    logger.info(
+        f"Imported {len(imported)}/{len(key)} declared task module(s)"
+        + (f"; {len(failures)} failed: {sorted(failures)}" if failures else ".")
+    )
+    return report
+
+
+def last_import_failures() -> dict[str, str]:
+    """Task modules that failed to import in this process, most recent call.
+
+    Diagnostics hook: a ``TaskRehydrationError`` naming an unresolved class
+    is far more actionable when it can add "…and by the way, these declared
+    task modules failed to import".
+    """
+    return dict(_last_failures)
+
+
+def import_failure_note(max_listed: int = 5) -> str:
+    """A one-line addendum naming import failures, or ``""`` if there were none."""
+    failures = _last_failures
+    if not failures:
+        return ""
+    listed = sorted(failures)[:max_listed]
+    rendered = "; ".join(f"{name} ({failures[name]})" for name in listed)
+    more = len(failures) - len(listed)
+    return (
+        f" Note: {len(failures)} declared task module(s) failed to import in "
+        f"this process, which is a likely cause: {rendered}"
+        + (f" (+{more} more)" if more else "")
+        + "."
+    )
+
+
+def count_registered_task_classes(modules: typing.Iterable[str]) -> int:
+    """How many registered task classes are defined in ``modules``."""
+    wanted = set(modules)
+    return sum(1 for cls in BaseTask._registry().classes() if cls.__module__ in wanted)
+
+
+def _reset_import_state_for_tests() -> None:
+    """Clear the per-process import cache/failure record (tests only)."""
+    _import_cache.clear()
+    _last_failures.clear()
+
+
+# =============================================================================
+# The ambient declaration (for code far from the app object)
+# =============================================================================
+
+_declared_patterns: tuple[str, ...] = ()
+
+
+def set_declared_task_module_patterns(patterns: typing.Sequence[str]) -> None:
+    """Record the executing app's task-module patterns for this process.
+
+    Deployed worker/scheduler entrypoints bake the app's patterns into
+    their closure and publish them here, because the code that needs them
+    — dynamic-dependency registration inside a worker, for instance — sits
+    several frames below any reference to the app object.
+    """
+    global _declared_patterns
+    _declared_patterns = tuple(patterns)
+
+
+def declared_task_module_patterns() -> tuple[str, ...]:
+    """The patterns published by :func:`set_declared_task_module_patterns`."""
+    return _declared_patterns
+
+
+# =============================================================================
+# Coverage of a concrete task set
+# =============================================================================
+
+_warned_classes: set[str] = set()
+
+
+def uncovered_task_classes(
+    tasks: typing.Iterable[BaseTask],
+    patterns: typing.Sequence[str],
+    *,
+    only_unwarned: bool = False,
+) -> list[type[BaseTask]]:
+    """Distinct classes in ``tasks`` that ``patterns`` does not reach.
+
+    Args:
+        tasks: The tasks to check. At trigger time this should be the
+            *incomplete* discovered set — the only tasks a tick ever
+            rehydrates.
+        patterns: The app's declared task-module patterns.
+        only_unwarned: Report each class at most once per process, and
+            record the ones reported. For hot paths (every worker
+            registering dynamic deps) where the same class would otherwise
+            produce the same warning on every invocation.
+    """
+    seen: dict[str, type[BaseTask]] = {}
+    for task in tasks:
+        cls = type(task)
+        key = f"{cls.__module__}.{cls.__qualname__}"
+        if key in seen or module_is_covered(cls.__module__, patterns):
+            continue
+        if only_unwarned:
+            if key in _warned_classes:
+                continue
+            _warned_classes.add(key)
+        seen[key] = cls
+    return [seen[key] for key in sorted(seen)]
+
+
+def format_uncovered_message(
+    uncovered: typing.Sequence[type[BaseTask]],
+    patterns: typing.Sequence[str],
+    *,
+    remedy: str = "",
+) -> str:
+    """Render the actionable "these classes are not covered" message."""
+    names = [f"{cls.__module__}.{cls.__qualname__}" for cls in uncovered]
+    suggestions = sorted({suggested_pattern_for(cls.__module__) for cls in uncovered})
+    head = (
+        f"Task class {names[0]} is"
+        if len(names) == 1
+        else f"{len(names)} task classes ({', '.join(names)}) are"
+    )
+    declared = list(patterns) if patterns else "not declared"
+    return (
+        f"{head} not covered by this app's task_modules ({declared}). A "
+        "reactive scheduler tick will not be able to reconstruct them from "
+        "registry data, so they stay dependent on the build task store's "
+        f"pickles. Add {suggestions} to task_modules and redeploy the app."
+        + (f" {remedy}" if remedy else "")
+    )
+
+
+# =============================================================================
+# Conditional pickle elision
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class PickleElisionPlan:
+    """Which tasks still need a pickle in the build task store, and why.
+
+    A task needs no pickle when its class is covered by the declared
+    patterns *and* its registration payload round-trips back to the same
+    task id. Everything else keeps the pickle it would have gotten anyway,
+    so the feature is purely subtractive — nothing that works today stops
+    working because a task did not qualify.
+    """
+
+    pickle_free: tuple[BaseTask, ...] = ()
+    # (task, reason) for the tasks that must still be pickled
+    pickled: tuple[tuple[BaseTask, str], ...] = ()
+
+    def summary(self) -> str:
+        """One-line log summary: counts, plus the distinct reasons."""
+        line = (
+            f"{len(self.pickle_free)} task(s) pickle-free, {len(self.pickled)} pickled"
+        )
+        if not self.pickled:
+            return line + "."
+        reasons: dict[str, int] = {}
+        for _, reason in self.pickled:
+            reasons[reason] = reasons.get(reason, 0) + 1
+        rendered = "; ".join(
+            f"{reason} (x{count})" if count > 1 else reason
+            for reason, count in sorted(reasons.items())
+        )
+        return f"{line} — {rendered}."
+
+    def require_pickle_free_error(self) -> str | None:
+        """Message for ``require_pickle_free``, or None if everything qualified."""
+        if not self.pickled:
+            return None
+        lines = [
+            f"  - {type(task).__module__}.{type(task).__qualname__} "
+            f"(task {task.id}): {reason}"
+            for task, reason in self.pickled
+        ]
+        return (
+            f"require_pickle_free=True, but {len(self.pickled)} task(s) "
+            "cannot be reconstructed from registry data alone and would "
+            "need a pickle in the build task store:\n" + "\n".join(lines)
+        )
+
+
+_UNCOVERED_REASON = "task class not covered by task_modules"
+
+
+def plan_pickle_elision(
+    tasks: typing.Iterable[BaseTask],
+    patterns: typing.Sequence[str],
+) -> PickleElisionPlan:
+    """Decide, per task, whether the build task store still needs its pickle.
+
+    The self-check reconstructs the task from exactly the payload that
+    registration stores (``model_dump(mode="json")`` — see
+    ``_get_task_data_for_registration``), so it is a faithful dry run of
+    what a scheduler tick will do. Note this is *cheaper* than the write it
+    replaces: pure CPU, versus a per-task target-root existence check plus
+    a conditional upload.
+
+    ``AliasTask`` payloads fail the check by construction (rehydration
+    refuses ``__aliased`` data, whose pickled ``loads_type`` would be an
+    execution primitive in a scheduler process), as do dynamically
+    generated and otherwise non-importable classes. Those are exactly the
+    cases that keep their pickles.
+    """
+    pickle_free: list[BaseTask] = []
+    pickled: list[tuple[BaseTask, str]] = []
+    for task in tasks:
+        if not module_is_covered(type(task).__module__, patterns):
+            pickled.append((task, _UNCOVERED_REASON))
+            continue
+        try:
+            task_from_registry_data(
+                task.model_dump(mode="json"), expected_task_id=task.id
+            )
+        except Exception as e:
+            pickled.append((task, f"registry-data round-trip failed ({e})"))
+            continue
+        pickle_free.append(task)
+    return PickleElisionPlan(pickle_free=tuple(pickle_free), pickled=tuple(pickled))

--- a/lib/stardag/src/stardag/build/_task_store.py
+++ b/lib/stardag/src/stardag/build/_task_store.py
@@ -22,6 +22,16 @@ immutable object), so the store is compatible with immutable/append-only
 target roots. Same-deployment guarantee applies: a pickle is only loaded by
 containers of the same deployed app version that wrote it — the same
 constraint as passing tasks to workers by value.
+
+The store is a *fallback*, not the primary path. When the app declares its
+task modules (see ``stardag.build._task_modules``) the writer skips every
+task a scheduler tick can rebuild from the registry's stored data, and a
+fully covered build writes nothing here at all — no target-root write
+access needed, and no same-deployment constraint to trip over. What
+remains are the payloads that genuinely cannot be reconstructed:
+``AliasTask`` (pickled ``loads_type``, deliberately never auto-unpickled
+from registry data), dynamically generated classes, and anything whose
+serialization does not round-trip to the same task id.
 """
 
 from __future__ import annotations

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -65,8 +65,12 @@ from stardag.build import (
 from stardag.build._base import GlobalLockConfig
 from stardag.build._base import BuildSummary
 from stardag.build._task_modules import (
+    declared_task_module_patterns,
     expand_task_module_patterns,
+    format_uncovered_message,
     import_task_modules,
+    set_declared_task_module_patterns,
+    uncovered_task_classes,
     validate_task_module_patterns,
 )
 from stardag.config import clear_config_cache, config_provider, load_config
@@ -1592,6 +1596,27 @@ class _WorkerLifecycleReporter:
             discover_and_register_aio(self.registry, self.build_id, task_struct)
         )
         store = BuildTaskStore(self.build_id)
+        # The trigger's pre-flight structurally cannot see dynamically
+        # yielded deps — they don't exist until their parent runs — so the
+        # coverage check is re-run here, on the app's patterns as published
+        # by the deployed worker wrapper. Once per class per process: this
+        # runs on every suspending worker invocation.
+        patterns = declared_task_module_patterns()
+        if patterns:
+            uncovered = uncovered_task_classes(
+                result.incomplete.values(), patterns, only_unwarned=True
+            )
+            if uncovered:
+                logger.warning(
+                    format_uncovered_message(
+                        uncovered,
+                        patterns,
+                        remedy=(
+                            "These were registered as dynamic dependencies, "
+                            "so the trigger's pre-flight could not see them."
+                        ),
+                    )
+                )
         store.save_tasks(result.incomplete.values())
         deps = flatten_task_struct(task_struct)
         self.registry.task_add_dependencies(
@@ -2303,7 +2328,8 @@ class StardagApp:
         # tick — it needs a redeploy, which is also when the operator gets
         # to see the list change. Only name expansion happens here (no
         # submodule imports): the CLI does the optional local import check.
-        task_modules = expand_task_module_patterns(self.task_modules)
+        task_module_patterns = self.task_modules
+        task_modules = expand_task_module_patterns(task_module_patterns)
         # Wrap callables in real functions for Modal compatibility.
         # Modal's is_async() only accepts inspect.isfunction()-compatible objects,
         # not callable class instances. The wrappers delegate to the actual callable
@@ -2328,6 +2354,15 @@ class StardagApp:
         def _modal_run(
             task: BaseTask, *, env_overrides: dict[str, str] | None = None
         ) -> typing.Any:
+            # Publish the app's task-module patterns for the worker-side
+            # code that needs them but is nowhere near the app object:
+            # _WorkerLifecycleReporter._register_dynamic_deps checks the
+            # coverage of dynamically yielded deps, which the trigger's
+            # pre-flight cannot see. The worker does not IMPORT the
+            # modules: its task arrived by value (self-importing) and its
+            # dynamic deps were just constructed by user code, so their
+            # classes are registered by definition.
+            set_declared_task_module_patterns(task_module_patterns)
             if run_fn_accepts_env:
                 run_fn_with_env = typing.cast(_RunFunctionWithEnv, run_fn)
                 return run_fn_with_env(task, env_overrides=env_overrides)
@@ -2480,6 +2515,7 @@ class StardagApp:
             # Failures warn rather than abort — and are retained, so a
             # later "could not rehydrate" error can name them.
             if task_modules:
+                set_declared_task_module_patterns(task_module_patterns)
                 import_task_modules(task_modules)
 
             executor = ModalTaskExecutor(
@@ -2758,6 +2794,47 @@ class StardagApp:
             )
         return metadata
 
+    def _preflight_task_modules(self, tasks: typing.Iterable[BaseTask]) -> None:
+        """Warn about discovered task classes ``task_modules`` doesn't cover.
+
+        The trigger is the one place that holds both the real DAG and the
+        app, so it is the only place that can catch a class no scheduler
+        tick will be able to reconstruct — before a single container
+        starts, rather than as a mystifying tick failure hours later.
+
+        **Severity is a warning, not an error.** An uncovered class is not
+        broken: it falls back to the pickle path, which is exactly how
+        every reactive build worked before ``task_modules`` existed.
+        Failing the trigger would therefore break working setups the
+        moment they upgrade, which is precisely what "this feature is
+        additive" forbids.
+
+        Known limitation: this reads the *local* app definition, so it
+        cannot detect that the deployed app was built from an older
+        ``task_modules``. Closing that needs the deployed list exposed for
+        comparison.
+
+        Skipped entirely when the app opted out of ``task_modules`` — an
+        app that never declared any would otherwise warn about every class
+        in every DAG, on every trigger.
+        """
+        if not self.task_modules:
+            return
+        uncovered = uncovered_task_classes(tasks, self.task_modules)
+        if not uncovered:
+            return
+        logger.warning(
+            format_uncovered_message(
+                uncovered,
+                self.task_modules,
+                remedy=(
+                    "Until then these tasks stay dependent on their "
+                    "build-task-store pickles, which need target-root "
+                    "write access and are invalidated by a redeploy."
+                ),
+            )
+        )
+
     def _trigger_reactive(
         self,
         task_list: list[BaseTask],
@@ -2840,6 +2917,11 @@ class StardagApp:
                     registry, build_id, tuple(task_list), retry_failed=True
                 )
             )
+            stage = "task-module coverage pre-flight"
+            # Runs on the DISCOVERED incomplete set: those are exactly the
+            # tasks a tick may have to rehydrate, and reusing discovery's
+            # walk avoids a second local traversal of the DAG.
+            self._preflight_task_modules(discovery.incomplete.values())
             stage = "task store write"
             store = BuildTaskStore(build_id)
             store.save_tasks(discovery.incomplete.values())

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -64,6 +64,11 @@ from stardag.build import (
 )
 from stardag.build._base import GlobalLockConfig
 from stardag.build._base import BuildSummary
+from stardag.build._task_modules import (
+    expand_task_module_patterns,
+    import_task_modules,
+    validate_task_module_patterns,
+)
 from stardag.config import clear_config_cache, config_provider, load_config
 from stardag.integration.modal._target import (
     MODAL_VOLUME_URI_PREFIX,
@@ -255,12 +260,17 @@ class FinalizeResult(typing.NamedTuple):
         functions: List of created Modal function names.
         volume_mounts: Dict of mount_path -> volume_name for auto-mounted volumes.
         auto_volumes: Dict of mount_path -> Volume for auto-mounted volumes.
+        task_modules: The app's ``task_modules`` patterns expanded to the
+            concrete, sorted module list baked into the deployed scheduler
+            tick (empty when the app opted out). Surfaced so the CLI can
+            report what the deployment will import.
     """
 
     volumes: dict[str, modal.Volume]
     functions: list[str]
     volume_mounts: dict[str, str] = {}
     auto_volumes: dict[str, modal.Volume] = {}
+    task_modules: list[str] = []
 
 
 # --- Function settings ---
@@ -1900,6 +1910,46 @@ def _setup_logging():
 # --- Stardag App ---
 
 
+def _infer_task_module_patterns(_depth: int = 2) -> tuple[str, ...]:
+    """Infer ``task_modules`` from the module that constructs the app.
+
+    The default declaration is "the root package of the module defining
+    this app, recursively" — which is right far more often than not: an
+    app and the tasks it schedules almost always live in the same
+    distribution, and a whole-package wildcard costs only import time.
+
+    Inference is impossible for a module that is not part of a package —
+    ``__main__``, or a loose script that Modal loads as a top-level module.
+    Such a module isn't importable in a container under a stable name in
+    the first place, so a pattern derived from it would be a lie. We warn
+    and opt out (the pickle path still works), rather than baking in a
+    module list that would fail to import in every tick container.
+
+    Args:
+        _depth: Stack frames back to the user's call site (``__init__``'s
+            caller by default). Not part of the public contract.
+    """
+    frame = inspect.currentframe()
+    for _ in range(_depth):
+        frame = frame.f_back if frame is not None else None
+    module_name = frame.f_globals.get("__name__") if frame is not None else None
+    package = frame.f_globals.get("__package__") if frame is not None else None
+    if not module_name or module_name == "__main__" or not package:
+        logger.warning(
+            "Could not infer StardagApp(task_modules=...): the app is "
+            f"defined in {module_name or 'an unknown module'!r}, which is "
+            "not part of an importable package. Reactive scheduler ticks "
+            "will therefore fall back to the build task store's pickles "
+            "(which need target-root write access at trigger time and are "
+            "invalidated by a redeploy). Declare the modules explicitly — "
+            'e.g. task_modules=["my_pkg.tasks.*"] — to let ticks '
+            "reconstruct tasks from registry data instead, or pass "
+            "task_modules=[] to silence this warning."
+        )
+        return ()
+    return (f"{module_name.split('.')[0]}.*",)
+
+
 class StardagApp:
     """Wrapper around modal.App for Stardag task execution.
 
@@ -1940,6 +1990,8 @@ class StardagApp:
         modal_app: The underlying modal.App instance.
         name: The app name.
         is_finalized: Whether finalize() has been called.
+        task_modules: The validated task-module patterns (see the
+            ``task_modules`` argument); empty when opted out.
     """
 
     def __init__(
@@ -1955,6 +2007,7 @@ class StardagApp:
         watchdog_period_minutes: int | None = None,
         limit_key_selector: typing.Callable[[BaseTask], typing.Sequence[str]]
         | None = None,
+        task_modules: typing.Sequence[str] | None = None,
         modal_workspace: str | None = None,
         stardag_api_key_secret: "modal.Secret | str | None" = "stardag-api-key",
     ):
@@ -2003,6 +2056,26 @@ class StardagApp:
                 concurrency-limit keys it runs under in reactive scheduling
                 (deployed-app configuration applied by every tick). Default:
                 no limits.
+            task_modules: Modules whose import registers the task classes
+                this app may schedule. **Only reactive scheduling needs
+                this**: a scheduler tick reconstructs tasks from registry
+                data and can resolve only classes that are already
+                registered in its process (registration happens at class
+                definition time). Resident builds hold the real task
+                objects and are entirely unaffected.
+
+                Each entry is an exact module (``"my_pkg.tasks.ingest"``)
+                or a package with a trailing recursive wildcard
+                (``"my_pkg.tasks.*"``); anything else raises. The patterns
+                are expanded to a concrete module list at ``finalize()``
+                and baked into the deployed tick, so **adding or moving
+                task classes requires a redeploy**. Declared modules become
+                import-hot — they are imported in every tick container —
+                so keep heavy runtime dependencies inside ``run()`` rather
+                than at module scope.
+
+                Default (``None``): infer ``"<root package of the module
+                defining this app>.*"``. Pass ``[]`` to opt out.
             modal_workspace: Explicit Modal workspace name recorded in the
                 executor metadata of triggered builds and started tasks
                 (used by the UI for Modal dashboard deep links). Default:
@@ -2051,6 +2124,15 @@ class StardagApp:
         # consistently (callables can't be persisted in the JSON build
         # meta like the scalar tick_kwargs).
         self.limit_key_selector = limit_key_selector
+        # Task-module declaration for reactive scheduling: the patterns
+        # whose expansion is imported by every scheduler tick so it can
+        # rebuild task objects from registry data (see
+        # stardag.build._task_modules). Validated eagerly — a malformed
+        # pattern must fail here, not silently match nothing and surface
+        # hours later as a tick that cannot reconstruct a task.
+        if task_modules is None:
+            task_modules = _infer_task_module_patterns()
+        self.task_modules: tuple[str, ...] = validate_task_module_patterns(task_modules)
         # Explicit Modal workspace name for executor metadata (UI deep
         # links). Default: resolved from the Modal token, best-effort.
         # Used by build_trigger and by the tick's executor; the resident
@@ -2130,10 +2212,13 @@ class StardagApp:
                 target roots if they don't exist.
 
         Returns:
-            FinalizeResult with created volumes, function names, and mount info.
+            FinalizeResult with created volumes, function names, mount info,
+            and the expanded ``task_modules`` baked into the tick.
 
         Raises:
             RuntimeError: If finalize() has already been called.
+            TaskModulesError: If a ``task_modules`` pattern cannot be
+                expanded (e.g. its root package is not importable here).
         """
         if self._is_finalized:
             raise RuntimeError("StardagApp has already been finalized")
@@ -2209,6 +2294,16 @@ class StardagApp:
                         f"proceeding: {e}"
                     )
             extra_secrets.append(self.stardag_api_key_secret)
+        # Expand the declared task-module patterns to a concrete, sorted
+        # module list ONCE, here, and bake it into the deployed functions
+        # below. Deploy-time expansion (rather than in-container) keeps the
+        # deployed set explicit and auditable, keeps container startup off
+        # the filesystem, and makes the deployment reproducible: a module
+        # added after this deploy is not silently picked up by a running
+        # tick — it needs a redeploy, which is also when the operator gets
+        # to see the list change. Only name expansion happens here (no
+        # submodule imports): the CLI does the optional local import check.
+        task_modules = expand_task_module_patterns(self.task_modules)
         # Wrap callables in real functions for Modal compatibility.
         # Modal's is_async() only accepts inspect.isfunction()-compatible objects,
         # not callable class instances. The wrappers delegate to the actual callable
@@ -2375,6 +2470,18 @@ class StardagApp:
                 build_info.reactive_tick_kwargs, tick_kwargs, limit_key_selector
             )
 
+            # Register the app's task classes in THIS container before the
+            # tick reconstructs anything: rehydrating a task from registry
+            # data is a dict lookup in the polymorphic registry, which is
+            # populated only as a side effect of importing the defining
+            # modules (unlike pickle, which self-imports). The list was
+            # expanded and frozen at deploy time; the import is cached per
+            # module list, so a container serving many ticks pays it once.
+            # Failures warn rather than abort — and are retained, so a
+            # later "could not rehydrate" error can name them.
+            if task_modules:
+                import_task_modules(task_modules)
+
             executor = ModalTaskExecutor(
                 modal_app_name=app_name,
                 worker_selector=default_worker_selector,
@@ -2442,6 +2549,7 @@ class StardagApp:
             functions=function_names,
             volume_mounts=volume_mounts,
             auto_volumes=auto_volumes,
+            task_modules=task_modules,
         )
 
     def build_spawn(

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -2119,6 +2119,13 @@ class StardagApp:
 
                 Default (``None``): infer ``"<root package of the module
                 defining this app>.*"``. Pass ``[]`` to opt out.
+
+                **Declaring this explicitly is also the opt-in to skipping
+                pickles** — the inferred default only drives the coverage
+                warning. The trigger reads the local app definition while
+                the tick runs the deployed one, so if inference alone
+                elided, upgrading stardag would start dropping pickles that
+                an app deployed by an older version cannot compensate for.
             require_pickle_free: Turn the pickle fallback from a silent
                 safety net into a hard error. With ``task_modules``
                 covering a build's classes, a reactive trigger writes no
@@ -2187,6 +2194,12 @@ class StardagApp:
         # stardag.build._task_modules). Validated eagerly — a malformed
         # pattern must fail here, not silently match nothing and surface
         # hours later as a tick that cannot reconstruct a task.
+        #
+        # Whether the patterns were *declared* or merely inferred decides
+        # whether pickles may be elided — see _persist_discovered_tasks.
+        # Inference must stay observation-only: it happens on every app,
+        # including apps written before this feature existed.
+        self._task_modules_declared = task_modules is not None
         if task_modules is None:
             task_modules = _infer_task_module_patterns()
         self.task_modules: tuple[str, ...] = validate_task_module_patterns(task_modules)
@@ -2885,17 +2898,33 @@ class StardagApp:
     ) -> None:
         """Write the build task store, skipping pickles that aren't needed.
 
-        With no declared ``task_modules`` this is byte-for-byte the old
-        behaviour: pickle everything. With them, each task gets a local
+        Unless the app *opted in*, this is byte-for-byte the old
+        behaviour: pickle everything. With opt-in, each task gets a local
         dry run of what a tick will do — reconstruct it from exactly the
         payload registration stored — and only the ones that fail keep a
         pickle. A build whose classes are all covered writes nothing to
         the target root at all, so the trigger stops needing write access
         there (and stops being vulnerable to a storage error minting an
         orphan RUNNING build).
+
+        Opt-in means ``task_modules`` was passed explicitly (or
+        ``require_pickle_free`` was), NOT merely inferred. This matters:
+        the trigger runs from the local app definition while the tick runs
+        from the *deployed* one, and nothing lets the trigger see the
+        deployed app's task modules (the stale-deploy blind spot). If
+        inference alone enabled elision, then simply upgrading the SDK
+        would start eliding pickles that an app deployed by an older SDK
+        has no baked-in module list to compensate for — turning an upgrade
+        into a broken build. Elision therefore requires an act by the user,
+        which is also what makes the "redeploy after changing
+        ``task_modules``" requirement land at a moment they are paying
+        attention. Inference still drives the coverage warning, which is
+        pure observation and safe to do everywhere.
         """
         store = BuildTaskStore(build_id)
-        if not self.task_modules:
+        if not self.task_modules or not (
+            self._task_modules_declared or self.require_pickle_free
+        ):
             store.save_tasks(tasks)
             return
         plan: PickleElisionPlan = plan_pickle_elision(tasks, self.task_modules)

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -1969,11 +1969,18 @@ def _infer_task_module_patterns(_depth: int = 2) -> tuple[str, ...]:
         _depth: Stack frames back to the user's call site (``__init__``'s
             caller by default). Not part of the public contract.
     """
+    # Frames hold their locals and globals alive and participate in
+    # reference cycles, so the walk is scoped and the references dropped
+    # rather than left for the collector — this runs in long-lived
+    # scheduler containers.
     frame = inspect.currentframe()
-    for _ in range(_depth):
-        frame = frame.f_back if frame is not None else None
-    module_name = frame.f_globals.get("__name__") if frame is not None else None
-    package = frame.f_globals.get("__package__") if frame is not None else None
+    try:
+        for _ in range(_depth):
+            frame = frame.f_back if frame is not None else None
+        module_name = frame.f_globals.get("__name__") if frame is not None else None
+        package = frame.f_globals.get("__package__") if frame is not None else None
+    finally:
+        del frame
     if not module_name or module_name == "__main__" or not package:
         logger.warning(
             "Could not infer StardagApp(task_modules=...): the app is "

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -65,10 +65,13 @@ from stardag.build import (
 from stardag.build._base import GlobalLockConfig
 from stardag.build._base import BuildSummary
 from stardag.build._task_modules import (
+    PickleElisionPlan,
+    TaskModulesError,
     declared_task_module_patterns,
     expand_task_module_patterns,
     format_uncovered_message,
     import_task_modules,
+    plan_pickle_elision,
     set_declared_task_module_patterns,
     uncovered_task_classes,
     validate_task_module_patterns,
@@ -1601,6 +1604,11 @@ class _WorkerLifecycleReporter:
         # coverage check is re-run here, on the app's patterns as published
         # by the deployed worker wrapper. Once per class per process: this
         # runs on every suspending worker invocation.
+        #
+        # The same elision applies (see StardagApp._persist_discovered_tasks):
+        # without it the pickle-free property would hold only until a task
+        # yielded its first dynamic dependency, and a build with dynamic
+        # deps would still need target-root write access.
         patterns = declared_task_module_patterns()
         if patterns:
             uncovered = uncovered_task_classes(
@@ -1617,7 +1625,14 @@ class _WorkerLifecycleReporter:
                         ),
                     )
                 )
-        store.save_tasks(result.incomplete.values())
+            plan = plan_pickle_elision(result.incomplete.values(), patterns)
+            store.save_tasks(task for task, _ in plan.pickled)
+            logger.info(
+                f"Build {self.build_id} dynamic deps of task "
+                f"{self.task.id}: {plan.summary()}"
+            )
+        else:
+            store.save_tasks(result.incomplete.values())
         deps = flatten_task_struct(task_struct)
         self.registry.task_add_dependencies(
             self.build_id, self.task, deps, is_dynamic=True
@@ -2017,6 +2032,8 @@ class StardagApp:
         is_finalized: Whether finalize() has been called.
         task_modules: The validated task-module patterns (see the
             ``task_modules`` argument); empty when opted out.
+        require_pickle_free: Whether a reactive trigger refuses to fall
+            back to writing task pickles.
     """
 
     def __init__(
@@ -2033,6 +2050,7 @@ class StardagApp:
         limit_key_selector: typing.Callable[[BaseTask], typing.Sequence[str]]
         | None = None,
         task_modules: typing.Sequence[str] | None = None,
+        require_pickle_free: bool = False,
         modal_workspace: str | None = None,
         stardag_api_key_secret: "modal.Secret | str | None" = "stardag-api-key",
     ):
@@ -2101,6 +2119,20 @@ class StardagApp:
 
                 Default (``None``): infer ``"<root package of the module
                 defining this app>.*"``. Pass ``[]`` to opt out.
+            require_pickle_free: Turn the pickle fallback from a silent
+                safety net into a hard error. With ``task_modules``
+                covering a build's classes, a reactive trigger writes no
+                task pickles at all and therefore needs no target-root
+                *write* access; with this flag, a trigger that *would* have
+                fallen back to pickling raises instead, naming every task
+                and why. Off by default (the fallback is what keeps the
+                feature additive).
+
+                Enforced at the trigger only. Dynamic dependencies
+                registered from inside a worker apply the same elision but
+                never raise: their task has already run, and failing its
+                bookkeeping to enforce a storage preference would be a
+                strictly worse outcome than one extra pickle.
             modal_workspace: Explicit Modal workspace name recorded in the
                 executor metadata of triggered builds and started tasks
                 (used by the UI for Modal dashboard deep links). Default:
@@ -2158,6 +2190,16 @@ class StardagApp:
         if task_modules is None:
             task_modules = _infer_task_module_patterns()
         self.task_modules: tuple[str, ...] = validate_task_module_patterns(task_modules)
+        if require_pickle_free and not self.task_modules:
+            raise TaskModulesError(
+                "require_pickle_free=True is meaningless without "
+                "task_modules: with no declared modules, no task can be "
+                "reconstructed from registry data and every task would "
+                "need a pickle. Declare task_modules explicitly (if you "
+                "left it at the default, inference was not possible — see "
+                "the warning above), or drop require_pickle_free."
+            )
+        self.require_pickle_free = require_pickle_free
         # Explicit Modal workspace name for executor metadata (UI deep
         # links). Default: resolved from the Modal token, best-effort.
         # Used by build_trigger and by the tick's executor; the resident
@@ -2802,12 +2844,15 @@ class StardagApp:
         tick will be able to reconstruct — before a single container
         starts, rather than as a mystifying tick failure hours later.
 
-        **Severity is a warning, not an error.** An uncovered class is not
-        broken: it falls back to the pickle path, which is exactly how
-        every reactive build worked before ``task_modules`` existed.
-        Failing the trigger would therefore break working setups the
-        moment they upgrade, which is precisely what "this feature is
-        additive" forbids.
+        **Severity is a warning, not an error** (unless
+        ``require_pickle_free``). An uncovered class is not broken: it
+        falls back to the pickle path, which is exactly how every reactive
+        build worked before ``task_modules`` existed. Failing the trigger
+        would therefore break working setups the moment they upgrade,
+        which is precisely what "this feature is additive" forbids. The
+        hard failure lives behind ``require_pickle_free=True``, raised
+        from the persistence step below (which additionally knows about
+        round-trip failures, not just coverage).
 
         Known limitation: this reads the *local* app definition, so it
         cannot detect that the deployed app was built from an older
@@ -2834,6 +2879,32 @@ class StardagApp:
                 ),
             )
         )
+
+    def _persist_discovered_tasks(
+        self, build_id: UUID, tasks: typing.Iterable[BaseTask]
+    ) -> None:
+        """Write the build task store, skipping pickles that aren't needed.
+
+        With no declared ``task_modules`` this is byte-for-byte the old
+        behaviour: pickle everything. With them, each task gets a local
+        dry run of what a tick will do — reconstruct it from exactly the
+        payload registration stored — and only the ones that fail keep a
+        pickle. A build whose classes are all covered writes nothing to
+        the target root at all, so the trigger stops needing write access
+        there (and stops being vulnerable to a storage error minting an
+        orphan RUNNING build).
+        """
+        store = BuildTaskStore(build_id)
+        if not self.task_modules:
+            store.save_tasks(tasks)
+            return
+        plan: PickleElisionPlan = plan_pickle_elision(tasks, self.task_modules)
+        if self.require_pickle_free:
+            error = plan.require_pickle_free_error()
+            if error is not None:
+                raise TaskModulesError(error)
+        store.save_tasks(task for task, _ in plan.pickled)
+        logger.info(f"Build {build_id} task store: {plan.summary()}")
 
     def _trigger_reactive(
         self,
@@ -2923,8 +2994,7 @@ class StardagApp:
             # walk avoids a second local traversal of the DAG.
             self._preflight_task_modules(discovery.incomplete.values())
             stage = "task store write"
-            store = BuildTaskStore(build_id)
-            store.save_tasks(discovery.incomplete.values())
+            self._persist_discovered_tasks(build_id, discovery.incomplete.values())
             stage = "reactive metadata write"
             # Persist the reactive marker/owner/config in the registry
             # (``reactive_app_name`` is the "this build is reactively

--- a/lib/stardag/src/stardag/polymorphic.py
+++ b/lib/stardag/src/stardag/polymorphic.py
@@ -214,6 +214,16 @@ class _TypeRegistry:
             raise KeyError(f"No class registered for type id: {type_id}")
         return cls
 
+    def classes(self) -> tuple[Type[BaseModel], ...]:
+        """Snapshot of every registered class.
+
+        Read-only introspection (e.g. "how many task classes did importing
+        these modules register?"). A tuple rather than a view: registration
+        happens at class-definition time, so an import triggered while
+        iterating would otherwise mutate the mapping mid-loop.
+        """
+        return tuple(self._type_id_to_class.values())
+
     def get_type_id(self, cls: Type[BaseModel]) -> TypeId:
         """Get registered type id for a model class."""
         type_id = self._class_to_type_id.get(cls)

--- a/lib/stardag/src/stardag/registry/__init__.py
+++ b/lib/stardag/src/stardag/registry/__init__.py
@@ -16,6 +16,7 @@ from stardag.registry._auth import StardagAPIKeyAuth, StardagTokenAuth
 from stardag.registry._base import (
     BuildFrontier,
     BuildInfo,
+    FrontierExternalBlocker,
     FrontierTaskRef,
     NoOpRegistry,
     RegisteredTaskInfo,
@@ -34,6 +35,7 @@ __all__ = [
     "APIRegistry",
     "BuildFrontier",
     "BuildInfo",
+    "FrontierExternalBlocker",
     "FrontierTaskRef",
     "NoOpRegistry",
     "RegisteredTaskInfo",

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -109,6 +109,51 @@ class FrontierTaskRef(StardagBaseModel):
     latest_status_at: datetime | None = None
 
 
+class FrontierExternalBlocker(StardagBaseModel):
+    """An upstream outside this build that holds one of its tasks back.
+
+    Task rows (and their dependency edges) are per *environment*, not per
+    build, so an upstream left non-COMPLETED by some *other* build still
+    gates this build's downstream tasks — silently, since such an upstream
+    need not be part of this build's task set at all (a dynamic dependency
+    registered under an earlier build is the common case). Each entry pairs
+    one blocked task of this build with one such blocker.
+
+    "Not this build's doing" is decided server-side by the build whose
+    event produced the blocker's current status: if that is not this build,
+    this build did not put the blocker in that state and cannot generally
+    get it out of it.
+
+    The blocked side carries only ``task_id`` (the caller registered it, and
+    every other frontier field is task_id-keyed too); the *blocking* side
+    carries name/namespace because it may be entirely unknown to the caller,
+    and a diagnostic is useless without something human-readable.
+    """
+
+    # Blocked task — always a member of this build's task set.
+    task_id: str
+    # The blocking upstream. Identity is spelled out because this build may
+    # never have seen this task.
+    blocking_task_id: str
+    blocking_task_namespace: str
+    blocking_task_name: str
+    # Task status value; never "completed" (a completed upstream blocks
+    # nothing).
+    blocking_status: str
+    # When the blocker entered its current status, and the build whose event
+    # put it there ("running under build Z since T"). Both are None only for
+    # rows predating status denormalisation server-side — a scheduler that
+    # bounds its wait on the age must handle the None (see
+    # ``TickConfig.stale_external_blocker_seconds``).
+    blocking_status_at: datetime | None = None
+    blocking_status_build_id: UUID | None = None
+    # Whether the blocker is also part of *this* build's task set. False is
+    # the pathological case: this build will never schedule it, so it can
+    # only wait for whoever owns it. True still blocks, but the blocker also
+    # shows up in this build's own ``actionable``/``running``.
+    blocking_in_build: bool
+
+
 class BuildFrontier(StardagBaseModel):
     """Scheduling state of a build, consumed by reactive scheduler ticks.
 
@@ -117,6 +162,12 @@ class BuildFrontier(StardagBaseModel):
     scheduler partitions them: pending/suspended → spawn; running → probe
     the detached execution ref. ``status_counts`` covers all tasks in the
     build (terminal detection).
+
+    ``blocked_by_external`` explains the gap between the two scopes this
+    payload mixes: dependency gating is environment-global while ``running``
+    and ``status_counts`` cover only tasks this build has events for, so a
+    build can have nothing actionable and nothing running yet still be
+    legitimately waiting. See :class:`FrontierExternalBlocker`.
     """
 
     build_id: UUID
@@ -130,6 +181,20 @@ class BuildFrontier(StardagBaseModel):
     # inside the dynamic-dep registration window) — cancellation targets.
     # Defaults to empty for servers predating the field.
     running: list[FrontierTaskRef] = []
+    # Non-terminal tasks of this build held back by an upstream this build
+    # does not own, capped server-side (hence the truncation flag — the list
+    # is a diagnostic, not a work queue; a truncated list still proves
+    # "waiting, not stuck").
+    #
+    # Populated ONLY when the build has nothing actionable and nothing
+    # running, i.e. only when it looks stalled — which keeps a per-edge join
+    # off the hot path of every healthy build's linger polls. So an EMPTY
+    # list means "not externally blocked, OR not stalled"; never read it as
+    # proof that no external blocker exists. Also empty on servers predating
+    # the fields, where the tick's terminal detection degrades to exactly its
+    # pre-fix behaviour.
+    blocked_by_external: list[FrontierExternalBlocker] = []
+    blocked_by_external_truncated: bool = False
     # Reactive-scheduling marker/owner, moved off the target root into the
     # registry. None means the build is NOT reactively scheduled (a stray
     # tick must no-op on it, so a resident-orchestrator build is never

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -220,6 +220,12 @@ class BuildInfo(StardagBaseModel):
     """
 
     id: UUID
+    # The build's *derived* status (computed server-side from its recorded
+    # events, same values as ``BuildFrontier.build_status``): pending /
+    # running / completed / failed / cancelled. None on servers or custom
+    # registries that don't report it — a consumer asking "is this build
+    # still live?" must treat None as unknown rather than as terminal.
+    status: str | None = None
     # Reactive-scheduling marker/owner (see ``BuildFrontier``). None = not
     # reactively scheduled.
     reactive_app_name: str | None = None

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -1225,6 +1225,74 @@ class TestRehydrationFallback:
         assert summary.terminal_status == "failed"
 
 
+class TestRehydrationDiagnostics:
+    """A rehydration failure names the declared task modules that failed to
+    import — "class X unresolved" and "the module defining X blew up on
+    import" are the same incident seen from two ends, and only the
+    annotation connects them."""
+
+    @pytest.fixture
+    def failed_task_module_import(self):
+        from stardag.build._task_modules import (
+            _reset_import_state_for_tests,
+            import_task_modules,
+        )
+
+        _reset_import_state_for_tests()
+        import_task_modules(["stardag_no_such_declared_task_module"])
+        yield
+        _reset_import_state_for_tests()
+
+    async def test_failure_note_is_appended_to_the_rehydration_error(
+        self,
+        caplog,
+        failed_task_module_import,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        (root,) = _chain("diagnostic-root")
+        registry, locks, executor, store = _setup([root], auto_complete=False)
+        store._tasks.clear()  # neither a pickle nor rehydratable metadata
+
+        with caplog.at_level("WARNING"):
+            await run_tick_aio(
+                uuid4(),
+                registry=registry,
+                task_executor=executor,
+                lock_manager=locks,
+                task_store=store,
+                config=FAST_TICK,
+            )
+
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert "could not be rehydrated from registry data" in messages
+        assert "stardag_no_such_declared_task_module" in messages
+        assert "likely cause" in messages
+
+    async def test_no_note_when_every_task_module_imported(
+        self, caplog, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        from stardag.build._task_modules import _reset_import_state_for_tests
+
+        _reset_import_state_for_tests()
+        (root,) = _chain("diagnostic-clean-root")
+        registry, locks, executor, store = _setup([root], auto_complete=False)
+        store._tasks.clear()
+
+        with caplog.at_level("WARNING"):
+            await run_tick_aio(
+                uuid4(),
+                registry=registry,
+                task_executor=executor,
+                lock_manager=locks,
+                task_store=store,
+                config=FAST_TICK,
+            )
+
+        messages = "\n".join(record.getMessage() for record in caplog.records)
+        assert "could not be rehydrated from registry data" in messages
+        assert "failed to import" not in messages
+
+
 class TestExecutorMetadataRecording:
     """The post-spawn ref-recording start carries the handle's
     executor_metadata (and drops it for pre-metadata registries)."""

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -32,7 +32,7 @@ from stardag.build._base import (
     LockAcquisitionResult,
     LockAcquisitionStatus,
 )
-from stardag.build._reactive import TickSummary, _skip_blocked
+from stardag.build._reactive import _RETRYABLE_STATUSES, TickSummary, _skip_blocked
 from stardag.exceptions import NotFoundError
 from stardag.registry import (
     BuildFrontier,
@@ -236,7 +236,9 @@ class FakeReactiveRegistry(NoOpRegistry):
     async def task_retry_aio(self, build_id, task):
         tid = str(task.id)
         self.calls.append(("retry", tid))
-        if self.statuses.get(tid) in ("failed", "cancelled", "skipped"):
+        # Same retryable set the server applies (suspended included: a
+        # suspended task has no live execution to orphan).
+        if self.statuses.get(tid) in _RETRYABLE_STATUSES:
             self.statuses[tid] = "pending"
             self.refs.pop(tid, None)
 
@@ -915,6 +917,51 @@ class TestRetryPath:
         )
         assert summary.terminal_status == "completed"
         assert registry.build_status == "completed"
+
+    async def test_retry_failed_resets_an_abandoned_suspended_task(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """#208 A2: a task left SUSPENDED — its execution yielded dynamic
+        dependencies and returned, then the build was abandoned — used to be
+        permanently unschedulable, since the re-trigger's retry skipped it.
+        It is now reset like any other non-completed status."""
+        (root,) = _chain("suspended-retry-root")
+        registry, locks, executor, store = _setup([root])
+        registry.add_task(str(root.id), status="suspended")
+
+        result = await discover_and_register_aio(
+            registry, uuid4(), root, retry_failed=True
+        )
+
+        assert [t.id for t in result.retried] == [root.id]
+        assert registry.statuses[str(root.id)] == "pending"
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+        assert summary.terminal_status == "completed"
+
+    async def test_worker_dynamic_dep_registration_never_resets_suspended(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """The other caller of discover_and_register_aio is a worker
+        registering its dynamically yielded deps — it takes the default
+        retry_failed=False, so widening the retryable set cannot make a
+        suspending worker reset its own task."""
+        (root,) = _chain("suspended-worker-root")
+        registry, _, _, _ = _setup([root], auto_complete=False)
+        registry.add_task(str(root.id), status="suspended")
+
+        result = await discover_and_register_aio(registry, uuid4(), root)
+
+        assert result.retried == []
+        assert registry.statuses[str(root.id)] == "suspended"
+        assert not any(method == "retry" for (method, _) in registry.calls)
 
     async def test_without_retry_failed_build_fail_fasts(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -98,13 +98,22 @@ class FakeReactiveRegistry(NoOpRegistry):
         # this build's tasks (dependency edges are global too) while
         # contributing to neither ``actionable`` nor ``status_counts``.
         self.not_in_build: set[str] = set()
-        # task_id -> the build whose event produced the current status.
-        # Absent means "this build's own doing" (the common case), which is
-        # what makes a task NOT an external blocker.
-        self.status_build_id: dict[str, UUID] = {}
+        # task_id -> the build whose event produced the current status. An
+        # ABSENT key means "this build's own doing" (the common case), which
+        # is what makes a task NOT an external blocker; an explicit None is a
+        # row predating status denormalisation — not this build's doing
+        # either, and with no build to ask about it.
+        self.status_build_id: dict[str, UUID | None] = {}
         # task_id -> (namespace, name), echoed on blocker entries.
         self.task_names: dict[str, tuple[str, str]] = {}
         self.blocked_by_external_truncated = False
+        # Derived status of OTHER builds in the environment, served by
+        # build_get_aio — how the tick decides whether the build owning a
+        # blocker is still going to schedule it. Absent ids 404, and
+        # ``build_get_status`` of None emulates a server that doesn't report
+        # the field.
+        self.other_build_statuses: dict[UUID, str | None] = {}
+        self.build_get_calls: list[UUID] = []
         # Set False to emulate a server predating blocked_by_external: the
         # fields stay at their model defaults, as they would deserialising
         # a response that never carried them.
@@ -135,6 +144,8 @@ class FakeReactiveRegistry(NoOpRegistry):
         blocks: "set[str]",
         status: str = "running",
         owner_build_id: "UUID | None" = None,
+        owner_build_status: "str | None" = "running",
+        owner_build_known: bool = True,
         name: str = "BlockingTask",
         namespace: str = "",
         status_at: "datetime | None" = None,
@@ -145,10 +156,15 @@ class FakeReactiveRegistry(NoOpRegistry):
         Defaults to the #208 A1 shape: RUNNING under some *other* build and
         absent from this build's task set, so it gates ``blocks`` while
         appearing in neither this build's ``running`` nor its
-        ``status_counts``.
+        ``status_counts``. ``owner_build_status`` is what ``build_get`` will
+        report for that other build (None = a server that doesn't report it);
+        ``owner_build_known=False`` makes the lookup 404 instead.
         """
         self.statuses[task_id] = status
-        self.status_build_id[task_id] = owner_build_id or uuid4()
+        owner_build_id = owner_build_id or uuid4()
+        self.status_build_id[task_id] = owner_build_id
+        if owner_build_known:
+            self.other_build_statuses[owner_build_id] = owner_build_status
         self.task_names[task_id] = (namespace, name)
         if status_at is not None:
             self.status_at[task_id] = status_at
@@ -320,6 +336,14 @@ class FakeReactiveRegistry(NoOpRegistry):
         if tick_kwargs is not None:
             self.reactive_tick_kwargs = tick_kwargs
 
+    async def build_get_aio(self, build_id):
+        from stardag.registry import BuildInfo
+
+        self.build_get_calls.append(build_id)
+        if build_id not in self.other_build_statuses:
+            raise NotFoundError(f"Build {build_id} not found", detail="Build not found")
+        return BuildInfo(id=build_id, status=self.other_build_statuses[build_id])
+
     async def build_notify_aio(self, build_id):
         self.needs_tick = True
 
@@ -370,8 +394,11 @@ class FakeReactiveRegistry(NoOpRegistry):
                         continue
                     if self.statuses[up] == "completed":
                         continue
-                    if self.status_build_id.get(up, build_id) == build_id:
+                    if up not in self.status_build_id:
                         continue  # this build's own doing — not external
+                    owner_id = self.status_build_id[up]
+                    if owner_id == build_id:
+                        continue
                     namespace, name = self.task_names.get(up, ("", up))
                     blocked_by_external.append(
                         FrontierExternalBlocker(
@@ -381,7 +408,7 @@ class FakeReactiveRegistry(NoOpRegistry):
                             blocking_task_name=name,
                             blocking_status=self.statuses[up],
                             blocking_status_at=self.status_at.get(up),
-                            blocking_status_build_id=self.status_build_id[up],
+                            blocking_status_build_id=owner_id,
                             blocking_in_build=up not in self.not_in_build,
                         )
                     )
@@ -1782,6 +1809,9 @@ class TestExternalBlockers:
         blocker_status: str = "running",
         blocker_age_seconds: float | None = 60.0,
         in_build: bool = False,
+        owner_build_id: "UUID | None" = None,
+        owner_build_status: "str | None" = "running",
+        owner_build_known: bool = True,
     ):
         """A build whose only task is gated by an upstream it does not own."""
         (root,) = _chain("ext-blocked-root")
@@ -1796,6 +1826,9 @@ class TestExternalBlockers:
                 else datetime.now(timezone.utc) - timedelta(seconds=blocker_age_seconds)
             ),
             in_build=in_build,
+            owner_build_id=owner_build_id,
+            owner_build_status=owner_build_status,
+            owner_build_known=owner_build_known,
             namespace="pipelines",
             name="Ingest",
         )
@@ -1890,11 +1923,12 @@ class TestExternalBlockers:
         blocker_status: str,
         default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
     ):
-        """Nobody is executing the blocker and this build will never schedule
-        it (it is not in this build's task set), so waiting would be waiting
-        forever — fail now, naming the task and the build that owns it."""
+        """Nobody is executing the blocker, the build that owns it has gone
+        terminal, and this build will never schedule it (it is not in this
+        build's task set) — so waiting would be waiting forever. Fail now,
+        naming the task and the build that owns it."""
         _, registry, locks, executor, store = self._blocked_build(
-            blocker_status=blocker_status
+            blocker_status=blocker_status, owner_build_status="completed"
         )
 
         summary = await run_tick_aio(
@@ -1917,6 +1951,166 @@ class TestExternalBlockers:
         # RUNNING blocker needs the cancel-first hint.
         assert "/retry" in message
         assert "release the claim" not in message
+
+    @pytest.mark.parametrize("owner_build_status", ["running", "pending"])
+    async def test_non_running_blocker_of_a_live_build_waits(
+        self,
+        owner_build_status: str,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """A PENDING blocker belonging to a build that is still live *will* be
+        scheduled by that build — failing here would be a brand-new spurious
+        failure, the very class of bug being fixed. A build the server still
+        reports as pending counts as live too: it may yet start, and the
+        staleness bound is what keeps that from being an unbounded wait."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="pending", owner_build_status=owner_build_status
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.outcome == "lingered_out"
+        assert registry.build_status == "running"
+        assert summary.external_blockers_waited == 1
+        assert summary.external_blockers_fatal == 0
+
+    async def test_non_running_blocker_of_a_live_build_is_still_bounded(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """The owner being live is not a licence to wait forever: a build that
+        has left a task pending past the bound is not making progress on it."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="pending",
+            owner_build_status="running",
+            blocker_age_seconds=60 * 60 * 24,
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.terminal_status == "failed"
+        assert summary.external_blockers_fatal == 1
+        assert "staleness bound" in (registry.build_error_message or "")
+
+    async def test_blocker_with_no_status_owning_build_fails(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """No build owns the blocker's status (a row predating status
+        denormalisation), so no status-moving event was ever recorded against
+        it — there is no evidence anyone intends to run it, and no build to
+        ask. Fail, with the remediation intact."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="pending"
+        )
+        registry.status_build_id[self.BLOCKER_ID] = None
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.terminal_status == "failed"
+        assert summary.external_blockers_fatal == 1
+        assert registry.build_get_calls == []  # nothing to look up
+        message = registry.build_error_message or ""
+        assert "no build owns its status" in message
+        assert "/retry" in message
+
+    async def test_failed_owner_lookup_fails_without_propagating(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """An unresolvable owner (deleted build, unreachable registry) is not
+        evidence of life: the build fails with a precise message rather than
+        the lookup error escaping the tick."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="pending", owner_build_known=False
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.terminal_status == "failed"
+        assert summary.external_blockers_fatal == 1
+        assert "status is unknown" in (registry.build_error_message or "")
+
+    async def test_server_not_reporting_build_status_fails(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """Same treatment for a server (or custom registry) that doesn't
+        report the derived build status: the field defaults to None, unknown
+        is not evidence of life, and the message says so."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="pending", owner_build_status=None
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.terminal_status == "failed"
+        assert "status is unknown" in (registry.build_error_message or "")
+
+    async def test_owner_status_is_resolved_once_per_build(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """A wide DAG stalled behind one build yields one blocker entry per
+        blocked edge, all naming the same owner — that must cost one request,
+        not one per entry."""
+        root, registry, locks, executor, store = self._blocked_build(
+            blocker_status="pending", owner_build_id=(owner := uuid4())
+        )
+        sibling = SyncOnlyTask(name="ext-memo-sibling")
+        store.save_task(sibling)
+        registry.add_task(str(sibling.id), status="pending")
+        registry.add_blocking_task(
+            "second-blocker",
+            blocks={str(sibling.id)},
+            status="pending",
+            owner_build_id=owner,  # same owner as the first blocker
+            namespace="pipelines",
+            name="Transform",
+        )
+        registry.build_get_calls.clear()
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(linger_seconds=0.0, poll_interval_seconds=0.01),
+        )
+
+        assert summary.external_blockers_waited == 2
+        assert registry.build_get_calls == [owner]
 
     async def test_in_build_blocker_does_not_cause_a_wait(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
@@ -2012,6 +2206,7 @@ class TestExternalBlockers:
             "dead-blocker",
             blocks={str(root.id)},
             status="suspended",
+            owner_build_status="cancelled",
             namespace="pipelines",
             name="Abandoned",
             status_at=datetime.now(timezone.utc),
@@ -2041,7 +2236,7 @@ class TestExternalBlockers:
         """The server caps its blocker list; the failure must not read as an
         exhaustive account of what is holding the build back."""
         _, registry, locks, executor, store = self._blocked_build(
-            blocker_status="suspended"
+            blocker_status="suspended", owner_build_status="failed"
         )
         registry.blocked_by_external_truncated = True
 

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -8,6 +8,7 @@ instantly (simulating worker-side lifecycle reporting + wake-up).
 
 from __future__ import annotations
 
+import asyncio
 import typing
 from datetime import datetime, timedelta, timezone
 from uuid import UUID, uuid4
@@ -35,6 +36,7 @@ from stardag.build._reactive import TickSummary, _skip_blocked
 from stardag.exceptions import NotFoundError
 from stardag.registry import (
     BuildFrontier,
+    FrontierExternalBlocker,
     FrontierTaskRef,
     NoOpRegistry,
     RegisteredTaskInfo,
@@ -81,6 +83,7 @@ class FakeReactiveRegistry(NoOpRegistry):
         self.start_metadata: dict[str, dict | None] = {}
         self.needs_tick = False
         self.build_status = "running"
+        self.build_error_message: str | None = None
         self.calls: list[tuple[str, str | None]] = []
         # Named concurrency limits: key -> cap; holders tracked per task.
         self.limits: dict[str, int] = {}
@@ -89,6 +92,23 @@ class FakeReactiveRegistry(NoOpRegistry):
         # task_id -> task_data body, served by task_get_metadata_aio
         # (rehydration fallback); missing key -> KeyError, like a 404.
         self.metadata_bodies: dict[str, dict] = {}
+        # --- cross-build scope (mirrors the API's two scopes) ---
+        # ``statuses`` is environment-global; these task ids exist in the
+        # environment but are NOT in this build's task set, so they gate
+        # this build's tasks (dependency edges are global too) while
+        # contributing to neither ``actionable`` nor ``status_counts``.
+        self.not_in_build: set[str] = set()
+        # task_id -> the build whose event produced the current status.
+        # Absent means "this build's own doing" (the common case), which is
+        # what makes a task NOT an external blocker.
+        self.status_build_id: dict[str, UUID] = {}
+        # task_id -> (namespace, name), echoed on blocker entries.
+        self.task_names: dict[str, tuple[str, str]] = {}
+        self.blocked_by_external_truncated = False
+        # Set False to emulate a server predating blocked_by_external: the
+        # fields stay at their model defaults, as they would deserialising
+        # a response that never carried them.
+        self.serves_blocked_by_external = True
 
     # --- test setup helpers ---
 
@@ -107,6 +127,35 @@ class FakeReactiveRegistry(NoOpRegistry):
             self.refs[task_id] = (executor, executor_ref)
         if status_at is not None:
             self.status_at[task_id] = status_at
+
+    def add_blocking_task(
+        self,
+        task_id: str,
+        *,
+        blocks: "set[str]",
+        status: str = "running",
+        owner_build_id: "UUID | None" = None,
+        name: str = "BlockingTask",
+        namespace: str = "",
+        status_at: "datetime | None" = None,
+        in_build: bool = False,
+    ) -> None:
+        """Register an upstream whose current status this build did not set.
+
+        Defaults to the #208 A1 shape: RUNNING under some *other* build and
+        absent from this build's task set, so it gates ``blocks`` while
+        appearing in neither this build's ``running`` nor its
+        ``status_counts``.
+        """
+        self.statuses[task_id] = status
+        self.status_build_id[task_id] = owner_build_id or uuid4()
+        self.task_names[task_id] = (namespace, name)
+        if status_at is not None:
+            self.status_at[task_id] = status_at
+        if not in_build:
+            self.not_in_build.add(task_id)
+        for downstream in blocks:
+            self.upstreams.setdefault(downstream, set()).add(task_id)
 
     # --- registry surface used by the tick ---
 
@@ -212,6 +261,7 @@ class FakeReactiveRegistry(NoOpRegistry):
     async def build_fail_aio(self, build_id, error_message=None):
         self.calls.append(("build_fail", None))
         self.build_status = "failed"
+        self.build_error_message = error_message
 
     async def task_get_metadata_aio(self, task_id):
         from stardag.registry._base import TaskMetadata
@@ -285,9 +335,16 @@ class FakeReactiveRegistry(NoOpRegistry):
                 latest_status_at=self.status_at.get(tid),
             )
 
+        # Build-scoped, like the API: actionable/running/status_counts see
+        # only this build's task set. Dependency gating below stays global.
+        in_build = {
+            tid: status
+            for tid, status in self.statuses.items()
+            if tid not in self.not_in_build
+        }
         actionable = [
             ref(tid)
-            for tid, status in self.statuses.items()
+            for tid, status in in_build.items()
             if status in ("pending", "suspended", "running")
             and all(
                 self.statuses.get(up) == "completed"
@@ -295,8 +352,37 @@ class FakeReactiveRegistry(NoOpRegistry):
             )
         ]
         counts: dict[str, int] = {}
-        for status in self.statuses.values():
+        for status in in_build.values():
             counts[status] = counts.get(status, 0) + 1
+        running = [ref(tid) for tid, status in in_build.items() if status == "running"]
+        # Mirrors the API: computed ONLY when the build has nothing
+        # actionable and nothing running, so an empty list means "not
+        # blocked externally, OR not stalled".
+        blocked_by_external: list[FrontierExternalBlocker] = []
+        if self.serves_blocked_by_external and not actionable and not running:
+            for tid, status in in_build.items():
+                if status not in ("pending", "suspended", "running"):
+                    continue
+                for up in sorted(self.upstreams.get(tid, set())):
+                    if up not in self.statuses:
+                        continue
+                    if self.statuses[up] == "completed":
+                        continue
+                    if self.status_build_id.get(up, build_id) == build_id:
+                        continue  # this build's own doing — not external
+                    namespace, name = self.task_names.get(up, ("", up))
+                    blocked_by_external.append(
+                        FrontierExternalBlocker(
+                            task_id=tid,
+                            blocking_task_id=up,
+                            blocking_task_namespace=namespace,
+                            blocking_task_name=name,
+                            blocking_status=self.statuses[up],
+                            blocking_status_at=self.status_at.get(up),
+                            blocking_status_build_id=self.status_build_id[up],
+                            blocking_in_build=up not in self.not_in_build,
+                        )
+                    )
         return BuildFrontier(
             build_id=build_id,
             build_status=self.build_status,
@@ -305,9 +391,11 @@ class FakeReactiveRegistry(NoOpRegistry):
             roots=[ref(t) for t in self.root_task_ids if t in self.statuses],
             status_counts=counts,
             actionable=actionable,
-            running=[
-                ref(tid) for tid, status in self.statuses.items() if status == "running"
-            ],
+            running=running,
+            blocked_by_external=blocked_by_external,
+            blocked_by_external_truncated=(
+                self.blocked_by_external_truncated and bool(blocked_by_external)
+            ),
             reactive_app_name=self.reactive_app_name,
             reactive_tick_kwargs=self.reactive_tick_kwargs,
         )
@@ -1627,3 +1715,372 @@ class TestTickClaims:
 
         assert summary.terminal_status == "completed"
         assert not any(m == "start_claim" for (m, _) in registry.calls)
+
+
+class TestExternalBlockers:
+    """Terminal detection when the blocker lives outside this build (#208 A1).
+
+    Dependency gating is environment-global while ``running`` and
+    ``status_counts`` are build-scoped, so a task another build is executing
+    gates this build's tasks while appearing in neither count. Read as
+    "nothing runnable, nothing running", that shape used to fail the build
+    outright.
+    """
+
+    BLOCKER_ID = "blocking-task-id"
+
+    def _blocked_build(
+        self,
+        *,
+        blocker_status: str = "running",
+        blocker_age_seconds: float | None = 60.0,
+        in_build: bool = False,
+    ):
+        """A build whose only task is gated by an upstream it does not own."""
+        (root,) = _chain("ext-blocked-root")
+        registry, locks, executor, store = _setup([root], auto_complete=False)
+        registry.add_blocking_task(
+            self.BLOCKER_ID,
+            blocks={str(root.id)},
+            status=blocker_status,
+            status_at=(
+                None
+                if blocker_age_seconds is None
+                else datetime.now(timezone.utc) - timedelta(seconds=blocker_age_seconds)
+            ),
+            in_build=in_build,
+            namespace="pipelines",
+            name="Ingest",
+        )
+        return root, registry, locks, executor, store
+
+    async def test_running_blocker_in_another_build_waits_instead_of_failing(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """The exact A1 repro: this build has nothing actionable and nothing
+        running because its task waits on an upstream another build is
+        executing. That upstream's completion will unblock it, so the tick
+        must wait (as it does for a concurrency-limit denial) rather than
+        fail the build."""
+        _, registry, locks, executor, store = self._blocked_build()
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.outcome == "lingered_out"
+        assert registry.build_status == "running"
+        assert not any(method == "build_fail" for (method, _) in registry.calls)
+        assert executor.spawned == []
+        assert (summary.external_blockers, summary.external_blockers_waited) == (1, 1)
+        assert summary.external_blockers_fatal == 0
+
+    async def test_wait_is_bounded_by_the_blockers_status_age(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """A blocker RUNNING far longer than the bound is a claim nobody is
+        going to release — waiting again would hang the build silently, so
+        the tick fails it with the full explanation."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_age_seconds=60 * 60 * 24  # a day; default bound is 6h
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.terminal_status == "failed"
+        assert summary.external_blockers_fatal == 1
+        assert summary.external_blockers_waited == 0
+        message = registry.build_error_message or ""
+        assert "pipelines.Ingest" in message
+        assert self.BLOCKER_ID in message
+        assert "RUNNING for 86400s" in message
+        assert str(registry.status_build_id[self.BLOCKER_ID]) in message
+        # The stale-claim escape hatch, which #208 A2 notes was undocumented.
+        assert "release the claim" in message
+
+    async def test_a_generous_bound_keeps_waiting_on_a_long_running_blocker(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """Control for the bound: the same age with a larger bound waits."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_age_seconds=60 * 60 * 24
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                stale_external_blocker_seconds=60 * 60 * 24 * 7,
+            ),
+        )
+
+        assert summary.outcome == "lingered_out"
+        assert summary.external_blockers_waited == 1
+        assert registry.build_status == "running"
+
+    @pytest.mark.parametrize(
+        "blocker_status", ["pending", "suspended", "failed", "cancelled", "skipped"]
+    )
+    async def test_non_running_external_blocker_fails_immediately(
+        self,
+        blocker_status: str,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """Nobody is executing the blocker and this build will never schedule
+        it (it is not in this build's task set), so waiting would be waiting
+        forever — fail now, naming the task and the build that owns it."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status=blocker_status
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.terminal_status == "failed"
+        assert summary.external_blockers_fatal == 1
+        assert summary.external_blockers_waited == 0
+        message = registry.build_error_message or ""
+        assert "pipelines.Ingest" in message
+        assert blocker_status.upper() in message
+        assert f"under build {registry.status_build_id[self.BLOCKER_ID]}" in message
+        # Actionable: retry now covers suspended too (#208 A2), and only a
+        # RUNNING blocker needs the cancel-first hint.
+        assert "/retry" in message
+        assert "release the claim" not in message
+
+    async def test_in_build_blocker_does_not_cause_a_wait(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """A blocker inside this build's own task set is already modelled by
+        actionable/running/status_counts, so it must not buy the build a
+        wait — but it does get named, since the status counts alone never
+        said which task was holding things up."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="cancelled", in_build=True
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                fail_mode=FailMode.CONTINUE,
+            ),
+        )
+
+        assert summary.terminal_status == "failed"
+        assert summary.external_blockers == 1
+        assert summary.external_blockers_waited == 0
+        assert summary.external_blockers_fatal == 0
+        message = registry.build_error_message or ""
+        assert "No runnable or running tasks left" in message
+        assert "Blocked within this build by" in message
+        assert "pipelines.Ingest" in message
+
+    async def test_unknown_blocker_age_waits_unbounded(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """No ``blocking_status_at`` (a task row predating server-side status
+        denormalisation) → the wait cannot be aged. Waiting is the safe
+        direction: failing on missing information would reintroduce exactly
+        the spurious failure this path removes."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_age_seconds=None
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                stale_external_blocker_seconds=0.0,  # would expire anything
+            ),
+        )
+
+        assert summary.outcome == "lingered_out"
+        assert summary.external_blockers_waited == 1
+        assert registry.build_status == "running"
+
+    async def test_bound_disabled_waits_indefinitely(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_age_seconds=60 * 60 * 24 * 365
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                stale_external_blocker_seconds=None,
+            ),
+        )
+
+        assert summary.outcome == "lingered_out"
+        assert summary.external_blockers_waited == 1
+
+    async def test_a_fatal_blocker_wins_over_a_waitable_one(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """One blocker nothing will ever run means the build cannot complete,
+        whatever else it is also waiting on."""
+        root, registry, locks, executor, store = self._blocked_build()
+        registry.add_blocking_task(
+            "dead-blocker",
+            blocks={str(root.id)},
+            status="suspended",
+            namespace="pipelines",
+            name="Abandoned",
+            status_at=datetime.now(timezone.utc),
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.terminal_status == "failed"
+        assert summary.external_blockers == 2
+        assert summary.external_blockers_waited == 1
+        assert summary.external_blockers_fatal == 1
+        # Only the fatal one is named as the reason to fail.
+        message = registry.build_error_message or ""
+        assert "pipelines.Abandoned" in message
+        assert "pipelines.Ingest" not in message
+
+    async def test_truncated_blocker_list_is_flagged_in_the_message(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """The server caps its blocker list; the failure must not read as an
+        exhaustive account of what is holding the build back."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="suspended"
+        )
+        registry.blocked_by_external_truncated = True
+
+        await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        message = registry.build_error_message or ""
+        assert "capped the blocker list" in message
+
+    async def test_older_server_without_the_fields_behaves_exactly_as_before(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """A server predating blocked_by_external leaves the fields at their
+        defaults, and terminal detection degrades to the pre-fix failure —
+        the bug is unfixable client-side there, but nothing regresses."""
+        _, registry, locks, executor, store = self._blocked_build()
+        registry.serves_blocked_by_external = False
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.terminal_status == "failed"
+        assert summary.external_blockers == 0
+        assert summary.external_blockers_waited == 0
+        assert summary.external_blockers_fatal == 0
+        assert "No runnable or running tasks left" in (
+            registry.build_error_message or ""
+        )
+
+    async def test_healthy_build_never_evaluates_blockers(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """The frontier reports blockers only while a build looks stalled, so
+        a build that runs to completion records none."""
+        dep, root = _chain("ext-healthy-dep", "ext-healthy-root")
+        registry, locks, executor, store = _setup([dep, root])
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=FAST_TICK,
+        )
+
+        assert summary.terminal_status == "completed"
+        assert summary.external_blockers == 0
+
+    async def test_blocker_completion_releases_the_waiting_build(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """End of the wait: once the owning build completes the blocker (and
+        wakes this scheduler), the same lingering tick schedules the task it
+        would previously have failed the build over."""
+        root, registry, locks, executor, store = self._blocked_build()
+        registry.auto_complete = True
+
+        async def complete_blocker_soon() -> None:
+            await asyncio.sleep(0.05)
+            registry.statuses[self.BLOCKER_ID] = "completed"
+            registry.needs_tick = True
+
+        waiter = asyncio.create_task(complete_blocker_soon())
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(linger_seconds=1.0, poll_interval_seconds=0.01),
+        )
+        await waiter
+
+        assert summary.terminal_status == "completed"
+        assert executor.spawned == [root.id]
+        assert summary.external_blockers_waited >= 1

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -2031,7 +2031,12 @@ class TestExternalBlockers:
         assert registry.build_get_calls == []  # nothing to look up
         message = registry.build_error_message or ""
         assert "no build owns its status" in message
-        assert "/retry" in message
+        # Both documented remedies are addressed to a build, so quoting
+        # them here would hand the reader a URL with no id to put in it.
+        # Say what can actually be done instead.
+        assert "/retry" not in message
+        assert "no build id to address a retry or cancel to" in message
+        assert "stardag tasks list" in message
 
     async def test_failed_owner_lookup_fails_without_propagating(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]

--- a/lib/stardag/tests/test_build/test_task_modules.py
+++ b/lib/stardag/tests/test_build/test_task_modules.py
@@ -1,0 +1,473 @@
+"""Unit tests for task-module declaration (stardag.build._task_modules).
+
+Expansion is exercised against a *real* package tree written to disk and
+put on ``sys.path``, because the property that matters most — expansion
+lists module names without importing them — cannot be observed with mocks.
+Each generated module appends its name to a marker file at import time, so
+the tests can assert exactly which modules were imported and when.
+"""
+
+from __future__ import annotations
+
+import itertools
+import sys
+import typing
+from pathlib import Path
+
+import pytest
+
+from stardag import BaseTask, auto_namespace
+from stardag.build._task_modules import (
+    TaskModulesError,
+    _reset_import_state_for_tests,
+    count_registered_task_classes,
+    declared_task_module_patterns,
+    expand_task_module_patterns,
+    format_uncovered_message,
+    import_failure_note,
+    import_task_modules,
+    last_import_failures,
+    module_is_covered,
+    plan_pickle_elision,
+    set_declared_task_module_patterns,
+    suggested_pattern_for,
+    uncovered_task_classes,
+    validate_task_module_patterns,
+)
+from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+auto_namespace(__name__)
+
+
+# =============================================================================
+# A real package tree on disk
+# =============================================================================
+
+_PACKAGE_COUNTER = itertools.count()
+
+# Prepended to every generated module: records the import in a marker file
+# whose path is baked in, so imports are observable from the test process
+# without importing anything itself.
+_IMPORT_MARKER_SOURCE = """\
+import pathlib
+
+pathlib.Path({marker!r}).open("a").write(__name__ + "\\n")
+"""
+
+
+class GeneratedPackage(typing.NamedTuple):
+    """A package tree written to disk and importable from ``sys.path``."""
+
+    name: str
+    root: Path
+    marker: Path
+
+    def imported(self) -> list[str]:
+        """Modules of this package imported so far, in import order."""
+        if not self.marker.exists():
+            return []
+        return [line for line in self.marker.read_text().splitlines() if line]
+
+    def reset_imports(self) -> None:
+        self.marker.unlink(missing_ok=True)
+
+
+@pytest.fixture
+def make_package(tmp_path: Path):
+    """Factory writing a uniquely-named package tree and cleaning up after.
+
+    Layout (``<pkg>`` is unique per call so ``sys.modules`` can't leak
+    between tests)::
+
+        <pkg>/__init__.py
+        <pkg>/_tasks.py          underscore-prefixed: must NOT be skipped
+        <pkg>/__main__.py        entrypoint: MUST be skipped
+        <pkg>/ingest/__init__.py
+        <pkg>/ingest/raw.py
+        <pkg>/reporting/__init__.py
+        <pkg>/reporting/nested/__init__.py
+        <pkg>/reporting/nested/deep.py
+    """
+    created: list[str] = []
+
+    def _make(*, broken_module: bool = False) -> GeneratedPackage:
+        name = f"generated_pkg_{next(_PACKAGE_COUNTER)}"
+        root = tmp_path / name
+        marker = tmp_path / f"{name}.imports"
+        header = _IMPORT_MARKER_SOURCE.format(marker=str(marker))
+
+        def write(relpath: str, extra: str = "") -> None:
+            path = root / relpath
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(header + extra)
+
+        write("__init__.py")
+        write("_tasks.py")
+        write("__main__.py")
+        write("ingest/__init__.py")
+        write("ingest/raw.py")
+        write("reporting/__init__.py")
+        write("reporting/nested/__init__.py")
+        write("reporting/nested/deep.py")
+        if broken_module:
+            write("broken.py", "raise RuntimeError('missing optional dep')\n")
+
+        created.append(name)
+        return GeneratedPackage(name=name, root=root, marker=marker)
+
+    sys.path.insert(0, str(tmp_path))
+    try:
+        yield _make
+    finally:
+        sys.path.remove(str(tmp_path))
+        for name in created:
+            for module in [
+                m for m in sys.modules if m == name or m.startswith(name + ".")
+            ]:
+                del sys.modules[module]
+        _reset_import_state_for_tests()
+
+
+# =============================================================================
+# Pattern validation
+# =============================================================================
+
+
+class TestPatternValidation:
+    def test_accepts_exact_and_wildcard_patterns(self):
+        assert validate_task_module_patterns(
+            ["my_pkg.tasks.ingest", "my_pkg.pipelines.*", "my_pkg"]
+        ) == ("my_pkg", "my_pkg.pipelines.*", "my_pkg.tasks.ingest")
+
+    def test_dedupes_and_sorts(self):
+        assert validate_task_module_patterns(["b.*", "a.*", "b.*"]) == ("a.*", "b.*")
+
+    def test_empty_is_allowed_as_opt_out(self):
+        assert validate_task_module_patterns([]) == ()
+
+    @pytest.mark.parametrize(
+        "pattern,expected_problem",
+        [
+            ("", "empty"),
+            ("  my_pkg.*", "whitespace"),
+            ("my_pkg.* ", "whitespace"),
+            ("my_pkg.*.tasks", "only allowed as the final component"),
+            ("*.tasks", "only allowed as the final component"),
+            ("*", "at least the root package"),
+            ("my_pkg.", "not a valid Python identifier"),
+            ("my_pkg..tasks", "not a valid Python identifier"),
+            ("1st_pkg.tasks", "not a valid Python identifier"),
+            ("my-pkg.tasks", "not a valid Python identifier"),
+            ("my_pkg.ta*sks", "not a valid Python identifier"),
+        ],
+    )
+    def test_rejects_malformed(self, pattern: str, expected_problem: str):
+        with pytest.raises(TaskModulesError) as exc:
+            validate_task_module_patterns([pattern])
+        assert expected_problem in str(exc.value)
+        # Always actionable: the message shows the accepted grammar.
+        assert "trailing recursive wildcard" in str(exc.value)
+
+    def test_rejects_non_string(self):
+        with pytest.raises(TaskModulesError, match="must be strings"):
+            validate_task_module_patterns([typing.cast(str, 42)])
+
+
+# =============================================================================
+# Expansion
+# =============================================================================
+
+
+class TestExpansion:
+    def test_wildcard_lists_the_whole_tree_without_importing_submodules(
+        self, make_package
+    ):
+        pkg: GeneratedPackage = make_package()
+
+        expanded = expand_task_module_patterns([f"{pkg.name}.*"])
+
+        assert expanded == [
+            pkg.name,
+            f"{pkg.name}._tasks",  # underscore modules are NOT skipped
+            f"{pkg.name}.ingest",
+            f"{pkg.name}.ingest.raw",
+            f"{pkg.name}.reporting",
+            f"{pkg.name}.reporting.nested",
+            f"{pkg.name}.reporting.nested.deep",
+        ]
+        # __main__ submodules are skipped (entrypoints, run for side effects).
+        assert f"{pkg.name}.__main__" not in expanded
+        # The heart of the matter: only the ROOT package was imported — its
+        # __path__ is the unavoidable entry point to the tree. Everything
+        # below it came from the filesystem.
+        assert pkg.imported() == [pkg.name]
+        assert not [m for m in sys.modules if m.startswith(pkg.name + ".")]
+
+    def test_exact_pattern_imports_nothing_at_all(self, make_package):
+        pkg: GeneratedPackage = make_package()
+
+        expanded = expand_task_module_patterns([f"{pkg.name}.ingest.raw"])
+
+        assert expanded == [f"{pkg.name}.ingest.raw"]
+        assert pkg.imported() == []
+
+    def test_narrower_wildcard_scopes_the_walk(self, make_package):
+        pkg: GeneratedPackage = make_package()
+
+        expanded = expand_task_module_patterns([f"{pkg.name}.reporting.*"])
+
+        assert expanded == [
+            f"{pkg.name}.reporting",
+            f"{pkg.name}.reporting.nested",
+            f"{pkg.name}.reporting.nested.deep",
+        ]
+
+    def test_overlapping_patterns_dedupe(self, make_package):
+        pkg: GeneratedPackage = make_package()
+
+        expanded = expand_task_module_patterns(
+            [f"{pkg.name}.*", f"{pkg.name}.ingest.*", f"{pkg.name}.ingest.raw"]
+        )
+
+        assert len(expanded) == len(set(expanded))
+        assert expanded == sorted(expanded)
+
+    def test_unimportable_root_raises_rather_than_expanding_to_nothing(self):
+        with pytest.raises(TaskModulesError) as exc:
+            expand_task_module_patterns(["no_such_package_anywhere.*"])
+        assert "could not be imported" in str(exc.value)
+        assert "typos" in str(exc.value)
+
+    def test_malformed_pattern_raises_from_expansion_too(self):
+        with pytest.raises(TaskModulesError):
+            expand_task_module_patterns(["my_pkg.*.tasks"])
+
+
+# =============================================================================
+# Importing
+# =============================================================================
+
+
+class TestImportTaskModules:
+    def test_imports_every_module_and_counts_classes(self, make_package):
+        pkg: GeneratedPackage = make_package()
+        modules = expand_task_module_patterns([f"{pkg.name}.*"])
+        pkg.reset_imports()
+        del sys.modules[pkg.name]
+
+        report = import_task_modules(modules)
+
+        assert report.failures == {}
+        assert sorted(report.imported) == sorted(modules)
+        assert sorted(pkg.imported()) == sorted(modules)
+        # The generated modules define no task classes.
+        assert report.task_classes_registered == 0
+
+    def test_failures_are_warned_about_and_retained(self, make_package):
+        pkg: GeneratedPackage = make_package(broken_module=True)
+        modules = expand_task_module_patterns([f"{pkg.name}.*"])
+        broken = f"{pkg.name}.broken"
+        assert broken in modules
+
+        report = import_task_modules(modules)
+
+        # One bad module does not abort the rest.
+        assert broken not in report.imported
+        assert f"{pkg.name}.ingest.raw" in report.imported
+        assert "RuntimeError: missing optional dep" in report.failures[broken]
+        # Retained process-wide for the rehydration-failure diagnostic.
+        assert last_import_failures() == report.failures
+        note = import_failure_note()
+        assert broken in note and "likely cause" in note
+
+    def test_no_failures_means_no_diagnostic_note(self, make_package):
+        pkg: GeneratedPackage = make_package()
+        import_task_modules(expand_task_module_patterns([f"{pkg.name}.*"]))
+        assert import_failure_note() == ""
+
+    def test_repeated_calls_are_cached_per_module_list(self, make_package):
+        pkg: GeneratedPackage = make_package()
+        modules = expand_task_module_patterns([f"{pkg.name}.*"])
+        first = import_task_modules(modules)
+        pkg.reset_imports()
+
+        second = import_task_modules(list(modules))
+
+        assert second is first
+        # Nothing re-executed: a container serving many ticks pays once.
+        assert pkg.imported() == []
+
+    def test_counts_only_classes_from_the_named_modules(self):
+        class _CountedTask(SyncOnlyTask):
+            pass
+
+        assert count_registered_task_classes([__name__]) >= 1
+        assert count_registered_task_classes(["definitely.not.a.module"]) == 0
+        assert _CountedTask  # referenced so the definition isn't flagged unused
+
+
+# =============================================================================
+# Coverage
+# =============================================================================
+
+
+class TestCoverage:
+    @pytest.mark.parametrize(
+        "module_name,covered",
+        [
+            ("my_pkg.tasks", True),
+            ("my_pkg.tasks.ingest", True),
+            ("my_pkg.tasks.ingest.deep", True),
+            ("my_pkg", False),
+            ("my_pkg.tasksomething", False),  # prefix, not a package boundary
+            ("my_pkg.experiments", False),
+            ("other.tasks", False),
+            ("my_pkg.exact", True),
+            ("my_pkg.exactly", False),
+        ],
+    )
+    def test_wildcard_and_exact_matching(self, module_name: str, covered: bool):
+        patterns = ["my_pkg.tasks.*", "my_pkg.exact"]
+        assert module_is_covered(module_name, patterns) is covered
+
+    def test_main_modules_are_never_covered(self):
+        # Consistent with expansion, which skips them: a class defined in a
+        # __main__ module can never be registered in a scheduler container.
+        assert module_is_covered("my_pkg.__main__", ["my_pkg.*"]) is False
+        assert module_is_covered("__main__", ["__main__"]) is False
+
+    def test_no_patterns_covers_nothing(self):
+        assert module_is_covered("my_pkg.tasks", []) is False
+
+    def test_suggested_pattern_is_the_defining_package(self):
+        assert suggested_pattern_for("my_pkg.experiments.scratch") == (
+            "my_pkg.experiments.*"
+        )
+        assert suggested_pattern_for("toplevel") == "toplevel"
+
+    def test_uncovered_task_classes_dedupes_and_sorts(self):
+        tasks = [
+            SyncOnlyTask(name="a"),
+            SyncOnlyTask(name="b"),  # same class, reported once
+        ]
+        uncovered = uncovered_task_classes(tasks, ["nothing_matching.*"])
+        assert uncovered == [SyncOnlyTask]
+
+    def test_covered_classes_are_not_reported(self):
+        tasks = [SyncOnlyTask(name="a")]
+        patterns = [f"{SyncOnlyTask.__module__}"]
+        assert uncovered_task_classes(tasks, patterns) == []
+
+    def test_only_unwarned_reports_each_class_once_per_process(self):
+        tasks = [SyncOnlyTask(name="once")]
+        first = uncovered_task_classes(tasks, ["nope.*"], only_unwarned=True)
+        second = uncovered_task_classes(tasks, ["nope.*"], only_unwarned=True)
+        assert first == [SyncOnlyTask]
+        assert second == []
+
+    def test_message_names_class_patterns_and_the_fix(self):
+        message = format_uncovered_message(
+            [SyncOnlyTask], ["my_pkg.tasks.*"], remedy="Then redeploy."
+        )
+        assert f"{SyncOnlyTask.__module__}.{SyncOnlyTask.__qualname__}" in message
+        assert "['my_pkg.tasks.*']" in message
+        assert suggested_pattern_for(SyncOnlyTask.__module__) in message
+        assert "redeploy" in message
+        assert "Then redeploy." in message
+
+    def test_message_without_declared_patterns(self):
+        message = format_uncovered_message([SyncOnlyTask], [])
+        assert "not declared" in message
+
+
+# =============================================================================
+# The ambient declaration
+# =============================================================================
+
+
+class TestDeclaredPatterns:
+    def test_set_and_read_back(self):
+        previous = declared_task_module_patterns()
+        try:
+            set_declared_task_module_patterns(["my_pkg.*"])
+            assert declared_task_module_patterns() == ("my_pkg.*",)
+        finally:
+            set_declared_task_module_patterns(previous)
+
+    def test_defaults_to_empty(self):
+        previous = declared_task_module_patterns()
+        try:
+            set_declared_task_module_patterns([])
+            assert declared_task_module_patterns() == ()
+        finally:
+            set_declared_task_module_patterns(previous)
+
+
+# =============================================================================
+# Pickle elision planning
+# =============================================================================
+
+
+class TestPlanPickleElision:
+    def test_covered_and_round_tripping_task_needs_no_pickle(self):
+        task = SyncOnlyTask(name="elide-me")
+        plan = plan_pickle_elision([task], [SyncOnlyTask.__module__])
+        assert plan.pickle_free == (task,)
+        assert plan.pickled == ()
+        assert plan.require_pickle_free_error() is None
+        assert "1 task(s) pickle-free, 0 pickled" in plan.summary()
+
+    def test_uncovered_class_keeps_its_pickle(self):
+        task = SyncOnlyTask(name="keep-me")
+        plan = plan_pickle_elision([task], ["unrelated_pkg.*"])
+        assert plan.pickle_free == ()
+        assert [reason for _, reason in plan.pickled] == [
+            "task class not covered by task_modules"
+        ]
+        assert "not covered" in plan.summary()
+
+    def test_alias_task_payload_stays_pickle_bound(self, default_in_memory_fs_target):
+        """AliasTask embeds a pickled ``loads_type``; rehydration refuses it
+        (auto-unpickling registry bytes in a scheduler is an RCE vector), so
+        the self-check fails and the pickle is written — by design."""
+        import stardag as sd
+
+        class ElisionAliasSource(sd.Task[int]):
+            def run(self) -> None:
+                self._save(42)
+
+        source = ElisionAliasSource()
+        alias = sd.AliasTask[int](aliased=sd.AliasedMetadata.from_task(source))
+        plan = plan_pickle_elision([alias], [type(alias).__module__, __name__])
+
+        assert plan.pickle_free == ()
+        assert len(plan.pickled) == 1
+        assert "round-trip failed" in plan.pickled[0][1]
+        assert "__aliased" in plan.pickled[0][1]
+
+    def test_require_pickle_free_error_names_every_task_and_reason(self):
+        tasks = [SyncOnlyTask(name="x"), SyncOnlyTask(name="y")]
+        plan = plan_pickle_elision(tasks, ["unrelated_pkg.*"])
+        error = plan.require_pickle_free_error()
+        assert error is not None
+        assert "2 task(s)" in error
+        for task in tasks:
+            assert str(task.id) in error
+        assert "not covered by task_modules" in error
+
+    def test_summary_aggregates_repeated_reasons(self):
+        tasks = [SyncOnlyTask(name=f"t{i}") for i in range(3)]
+        plan = plan_pickle_elision(tasks, ["unrelated_pkg.*"])
+        assert "(x3)" in plan.summary()
+
+    def test_no_patterns_means_everything_pickled(self):
+        task = SyncOnlyTask(name="no-patterns")
+        plan = plan_pickle_elision([task], [])
+        assert plan.pickle_free == ()
+        assert len(plan.pickled) == 1
+
+
+def test_base_task_registry_exposes_registered_classes():
+    """``count_registered_task_classes`` relies on this accessor."""
+    classes = BaseTask._registry().classes()
+    assert SyncOnlyTask in classes

--- a/lib/stardag/tests/test_build/test_task_modules.py
+++ b/lib/stardag/tests/test_build/test_task_modules.py
@@ -471,3 +471,50 @@ def test_base_task_registry_exposes_registered_classes():
     """``count_registered_task_classes`` relies on this accessor."""
     classes = BaseTask._registry().classes()
     assert SyncOnlyTask in classes
+
+
+class TestDeclarationHygiene:
+    def test_a_whitespace_padded_pattern_is_normalised(self):
+        from stardag.build._task_modules import (
+            _reset_import_state_for_tests,
+            declared_task_module_patterns,
+            set_declared_task_module_patterns,
+        )
+
+        _reset_import_state_for_tests()
+        set_declared_task_module_patterns([" pkg.tasks ", "pkg.more"])
+        assert declared_task_module_patterns() == ("pkg.tasks", "pkg.more")
+        _reset_import_state_for_tests()
+
+    def test_an_empty_pattern_is_refused_rather_than_stored(self):
+        """It would match no module while still reading as a declaration,
+        quietly returning ticks to the pickle path."""
+        import pytest
+
+        from stardag.build._task_modules import (
+            _reset_import_state_for_tests,
+            set_declared_task_module_patterns,
+        )
+
+        _reset_import_state_for_tests()
+        with pytest.raises(ValueError, match="non-empty"):
+            set_declared_task_module_patterns(["pkg.tasks", "   "])
+        _reset_import_state_for_tests()
+
+    def test_the_test_reset_hook_clears_every_piece_of_ambient_state(self):
+        """Otherwise a declaration or a one-shot warning leaks into the next
+        test and results depend on execution order."""
+        from stardag.build._task_modules import (
+            _reset_import_state_for_tests,
+            _warned_classes,
+            declared_task_module_patterns,
+            set_declared_task_module_patterns,
+        )
+
+        set_declared_task_module_patterns(["pkg.tasks"])
+        _warned_classes.add("some.Class")
+
+        _reset_import_state_for_tests()
+
+        assert declared_task_module_patterns() == ()
+        assert _warned_classes == set()

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -795,6 +795,182 @@ class TestStardagAppReactiveTrigger:
                 )
 
 
+# ---------------------------------------------------------------------------
+# task_modules: declaration, deploy-time expansion, pre-flight, pickle elision
+# ---------------------------------------------------------------------------
+
+
+def _app_with_task_modules(name: str, **kwargs) -> StardagApp:
+    return StardagApp(
+        name,
+        builder_settings=FunctionSettings(image=_make_image()),
+        worker_settings={"default": FunctionSettings(image=_make_image())},
+        **kwargs,
+    )
+
+
+class TestTaskModulesDeclaration:
+    """`StardagApp(task_modules=...)` validation and inference."""
+
+    def test_patterns_are_validated_eagerly(self):
+        from stardag.build import TaskModulesError
+
+        with pytest.raises(TaskModulesError, match="only allowed as the final"):
+            _app_with_task_modules("tm-bad", task_modules=["my_pkg.*.tasks"])
+
+    def test_empty_list_opts_out_silently(self, caplog):
+        with caplog.at_level("WARNING"):
+            app = _app_with_task_modules("tm-optout", task_modules=[])
+        assert app.task_modules == ()
+        assert "task_modules" not in caplog.text
+
+    def test_declared_patterns_are_deduped_and_sorted(self):
+        app = _app_with_task_modules(
+            "tm-declared", task_modules=["b_pkg.*", "a_pkg.tasks", "b_pkg.*"]
+        )
+        assert app.task_modules == ("a_pkg.tasks", "b_pkg.*")
+
+    def test_default_infers_from_the_defining_module(self):
+        """The default is "the root package of the module defining the app,
+        recursively" — resolved from the caller's frame, so it matches what
+        inference sees from this very test function."""
+        from stardag.integration.modal._app import _infer_task_module_patterns
+
+        expected = _infer_task_module_patterns(_depth=1)
+        app = _app_with_task_modules("tm-inferred")
+        assert app.task_modules == expected
+
+    def test_inference_uses_the_callers_root_package(self):
+        from stardag.integration.modal._app import _infer_task_module_patterns
+
+        namespace = {
+            "__name__": "acme_pipelines.deploy.app",
+            "__package__": "acme_pipelines.deploy",
+            "_infer": _infer_task_module_patterns,
+        }
+        exec("result = _infer(_depth=1)", namespace)  # noqa: S102
+        assert namespace["result"] == ("acme_pipelines.*",)
+
+    @pytest.mark.parametrize(
+        "module_name,package",
+        [("__main__", None), ("loose_deploy_script", ""), ("__main__", "")],
+    )
+    def test_inference_opts_out_with_a_warning_for_unpackaged_modules(
+        self, caplog, module_name, package
+    ):
+        """A module that isn't part of a package has no importable name in a
+        container, so a pattern derived from it would be a lie: warn (naming
+        the fallback and the fix) and opt out."""
+        from stardag.integration.modal._app import _infer_task_module_patterns
+
+        namespace = {
+            "__name__": module_name,
+            "__package__": package,
+            "_infer": _infer_task_module_patterns,
+        }
+        with caplog.at_level("WARNING"):
+            exec("result = _infer(_depth=1)", namespace)  # noqa: S102
+
+        assert namespace["result"] == ()
+        assert "Could not infer StardagApp(task_modules=...)" in caplog.text
+        assert "fall back to the build task store's pickles" in caplog.text
+        assert 'task_modules=["my_pkg.tasks.*"]' in caplog.text
+
+
+class TestFinalizeBakesTaskModules:
+    """finalize() expands the patterns once and freezes the result into the
+    deployed tick — so the deployed set is explicit, auditable, and only
+    changes on redeploy."""
+
+    def _finalize(self, **app_kwargs):
+        app = _app_with_task_modules("tm-finalize", **app_kwargs)
+        captured: dict = {}
+
+        def capture_function(**kwargs):
+            def decorator(fn):
+                captured[kwargs.get("name", "unknown")] = fn
+                return fn
+
+            return decorator
+
+        app.modal_app.function = capture_function  # type: ignore[assignment]
+        with patch("stardag.integration.modal._app.get_target_roots_volumes") as mv:
+            mv.return_value = MagicMock(by_volume_name={}, by_root_key={})
+            result = app.finalize()
+        return app, result, captured
+
+    def test_expansion_is_surfaced_on_the_finalize_result(self):
+        _, result, _ = self._finalize(task_modules=["stardag.utils.*"])
+
+        assert "stardag.utils" in result.task_modules
+        assert "stardag.utils.testing.helper_tasks" in result.task_modules
+        assert result.task_modules == sorted(set(result.task_modules))
+
+    def test_opted_out_app_bakes_nothing(self):
+        _, result, _ = self._finalize(task_modules=[])
+        assert result.task_modules == []
+
+    def test_tick_imports_the_baked_list(self, default_in_memory_fs_target):
+        from stardag.build import TickSummary
+        from stardag.registry import BuildInfo
+
+        _, result, captured = self._finalize(task_modules=["stardag.utils.*"])
+        build_id = uuid4()
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_get.return_value = BuildInfo(
+            id=build_id, reactive_app_name="tm-finalize", reactive_tick_kwargs=None
+        )
+
+        async def stub_tick_aio(build_uuid, **kwargs):
+            return TickSummary(outcome="noop")
+
+        with (
+            patch("stardag.integration.modal._app.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch(
+                "stardag.integration.modal._app.RegistryGlobalConcurrencyLockManager"
+            ),
+            patch(
+                "stardag.integration.modal._app.import_task_modules"
+            ) as import_modules,
+        ):
+            rp.get.return_value = registry
+            captured["tick"](str(build_id))
+
+        # Exactly the list frozen at deploy time — not re-derived in the
+        # container, where the filesystem walk would cost cold-start time.
+        import_modules.assert_called_once_with(result.task_modules)
+
+    def test_opted_out_tick_imports_nothing(self, default_in_memory_fs_target):
+        from stardag.build import TickSummary
+        from stardag.registry import BuildInfo
+
+        _, _, captured = self._finalize(task_modules=[])
+        build_id = uuid4()
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_get.return_value = BuildInfo(
+            id=build_id, reactive_app_name="tm-finalize", reactive_tick_kwargs=None
+        )
+
+        async def stub_tick_aio(build_uuid, **kwargs):
+            return TickSummary(outcome="noop")
+
+        with (
+            patch("stardag.integration.modal._app.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch(
+                "stardag.integration.modal._app.RegistryGlobalConcurrencyLockManager"
+            ),
+            patch(
+                "stardag.integration.modal._app.import_task_modules"
+            ) as import_modules,
+        ):
+            rp.get.return_value = registry
+            captured["tick"](str(build_id))
+
+        import_modules.assert_not_called()
+
+
 class TestReactiveTriggerFailureLeavesNoOrphanBuild:
     """A build minted by ``build_start`` is RUNNING until a terminal EVENT
     says otherwise — and no orchestrator exists yet to emit one. So a

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -10,6 +10,7 @@ except ImportError:
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
+import stardag as _sd
 from stardag import BaseTask
 from stardag.build._base import BuildSummary
 from stardag.integration.modal import (
@@ -876,6 +877,14 @@ class TestTaskModulesDeclaration:
         assert "fall back to the build task store's pickles" in caplog.text
         assert 'task_modules=["my_pkg.tasks.*"]' in caplog.text
 
+    def test_require_pickle_free_without_task_modules_is_rejected(self):
+        from stardag.build import TaskModulesError
+
+        with pytest.raises(TaskModulesError, match="meaningless without"):
+            _app_with_task_modules(
+                "tm-contradiction", task_modules=[], require_pickle_free=True
+            )
+
 
 class TestFinalizeBakesTaskModules:
     """finalize() expands the patterns once and freezes the result into the
@@ -973,8 +982,7 @@ class TestFinalizeBakesTaskModules:
     def test_worker_publishes_the_patterns_for_dynamic_dep_registration(self):
         """The worker doesn't import the modules (its task arrived by value,
         self-importing) but it does need the patterns: dynamic deps are
-        coverage-checked there, where the trigger's pre-flight can't see
-        them."""
+        persisted with the same elision as the trigger's discovered set."""
         from stardag.build import declared_task_module_patterns
         from stardag.utils.testing.helper_tasks import SyncOnlyTask
 
@@ -1069,6 +1077,243 @@ class TestReactiveTriggerCoveragePreflight:
         # class is reported once regardless, but the point is the completed
         # dep never entered the checked set.
         assert caplog.text.count("not covered by this app's task_modules") == 1
+
+
+class _ElisionAliasedSource(_sd.Task[int]):
+    """Module-level (pickle-able) source for the AliasTask elision test."""
+
+    def run(self) -> None:
+        self._save(7)
+
+
+class _ElisionIntAlias(_sd.AliasTask[int]):
+    """Concrete alias class (module-level so the store can pickle it)."""
+
+
+class _ElisionAliasConsumer(_sd.Task[int]):
+    """Consumes an aliased upstream — its payload therefore embeds the
+    ``__aliased`` marker that rehydration refuses."""
+
+    loads_int: _sd.TaskLoads[int]
+
+    def run(self) -> None:
+        self._save(self.loads_int.load() + 1)
+
+
+class TestReactivePickleElision:
+    """With task_modules covering the classes, the trigger writes no
+    pickles: a scheduler tick rebuilds the tasks from registry data."""
+
+    def _trigger(self, app, root, build_id=None):
+        build_id = build_id or uuid4()
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_start.return_value = build_id
+        registry.task_register_bulk_aio.return_value = None
+        with registry_provider.override(registry):
+            result = app.build_trigger(root, reactive=True)
+        return result, registry
+
+    def test_covered_round_tripping_tasks_get_no_pickle(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules("tm-elide", task_modules=[SyncOnlyTask.__module__])
+        dep = SyncOnlyTask(name="elide-dep")
+        root = SyncOnlyTask(name="elide-root", deps=(dep,))
+
+        with caplog.at_level("INFO"):
+            result, _ = self._trigger(app, root)
+
+        store = BuildTaskStore(result.build_id)
+        assert store.load_task(root.id) is None
+        assert store.load_task(dep.id) is None
+        assert "2 task(s) pickle-free, 0 pickled" in caplog.text
+
+    def test_uncovered_tasks_still_get_their_pickle(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-elide-uncovered", task_modules=["acme_pipelines.*"]
+        )
+        root = SyncOnlyTask(name="elide-uncovered-root")
+
+        result, _ = self._trigger(app, root)
+
+        store = BuildTaskStore(result.build_id)
+        loaded = store.load_task(root.id)
+        assert loaded is not None and loaded.id == root.id
+
+    def test_opted_out_app_pickles_everything_exactly_as_before(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules("tm-elide-optout", task_modules=[])
+        root = SyncOnlyTask(name="elide-optout-root")
+
+        result, _ = self._trigger(app, root)
+
+        assert BuildTaskStore(result.build_id).load_task(root.id) is not None
+
+    def test_alias_task_dag_keeps_its_pickle(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        """AliasTask is pickle-bound by design: its ``loads_type`` is pickled
+        bytes that a scheduler tick must never auto-unpickle from registry
+        data. The self-check fails, so the pickle is written."""
+        from stardag.build import BuildTaskStore
+
+        source = _ElisionAliasedSource()
+        source.run()
+        alias = _ElisionIntAlias(aliased=_sd.AliasedMetadata.from_task(source))
+        root = _ElisionAliasConsumer(loads_int=alias)
+        app = _app_with_task_modules("tm-elide-alias", task_modules=[__name__])
+
+        result, _ = self._trigger(app, root)
+
+        store = BuildTaskStore(result.build_id)
+        # The consumer embeds the alias payload, so it too fails the
+        # round-trip and keeps its pickle.
+        assert store.load_task(root.id) is not None
+
+    def test_require_pickle_free_raises_naming_every_task(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import TaskModulesError
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-require-pickle-free",
+            task_modules=["acme_pipelines.*"],
+            require_pickle_free=True,
+        )
+        dep = SyncOnlyTask(name="require-dep")
+        root = SyncOnlyTask(name="require-root", deps=(dep,))
+
+        with pytest.raises(TaskModulesError) as exc:
+            self._trigger(app, root)
+
+        message = str(exc.value)
+        assert "require_pickle_free=True" in message
+        assert "2 task(s)" in message
+        assert str(root.id) in message and str(dep.id) in message
+        assert "not covered by task_modules" in message
+
+    def test_require_pickle_free_passes_when_everything_is_covered(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-require-ok",
+            task_modules=[SyncOnlyTask.__module__],
+            require_pickle_free=True,
+        )
+        root = SyncOnlyTask(name="require-ok-root")
+
+        result, _ = self._trigger(app, root)
+
+        assert BuildTaskStore(result.build_id).load_task(root.id) is None
+
+
+class TestDynamicDepPickleElision:
+    """Dynamic deps registered from inside a worker get the same treatment —
+    without it, ``require_pickle_free`` would hold only until a task yielded
+    its first dynamic dependency."""
+
+    def _reporter(self, build_id):
+        from stardag.integration.modal._app import _WorkerLifecycleReporter
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        registry = MagicMock(spec=RegistryABC)
+        registry.task_register_bulk_aio.return_value = None
+        return (
+            _WorkerLifecycleReporter(
+                registry,
+                build_id,
+                SyncOnlyTask(name="dyn-parent"),
+                reactive=True,
+                app_name="tm-dynamic",
+            ),
+            registry,
+        )
+
+    def test_covered_dynamic_deps_are_not_pickled(self, default_in_memory_fs_target):
+        from stardag.build import (
+            BuildTaskStore,
+            set_declared_task_module_patterns,
+        )
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        build_id = uuid4()
+        reporter, _ = self._reporter(build_id)
+        dyn = SyncOnlyTask(name="dyn-dep-covered")
+
+        set_declared_task_module_patterns([SyncOnlyTask.__module__])
+        try:
+            reporter._register_dynamic_deps((dyn,))
+        finally:
+            set_declared_task_module_patterns([])
+
+        assert BuildTaskStore(build_id).load_task(dyn.id) is None
+
+    def test_uncovered_dynamic_deps_are_pickled_and_warned_once(
+        self, caplog, default_in_memory_fs_target
+    ):
+        from stardag.build import (
+            BuildTaskStore,
+            set_declared_task_module_patterns,
+        )
+        from stardag.build._task_modules import _warned_classes
+        from stardag.utils.testing.helper_tasks import AsyncOnlyTask
+
+        build_id = uuid4()
+        reporter, _ = self._reporter(build_id)
+        first = AsyncOnlyTask(name="dyn-dep-uncovered-1")
+        second = AsyncOnlyTask(name="dyn-dep-uncovered-2")
+
+        _warned_classes.discard(
+            f"{AsyncOnlyTask.__module__}.{AsyncOnlyTask.__qualname__}"
+        )
+        set_declared_task_module_patterns(["acme_pipelines.*"])
+        try:
+            with caplog.at_level("WARNING"):
+                reporter._register_dynamic_deps((first,))
+                reporter._register_dynamic_deps((second,))
+        finally:
+            set_declared_task_module_patterns([])
+
+        store = BuildTaskStore(build_id)
+        assert store.load_task(first.id) is not None
+        assert store.load_task(second.id) is not None
+        # Once per class per process — this runs on every suspending worker.
+        assert caplog.text.count("not covered by this app's task_modules") == 1
+        assert "the trigger's pre-flight could not see them" in caplog.text
+
+    def test_without_declared_patterns_behaviour_is_unchanged(
+        self, default_in_memory_fs_target
+    ):
+        from stardag.build import (
+            BuildTaskStore,
+            set_declared_task_module_patterns,
+        )
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        build_id = uuid4()
+        reporter, _ = self._reporter(build_id)
+        dyn = SyncOnlyTask(name="dyn-dep-no-patterns")
+
+        set_declared_task_module_patterns([])
+        reporter._register_dynamic_deps((dyn,))
+
+        assert BuildTaskStore(build_id).load_task(dyn.id) is not None
 
 
 class TestReactiveTriggerFailureLeavesNoOrphanBuild:

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -970,6 +970,106 @@ class TestFinalizeBakesTaskModules:
 
         import_modules.assert_not_called()
 
+    def test_worker_publishes_the_patterns_for_dynamic_dep_registration(self):
+        """The worker doesn't import the modules (its task arrived by value,
+        self-importing) but it does need the patterns: dynamic deps are
+        coverage-checked there, where the trigger's pre-flight can't see
+        them."""
+        from stardag.build import declared_task_module_patterns
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app, _, captured = self._finalize(task_modules=["stardag.utils.*"])
+        from stardag.build import set_declared_task_module_patterns
+
+        set_declared_task_module_patterns([])
+        try:
+            with patch.object(Runner, "run", return_value=None):
+                captured["worker_default"](SyncOnlyTask(name="publishes"))
+            assert declared_task_module_patterns() == app.task_modules
+        finally:
+            set_declared_task_module_patterns([])
+
+
+class TestReactiveTriggerCoveragePreflight:
+    """The trigger holds both the real DAG and the app, so it is the only
+    place that can tell the user a scheduler tick won't be able to rebuild
+    one of their task classes — before a single container starts."""
+
+    def _trigger(self, app, root):
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_start.return_value = uuid4()
+        registry.task_register_bulk_aio.return_value = None
+        with registry_provider.override(registry):
+            return app.build_trigger(root, reactive=True), registry
+
+    def test_uncovered_class_warns_with_the_pattern_to_add(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-preflight", task_modules=["acme_pipelines.tasks.*"]
+        )
+        root = SyncOnlyTask(name="preflight-uncovered")
+
+        with caplog.at_level("WARNING"):
+            self._trigger(app, root)
+
+        assert "not covered by this app's task_modules" in caplog.text
+        assert "['acme_pipelines.tasks.*']" in caplog.text
+        # The exact pattern that would fix it, and the redeploy requirement.
+        assert f"{SyncOnlyTask.__module__.rsplit('.', 1)[0]}.*" in caplog.text
+        assert "redeploy" in caplog.text
+
+    def test_covered_class_does_not_warn(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules(
+            "tm-preflight-ok", task_modules=[SyncOnlyTask.__module__]
+        )
+        with caplog.at_level("WARNING"):
+            self._trigger(app, SyncOnlyTask(name="preflight-covered"))
+
+        assert "not covered" not in caplog.text
+
+    def test_opted_out_app_never_warns(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        """An app that declared nothing would otherwise warn about every
+        class in every DAG, on every trigger."""
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules("tm-preflight-optout", task_modules=[])
+        with caplog.at_level("WARNING"):
+            self._trigger(app, SyncOnlyTask(name="preflight-optout"))
+
+        assert "not covered" not in caplog.text
+
+    def test_only_incomplete_tasks_are_checked(
+        self, caplog, modal_function_stub, default_in_memory_fs_target
+    ):
+        """Discovery stops at complete tasks and only incomplete ones are
+        ever rehydrated by a tick — so a completed dep's class is
+        irrelevant, and checking it would be a false alarm."""
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        dep = SyncOnlyTask(name="preflight-complete-dep")
+        dep.run()  # writes its target -> discovery treats it as complete
+        root = SyncOnlyTask(name="preflight-root", deps=(dep,))
+        app = _app_with_task_modules(
+            "tm-preflight-incomplete", task_modules=["acme_pipelines.*"]
+        )
+
+        with caplog.at_level("WARNING"):
+            _, registry = self._trigger(app, root)
+
+        # One warning for the class, naming only the root's occurrence: the
+        # class is reported once regardless, but the point is the completed
+        # dep never entered the checked set.
+        assert caplog.text.count("not covered by this app's task_modules") == 1
+
 
 class TestReactiveTriggerFailureLeavesNoOrphanBuild:
     """A build minted by ``build_start`` is RUNNING until a terminal EVENT

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1148,6 +1148,49 @@ class TestReactivePickleElision:
         loaded = store.load_task(root.id)
         assert loaded is not None and loaded.id == root.id
 
+    def test_inferred_task_modules_do_not_elide(
+        self, monkeypatch, modal_function_stub, default_in_memory_fs_target
+    ):
+        """Inference is observation-only; only an explicit declaration elides.
+
+        The trigger reads the LOCAL app definition while the tick runs the
+        DEPLOYED one, and nothing lets the trigger see the deployed app's
+        baked module list. If inference alone enabled elision, merely
+        upgrading the SDK would start dropping pickles that an app deployed
+        by an older SDK has no module list to compensate for — an upgrade
+        that breaks builds.
+        """
+        from stardag.build import BuildTaskStore
+        from stardag.integration.modal import _app as app_module
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        monkeypatch.setattr(
+            app_module, "_infer_task_module_patterns", lambda *a, **k: ("stardag.*",)
+        )
+        app = _app_with_task_modules("tm-elide-inferred")
+        # The inferred patterns DO cover the task class — coverage is not
+        # what is being withheld here, the opt-in is.
+        assert app.task_modules == ("stardag.*",)
+        root = SyncOnlyTask(name="elide-inferred-root")
+
+        result, _ = self._trigger(app, root)
+
+        assert BuildTaskStore(result.build_id).load_task(root.id) is not None
+
+    def test_the_same_patterns_declared_explicitly_do_elide(
+        self, modal_function_stub, default_in_memory_fs_target
+    ):
+        """The opt-in is the user's act, not the patterns' content."""
+        from stardag.build import BuildTaskStore
+        from stardag.utils.testing.helper_tasks import SyncOnlyTask
+
+        app = _app_with_task_modules("tm-elide-explicit", task_modules=["stardag.*"])
+        root = SyncOnlyTask(name="elide-explicit-root")
+
+        result, _ = self._trigger(app, root)
+
+        assert BuildTaskStore(result.build_id).load_task(root.id) is None
+
     def test_opted_out_app_pickles_everything_exactly_as_before(
         self, modal_function_stub, default_in_memory_fs_target
     ):


### PR DESCRIPTION
SDK side of **A1** and **A2** from #208. `lib/` and `docs/` only. The
server half (#210) is what makes the frontier carry the information this
consumes; against an older server every behaviour here degrades to exactly
what ships today.

## A1 — a blocker in another build no longer kills the build

A tick read `not frontier.actionable and running == 0` as "this build
cannot progress" and failed it. Both signals are **build-scoped** while
dependency gating is **environment-global**: task rows and their dependency
edges are per environment, so an upstream some other build left RUNNING
gates this build's downstream tasks while contributing to neither this
build's `running` nor its `status_counts`. It need not be in this build's
task set at all — a dynamic dependency registered under an earlier build is
the usual case. Result: healthy builds died within seconds of triggering,
with an error reporting only status counts, which points nowhere near the
cause.

Terminal detection now classifies the frontier's `blocked_by_external` on
two questions — is the blocker in this build's own task set, and **is
anyone going to move it**:

| `blocking_in_build` | `blocking_status` | owning build (`blocking_status_build_id`) | action |
| --- | --- | --- | --- |
| `true` | any | not consulted | **ignored** for the wait/fail decision — the blocker is in this build's own task set and is already modelled by `actionable` / `running` / `status_counts`. Still named in the message, since the counts alone never said which task was holding things up. |
| `false` | `running` | not consulted | **wait** — another build is executing it; a completion frees this build. Treated exactly like the existing `denied_this_round > 0` case: return `None`, don't fail. |
| `false` | not `running` | live (`running`, or `pending` — it may yet start) | **wait** — that build is going to schedule it. |
| `false` | not `running` | terminal (`completed` / `failed` / `cancelled`) | **fail now** — nothing is going to move it and this build never will. |
| `false` | not `running` | `None` (no build owns its status) | **fail now**, without a lookup — no status-moving event was ever recorded against the blocker, so there is no evidence anyone intends to run it, and no build to ask. |
| `false` | not `running` | unresolvable (deleted build, unreachable registry, or a server that doesn't report `status`) | **fail now** — unknown is not evidence of life, and a silent indefinite hang is the failure mode #208 exists to kill. |

Both waits are bounded (below). `fatal` outvotes `waiting`: one blocker
nothing will ever run means the build cannot complete, whatever else it is
also waiting on.

The owner-liveness row is the fix for the gap an earlier revision of this PR
left open — an out-of-build blocker that was merely *pending* under a
perfectly healthy concurrent build would have been failed, which is a *new*
spurious failure, the exact class of bug being fixed. The frontier already
names the owning build and `GET /builds/{id}` already returns its derived
status; the SDK was discarding it because `BuildInfo` didn't model the field
and `StardagBaseModel` ignores extras. `BuildInfo.status: str | None = None`
now models it (defaulted, so older servers and custom registries
deserialize unchanged). `build_get_aio` already existed on both
`RegistryABC` and `APIRegistry`, so no new registry surface was needed.

**Cost:** the owner status is resolved **once per distinct owning build per
classification pass** — a wide DAG stalled behind one build yields one
blocker entry per blocked edge, every one naming the same owner, so without
the memo this would be N requests for one answer. Deliberately not cached
across passes, so a later pass can see the owner go terminal. And the whole
lookup only happens on the stalled path, since the frontier populates
`blocked_by_external` solely when the build has nothing actionable and
nothing running — a healthy build issues **zero** extra requests however
often it polls. Stated in a comment so nobody "optimises" it away later.
Lookup failures are swallowed with a warning rather than escaping the tick:
this path decides a build's fate and must produce a precise failure, not a
traceback.

### The bounded wait

New `TickConfig.stale_external_blocker_seconds`, **default 21600.0 (6 h)**,
measured on the blocker's own `blocking_status_at` — how long it has sat in
that status — not on tick-local time. A tick is short-lived and the watchdog
re-ticks forever, so a tick-local bound would never expire; the build would
just hang quietly, which is the failure mode #208 is about. It applies to
both wait cases: a live owner is not a licence to wait forever, since a
build that has left a task pending for a day is not making progress on it.

Deliberately generous. Waiting is the cheap direction: the blocker's own
build has far better information about it (a live executor ref it can probe)
and its completion wakes this build within a watchdog period, whereas
failing a build whose blocker was merely slow is a regression of the exact
spurious-failure bug being fixed. The bound is a backstop for a blocker
nobody will ever move, not a scheduling deadline. `None` waits indefinitely
(with a per-tick log line saying so).

**`blocking_status_at is None`** (a task row predating server-side status
denormalisation): the wait cannot be aged, so the blocker is waited on
regardless of the bound, and the log line says the wait is unbounded.
Failing on missing information would reintroduce the very failures this
removes. Documented on the config field and covered by a test.

Not added to `_TICK_KWARGS_ALLOWED` (the per-build tick kwargs persisted in
the registry), matching `stale_running_no_ref_seconds`, which is likewise
app-level only.

### The two messages

They read differently on purpose: waiting because another *live* build owns
the blocker is a different operational situation from failing because none
does, and the operator needs to be told which. Each blocker also carries the
verdict's reason (`_BlockerVerdict`), so the description says *why* it
landed where it did.

**Waiting** (`INFO`), verbatim, from a test — note the executing/queued
split and the unbounded-wait note:

```
Build 66a2… has nothing runnable or running of its own but is waiting on 2
upstream task(s) owned by other builds (2 queued in a build that is still
live); waiting rather than failing (a blocker carries no status timestamp,
so its wait cannot be bounded): task 132e8369-… is blocked by
pipelines.Ingest (blocking-task-id), PENDING for 60s under build 66a29a9c-…
— its owning build is still running; task 9896df36-… is blocked by
pipelines.Transform (second-blocker), PENDING under build 66a29a9c-… — its
owning build is still running
```

**Failing** (`ERROR`, and the build's `error_message`), verbatim:

```
Build cannot progress: it has nothing runnable or running of its own, and 1
of its task(s) are blocked by an upstream owned by another build that no
live build is going to run (status counts: {'pending': 1}). Blocked by: task
132e8369-… is blocked by pipelines.Ingest (blocking-task-id), SUSPENDED for
60s under build e85c3f0e-… — its owning build is completed. Retry the
blocking task under the build that owns it (POST
/api/v1/builds/{build_id}/tasks/{task_id}/retry) to reset it to pending —
this now works from suspended as well as from failed/cancelled/skipped —
then re-trigger this build.
```

The cancel-first clause ("A blocker stuck RUNNING holds an execution claim
no retry can take…") is appended only when a fatal blocker is RUNNING. The
message names at most 5 blockers and appends "and N more"; when the server
set `blocked_by_external_truncated` it says so rather than implying the list
is exhaustive. The generic stuck-build failure keeps its old wording and now
appends any **in-build** blockers, which the status counts never identified.

`TickSummary` gains three flat counters (a later PR posts the summary to
the registry): **`external_blockers`**, **`external_blockers_waited`**,
**`external_blockers_fatal`**. The first counts every entry reported while
the build looked stalled, including in-build ones; the two splits cover
only out-of-build entries, so they do not add up — documented on the
fields. Existing field names untouched.

## A2 — `suspended` is retryable

`_RETRYABLE_STATUSES` gains `"suspended"`, so a re-trigger's
`discover_and_register_aio(..., retry_failed=True)` resets a task left
SUSPENDED — its execution registered dynamic dependencies, yielded and
returned, and then the orchestrator died or the build was cancelled —
instead of skipping it. Previously such a task was permanently
unschedulable, and the only escape was cancelling it purely to reach a
status that *was* retryable.

Safe precisely because a SUSPENDED task has **no live execution**: the
suspension means the execution yielded and *returned*, so resetting it
cannot orphan a running worker. Stated beside the constant, where someone
wondering whether this can strand an execution will look.

The other caller of `discover_and_register_aio` is a worker registering its
dynamically yielded deps; it takes the default `retry_failed=False` and so
never retries anything — verified, noted beside the constant, and pinned by
a test, since that is what stops a suspending worker from resetting its own
task out from under itself. `running` remains deliberately non-retryable:
it holds a live execution claim, and releasing that is cancellation.

## Behaviour change worth knowing: `stale_running_no_ref_seconds` now works

#210 also fixed `FrontierTaskRef.latest_status_at`, which was declared and
documented as the input to scheduler staleness bounds but never populated —
it silently serialised as `null` on every ref, leaving the guard dead.
Against a matching server, a task stuck RUNNING without an executor ref for
longer than the bound (**default 30 minutes**) is now failed as intended.
Raise the bound if you run long ref-less tasks — e.g. a resident build
sharing tasks with a concurrently ticking reactive one. No SDK change was
needed for this; it starts working on upgrade, which is why it is called
out here.

## Model

`FrontierExternalBlocker` in `stardag.registry` (exported alongside
`FrontierTaskRef`), plus `BuildFrontier.blocked_by_external` /
`.blocked_by_external_truncated` and `BuildInfo.status`, all defaulted so an
older server's response deserializes unchanged. The frontier field comment
records the semantics that matter most to a consumer: the server computes
the list **only** when the build has nothing actionable and nothing running,
so an **empty list means "not externally blocked, OR not stalled"** and must
never be read as proof that no external blocker exists.

## Tests

`FakeReactiveRegistry` gained the API's two scopes — an environment-global
status map plus `not_in_build`, the ids that exist in the environment but
not in this build's task set — computes `blocked_by_external` under the same
"only when stalled" gate as the server, and now serves per-build derived
status from `build_get_aio` (recording every call, so memoisation is
assertable). New `TestExternalBlockers` covers:

- the A1 repro: a build whose task waits on an upstream RUNNING in another
  build now lingers out with the build still RUNNING, where it used to be
  failed;
- a non-RUNNING blocker under a `running` **and** under a `pending` owner →
  waits; the same blocker past the bound → fails, message naming the bound;
- a terminal owner → fails; `blocking_status_build_id is None` → fails with
  no lookup at all; a 404ing lookup → fails without propagating; a server
  not reporting `status` → fails the same way and says so;
- **memoisation**: two blocker entries sharing one owner produce exactly one
  `build_get` call;
- the RUNNING-blocker bound expiring (a blocker RUNNING for a day) and the
  control case (the same age under a larger bound still waits);
- an in-build blocker that buys no wait but does get named;
- an unbounded wait: no `blocking_status_at` even with the bound set to 0,
  and `stale_external_blocker_seconds=None`;
- a fatal blocker outvoting a waitable one, and only the fatal one named;
- the truncation flag reaching the message;
- an older server (`serves_blocked_by_external = False`) producing exactly
  the pre-fix failure and zero counters;
- a healthy build recording no blockers at all;
- the end of the wait: the owning build completes the blocker, and the same
  lingering tick schedules the task it would previously have failed over.

Plus, in `TestRetryPath`: a suspended task reset by `retry_failed=True` and
the build running to completion, and a worker-style call (`retry_failed`
defaulted) leaving `suspended` untouched with no retry call at all.

`FakeReactiveRegistry.task_retry_aio` now applies `_RETRYABLE_STATUSES`
directly instead of its own copy of the tuple, so the fake cannot drift
from the code under test.

## Verification

From `lib/stardag`:

```
uv run pytest tests -q -m "not modal_live"   # 1053 passed, 29 deselected
uv run pyright src tests                     # 0 errors, 0 warnings
```

plus `pre-commit` (prettier, ruff, ruff-format, pyright) on every changed
file. The `modal_live` tier was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NyR9Kc9ZP5Ko7dVndhi3Y
