### PR TITLE
feat(ui): Builds view with staleness, batch selection and bulk cleanup (#208 B3/B5)

### DIFF
--- a/app/stardag-ui/src/App.tsx
+++ b/app/stardag-ui/src/App.tsx
@@ -111,21 +111,21 @@ interface SidebarStateProps {
   onToggleSidebar: () => void;
 }
 
-// Home page with builds list
-interface HomePageProps extends SidebarStateProps {
+// Builds list page (the app root view)
+interface BuildsPageProps extends SidebarStateProps {
   onNavigate: (item: NavItem) => void;
   onSelectBuild: (buildId: string) => void;
 }
 
-function HomePage({
+function BuildsPage({
   onNavigate,
   onSelectBuild,
   sidebarCollapsed,
   onToggleSidebar,
-}: HomePageProps) {
+}: BuildsPageProps) {
   return (
     <MainLayout
-      activeNav="home"
+      activeNav="builds"
       onNavigate={onNavigate}
       sidebarCollapsed={sidebarCollapsed}
       onToggleSidebar={onToggleSidebar}
@@ -153,7 +153,7 @@ function BuildPage({
 }: BuildPageProps) {
   return (
     <MainLayout
-      activeNav="home"
+      activeNav="builds"
       onNavigate={onNavigate}
       sidebarCollapsed={sidebarCollapsed}
       onToggleSidebar={onToggleSidebar}
@@ -611,7 +611,7 @@ function Router() {
       return "build";
     }
 
-    return "home";
+    return "builds";
   }, [path]);
 
   // Handle sidebar navigation
@@ -619,7 +619,7 @@ function Router() {
     (item: NavItem) => {
       const basePath = getEnvironmentPath();
       switch (item) {
-        case "home":
+        case "builds":
           navigateTo(basePath || "/");
           break;
         case "tasks":
@@ -722,7 +722,7 @@ function Router() {
           );
         }
         return (
-          <HomePage
+          <BuildsPage
             onNavigate={handleNavigation}
             onSelectBuild={handleSelectBuild}
             sidebarCollapsed={sidebarCollapsed}
@@ -730,10 +730,10 @@ function Router() {
           />
         );
 
-      case "home":
+      case "builds":
       default:
         return (
-          <HomePage
+          <BuildsPage
             onNavigate={handleNavigation}
             onSelectBuild={handleSelectBuild}
             sidebarCollapsed={sidebarCollapsed}

--- a/app/stardag-ui/src/api/tasks.ts
+++ b/app/stardag-ui/src/api/tasks.ts
@@ -51,6 +51,15 @@ export interface BuildFilters {
   status?: BuildStatus;
   // Only builds reactively scheduled by the named app.
   reactive_app_name?: string;
+  // Only builds with no activity for at least this long, measured on
+  // `last_activity_at`. Same definition and same 60s floor as
+  // POST /builds/bulk-cancel — deliberately the one predicate, so what a
+  // list shows and what a cleanup would act on cannot disagree. Ordering
+  // flips to stalest-first when it is set.
+  //
+  // Only `status=running` may accompany it (that pair is the
+  // abandoned-build query and stays exact); any other status is a 422.
+  idle_for_seconds?: number;
 }
 
 export async function fetchBuilds(
@@ -63,6 +72,8 @@ export async function fetchBuilds(
   if (filters.status) params.set("status", filters.status);
   if (filters.reactive_app_name)
     params.set("reactive_app_name", filters.reactive_app_name);
+  if (filters.idle_for_seconds)
+    params.set("idle_for_seconds", String(filters.idle_for_seconds));
 
   const url = `${API_BASE}/builds?${params.toString()}`;
   const response = await fetchWithAuth(url);

--- a/app/stardag-ui/src/api/tasks.ts
+++ b/app/stardag-ui/src/api/tasks.ts
@@ -1,6 +1,10 @@
 import type {
   Build,
+  BuildCancelResult,
   BuildListResponse,
+  BuildStatus,
+  BulkCancelBuildsRequest,
+  BulkCancelBuildsResponse,
   Task,
   TaskArtifactListResponse,
   TaskEvent,
@@ -13,12 +17,40 @@ import { API_V1 } from "./config";
 
 const API_BASE = API_V1;
 
+/**
+ * Best-effort error message for a failed response.
+ *
+ * FastAPI puts the useful part in a JSON ``detail`` (the 422 "provide
+ * build_ids and/or idle_for_seconds" and the 403 admin gate both say
+ * exactly what went wrong), while ``statusText`` says only
+ * "Unprocessable Entity". Falls back to the status line when the body is
+ * missing or not JSON.
+ */
+async function errorMessage(response: Response, fallback: string): Promise<string> {
+  try {
+    const body = await response.json();
+    const detail = (body as { detail?: unknown }).detail;
+    if (typeof detail === "string" && detail) return detail;
+    if (Array.isArray(detail) && detail.length > 0) {
+      const first = detail[0] as { msg?: unknown };
+      if (typeof first?.msg === "string") return first.msg;
+    }
+  } catch {
+    // Not JSON (or already consumed) — fall through to the status line.
+  }
+  return `${fallback}: ${response.statusText}`;
+}
+
 // Build API
 
 export interface BuildFilters {
   page?: number;
   page_size?: number;
   environment_id?: string;
+  // Derived build status, filtered server-side.
+  status?: BuildStatus;
+  // Only builds reactively scheduled by the named app.
+  reactive_app_name?: string;
 }
 
 export async function fetchBuilds(
@@ -28,6 +60,9 @@ export async function fetchBuilds(
   if (filters.page) params.set("page", String(filters.page));
   if (filters.page_size) params.set("page_size", String(filters.page_size));
   if (filters.environment_id) params.set("environment_id", filters.environment_id);
+  if (filters.status) params.set("status", filters.status);
+  if (filters.reactive_app_name)
+    params.set("reactive_app_name", filters.reactive_app_name);
 
   const url = `${API_BASE}/builds?${params.toString()}`;
   const response = await fetchWithAuth(url);
@@ -208,19 +243,59 @@ export async function fetchTaskEvents(
 
 // Build actions
 
+/**
+ * Cancel a single build.
+ *
+ * ``cascade`` additionally emits TASK_CANCELLED for the build's
+ * RUNNING/SUSPENDED tasks, releasing the execution claims and
+ * concurrency-limit slots they hold. It defaults to false server-side, so
+ * an omitted argument keeps the historical behaviour (a build-level event
+ * and nothing else).
+ */
 export async function cancelBuild(
   buildId: string,
   environmentId?: string,
   triggeredByUserId?: string,
-): Promise<Build> {
+  cascade = false,
+): Promise<BuildCancelResult> {
   const params = new URLSearchParams();
   if (environmentId) params.set("environment_id", environmentId);
   if (triggeredByUserId) params.set("triggered_by_user_id", triggeredByUserId);
+  if (cascade) params.set("cascade", "true");
 
   const url = `${API_BASE}/builds/${buildId}/cancel?${params.toString()}`;
   const response = await fetchWithAuth(url, { method: "POST" });
   if (!response.ok) {
-    throw new Error(`Failed to cancel build: ${response.statusText}`);
+    throw new Error(await errorMessage(response, "Failed to cancel build"));
+  }
+  return response.json();
+}
+
+/**
+ * Cancel every RUNNING build matching an explicit id set and/or an
+ * idleness threshold, optionally releasing the claims their tasks hold.
+ *
+ * Pass ``dry_run: true`` first: the response then reports the exact same
+ * selection (builds, cascaded task ids, per-build skip reasons,
+ * truncation) that a real call would act on, and writes nothing.
+ *
+ * On the JWT path this requires the workspace admin role.
+ */
+export async function bulkCancelBuilds(
+  request: BulkCancelBuildsRequest,
+  environmentId: string,
+): Promise<BulkCancelBuildsResponse> {
+  const params = new URLSearchParams();
+  params.set("environment_id", environmentId);
+
+  const url = `${API_BASE}/builds/bulk-cancel?${params.toString()}`;
+  const response = await fetchWithAuth(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, "Failed to cancel builds"));
   }
   return response.json();
 }

--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -36,6 +36,7 @@ import {
 } from "./dagLayout";
 import { TaskDetail } from "./TaskDetail";
 import { TaskFilters } from "./TaskFilters";
+import { ConfirmDialog } from "./ui/ConfirmDialog";
 import { TaskTable } from "./TaskTable";
 
 interface BuildViewProps {
@@ -77,7 +78,12 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
   const [showOverrideMenu, setShowOverrideMenu] = useState(false);
   const [overriding, setOverriding] = useState(false);
   const [overrideError, setOverrideError] = useState<string | null>(null);
+  const [overrideNotice, setOverrideNotice] = useState<string | null>(null);
   const overrideMenuRef = useRef<HTMLDivElement>(null);
+  // Cascading cancel is a different operation from plain cancel — it also
+  // releases the claims this build's tasks hold — so it gets a real
+  // confirmation dialog that says so, rather than a `window.confirm`.
+  const [cascadeConfirmOpen, setCascadeConfirmOpen] = useState(false);
 
   // Refresh state
   const [refreshing, setRefreshing] = useState(false);
@@ -197,6 +203,7 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
       setShowOverrideMenu(false);
       setOverriding(true);
       setOverrideError(null);
+      setOverrideNotice(null);
 
       const userId = user?.profile?.sub;
 
@@ -222,6 +229,41 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
     },
     [activeEnvironment?.id, buildId, user?.profile?.sub],
   );
+
+  // Cancel the build AND release the claims its tasks hold. Plain cancel
+  // writes only a build-level event, so a task the build left RUNNING
+  // keeps denying its execution claim to every future build that needs
+  // it — cascading is what actually cleans that up. Kept as a separate
+  // action rather than a changed default so existing behaviour is
+  // untouched and the difference is visible in the menu.
+  const handleCascadeCancel = useCallback(async () => {
+    if (!activeEnvironment?.id || !buildId) return;
+    setOverriding(true);
+    setOverrideError(null);
+    setOverrideNotice(null);
+    try {
+      const result = await cancelBuild(
+        buildId,
+        activeEnvironment.id,
+        user?.profile?.sub,
+        true,
+      );
+      setCascadeConfirmOpen(false);
+      setOverrideNotice(
+        result.cascaded_task_count === 0
+          ? "Build cancelled — it held no execution claims."
+          : `Build cancelled — released ${result.cascaded_task_count} execution claim${
+              result.cascaded_task_count === 1 ? "" : "s"
+            }.`,
+      );
+      // Refetch so the task table and DAG show the cancelled tasks.
+      await loadBuild();
+    } catch (err) {
+      setOverrideError(err instanceof Error ? err.message : "Failed to cancel build");
+    } finally {
+      setOverriding(false);
+    }
+  }, [activeEnvironment?.id, buildId, user?.profile?.sub, loadBuild]);
 
   // ESC to exit DAG fullscreen
   useEffect(() => {
@@ -494,7 +536,7 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
                         </svg>
                       </button>
                       {showOverrideMenu && (
-                        <div className="absolute right-0 z-10 mt-1 w-40 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-gray-800 dark:ring-gray-700">
+                        <div className="absolute right-0 z-10 mt-1 w-56 origin-top-right rounded-md bg-white shadow-lg ring-1 ring-black ring-opacity-5 dark:bg-gray-800 dark:ring-gray-700">
                           <div className="py-1">
                             <button
                               onClick={() => handleOverride("complete")}
@@ -517,6 +559,19 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
                               <span className="h-2 w-2 rounded-full bg-gray-500" />
                               Cancel
                             </button>
+                            <button
+                              onClick={() => {
+                                setShowOverrideMenu(false);
+                                setOverrideError(null);
+                                setOverrideNotice(null);
+                                setCascadeConfirmOpen(true);
+                              }}
+                              title="Cancel the build and release the execution claims its tasks hold"
+                              className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+                            >
+                              <span className="h-2 w-2 flex-shrink-0 rounded-full bg-red-400" />
+                              Cancel &amp; Release Claims
+                            </button>
                           </div>
                         </div>
                       )}
@@ -525,6 +580,14 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
                   {overrideError && (
                     <span className="text-xs text-red-600 dark:text-red-400">
                       {overrideError}
+                    </span>
+                  )}
+                  {overrideNotice && (
+                    <span
+                      role="status"
+                      className="text-xs text-green-700 dark:text-green-400"
+                    >
+                      {overrideNotice}
                     </span>
                   )}
                 </div>
@@ -711,6 +774,37 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
           </div>
         </div>
       )}
+
+      <ConfirmDialog
+        isOpen={cascadeConfirmOpen}
+        title="Cancel build and release its claims"
+        destructive
+        confirmLabel="Cancel build & release claims"
+        busyLabel="Cancelling…"
+        cancelLabel="Close"
+        busy={overriding}
+        error={overrideError}
+        onConfirm={handleCascadeCancel}
+        onCancel={() => {
+          setCascadeConfirmOpen(false);
+          setOverrideError(null);
+        }}
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Cancels this build and — unlike plain <em>Cancel</em> — also cancels its
+          running and suspended tasks, freeing the execution claims and
+          concurrency-limit slots they hold. A task left running by this build denies
+          its claim to every future build that needs it until something releases it.
+        </p>
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Pending tasks are left alone (they hold no claim and may be referenced by
+          other builds), as are tasks another build put into running.
+        </p>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          The server cannot stop anything: a worker whose task is cancelled here keeps
+          going until it notices, and if it completes anyway, completed wins.
+        </p>
+      </ConfirmDialog>
     </div>
   );
 }

--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -597,6 +597,11 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
               <div className="flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-700">
                 <button
                   onClick={handleToggleDag}
+                  // A disclosure control whose only state cue was a rotated
+                  // chevron: invisible to assistive tech, and to any test that
+                  // isn't reading CSS classes.
+                  aria-expanded={showDag}
+                  aria-controls="build-dag-panel"
                   className="flex items-center gap-2 text-sm text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
                 >
                   <svg
@@ -662,7 +667,7 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
                   onExpand={() => setShowDag(true)}
                 >
                   {showDag && !dagFullscreen && (
-                    <div className="h-full">
+                    <div id="build-dag-panel" className="h-full">
                       <DagGraph
                         tasks={tasksWithContext}
                         graph={graph}

--- a/app/stardag-ui/src/components/BuildsList.test.tsx
+++ b/app/stardag-ui/src/components/BuildsList.test.tsx
@@ -206,9 +206,7 @@ describe("BuildsList", () => {
         }),
       ),
     );
-    expect(
-      await screen.findByText(/1 build idle ≥ 24h, stalest first/),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(/1 build running, idle ≥ 24h/)).toBeInTheDocument();
     // No over-fetching and no local caveat: `total` is exact and
     // pagination is server-side for this filter.
     expect(fetchBuilds).not.toHaveBeenCalledWith(
@@ -236,9 +234,7 @@ describe("BuildsList", () => {
     );
 
     await waitFor(() =>
-      expect(
-        screen.getByText("2 builds idle ≥ 24h, stalest first"),
-      ).toBeInTheDocument(),
+      expect(screen.getByText("2 builds running, idle ≥ 24h")).toBeInTheDocument(),
     );
     const names = screen
       .getAllByRole("row")

--- a/app/stardag-ui/src/components/BuildsList.test.tsx
+++ b/app/stardag-ui/src/components/BuildsList.test.tsx
@@ -1,0 +1,486 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BreadcrumbProvider } from "../context/BreadcrumbContext";
+import type { Build, BulkCancelBuildsResponse } from "../types/task";
+import { BuildsList } from "./BuildsList";
+
+let mockEnvironmentId = "env-1";
+let mockWorkspaceRole: "owner" | "admin" | "member" | null = "admin";
+vi.mock("../context/EnvironmentContext", () => ({
+  useEnvironment: () => ({
+    activeEnvironment: {
+      id: mockEnvironmentId,
+      slug: "default",
+      name: "default",
+    },
+    activeWorkspaceRole: mockWorkspaceRole,
+  }),
+}));
+
+vi.mock("../api/tasks", () => ({
+  fetchBuilds: vi.fn(),
+  bulkCancelBuilds: vi.fn(),
+}));
+
+import { bulkCancelBuilds, fetchBuilds } from "../api/tasks";
+
+const HOUR = 3600 * 1000;
+const DAY = 24 * HOUR;
+const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+function makeBuild(overrides: Partial<Build> & Pick<Build, "id" | "name">): Build {
+  return {
+    environment_id: "env-1",
+    user_id: null,
+    description: null,
+    commit_hash: null,
+    root_task_ids: [],
+    created_at: ago(10 * DAY),
+    status: "running",
+    started_at: ago(10 * DAY),
+    completed_at: null,
+    status_triggered_by_user: null,
+    // Deliberately older than every `last_activity_at` below: the table
+    // must never surface this lifecycle timestamp as activity.
+    last_active_at: ago(6 * DAY),
+    last_activity_at: ago(2 * HOUR),
+    ...overrides,
+  };
+}
+
+// Three obviously fictional builds: one stale, one busy reactive build,
+// one already finished.
+const staleBuild = makeBuild({
+  id: "b-stale",
+  name: "nightly-refresh",
+  description: "Refresh the demo warehouse",
+  commit_hash: "abcdef1234567",
+  last_activity_at: ago(3 * DAY),
+});
+const busyBuild = makeBuild({
+  id: "b-busy",
+  name: "hourly-ingest",
+  reactive_app_name: "demo-scheduler",
+  last_activity_at: ago(5 * 60 * 1000),
+});
+const doneBuild = makeBuild({
+  id: "b-done",
+  name: "feature-sandbox",
+  status: "completed",
+  completed_at: ago(2 * HOUR),
+  last_activity_at: ago(2 * HOUR),
+});
+
+const ALL_BUILDS = [staleBuild, busyBuild, doneBuild];
+
+function buildsResponse(builds: Build[], total = builds.length) {
+  return { builds, total, page: 1, page_size: 20 };
+}
+
+function bulkResponse(
+  overrides: Partial<BulkCancelBuildsResponse> = {},
+): BulkCancelBuildsResponse {
+  return {
+    dry_run: false,
+    builds: [],
+    build_count: 0,
+    task_count: 0,
+    skipped: {},
+    truncated: false,
+    ...overrides,
+  };
+}
+
+const onSelectBuild = vi.fn();
+
+function renderList() {
+  return render(
+    <BreadcrumbProvider>
+      <BuildsList onSelectBuild={onSelectBuild} />
+    </BreadcrumbProvider>,
+  );
+}
+
+/** The row whose Build cell carries `name`. */
+function rowFor(name: string): HTMLElement {
+  return screen.getByRole("button", { name }).closest("tr") as HTMLElement;
+}
+
+describe("BuildsList", () => {
+  beforeEach(() => {
+    mockEnvironmentId = "env-1";
+    mockWorkspaceRole = "admin";
+    vi.mocked(fetchBuilds).mockResolvedValue(buildsResponse(ALL_BUILDS));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows last_activity_at as the activity signal, never last_active_at", async () => {
+    renderList();
+
+    expect(await screen.findByText("nightly-refresh")).toBeInTheDocument();
+    // last_activity_at of each build renders...
+    expect(screen.getByText("3d ago")).toBeInTheDocument();
+    expect(screen.getByText("5m ago")).toBeInTheDocument();
+    // ...and the (older) lifecycle column never does.
+    expect(screen.queryByText("6d ago")).not.toBeInTheDocument();
+
+    // The absolute time is available on hover.
+    expect(screen.getByText("3d ago")).toHaveAttribute(
+      "title",
+      expect.stringContaining("Last activity"),
+    );
+    // A running build quiet for over a day is flagged as such.
+    expect(screen.getByText("3d ago").getAttribute("title")).toContain(
+      "nothing has happened for over a day",
+    );
+  });
+
+  it("renders the short commit chip and the reactive app chip", async () => {
+    renderList();
+    expect(await screen.findByText("abcdef1")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "demo-scheduler" })).toBeInTheDocument();
+  });
+
+  it("sends the status filter to the server", async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    await user.selectOptions(
+      screen.getByLabelText("Filter by build status"),
+      "running",
+    );
+
+    await waitFor(() =>
+      expect(fetchBuilds).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "running", environment_id: "env-1" }),
+      ),
+    );
+  });
+
+  it("filters by reactive app when its chip is clicked", async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    await user.click(screen.getByRole("button", { name: "demo-scheduler" }));
+
+    // Debounced, so the request lands shortly after the click.
+    await waitFor(() =>
+      expect(fetchBuilds).toHaveBeenCalledWith(
+        expect.objectContaining({ reactive_app_name: "demo-scheduler" }),
+      ),
+    );
+    // The filter is visible, not hidden state.
+    expect(screen.getByLabelText("Filter by reactive app")).toHaveValue(
+      "demo-scheduler",
+    );
+    expect(screen.getByRole("button", { name: "Clear filters" })).toBeInTheDocument();
+  });
+
+  it("keeps only builds idle beyond the threshold, stalest first", async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    await user.selectOptions(
+      screen.getByLabelText("Filter by time since last activity"),
+      String(DAY / 1000),
+    );
+
+    await waitFor(() =>
+      expect(screen.queryByText("hourly-ingest")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("nightly-refresh")).toBeInTheDocument();
+    expect(screen.queryByText("feature-sandbox")).not.toBeInTheDocument();
+    expect(screen.getByText(/1 build idle ≥ 24h, stalest first/)).toBeInTheDocument();
+  });
+
+  it("selects rows, supports select-all, and reports an indeterminate header", async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    const selectAll = screen.getByRole("checkbox", {
+      name: "Select all builds on this page",
+    }) as HTMLInputElement;
+    await user.click(selectAll);
+
+    expect(
+      screen.getByRole("checkbox", { name: "Select build nightly-refresh" }),
+    ).toBeChecked();
+    expect(screen.getByText("3 builds selected")).toBeInTheDocument();
+    expect(selectAll.indeterminate).toBe(false);
+
+    // Deselecting one row leaves the header mixed.
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select build hourly-ingest" }),
+    );
+    expect(screen.getByText("2 builds selected")).toBeInTheDocument();
+    expect(selectAll).not.toBeChecked();
+    expect(selectAll.indeterminate).toBe(true);
+  });
+
+  it("does not navigate when the selection checkbox is clicked", async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select build nightly-refresh" }),
+    );
+    expect(onSelectBuild).not.toHaveBeenCalled();
+    expect(screen.getByText("1 build selected")).toBeInTheDocument();
+
+    // Clicking the cell around the checkbox is equally inert.
+    const cell = screen
+      .getByRole("checkbox", { name: "Select build nightly-refresh" })
+      .closest("td") as HTMLElement;
+    await user.click(cell);
+    expect(onSelectBuild).not.toHaveBeenCalled();
+  });
+
+  it("opens the build from the row and from the keyboard-focusable name button", async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    // The name is a real button, so it is reachable and activatable by
+    // keyboard — the row itself is only a mouse convenience.
+    const nameButton = screen.getByRole("button", { name: "nightly-refresh" });
+    nameButton.focus();
+    expect(nameButton).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(onSelectBuild).toHaveBeenCalledWith("b-stale");
+
+    onSelectBuild.mockClear();
+    await user.click(within(rowFor("feature-sandbox")).getByText("feature-sandbox"));
+    expect(onSelectBuild).toHaveBeenCalledWith("b-done");
+  });
+
+  it("clears the selection when the page changes", async () => {
+    vi.mocked(fetchBuilds).mockResolvedValue(buildsResponse(ALL_BUILDS, 45));
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select build nightly-refresh" }),
+    );
+    expect(screen.getByText("1 build selected")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Next" }));
+    await waitFor(() =>
+      expect(screen.queryByText("1 build selected")).not.toBeInTheDocument(),
+    );
+  });
+
+  it("dry-runs a bulk cancel, shows the consequences, then applies", async () => {
+    vi.mocked(bulkCancelBuilds).mockImplementation(async (request) =>
+      request.dry_run
+        ? bulkResponse({
+            dry_run: true,
+            builds: [
+              {
+                build_id: "b-stale",
+                name: "nightly-refresh",
+                last_activity_at: staleBuild.last_activity_at ?? null,
+                reactive_app_name: null,
+                cascaded_task_ids: ["t-1", "t-2"],
+              },
+              {
+                build_id: "b-busy",
+                name: "hourly-ingest",
+                last_activity_at: busyBuild.last_activity_at ?? null,
+                reactive_app_name: "demo-scheduler",
+                cascaded_task_ids: ["t-3"],
+              },
+            ],
+            build_count: 2,
+            task_count: 3,
+            skipped: { "b-done": "not_running" },
+          })
+        : bulkResponse({ build_count: 2, task_count: 3, skipped: {} }),
+    );
+
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select all builds on this page" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel builds…" }));
+
+    // The dry run runs first and reports exactly what will happen.
+    expect(
+      await screen.findByText("Will cancel 2 builds and release 3 task claims."),
+    ).toBeInTheDocument();
+    expect(bulkCancelBuilds).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dry_run: true,
+        cascade: true,
+        include_reactive: false,
+        build_ids: ["b-stale", "b-busy", "b-done"],
+      }),
+      "env-1",
+    );
+    // Per-build skip reason is surfaced, not swallowed — named, with the
+    // reason spelled out rather than left as an opaque enum value.
+    const skippedBlock = screen.getByText("Skipped (1)").parentElement as HTMLElement;
+    expect(skippedBlock).toHaveTextContent(
+      "feature-sandbox — Already finished — only running builds can be cancelled",
+    );
+
+    // Nothing has been written yet.
+    expect(bulkCancelBuilds).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: "Cancel 2 builds" }));
+
+    await waitFor(() =>
+      expect(bulkCancelBuilds).toHaveBeenCalledWith(
+        expect.objectContaining({ dry_run: false, cascade: true }),
+        "env-1",
+      ),
+    );
+    expect(
+      await screen.findByText(/Cancelled 2 builds and released 3 task claims\./),
+    ).toBeInTheDocument();
+    // Selection cleared and the list refetched after the mutation.
+    expect(screen.queryByText("2 builds selected")).not.toBeInTheDocument();
+  });
+
+  it("re-runs the dry run when cascade is switched off", async () => {
+    vi.mocked(bulkCancelBuilds).mockImplementation(async (request) =>
+      bulkResponse({
+        dry_run: true,
+        build_count: 1,
+        task_count: request.cascade ? 4 : 0,
+      }),
+    );
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select build nightly-refresh" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel builds…" }));
+    expect(
+      await screen.findByText("Will cancel 1 build and release 4 task claims."),
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "Release the execution claims these builds' tasks hold",
+      }),
+    );
+    expect(
+      await screen.findByText(
+        "Will cancel 1 build and release no task claims (cascade is off).",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces truncation and a dry-run failure in the dialog", async () => {
+    vi.mocked(bulkCancelBuilds).mockRejectedValue(
+      new Error("Provide build_ids and/or idle_for_seconds."),
+    );
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select build nightly-refresh" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Cancel builds…" }));
+
+    expect(
+      await screen.findByText("Provide build_ids and/or idle_for_seconds."),
+    ).toBeInTheDocument();
+    // Nothing to confirm when the preview failed.
+    expect(screen.getByRole("button", { name: "Cancel 0 builds" })).toBeDisabled();
+  });
+
+  it("sweeps by idleness server-side once an idle filter is chosen", async () => {
+    vi.mocked(bulkCancelBuilds).mockResolvedValue(
+      bulkResponse({ dry_run: true, build_count: 12, task_count: 30, truncated: true }),
+    );
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    // Disabled until the threshold is explicit and visible in the filters.
+    expect(
+      screen.getByRole("button", { name: "Clean up idle builds…" }),
+    ).toBeDisabled();
+
+    await user.selectOptions(
+      screen.getByLabelText("Filter by time since last activity"),
+      String(DAY / 1000),
+    );
+    const sweep = screen.getByRole("button", { name: "Clean up idle builds…" });
+    expect(sweep).toBeEnabled();
+    await user.click(sweep);
+
+    expect(
+      await screen.findByText("Will cancel 12 builds and release 30 task claims."),
+    ).toBeInTheDocument();
+    expect(bulkCancelBuilds).toHaveBeenCalledWith(
+      expect.objectContaining({ dry_run: true, idle_for_seconds: 86400 }),
+      "env-1",
+    );
+    expect(
+      screen.getByText(/More builds match than one call may cancel/),
+    ).toBeInTheDocument();
+  });
+
+  it("hides selection and bulk cleanup from non-admin members", async () => {
+    mockWorkspaceRole = "member";
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Clean up idle builds…" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Bulk cleanup requires the workspace admin role"),
+    ).toBeInTheDocument();
+    // Filters and navigation still work for everyone.
+    expect(screen.getByLabelText("Filter by build status")).toBeInTheDocument();
+  });
+
+  it("distinguishes an empty environment from an empty filter result", async () => {
+    vi.mocked(fetchBuilds).mockResolvedValue(buildsResponse([]));
+    const user = userEvent.setup();
+    renderList();
+
+    expect(await screen.findByText("No builds yet")).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Filter by build status"), "failed");
+    expect(
+      await screen.findByText("No builds match these filters"),
+    ).toBeInTheDocument();
+    await user.click(screen.getAllByRole("button", { name: "Clear filters" })[0]);
+    expect(await screen.findByText("No builds yet")).toBeInTheDocument();
+  });
+
+  it("shows a load error with a retry that refetches", async () => {
+    vi.mocked(fetchBuilds).mockRejectedValueOnce(new Error("Failed to fetch builds"));
+    const user = userEvent.setup();
+    renderList();
+
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "Failed to fetch builds",
+    );
+
+    vi.mocked(fetchBuilds).mockResolvedValue(buildsResponse(ALL_BUILDS));
+    await user.click(screen.getByRole("button", { name: "Retry" }));
+    expect(await screen.findByText("nightly-refresh")).toBeInTheDocument();
+  });
+});

--- a/app/stardag-ui/src/components/BuildsList.test.tsx
+++ b/app/stardag-ui/src/components/BuildsList.test.tsx
@@ -182,10 +182,14 @@ describe("BuildsList", () => {
     expect(screen.getByRole("button", { name: "Clear filters" })).toBeInTheDocument();
   });
 
-  it("keeps only builds idle beyond the threshold, stalest first", async () => {
+  it("asks the server for idle builds instead of filtering locally", async () => {
+    // The API filters, counts, paginates and orders by idleness with the
+    // same predicate the cleanup sweep uses, so the component must send
+    // the threshold and render whatever comes back verbatim.
+    vi.mocked(fetchBuilds).mockResolvedValue(buildsResponse([staleBuild], 1));
     const user = userEvent.setup();
     renderList();
-    await screen.findByText("nightly-refresh");
+    await screen.findByLabelText("Filter by time since last activity");
 
     await user.selectOptions(
       screen.getByLabelText("Filter by time since last activity"),
@@ -193,11 +197,86 @@ describe("BuildsList", () => {
     );
 
     await waitFor(() =>
-      expect(screen.queryByText("hourly-ingest")).not.toBeInTheDocument(),
+      expect(fetchBuilds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          idle_for_seconds: 86400,
+          page: 1,
+          page_size: 20,
+          environment_id: "env-1",
+        }),
+      ),
     );
-    expect(screen.getByText("nightly-refresh")).toBeInTheDocument();
-    expect(screen.queryByText("feature-sandbox")).not.toBeInTheDocument();
-    expect(screen.getByText(/1 build idle ≥ 24h, stalest first/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/1 build idle ≥ 24h, stalest first/),
+    ).toBeInTheDocument();
+    // No over-fetching and no local caveat: `total` is exact and
+    // pagination is server-side for this filter.
+    expect(fetchBuilds).not.toHaveBeenCalledWith(
+      expect.objectContaining({ page_size: 100 }),
+    );
+    expect(screen.queryByText(/older matches may be missing/)).not.toBeInTheDocument();
+  });
+
+  it("does not re-sort or re-filter the page the server returned", async () => {
+    // The server orders stalest-first on an index-backed proxy for last
+    // activity, so the rendered column is not strictly monotonic. The
+    // component must render the server's order as given rather than
+    // imposing a local ordering on one page of a server-side set — and it
+    // must not drop a row whose `last_activity_at` looks too recent.
+    vi.mocked(fetchBuilds).mockResolvedValue(
+      buildsResponse([busyBuild, staleBuild], 2),
+    );
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByLabelText("Filter by time since last activity");
+
+    await user.selectOptions(
+      screen.getByLabelText("Filter by time since last activity"),
+      String(DAY / 1000),
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("2 builds idle ≥ 24h, stalest first"),
+      ).toBeInTheDocument(),
+    );
+    const names = screen
+      .getAllByRole("row")
+      .slice(1)
+      .map((row) => row.querySelector("td:nth-child(3) button")?.textContent);
+    expect(names).toEqual(["hourly-ingest", "nightly-refresh"]);
+  });
+
+  it("makes the status + idleness combination the API rejects unreachable", async () => {
+    const user = userEvent.setup();
+    renderList();
+    await screen.findByText("nightly-refresh");
+
+    const statusSelect = screen.getByLabelText("Filter by build status");
+    const idleSelect = screen.getByLabelText("Filter by time since last activity");
+
+    // With an idle filter set, only "All statuses" and "Running" remain
+    // selectable — the rest are the 422.
+    await user.selectOptions(idleSelect, String(DAY / 1000));
+    expect(
+      within(statusSelect).getByRole("option", { name: /^Running/ }),
+    ).toBeEnabled();
+    expect(
+      within(statusSelect).getByRole("option", { name: /^Failed/ }),
+    ).toBeDisabled();
+    await user.selectOptions(statusSelect, "running");
+    await waitFor(() =>
+      expect(fetchBuilds).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "running", idle_for_seconds: 86400 }),
+      ),
+    );
+
+    // ...and symmetrically: an incompatible status disables the idle
+    // filter rather than silently dropping it.
+    await user.selectOptions(idleSelect, "0");
+    await user.selectOptions(statusSelect, "failed");
+    expect(idleSelect).toBeDisabled();
+    expect(idleSelect).toHaveValue("0");
   });
 
   it("selects rows, supports select-all, and reports an indeterminate header", async () => {

--- a/app/stardag-ui/src/components/BuildsList.tsx
+++ b/app/stardag-ui/src/components/BuildsList.tsx
@@ -143,6 +143,12 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
 
   const loadBuilds = useCallback(async () => {
     if (!activeEnvironment?.id) {
+      // Invalidate any in-flight request before bailing. Without this an
+      // earlier fetch can still satisfy its own `fresh()` check and write
+      // the previous environment's builds into state *after* the UI has
+      // been gated — the exact leak the epoch exists to prevent, on the
+      // one path that skipped bumping it.
+      fetchEpochRef.current += 1;
       // Don't flip loading=false here — the parent gate handles the
       // no-environment case, and clearing loading would briefly leak
       // the empty-state UI on env transitions.
@@ -162,6 +168,9 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
       lastFetchedEnvIdRef.current !== activeEnvironment.id &&
       page !== 1
     ) {
+      // Same reasoning as above: this bail-out abandons the current
+      // render's fetch intent, so anything already in flight is stale.
+      fetchEpochRef.current += 1;
       setPage(1);
       return;
     }

--- a/app/stardag-ui/src/components/BuildsList.tsx
+++ b/app/stardag-ui/src/components/BuildsList.tsx
@@ -23,14 +23,13 @@ interface BuildsListProps {
 
 const PAGE_SIZE = 20;
 
-// `GET /builds` filters by status and reactive app server-side, but it has
-// no activity filter — so the "idle for" filter is evaluated in the
-// browser over a wider scan window (the server's maximum page size) and
-// discloses when that window was not the whole environment. The
-// authoritative, whole-environment version of the same question is the
-// server-side `idle_for_seconds` sweep behind "Clean up idle builds".
-const IDLE_SCAN_PAGE_SIZE = 100;
-
+// Every filter here is server-side. The "idle for" one matters most:
+// `GET /builds?idle_for_seconds=` and `POST /builds/bulk-cancel` share one
+// SQL predicate on the API side, so the set this table shows and the set
+// "Clean up idle builds" acts on are identical by construction rather than
+// by two implementations happening to agree. `total` is an exact COUNT
+// over that predicate and pagination is unbounded — nothing is dropped, so
+// there is nothing to caveat.
 const IDLE_OPTIONS: { seconds: number; label: string }[] = [
   { seconds: 3600, label: "1 hour" },
   { seconds: 6 * 3600, label: "6 hours" },
@@ -68,6 +67,29 @@ const LAST_ACTIVITY_EXPLAINER =
   "the signal stale-build cleanup measures idleness against — not the " +
   "build's last lifecycle change, which stays put while tasks are running.";
 
+// With an idle filter the API returns stalest-first, but it sorts on the
+// index-backed `last_active_at` proxy rather than on the composed
+// `last_activity_at` this column renders. The two nearly always agree;
+// where they don't, a row can sit slightly out of order. Said plainly here
+// rather than "fixed" by re-sorting the page, which would only impose a
+// local ordering on one page of a server-side result set.
+const STALEST_FIRST_CAVEAT =
+  "Stalest first. The server orders on the build's last lifecycle change, " +
+  "an index-backed proxy for last activity, so this column runs close to — " +
+  "but not strictly — oldest-first.";
+
+// Statuses other than "running" cannot be combined with an idle filter:
+// only RUNNING has a SQL predicate, so the API answers 422 rather than
+// serving an approximate `total` that looks exact. The controls below make
+// that combination unreachable instead of letting a user click into it.
+const IDLE_COMPATIBLE_STATUSES: (BuildStatus | "")[] = ["", "running"];
+
+const STATUS_WITH_IDLE_HINT =
+  "An idle filter can only be combined with All statuses or Running. The " +
+  "other statuses are derived by scanning a bounded window of builds, so " +
+  "pairing them with idleness would silently drop the oldest matches — " +
+  "exactly the builds a staleness query is looking for.";
+
 export function BuildsList({ onSelectBuild }: BuildsListProps) {
   const { activeEnvironment, activeWorkspaceRole } = useEnvironment();
   const { setItems: setBreadcrumb } = useBreadcrumb();
@@ -76,8 +98,8 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
   // that can only 403 — same rule as the concurrency-limit admin surface.
   const isAdmin = activeWorkspaceRole === "owner" || activeWorkspaceRole === "admin";
 
-  const [rawBuilds, setRawBuilds] = useState<Build[]>([]);
-  const [serverTotal, setServerTotal] = useState(0);
+  const [pageBuilds, setPageBuilds] = useState<Build[]>([]);
+  const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
@@ -93,6 +115,13 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
   const [result, setResult] = useState<BulkCancelBuildsResponse | null>(null);
 
   const idleFilterActive = idleForSeconds > 0;
+  // The API rejects `idle_for_seconds` alongside any status but "running"
+  // (422). Both controls are constrained so that pair cannot be built:
+  // incompatible statuses are disabled while an idle filter is set, and
+  // the idle select is disabled while such a status is selected. Nothing
+  // is silently rewritten behind the user — the block is visible and
+  // explained on both sides.
+  const idleBlockedByStatus = !IDLE_COMPATIBLE_STATUSES.includes(statusFilter);
 
   useEffect(() => {
     setBreadcrumb([{ label: "Builds" }]);
@@ -122,8 +151,8 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
       // Don't flip loading=false here — the parent gate handles the
       // no-environment case, and clearing loading would briefly leak
       // the empty-state UI on env transitions.
-      setRawBuilds([]);
-      setServerTotal(0);
+      setPageBuilds([]);
+      setTotal(0);
       return;
     }
 
@@ -149,60 +178,33 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
     setError(null);
     try {
       const response = await fetchBuilds({
-        // With an idle filter the matching set is computed in the
-        // browser, so fetch one wide window and paginate it locally.
-        page: idleFilterActive ? 1 : page,
-        page_size: idleFilterActive ? IDLE_SCAN_PAGE_SIZE : PAGE_SIZE,
+        page,
+        page_size: PAGE_SIZE,
         environment_id: activeEnvironment.id,
         status: statusFilter || undefined,
         reactive_app_name: reactiveApp || undefined,
+        // Filtered, counted, paginated and ordered by the server, using
+        // the same predicate the cleanup sweep runs.
+        idle_for_seconds: idleForSeconds || undefined,
       });
       if (!fresh()) return;
-      setRawBuilds(response.builds);
-      setServerTotal(response.total);
+      setPageBuilds(response.builds);
+      setTotal(response.total);
     } catch (err) {
       if (!fresh()) return;
-      setRawBuilds([]);
-      setServerTotal(0);
+      setPageBuilds([]);
+      setTotal(0);
       setError(err instanceof Error ? err.message : "Failed to load builds");
     } finally {
       if (fresh()) setLoading(false);
     }
-  }, [activeEnvironment?.id, page, idleFilterActive, statusFilter, reactiveApp]);
+  }, [activeEnvironment?.id, page, idleForSeconds, statusFilter, reactiveApp]);
 
   useEffect(() => {
     loadBuilds();
   }, [loadBuilds]);
 
-  const { pageBuilds, total, totalPages, scanIncomplete } = useMemo(() => {
-    if (!idleFilterActive) {
-      return {
-        pageBuilds: rawBuilds,
-        total: serverTotal,
-        totalPages: Math.ceil(serverTotal / PAGE_SIZE),
-        scanIncomplete: false,
-      };
-    }
-    const cutoffMs = Date.now() - idleForSeconds * 1000;
-    const activityMs = (build: Build) =>
-      build.last_activity_at ? new Date(build.last_activity_at).getTime() : NaN;
-    const matched = rawBuilds
-      // A build with no activity timestamp at all (an API response
-      // predating the field) is not claimed to be idle.
-      .filter((build) => {
-        const ms = activityMs(build);
-        return !Number.isNaN(ms) && ms <= cutoffMs;
-      })
-      // Stalest first: with an idle filter the interesting end of the
-      // list is the oldest, not the newest.
-      .sort((a, b) => activityMs(a) - activityMs(b));
-    return {
-      pageBuilds: matched.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
-      total: matched.length,
-      totalPages: Math.ceil(matched.length / PAGE_SIZE),
-      scanIncomplete: serverTotal > rawBuilds.length,
-    };
-  }, [rawBuilds, serverTotal, idleFilterActive, idleForSeconds, page]);
+  const totalPages = Math.ceil(total / PAGE_SIZE);
 
   const visibleIds = useMemo(() => pageBuilds.map((build) => build.id), [pageBuilds]);
   // Selection is scoped to the visible page and cleared whenever the
@@ -265,12 +267,12 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
     () =>
       Array.from(
         new Set(
-          rawBuilds
+          pageBuilds
             .map((build) => build.reactive_app_name)
             .filter((name): name is string => !!name),
         ),
       ).sort(),
-    [rawBuilds],
+    [pageBuilds],
   );
 
   if (!activeEnvironment) {
@@ -296,21 +298,38 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
             className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
           >
             <option value="">All statuses</option>
-            {STATUS_OPTIONS.map((status) => (
-              <option key={status} value={status}>
-                {STATUS_LABELS[status]}
-              </option>
-            ))}
+            {STATUS_OPTIONS.map((status) => {
+              // Disabled rather than hidden while an idle filter is set:
+              // the option stays visible so the constraint is legible, and
+              // the pair the API rejects can never be submitted.
+              const blocked =
+                idleFilterActive && !IDLE_COMPATIBLE_STATUSES.includes(status);
+              return (
+                <option
+                  key={status}
+                  value={status}
+                  disabled={blocked}
+                  title={blocked ? STATUS_WITH_IDLE_HINT : undefined}
+                >
+                  {STATUS_LABELS[status]}
+                  {blocked ? " — n/a with an idle filter" : ""}
+                </option>
+              );
+            })}
           </select>
         </label>
 
-        <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+        <label
+          className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400"
+          title={idleBlockedByStatus ? STATUS_WITH_IDLE_HINT : undefined}
+        >
           Idle for
           <select
             aria-label="Filter by time since last activity"
             value={idleForSeconds}
+            disabled={idleBlockedByStatus}
             onChange={(e) => handleIdleChange(Number(e.target.value))}
-            className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+            className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
           >
             <option value={0}>Any</option>
             {IDLE_OPTIONS.map((option) => (
@@ -346,7 +365,10 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
         )}
 
         <div className="ml-auto flex items-center gap-3">
-          <span className="text-xs text-gray-500 dark:text-gray-400">
+          <span
+            className="text-xs text-gray-500 dark:text-gray-400"
+            title={idleFilterActive ? STALEST_FIRST_CAVEAT : undefined}
+          >
             {loading
               ? "Loading…"
               : `${total} build${total === 1 ? "" : "s"}` +
@@ -378,7 +400,7 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
       </div>
 
       {/* Outcome of the last cleanup, and load errors */}
-      {(result || error || (idleFilterActive && scanIncomplete)) && (
+      {(result || error) && (
         <div className="space-y-2 border-b border-gray-200 bg-white px-4 py-2 dark:border-gray-700 dark:bg-gray-800">
           {result && (
             <ResultBanner
@@ -410,14 +432,6 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
               </button>
             </ResultBanner>
           )}
-          {idleFilterActive && scanIncomplete && (
-            <ResultBanner tone="info">
-              The idle filter is applied in the browser over the {rawBuilds.length}{" "}
-              builds loaded here, of {serverTotal} matching in this environment — older
-              matches may be missing. “Clean up idle builds” evaluates the same
-              threshold server-side across all of them.
-            </ResultBanner>
-          )}
         </div>
       )}
 
@@ -447,7 +461,15 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
                 <HeaderCell>Build</HeaderCell>
                 <HeaderCell>Description</HeaderCell>
                 <HeaderCell>Duration</HeaderCell>
-                <HeaderCell title={LAST_ACTIVITY_EXPLAINER}>Last activity</HeaderCell>
+                <HeaderCell
+                  title={
+                    idleFilterActive
+                      ? `${LAST_ACTIVITY_EXPLAINER} ${STALEST_FIRST_CAVEAT}`
+                      : LAST_ACTIVITY_EXPLAINER
+                  }
+                >
+                  Last activity
+                </HeaderCell>
                 <HeaderCell>Created</HeaderCell>
                 <th scope="col" className="w-8" />
               </tr>

--- a/app/stardag-ui/src/components/BuildsList.tsx
+++ b/app/stardag-ui/src/components/BuildsList.tsx
@@ -1,74 +1,129 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { fetchBuilds } from "../api/tasks";
 import { useBreadcrumb } from "../context/BreadcrumbContext";
 import { useEnvironment } from "../context/EnvironmentContext";
-import type { Build } from "../types/task";
+import { useRowSelection } from "../hooks/useRowSelection";
+import type { Build, BuildStatus, BulkCancelBuildsResponse } from "../types/task";
+import {
+  formatAbsoluteTime,
+  formatDuration,
+  formatIdleThreshold,
+  formatRelativeTime,
+  secondsSince,
+} from "../utils/time";
 import { BuildStatusBadge } from "./BuildStatusBadge";
+import { BulkCancelDialog } from "./BulkCancelDialog";
+import { BulkActionBar } from "./ui/BulkActionBar";
+import { Checkbox } from "./ui/Checkbox";
+import { ResultBanner } from "./ui/ResultBanner";
 
 interface BuildsListProps {
   onSelectBuild: (buildId: string) => void;
 }
 
-interface BuildWithStats extends Build {
-  taskCount?: number;
-}
+const PAGE_SIZE = 20;
 
-function formatRelativeTime(dateString: string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffSecs = Math.floor(diffMs / 1000);
-  const diffMins = Math.floor(diffSecs / 60);
-  const diffHours = Math.floor(diffMins / 60);
-  const diffDays = Math.floor(diffHours / 24);
+// `GET /builds` filters by status and reactive app server-side, but it has
+// no activity filter — so the "idle for" filter is evaluated in the
+// browser over a wider scan window (the server's maximum page size) and
+// discloses when that window was not the whole environment. The
+// authoritative, whole-environment version of the same question is the
+// server-side `idle_for_seconds` sweep behind "Clean up idle builds".
+const IDLE_SCAN_PAGE_SIZE = 100;
 
-  if (diffSecs < 60) return "just now";
-  if (diffMins < 60) return `${diffMins}m ago`;
-  if (diffHours < 24) return `${diffHours}h ago`;
-  if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
-}
+const IDLE_OPTIONS: { seconds: number; label: string }[] = [
+  { seconds: 3600, label: "1 hour" },
+  { seconds: 6 * 3600, label: "6 hours" },
+  { seconds: 24 * 3600, label: "24 hours" },
+  { seconds: 7 * 86400, label: "7 days" },
+  { seconds: 30 * 86400, label: "30 days" },
+];
 
-function formatDuration(startedAt: string | null, completedAt: string | null): string {
-  if (!startedAt) return "-";
-  const start = new Date(startedAt);
-  const end = completedAt ? new Date(completedAt) : new Date();
-  const diffMs = end.getTime() - start.getTime();
-  const diffSecs = Math.floor(diffMs / 1000);
-  const diffMins = Math.floor(diffSecs / 60);
-  const diffHours = Math.floor(diffMins / 60);
+const STATUS_OPTIONS: BuildStatus[] = [
+  "running",
+  "pending",
+  "completed",
+  "failed",
+  "cancelled",
+  "exit_early",
+];
 
-  if (diffSecs < 60) return `${diffSecs}s`;
-  if (diffMins < 60) return `${diffMins}m ${diffSecs % 60}s`;
-  return `${diffHours}h ${diffMins % 60}m`;
-}
+const STATUS_LABELS: Record<BuildStatus, string> = {
+  running: "Running",
+  pending: "Pending",
+  completed: "Completed",
+  failed: "Failed",
+  cancelled: "Cancelled",
+  exit_early: "Exited early",
+};
+
+// A running build with no activity for longer than this is flagged in the
+// table even with no idle filter set — the at-a-glance version of "which
+// builds are stale?".
+const STALE_HINT_SECONDS = 24 * 3600;
+
+const LAST_ACTIVITY_EXPLAINER =
+  "Newest of the build's whole event stream (task events included), its " +
+  "last lifecycle transition, and any pending scheduler wake-up. This is " +
+  "the signal stale-build cleanup measures idleness against — not the " +
+  "build's last lifecycle change, which stays put while tasks are running.";
 
 export function BuildsList({ onSelectBuild }: BuildsListProps) {
-  const { activeEnvironment } = useEnvironment();
+  const { activeEnvironment, activeWorkspaceRole } = useEnvironment();
   const { setItems: setBreadcrumb } = useBreadcrumb();
-  const [builds, setBuilds] = useState<BuildWithStats[]>([]);
+  // Bulk cancel is destructive and the API gates it to workspace admins on
+  // the JWT path, so mirror that gate here rather than offering a control
+  // that can only 403 — same rule as the concurrency-limit admin surface.
+  const isAdmin = activeWorkspaceRole === "owner" || activeWorkspaceRole === "admin";
+
+  const [rawBuilds, setRawBuilds] = useState<Build[]>([]);
+  const [serverTotal, setServerTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [page, setPage] = useState(1);
-  const [total, setTotal] = useState(0);
-  const pageSize = 20;
 
-  // Set breadcrumb for builds list
+  // Filters — all visible in the toolbar, all clearable.
+  const [statusFilter, setStatusFilter] = useState<BuildStatus | "">("");
+  const [idleForSeconds, setIdleForSeconds] = useState(0);
+  const [reactiveAppInput, setReactiveAppInput] = useState("");
+  const [reactiveApp, setReactiveApp] = useState("");
+
+  // Bulk cleanup
+  const [dialogMode, setDialogMode] = useState<"selection" | "idle" | null>(null);
+  const [result, setResult] = useState<BulkCancelBuildsResponse | null>(null);
+
+  const idleFilterActive = idleForSeconds > 0;
+
   useEffect(() => {
     setBreadcrumb([{ label: "Builds" }]);
     return () => setBreadcrumb([]);
   }, [setBreadcrumb]);
 
+  // Debounce the reactive-app box: it is a server-side filter, so a
+  // refetch per keystroke would be wasteful.
+  useEffect(() => {
+    const next = reactiveAppInput.trim();
+    const handle = setTimeout(() => {
+      setReactiveApp(next);
+      setPage(1);
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [reactiveAppInput]);
+
   // Track the env id of the most recent fetch we initiated. Used below
   // to detect "env just changed" inside loadBuilds — see comment there.
   const lastFetchedEnvIdRef = useRef<string | null>(null);
+  // Stale-response guard: a slow response for a previous environment (or
+  // a superseded filter) must not overwrite the current state.
+  const fetchEpochRef = useRef(0);
 
   const loadBuilds = useCallback(async () => {
     if (!activeEnvironment?.id) {
       // Don't flip loading=false here — the parent gate handles the
       // no-environment case, and clearing loading would briefly leak
       // the empty-state UI on env transitions.
-      setBuilds([]);
+      setRawBuilds([]);
+      setServerTotal(0);
       return;
     }
 
@@ -88,28 +143,135 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
     }
     lastFetchedEnvIdRef.current = activeEnvironment.id;
 
+    const epoch = ++fetchEpochRef.current;
+    const fresh = () => fetchEpochRef.current === epoch;
     setLoading(true);
     setError(null);
     try {
       const response = await fetchBuilds({
-        page,
-        page_size: pageSize,
+        // With an idle filter the matching set is computed in the
+        // browser, so fetch one wide window and paginate it locally.
+        page: idleFilterActive ? 1 : page,
+        page_size: idleFilterActive ? IDLE_SCAN_PAGE_SIZE : PAGE_SIZE,
         environment_id: activeEnvironment.id,
+        status: statusFilter || undefined,
+        reactive_app_name: reactiveApp || undefined,
       });
-      setBuilds(response.builds);
-      setTotal(response.total);
+      if (!fresh()) return;
+      setRawBuilds(response.builds);
+      setServerTotal(response.total);
     } catch (err) {
+      if (!fresh()) return;
+      setRawBuilds([]);
+      setServerTotal(0);
       setError(err instanceof Error ? err.message : "Failed to load builds");
     } finally {
-      setLoading(false);
+      if (fresh()) setLoading(false);
     }
-  }, [activeEnvironment?.id, page]);
+  }, [activeEnvironment?.id, page, idleFilterActive, statusFilter, reactiveApp]);
 
   useEffect(() => {
     loadBuilds();
   }, [loadBuilds]);
 
-  const totalPages = Math.ceil(total / pageSize);
+  const { pageBuilds, total, totalPages, scanIncomplete } = useMemo(() => {
+    if (!idleFilterActive) {
+      return {
+        pageBuilds: rawBuilds,
+        total: serverTotal,
+        totalPages: Math.ceil(serverTotal / PAGE_SIZE),
+        scanIncomplete: false,
+      };
+    }
+    const cutoffMs = Date.now() - idleForSeconds * 1000;
+    const activityMs = (build: Build) =>
+      build.last_activity_at ? new Date(build.last_activity_at).getTime() : NaN;
+    const matched = rawBuilds
+      // A build with no activity timestamp at all (an API response
+      // predating the field) is not claimed to be idle.
+      .filter((build) => {
+        const ms = activityMs(build);
+        return !Number.isNaN(ms) && ms <= cutoffMs;
+      })
+      // Stalest first: with an idle filter the interesting end of the
+      // list is the oldest, not the newest.
+      .sort((a, b) => activityMs(a) - activityMs(b));
+    return {
+      pageBuilds: matched.slice((page - 1) * PAGE_SIZE, page * PAGE_SIZE),
+      total: matched.length,
+      totalPages: Math.ceil(matched.length / PAGE_SIZE),
+      scanIncomplete: serverTotal > rawBuilds.length,
+    };
+  }, [rawBuilds, serverTotal, idleFilterActive, idleForSeconds, page]);
+
+  const visibleIds = useMemo(() => pageBuilds.map((build) => build.id), [pageBuilds]);
+  // Selection is scoped to the visible page and cleared whenever the
+  // visible set changes. See useRowSelection for why.
+  const selectionResetKey = `${
+    activeEnvironment?.id ?? ""
+  }|${statusFilter}|${idleForSeconds}|${reactiveApp}|${page}`;
+  const {
+    selectedIds,
+    selectedCount,
+    isSelected,
+    toggle,
+    toggleAllVisible,
+    clear: clearSelection,
+    allVisibleSelected,
+    someVisibleSelected,
+  } = useRowSelection(visibleIds, selectionResetKey);
+
+  const buildNames = useMemo(
+    () => Object.fromEntries(pageBuilds.map((build) => [build.id, build.name])),
+    [pageBuilds],
+  );
+
+  const handleApplied = useCallback(
+    (applied: BulkCancelBuildsResponse) => {
+      setDialogMode(null);
+      setResult(applied);
+      clearSelection();
+      loadBuilds();
+    },
+    [clearSelection, loadBuilds],
+  );
+
+  const handleStatusChange = useCallback((value: BuildStatus | "") => {
+    setStatusFilter(value);
+    setPage(1);
+  }, []);
+
+  const handleIdleChange = useCallback((seconds: number) => {
+    setIdleForSeconds(seconds);
+    setPage(1);
+  }, []);
+
+  const handleFilterReactiveApp = useCallback((appName: string) => {
+    setReactiveAppInput(appName);
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setStatusFilter("");
+    setIdleForSeconds(0);
+    setReactiveAppInput("");
+    setReactiveApp("");
+    setPage(1);
+  }, []);
+
+  const filtersActive = statusFilter !== "" || idleFilterActive || reactiveApp !== "";
+
+  // Names offered by the reactive-app box, taken from what is loaded.
+  const knownReactiveApps = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          rawBuilds
+            .map((build) => build.reactive_app_name)
+            .filter((name): name is string => !!name),
+        ),
+      ).sort(),
+    [rawBuilds],
+  );
 
   if (!activeEnvironment) {
     return (
@@ -119,126 +281,207 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
     );
   }
 
-  if (loading) {
-    return (
-      <div className="flex h-full items-center justify-center">
-        <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="flex h-full items-center justify-center text-red-500">
-        <p>{error}</p>
-      </div>
-    );
-  }
-
-  if (builds.length === 0) {
-    return (
-      <div className="flex h-full flex-col items-center justify-center text-gray-500 dark:text-gray-400">
-        <svg
-          className="mb-4 h-16 w-16"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={1.5}
-            d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
-          />
-        </svg>
-        <p className="text-lg font-medium">No builds yet</p>
-        <p className="mt-1 text-sm">Run a build with the Stardag SDK to see it here</p>
-      </div>
-    );
-  }
+  const skippedCount = Object.keys(result?.skipped ?? {}).length;
 
   return (
     <div className="flex h-full flex-col">
-      {/* Build list */}
-      <div className="flex-1 overflow-auto">
-        <div className="divide-y divide-gray-200 dark:divide-gray-700">
-          {builds.map((build) => (
-            <button
-              key={build.id}
-              onClick={() => onSelectBuild(build.id)}
-              className="flex w-full items-center gap-4 px-6 py-4 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-700/50"
-            >
-              {/* Status indicator */}
-              <div className="flex-shrink-0">
-                <BuildStatusBadge status={build.status} isResumed={build.is_resumed} />
-              </div>
+      {/* Filters + cleanup entry point */}
+      <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-b border-gray-200 bg-white px-4 py-2 dark:border-gray-700 dark:bg-gray-800">
+        <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+          Status
+          <select
+            aria-label="Filter by build status"
+            value={statusFilter}
+            onChange={(e) => handleStatusChange(e.target.value as BuildStatus | "")}
+            className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          >
+            <option value="">All statuses</option>
+            {STATUS_OPTIONS.map((status) => (
+              <option key={status} value={status}>
+                {STATUS_LABELS[status]}
+              </option>
+            ))}
+          </select>
+        </label>
 
-              {/* Build info */}
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <span className="font-medium text-gray-900 dark:text-gray-100">
-                    {build.name}
-                  </span>
-                  {build.commit_hash && (
-                    <span className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-400">
-                      {build.commit_hash.slice(0, 7)}
-                    </span>
-                  )}
-                </div>
-                {build.description && (
-                  <p className="mt-0.5 truncate text-sm text-gray-500 dark:text-gray-400">
-                    {build.description}
-                  </p>
-                )}
-              </div>
+        <label className="flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+          Idle for
+          <select
+            aria-label="Filter by time since last activity"
+            value={idleForSeconds}
+            onChange={(e) => handleIdleChange(Number(e.target.value))}
+            className="rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          >
+            <option value={0}>Any</option>
+            {IDLE_OPTIONS.map((option) => (
+              <option key={option.seconds} value={option.seconds}>
+                ≥ {option.label}
+              </option>
+            ))}
+          </select>
+        </label>
 
-              {/* Stats */}
-              <div className="flex items-center gap-6 text-sm text-gray-500 dark:text-gray-400">
-                {/* Duration */}
-                <div className="flex items-center gap-1.5" title="Duration">
-                  <svg
-                    className="h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  <span>{formatDuration(build.started_at, build.completed_at)}</span>
-                </div>
-
-                {/* Time ago */}
-                <div
-                  className="w-20 text-right"
-                  title={new Date(build.created_at).toLocaleString()}
-                >
-                  {formatRelativeTime(build.created_at)}
-                </div>
-
-                {/* Arrow */}
-                <svg
-                  className="h-5 w-5 text-gray-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 5l7 7-7 7"
-                  />
-                </svg>
-              </div>
-            </button>
+        <input
+          type="text"
+          list="builds-reactive-apps"
+          aria-label="Filter by reactive app"
+          placeholder="Reactive app…"
+          value={reactiveAppInput}
+          onChange={(e) => setReactiveAppInput(e.target.value)}
+          className="w-36 rounded-md border border-gray-300 px-2 py-1 text-xs text-gray-900 placeholder-gray-500 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400"
+        />
+        <datalist id="builds-reactive-apps">
+          {knownReactiveApps.map((name) => (
+            <option key={name} value={name} />
           ))}
+        </datalist>
+
+        {filtersActive && (
+          <button
+            onClick={clearFilters}
+            className="rounded-md px-2 py-1 text-xs font-medium text-blue-600 hover:bg-blue-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-400 dark:hover:bg-blue-900/30"
+          >
+            Clear filters
+          </button>
+        )}
+
+        <div className="ml-auto flex items-center gap-3">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {loading
+              ? "Loading…"
+              : `${total} build${total === 1 ? "" : "s"}` +
+                (idleFilterActive
+                  ? ` idle ≥ ${formatIdleThreshold(idleForSeconds)}, stalest first`
+                  : "")}
+          </span>
+          {isAdmin ? (
+            <button
+              onClick={() => setDialogMode("idle")}
+              disabled={!idleFilterActive}
+              title={
+                idleFilterActive
+                  ? `Cancel every running build in this environment idle for at least ${formatIdleThreshold(
+                      idleForSeconds,
+                    )}`
+                  : "Pick an “Idle for” filter first — the sweep uses that threshold, server-side, across the whole environment"
+              }
+              className="rounded-md border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              Clean up idle builds…
+            </button>
+          ) : (
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              Bulk cleanup requires the workspace admin role
+            </span>
+          )}
         </div>
       </div>
+
+      {/* Outcome of the last cleanup, and load errors */}
+      {(result || error || (idleFilterActive && scanIncomplete)) && (
+        <div className="space-y-2 border-b border-gray-200 bg-white px-4 py-2 dark:border-gray-700 dark:bg-gray-800">
+          {result && (
+            <ResultBanner
+              tone={result.build_count > 0 ? "success" : "info"}
+              onDismiss={() => setResult(null)}
+            >
+              {result.build_count === 0
+                ? "No running build matched — nothing was cancelled."
+                : `Cancelled ${result.build_count} build${
+                    result.build_count === 1 ? "" : "s"
+                  } and released ${result.task_count} task claim${
+                    result.task_count === 1 ? "" : "s"
+                  }.`}
+              {skippedCount > 0 &&
+                ` ${skippedCount} build${
+                  skippedCount === 1 ? " was" : "s were"
+                } skipped.`}
+              {result.truncated && " More builds still match — run the cleanup again."}
+            </ResultBanner>
+          )}
+          {error && (
+            <ResultBanner tone="error">
+              {error}{" "}
+              <button
+                onClick={loadBuilds}
+                className="font-medium underline hover:no-underline"
+              >
+                Retry
+              </button>
+            </ResultBanner>
+          )}
+          {idleFilterActive && scanIncomplete && (
+            <ResultBanner tone="info">
+              The idle filter is applied in the browser over the {rawBuilds.length}{" "}
+              builds loaded here, of {serverTotal} matching in this environment — older
+              matches may be missing. “Clean up idle builds” evaluates the same
+              threshold server-side across all of them.
+            </ResultBanner>
+          )}
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="flex-1 overflow-auto">
+        {loading ? (
+          <div className="flex h-full items-center justify-center py-12">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+          </div>
+        ) : pageBuilds.length === 0 ? (
+          <EmptyState filtersActive={filtersActive} onClearFilters={clearFilters} />
+        ) : (
+          <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+            <thead className="sticky top-0 z-10 bg-gray-50 dark:bg-gray-800">
+              <tr>
+                {isAdmin && (
+                  <th scope="col" className="w-10 px-4 py-2">
+                    <Checkbox
+                      checked={allVisibleSelected}
+                      indeterminate={someVisibleSelected}
+                      onChange={toggleAllVisible}
+                      label="Select all builds on this page"
+                    />
+                  </th>
+                )}
+                <HeaderCell>Status</HeaderCell>
+                <HeaderCell>Build</HeaderCell>
+                <HeaderCell>Description</HeaderCell>
+                <HeaderCell>Duration</HeaderCell>
+                <HeaderCell title={LAST_ACTIVITY_EXPLAINER}>Last activity</HeaderCell>
+                <HeaderCell>Created</HeaderCell>
+                <th scope="col" className="w-8" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-900">
+              {pageBuilds.map((build) => (
+                <BuildRow
+                  key={build.id}
+                  build={build}
+                  selectable={isAdmin}
+                  selected={isSelected(build.id)}
+                  onToggleSelect={toggle}
+                  onOpen={onSelectBuild}
+                  onFilterReactiveApp={handleFilterReactiveApp}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <BulkActionBar
+        count={selectedCount}
+        noun="build"
+        onClear={clearSelection}
+        note="Applies to this page only — the selection clears when you change page or filters."
+      >
+        <button
+          onClick={() => setDialogMode("selection")}
+          className="rounded-md bg-red-600 px-3 py-1 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:ring-offset-2 dark:focus-visible:ring-offset-blue-950"
+        >
+          Cancel builds…
+        </button>
+      </BulkActionBar>
 
       {/* Pagination */}
       {totalPages > 1 && (
@@ -262,6 +505,221 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
           </button>
         </div>
       )}
+
+      {dialogMode && activeEnvironment && (
+        <BulkCancelDialog
+          environmentId={activeEnvironment.id}
+          mode={dialogMode}
+          buildIds={dialogMode === "selection" ? selectedIds : undefined}
+          buildNames={dialogMode === "selection" ? buildNames : undefined}
+          idleForSeconds={dialogMode === "idle" ? idleForSeconds : undefined}
+          reactiveAppName={dialogMode === "idle" ? reactiveApp || null : null}
+          onClose={() => setDialogMode(null)}
+          onApplied={handleApplied}
+        />
+      )}
     </div>
+  );
+}
+
+function HeaderCell({
+  children,
+  title,
+}: {
+  children: React.ReactNode;
+  title?: string;
+}) {
+  return (
+    <th
+      scope="col"
+      title={title}
+      className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+    >
+      {children}
+      {title && <span aria-hidden="true"> ⓘ</span>}
+    </th>
+  );
+}
+
+function EmptyState({
+  filtersActive,
+  onClearFilters,
+}: {
+  filtersActive: boolean;
+  onClearFilters: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center py-12 text-gray-500 dark:text-gray-400">
+      <svg
+        className="mb-4 h-16 w-16"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={1.5}
+          d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+        />
+      </svg>
+      {filtersActive ? (
+        <>
+          <p className="text-lg font-medium">No builds match these filters</p>
+          <button
+            onClick={onClearFilters}
+            className="mt-3 rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            Clear filters
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="text-lg font-medium">No builds yet</p>
+          <p className="mt-1 text-sm">
+            Run a build with the Stardag SDK to see it here
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+interface BuildRowProps {
+  build: Build;
+  selectable: boolean;
+  selected: boolean;
+  onToggleSelect: (buildId: string, checked: boolean) => void;
+  onOpen: (buildId: string) => void;
+  onFilterReactiveApp: (appName: string) => void;
+}
+
+function BuildRow({
+  build,
+  selectable,
+  selected,
+  onToggleSelect,
+  onOpen,
+  onFilterReactiveApp,
+}: BuildRowProps) {
+  const idleSeconds = secondsSince(build.last_activity_at);
+  const stale =
+    build.status === "running" &&
+    idleSeconds !== null &&
+    idleSeconds >= STALE_HINT_SECONDS;
+  const activityTitle = build.last_activity_at
+    ? `Last activity ${formatAbsoluteTime(build.last_activity_at)}${
+        stale ? " — running, but nothing has happened for over a day" : ""
+      }`
+    : "No activity recorded for this build";
+
+  return (
+    <tr
+      // Whole-row click is a mouse convenience. Keyboard users reach the
+      // build through the real button in the Build cell, which is the
+      // focusable, accessibly-named way in — the row itself is not
+      // focusable and carries no interactive role.
+      onClick={() => onOpen(build.id)}
+      className={`cursor-pointer transition-colors ${
+        selected
+          ? "bg-blue-50 dark:bg-blue-950/40"
+          : "hover:bg-gray-50 dark:hover:bg-gray-700/50"
+      }`}
+    >
+      {selectable && (
+        <td
+          className="w-10 px-4 py-3"
+          // Selecting a row must never navigate away from the list, so the
+          // whole cell swallows the click rather than only the input.
+          onClick={(e) => e.stopPropagation()}
+        >
+          <Checkbox
+            checked={selected}
+            onChange={(checked) => onToggleSelect(build.id, checked)}
+            label={`Select build ${build.name}`}
+          />
+        </td>
+      )}
+      <td className="px-4 py-3">
+        <BuildStatusBadge status={build.status} isResumed={build.is_resumed} />
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex flex-wrap items-center gap-1.5">
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onOpen(build.id);
+            }}
+            className="rounded text-left font-medium text-gray-900 hover:text-blue-700 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-100 dark:hover:text-blue-400"
+          >
+            {build.name}
+          </button>
+          {build.commit_hash && (
+            <span
+              title={build.commit_hash}
+              className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-xs text-gray-600 dark:bg-gray-700 dark:text-gray-400"
+            >
+              {build.commit_hash.slice(0, 7)}
+            </span>
+          )}
+          {build.reactive_app_name && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                onFilterReactiveApp(build.reactive_app_name as string);
+              }}
+              title={`Reactive build — filter by app “${build.reactive_app_name}”`}
+              className="rounded bg-purple-100 px-1.5 py-0.5 text-xs text-purple-700 hover:bg-purple-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-purple-500 dark:bg-purple-900/40 dark:text-purple-300 dark:hover:bg-purple-900/70"
+            >
+              {build.reactive_app_name}
+            </button>
+          )}
+        </div>
+      </td>
+      <td className="max-w-xs px-4 py-3">
+        <p className="truncate text-sm text-gray-500 dark:text-gray-400">
+          {build.description || "—"}
+        </p>
+      </td>
+      <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
+        {formatDuration(build.started_at, build.completed_at)}
+      </td>
+      <td className="whitespace-nowrap px-4 py-3 text-sm">
+        <span
+          title={activityTitle}
+          className={
+            stale
+              ? "font-medium text-amber-600 dark:text-amber-400"
+              : "text-gray-500 dark:text-gray-400"
+          }
+        >
+          {formatRelativeTime(build.last_activity_at)}
+        </span>
+      </td>
+      <td
+        className="whitespace-nowrap px-4 py-3 text-sm text-gray-500 dark:text-gray-400"
+        title={formatAbsoluteTime(build.created_at)}
+      >
+        {formatRelativeTime(build.created_at)}
+      </td>
+      <td className="px-2 py-3">
+        <svg
+          aria-hidden="true"
+          className="h-5 w-5 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M9 5l7 7-7 7"
+          />
+        </svg>
+      </td>
+    </tr>
   );
 }

--- a/app/stardag-ui/src/components/BuildsList.tsx
+++ b/app/stardag-ui/src/components/BuildsList.tsx
@@ -62,10 +62,8 @@ const STATUS_LABELS: Record<BuildStatus, string> = {
 const STALE_HINT_SECONDS = 24 * 3600;
 
 const LAST_ACTIVITY_EXPLAINER =
-  "Newest of the build's whole event stream (task events included), its " +
-  "last lifecycle transition, and any pending scheduler wake-up. This is " +
-  "the signal stale-build cleanup measures idleness against — not the " +
-  "build's last lifecycle change, which stays put while tasks are running.";
+  "The last thing that happened anywhere in this build — including its " +
+  "tasks, and any scheduler wake-up already queued.";
 
 // With an idle filter the API returns stalest-first, but it sorts on the
 // index-backed `last_active_at` proxy rather than on the composed
@@ -74,21 +72,18 @@ const LAST_ACTIVITY_EXPLAINER =
 // rather than "fixed" by re-sorting the page, which would only impose a
 // local ordering on one page of a server-side result set.
 const STALEST_FIRST_CAVEAT =
-  "Stalest first. The server orders on the build's last lifecycle change, " +
-  "an index-backed proxy for last activity, so this column runs close to — " +
-  "but not strictly — oldest-first.";
+  "Stalest first, approximately — ordered on the " +
+  "build's last lifecycle change rather than this composed timestamp.";
 
-// Statuses other than "running" cannot be combined with an idle filter:
-// only RUNNING has a SQL predicate, so the API answers 422 rather than
-// serving an approximate `total` that looks exact. The controls below make
-// that combination unreachable instead of letting a user click into it.
+// An idle filter means "running, but stuck", so the server already implies
+// RUNNING and rejects any other status as a contradiction. The controls
+// below make that pairing unreachable rather than letting a user click
+// into a 422.
 const IDLE_COMPATIBLE_STATUSES: (BuildStatus | "")[] = ["", "running"];
 
 const STATUS_WITH_IDLE_HINT =
-  "An idle filter can only be combined with All statuses or Running. The " +
-  "other statuses are derived by scanning a bounded window of builds, so " +
-  "pairing them with idleness would silently drop the oldest matches — " +
-  "exactly the builds a staleness query is looking for.";
+  "“Idle for” finds builds that are still running but stuck, so it only " +
+  "combines with Running (or All). A build that finished isn’t idle.";
 
 export function BuildsList({ onSelectBuild }: BuildsListProps) {
   const { activeEnvironment, activeWorkspaceRole } = useEnvironment();
@@ -312,7 +307,7 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
                   title={blocked ? STATUS_WITH_IDLE_HINT : undefined}
                 >
                   {STATUS_LABELS[status]}
-                  {blocked ? " — n/a with an idle filter" : ""}
+                  {blocked ? " — not idle-filterable" : ""}
                 </option>
               );
             })}
@@ -373,7 +368,7 @@ export function BuildsList({ onSelectBuild }: BuildsListProps) {
               ? "Loading…"
               : `${total} build${total === 1 ? "" : "s"}` +
                 (idleFilterActive
-                  ? ` idle ≥ ${formatIdleThreshold(idleForSeconds)}, stalest first`
+                  ? ` running, idle ≥ ${formatIdleThreshold(idleForSeconds)}`
                   : "")}
           </span>
           {isAdmin ? (

--- a/app/stardag-ui/src/components/BulkCancelDialog.tsx
+++ b/app/stardag-ui/src/components/BulkCancelDialog.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { bulkCancelBuilds } from "../api/tasks";
+import type { BulkCancelBuildsRequest, BulkCancelBuildsResponse } from "../types/task";
+import {
+  formatAbsoluteTime,
+  formatIdleThreshold,
+  formatRelativeTime,
+} from "../utils/time";
+import { Checkbox } from "./ui/Checkbox";
+import { ConfirmDialog } from "./ui/ConfirmDialog";
+import { ResultBanner } from "./ui/ResultBanner";
+
+// The API's per-build skip reasons, spelled out. Anything unrecognised
+// falls back to the raw reason so a newly added server reason still shows
+// rather than vanishing.
+const SKIP_REASONS: Record<string, string> = {
+  not_found: "Not found in this environment",
+  not_running: "Already finished — only running builds can be cancelled",
+  reactive: "Reactive build — tick “Include reactive builds” to cancel it",
+  not_idle: "Active more recently than the idle threshold",
+  limit_reached: "Batch limit reached — run the cleanup again to include it",
+};
+
+interface BulkCancelDialogProps {
+  environmentId: string;
+  /**
+   * "selection" cancels an explicit set of build ids; "idle" is the
+   * reaper sweep over everything quiet beyond a threshold. Both are the
+   * same endpoint with a different filter.
+   */
+  mode: "selection" | "idle";
+  /** mode="selection": the ids to cancel. */
+  buildIds?: string[];
+  /** mode="selection": id -> name, so skipped ids read as build names. */
+  buildNames?: Record<string, string>;
+  /** mode="idle": the idleness threshold, in seconds. */
+  idleForSeconds?: number;
+  /** mode="idle": restrict the sweep to one reactive app. */
+  reactiveAppName?: string | null;
+  onClose: () => void;
+  onApplied: (result: BulkCancelBuildsResponse) => void;
+}
+
+/**
+ * Confirm a bulk build cancellation by showing what it will do first.
+ *
+ * The endpoint has a `dry_run` that reports the exact selection a real
+ * call would act on — builds, the task claims a cascade would release,
+ * per-build skip reasons, truncation — so this dialog runs the dry run on
+ * open (and again whenever an option changes) and only ever applies what
+ * the user has just been shown. A destructive bulk action that reports its
+ * consequences before committing is the entire point.
+ *
+ * Mount only while the dialog should be open: the component keeps its
+ * options in local state and relies on unmounting to reset them.
+ */
+export function BulkCancelDialog({
+  environmentId,
+  mode,
+  buildIds,
+  buildNames,
+  idleForSeconds,
+  reactiveAppName,
+  onClose,
+  onApplied,
+}: BulkCancelDialogProps) {
+  const [cascade, setCascade] = useState(true);
+  const [includeReactive, setIncludeReactive] = useState(false);
+  const [reason, setReason] = useState("");
+
+  const [preview, setPreview] = useState<BulkCancelBuildsResponse | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(true);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+  const [applying, setApplying] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+
+  // Primitive-valued deps so the dry-run effect can't loop on a fresh
+  // array/object identity from the parent's render.
+  const buildIdsKey = (buildIds ?? []).join(",");
+  const selectedIds = useMemo(
+    () => (buildIdsKey ? buildIdsKey.split(",") : []),
+    [buildIdsKey],
+  );
+  const sweepIdleSeconds = mode === "idle" ? idleForSeconds ?? null : null;
+  const sweepApp = mode === "idle" ? reactiveAppName ?? null : null;
+
+  // `reason` is deliberately absent: it does not change the selection, so
+  // typing it must not re-run the dry run.
+  const filters = useMemo<BulkCancelBuildsRequest>(
+    () => ({
+      ...(selectedIds.length > 0 ? { build_ids: selectedIds } : {}),
+      ...(sweepIdleSeconds !== null ? { idle_for_seconds: sweepIdleSeconds } : {}),
+      ...(sweepApp ? { reactive_app_name: sweepApp } : {}),
+      include_reactive: includeReactive,
+      cascade,
+    }),
+    [selectedIds, sweepIdleSeconds, sweepApp, includeReactive, cascade],
+  );
+
+  // Stale-response guard: an option toggled while a dry run is in flight
+  // must not have the older answer land on top of the newer one.
+  const previewEpochRef = useRef(0);
+
+  useEffect(() => {
+    const epoch = ++previewEpochRef.current;
+    const fresh = () => previewEpochRef.current === epoch;
+    setPreviewLoading(true);
+    setPreviewError(null);
+    bulkCancelBuilds({ ...filters, dry_run: true }, environmentId)
+      .then((result) => {
+        if (fresh()) setPreview(result);
+      })
+      .catch((err: unknown) => {
+        if (!fresh()) return;
+        setPreview(null);
+        setPreviewError(
+          err instanceof Error ? err.message : "Failed to preview the cleanup",
+        );
+      })
+      .finally(() => {
+        if (fresh()) setPreviewLoading(false);
+      });
+  }, [filters, environmentId]);
+
+  const handleConfirm = async () => {
+    setApplying(true);
+    setApplyError(null);
+    try {
+      const result = await bulkCancelBuilds(
+        { ...filters, dry_run: false, reason: reason.trim() || null },
+        environmentId,
+      );
+      onApplied(result);
+    } catch (err) {
+      setApplyError(err instanceof Error ? err.message : "Failed to cancel builds");
+    } finally {
+      setApplying(false);
+    }
+  };
+
+  const skippedEntries = Object.entries(preview?.skipped ?? {});
+  const buildCount = preview?.build_count ?? 0;
+  const confirmLabel =
+    buildCount === 1 ? "Cancel 1 build" : `Cancel ${buildCount} builds`;
+
+  return (
+    <ConfirmDialog
+      isOpen
+      title={mode === "idle" ? "Clean up idle builds" : "Cancel selected builds"}
+      maxWidthClass="max-w-2xl"
+      destructive
+      confirmLabel={confirmLabel}
+      busyLabel="Cancelling…"
+      cancelLabel="Close"
+      confirmDisabled={previewLoading || buildCount === 0}
+      busy={applying}
+      error={applyError}
+      onConfirm={handleConfirm}
+      onCancel={onClose}
+    >
+      <p className="text-sm text-gray-600 dark:text-gray-400">
+        {mode === "idle" ? (
+          <>
+            Cancel every <strong>running</strong> build in this environment with no
+            activity for at least{" "}
+            <strong>{formatIdleThreshold(sweepIdleSeconds ?? 0)}</strong>
+            {sweepApp ? (
+              <>
+                {" "}
+                owned by the reactive app <code className="font-mono">{sweepApp}</code>
+              </>
+            ) : null}
+            . Idleness is measured on <em>last activity</em> — the same signal the
+            server reaps on — not on the build's last lifecycle transition.
+          </>
+        ) : (
+          <>
+            Cancel the {selectedIds.length} selected build
+            {selectedIds.length === 1 ? "" : "s"}. Only builds that are still{" "}
+            <strong>running</strong> can be cancelled; anything already finished is
+            reported below and left alone.
+          </>
+        )}
+      </p>
+
+      <div className="space-y-2 rounded-md border border-gray-200 p-3 dark:border-gray-700">
+        <Checkbox
+          checked={cascade}
+          onChange={setCascade}
+          labelHidden={false}
+          label="Release the execution claims these builds' tasks hold"
+        />
+        <p className="ml-6 text-xs text-gray-500 dark:text-gray-400">
+          Cancels each build's running and suspended tasks too, freeing their execution
+          claims and concurrency-limit slots. Without this, cancelling a build leaves
+          behind exactly the leaked claims a cleanup exists to remove.
+        </p>
+        <Checkbox
+          checked={includeReactive || !!sweepApp}
+          disabled={!!sweepApp}
+          onChange={setIncludeReactive}
+          labelHidden={false}
+          label="Include reactive builds"
+        />
+        <p className="ml-6 text-xs text-gray-500 dark:text-gray-400">
+          {sweepApp
+            ? "Implied: the sweep is already scoped to a single reactive app."
+            : "A reactive build is quiet between ticks by design, so quiet does not mean abandoned. Tick this only when the owning app is gone."}
+        </p>
+        <div className="pt-1">
+          <label
+            htmlFor="bulk-cancel-reason"
+            className="block text-xs font-medium text-gray-500 dark:text-gray-400"
+          >
+            Reason (optional)
+          </label>
+          <input
+            id="bulk-cancel-reason"
+            type="text"
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            placeholder="Recorded on each cancellation event"
+            className="mt-1 w-full rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-900 placeholder-gray-400 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-900 dark:text-gray-100"
+          />
+        </div>
+      </div>
+
+      {/* Dry-run preview: exactly what the confirm button will do. */}
+      <div className="space-y-3">
+        {previewLoading && (
+          <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+            <span className="h-4 w-4 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+            Checking what this will affect…
+          </div>
+        )}
+
+        {previewError && <ResultBanner tone="error">{previewError}</ResultBanner>}
+
+        {preview && !previewLoading && (
+          <>
+            <p
+              role="status"
+              className="text-sm font-medium text-gray-900 dark:text-gray-100"
+            >
+              {buildCount === 0
+                ? "Nothing to cancel — no running build matches."
+                : `Will cancel ${buildCount} build${buildCount === 1 ? "" : "s"}` +
+                  (cascade
+                    ? ` and release ${preview.task_count} task claim${
+                        preview.task_count === 1 ? "" : "s"
+                      }.`
+                    : " and release no task claims (cascade is off).")}
+            </p>
+
+            {preview.truncated && (
+              <ResultBanner tone="warning">
+                More builds match than one call may cancel. Run the cleanup again
+                afterwards to continue.
+              </ResultBanner>
+            )}
+
+            {preview.builds.length > 0 && (
+              <ul className="max-h-48 divide-y divide-gray-200 overflow-y-auto rounded-md border border-gray-200 text-sm dark:divide-gray-700 dark:border-gray-700">
+                {preview.builds.map((build) => (
+                  <li
+                    key={build.build_id}
+                    className="flex items-center gap-2 px-3 py-1.5"
+                  >
+                    <span className="min-w-0 flex-1 truncate text-gray-900 dark:text-gray-100">
+                      {build.name}
+                      {build.reactive_app_name && (
+                        <span className="ml-1.5 rounded bg-purple-100 px-1.5 py-0.5 text-xs text-purple-700 dark:bg-purple-900/40 dark:text-purple-300">
+                          {build.reactive_app_name}
+                        </span>
+                      )}
+                    </span>
+                    {cascade && build.cascaded_task_ids.length > 0 && (
+                      <span className="flex-shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                        {build.cascaded_task_ids.length} claim
+                        {build.cascaded_task_ids.length === 1 ? "" : "s"}
+                      </span>
+                    )}
+                    <span
+                      className="flex-shrink-0 text-xs text-gray-500 dark:text-gray-400"
+                      title={formatAbsoluteTime(build.last_activity_at)}
+                    >
+                      idle {formatRelativeTime(build.last_activity_at)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+
+            {skippedEntries.length > 0 && (
+              <div className="rounded-md border border-amber-200 bg-amber-50 p-3 dark:border-amber-900 dark:bg-amber-900/20">
+                <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+                  Skipped ({skippedEntries.length})
+                </p>
+                <ul className="mt-1 space-y-0.5 text-xs text-amber-800 dark:text-amber-300">
+                  {skippedEntries.map(([buildId, skipReason]) => (
+                    <li key={buildId}>
+                      <span className="font-medium">
+                        {buildNames?.[buildId] ?? buildId.slice(0, 8)}
+                      </span>
+                      {" — "}
+                      {SKIP_REASONS[skipReason] ?? skipReason}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Cancelling rewrites the registry's view of a build. It does not stop a process
+        that is still alive — a worker keeps going until it notices.
+      </p>
+    </ConfirmDialog>
+  );
+}

--- a/app/stardag-ui/src/components/BulkCancelDialog.tsx
+++ b/app/stardag-ui/src/components/BulkCancelDialog.tsx
@@ -120,6 +120,13 @@ export function BulkCancelDialog({
       .finally(() => {
         if (fresh()) setPreviewLoading(false);
       });
+    // Unmount invalidates the request too. Closing the dialog while a dry
+    // run is in flight would otherwise let the response resolve into
+    // `setState` on a component that no longer exists — the same staleness
+    // the epoch guards against, arriving by a different route.
+    return () => {
+      previewEpochRef.current += 1;
+    };
   }, [filters, environmentId]);
 
   const handleConfirm = async () => {

--- a/app/stardag-ui/src/components/Modal.tsx
+++ b/app/stardag-ui/src/components/Modal.tsx
@@ -1,5 +1,14 @@
 import { useEffect, type ReactNode } from "react";
 
+// TODO(a11y): this modal does not trap focus. Escape closes it and the
+// body is scroll-locked, but Tab walks straight out of the dialog into the
+// page behind it, and focus is not restored to the trigger on close. Every
+// caller (ChangePasswordModal, OnboardingModal, ConfirmDialog, …) inherits
+// the gap. Fixing it means cycling Tab/Shift-Tab within the dialog,
+// marking the rest of the page `aria-hidden`/`inert` while open, and
+// remembering `document.activeElement` — a change to shared behaviour that
+// deserves its own PR rather than riding along with a feature.
+
 interface ModalProps {
   isOpen: boolean;
   onClose: () => void;

--- a/app/stardag-ui/src/components/Modal.tsx
+++ b/app/stardag-ui/src/components/Modal.tsx
@@ -9,6 +9,12 @@ interface ModalProps {
   closeOnOverlay?: boolean;
   /** Whether to show the close button */
   showCloseButton?: boolean;
+  /**
+   * Tailwind max-width class for the dialog. Defaults to the narrow
+   * form-sized dialog; widen it for content that has to be read and
+   * compared (e.g. a dry-run preview listing what is about to change).
+   */
+  maxWidthClass?: string;
 }
 
 export function Modal({
@@ -18,6 +24,7 @@ export function Modal({
   children,
   closeOnOverlay = true,
   showCloseButton = true,
+  maxWidthClass = "max-w-md",
 }: ModalProps) {
   // Handle escape key
   useEffect(() => {
@@ -56,7 +63,9 @@ export function Modal({
       />
 
       {/* Modal content */}
-      <div className="relative z-10 w-full max-w-md rounded-lg bg-white dark:bg-gray-800 shadow-xl mx-4">
+      <div
+        className={`relative z-10 w-full ${maxWidthClass} rounded-lg bg-white dark:bg-gray-800 shadow-xl mx-4`}
+      >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-gray-200 dark:border-gray-700 px-6 py-4">
           <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">

--- a/app/stardag-ui/src/components/Sidebar.test.tsx
+++ b/app/stardag-ui/src/components/Sidebar.test.tsx
@@ -4,15 +4,15 @@ import { Sidebar } from "./Sidebar";
 
 describe("Sidebar", () => {
   it("labels the concurrency nav item 'Concurrency' (single-line, see #174)", () => {
-    render(<Sidebar activeItem="home" onNavigate={vi.fn()} />);
+    render(<Sidebar activeItem="builds" onNavigate={vi.fn()} />);
     expect(screen.getByText("Concurrency")).toBeInTheDocument();
     // The old two-word label wrapped and center-aligned; it must be gone.
     expect(screen.queryByText("Concurrency Limits")).not.toBeInTheDocument();
   });
 
   it("renders each nav label left-aligned with no-wrap truncation", () => {
-    render(<Sidebar activeItem="home" onNavigate={vi.fn()} />);
-    for (const label of ["Home", "Task Explorer", "Concurrency", "Settings"]) {
+    render(<Sidebar activeItem="builds" onNavigate={vi.fn()} />);
+    for (const label of ["Builds", "Task Explorer", "Concurrency", "Settings"]) {
       const span = screen.getByText(label);
       expect(span.className).toContain("truncate");
       expect(span.className).toContain("text-left");
@@ -22,15 +22,15 @@ describe("Sidebar", () => {
   it("gives each nav item a title tooltip carrying the full label", () => {
     // With single-line `truncate`, an ellipsized label must still be
     // readable on hover — so every item carries `title={label}` (see #174).
-    render(<Sidebar activeItem="home" onNavigate={vi.fn()} />);
-    for (const label of ["Home", "Task Explorer", "Concurrency", "Settings"]) {
+    render(<Sidebar activeItem="builds" onNavigate={vi.fn()} />);
+    for (const label of ["Builds", "Task Explorer", "Concurrency", "Settings"]) {
       const button = screen.getByRole("button", { name: label });
       expect(button).toHaveAttribute("title", label);
     }
   });
 
   it("hides labels when collapsed", () => {
-    render(<Sidebar activeItem="home" onNavigate={vi.fn()} collapsed />);
+    render(<Sidebar activeItem="builds" onNavigate={vi.fn()} collapsed />);
     expect(screen.queryByText("Concurrency")).not.toBeInTheDocument();
   });
 });

--- a/app/stardag-ui/src/components/Sidebar.tsx
+++ b/app/stardag-ui/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Logo } from "./Logo";
 
-export type NavItem = "home" | "builds" | "tasks" | "limits" | "settings";
+export type NavItem = "builds" | "tasks" | "limits" | "settings";
 
 interface SidebarProps {
   activeItem: NavItem;
@@ -17,15 +17,15 @@ export function Sidebar({
 }: SidebarProps) {
   const navItems: { id: NavItem; label: string; icon: React.ReactNode }[] = [
     {
-      id: "home",
-      label: "Home",
+      id: "builds",
+      label: "Builds",
       icon: (
         <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path
             strokeLinecap="round"
             strokeLinejoin="round"
             strokeWidth={2}
-            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+            d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
           />
         </svg>
       ),

--- a/app/stardag-ui/src/components/ui/BulkActionBar.tsx
+++ b/app/stardag-ui/src/components/ui/BulkActionBar.tsx
@@ -46,7 +46,9 @@ export function BulkActionBar({
           {count === 1 ? "" : "s"} selected
         </p>
         {note && (
-          <p className="mt-0.5 text-xs text-blue-700/80 dark:text-blue-300/70">{note}</p>
+          <p className="mt-0.5 text-xs text-blue-700/80 dark:text-blue-300/70">
+            {note}
+          </p>
         )}
       </div>
       <div className="flex items-center gap-2">

--- a/app/stardag-ui/src/components/ui/BulkActionBar.tsx
+++ b/app/stardag-ui/src/components/ui/BulkActionBar.tsx
@@ -1,0 +1,63 @@
+import type { ReactNode } from "react";
+
+interface BulkActionBarProps {
+  count: number;
+  /** Singular noun for the selected rows; pluralised with a trailing "s". */
+  noun?: string;
+  onClear: () => void;
+  /** Action buttons, rendered right-aligned. */
+  children?: ReactNode;
+  /**
+   * Scope caveat rendered under the count — e.g. that the selection only
+   * covers the current page. Keep it short.
+   */
+  note?: ReactNode;
+}
+
+/**
+ * Bar that appears when a table has a selection, carrying the count and
+ * the actions that apply to it.
+ *
+ * Renders nothing at all when the selection is empty, so callers can drop
+ * it into a layout unconditionally. The count lives in an ``aria-live``
+ * region so screen-reader users hear the selection grow and shrink.
+ */
+export function BulkActionBar({
+  count,
+  noun = "item",
+  onClear,
+  children,
+  note,
+}: BulkActionBarProps) {
+  if (count === 0) return null;
+
+  return (
+    <div
+      role="region"
+      aria-label={`${noun} selection`}
+      className="flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-blue-200 bg-blue-50 px-4 py-2 dark:border-blue-900 dark:bg-blue-950/40"
+    >
+      <div className="min-w-0 flex-1">
+        <p
+          aria-live="polite"
+          className="text-sm font-medium text-blue-900 dark:text-blue-200"
+        >
+          {count} {noun}
+          {count === 1 ? "" : "s"} selected
+        </p>
+        {note && (
+          <p className="mt-0.5 text-xs text-blue-700/80 dark:text-blue-300/70">{note}</p>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        {children}
+        <button
+          onClick={onClear}
+          className="rounded-md px-2 py-1 text-sm font-medium text-blue-700 hover:bg-blue-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-300 dark:hover:bg-blue-900/50"
+        >
+          Clear selection
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/stardag-ui/src/components/ui/Checkbox.test.tsx
+++ b/app/stardag-ui/src/components/ui/Checkbox.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { Checkbox } from "./Checkbox";
+
+describe("Checkbox", () => {
+  it("exposes the label as the accessible name when visually hidden", () => {
+    render(<Checkbox checked={false} onChange={vi.fn()} label="Select build Alpha" />);
+    expect(
+      screen.getByRole("checkbox", { name: "Select build Alpha" }),
+    ).toBeInTheDocument();
+    // Hidden label: not rendered as visible text.
+    expect(screen.queryByText("Select build Alpha")).not.toBeInTheDocument();
+  });
+
+  it("renders a visible label when asked", () => {
+    render(
+      <Checkbox
+        checked
+        onChange={vi.fn()}
+        label="Release execution claims"
+        labelHidden={false}
+      />,
+    );
+    const box = screen.getByRole("checkbox", { name: "Release execution claims" });
+    expect(box).toBeChecked();
+    expect(screen.getByText("Release execution claims")).toBeInTheDocument();
+  });
+
+  it("sets the indeterminate DOM property only while unchecked", () => {
+    const { rerender } = render(
+      <Checkbox checked={false} indeterminate onChange={vi.fn()} label="Select all" />,
+    );
+    const box = screen.getByRole("checkbox", { name: "Select all" }) as HTMLInputElement;
+    expect(box.indeterminate).toBe(true);
+
+    rerender(<Checkbox checked indeterminate onChange={vi.fn()} label="Select all" />);
+    expect(box.indeterminate).toBe(false);
+  });
+
+  it("reports the new checked state on toggle", async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Checkbox checked={false} onChange={onChange} label="Select all" />);
+
+    await user.click(screen.getByRole("checkbox", { name: "Select all" }));
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/app/stardag-ui/src/components/ui/Checkbox.test.tsx
+++ b/app/stardag-ui/src/components/ui/Checkbox.test.tsx
@@ -31,7 +31,9 @@ describe("Checkbox", () => {
     const { rerender } = render(
       <Checkbox checked={false} indeterminate onChange={vi.fn()} label="Select all" />,
     );
-    const box = screen.getByRole("checkbox", { name: "Select all" }) as HTMLInputElement;
+    const box = screen.getByRole("checkbox", {
+      name: "Select all",
+    }) as HTMLInputElement;
     expect(box.indeterminate).toBe(true);
 
     rerender(<Checkbox checked indeterminate onChange={vi.fn()} label="Select all" />);

--- a/app/stardag-ui/src/components/ui/Checkbox.tsx
+++ b/app/stardag-ui/src/components/ui/Checkbox.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef } from "react";
+
+interface CheckboxProps {
+  checked: boolean;
+  /**
+   * Renders the mixed ("some but not all") state. Only meaningful while
+   * ``checked`` is false — a checked box is never indeterminate, which is
+   * also how the DOM property behaves.
+   */
+  indeterminate?: boolean;
+  onChange: (checked: boolean) => void;
+  /**
+   * Accessible name. Required: a bare checkbox in a table row is
+   * unusable without one, and the tests query by it.
+   */
+  label: string;
+  /**
+   * When false the label renders as visible text next to the box. The
+   * default (true) keeps the label available to assistive technology
+   * only — the right choice for per-row selection boxes.
+   */
+  labelHidden?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * The one checkbox in this codebase.
+ *
+ * Introduced for row selection in the builds table; kept generic (and
+ * indeterminate-capable) so any later multi-select surface reuses it
+ * rather than hand-rolling a fourth set of Tailwind classes.
+ */
+export function Checkbox({
+  checked,
+  indeterminate = false,
+  onChange,
+  label,
+  labelHidden = true,
+  disabled = false,
+  className = "",
+}: CheckboxProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // `indeterminate` is a DOM property with no HTML attribute, so it can
+  // only be set imperatively.
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.indeterminate = !checked && indeterminate;
+    }
+  }, [checked, indeterminate]);
+
+  const input = (
+    <input
+      ref={inputRef}
+      type="checkbox"
+      checked={checked}
+      disabled={disabled}
+      onChange={(e) => onChange(e.target.checked)}
+      aria-label={labelHidden ? label : undefined}
+      className="h-4 w-4 cursor-pointer rounded border-gray-300 accent-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:accent-blue-500"
+    />
+  );
+
+  if (labelHidden) {
+    return <span className={`inline-flex items-center ${className}`}>{input}</span>;
+  }
+
+  return (
+    <label
+      className={`inline-flex cursor-pointer items-center gap-2 text-sm text-gray-700 select-none dark:text-gray-300 ${
+        disabled ? "cursor-not-allowed opacity-50" : ""
+      } ${className}`}
+    >
+      {input}
+      <span>{label}</span>
+    </label>
+  );
+}

--- a/app/stardag-ui/src/components/ui/ConfirmDialog.tsx
+++ b/app/stardag-ui/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,90 @@
+import type { ReactNode } from "react";
+import { Modal } from "../Modal";
+import { ResultBanner } from "./ResultBanner";
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  /** Body: prose, options, and — for bulk actions — a preview of the effect. */
+  children?: ReactNode;
+  confirmLabel: string;
+  /** Label while the action is in flight (defaults to confirmLabel + "…"). */
+  busyLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  /** Red confirm button and an alert-toned error area. */
+  destructive?: boolean;
+  confirmDisabled?: boolean;
+  busy?: boolean;
+  /** Failure of the confirmed action, rendered above the buttons. */
+  error?: string | null;
+  /** Tailwind max-width class forwarded to the underlying Modal. */
+  maxWidthClass?: string;
+}
+
+/**
+ * Confirmation dialog for actions whose consequences are worth showing
+ * before they happen.
+ *
+ * Composed from ``Modal`` (escape-to-close, overlay, scroll lock) rather
+ * than being a third dialog implementation. The body is free-form so a
+ * destructive bulk action can render its dry-run preview inside the same
+ * dialog the user will confirm from — see ``BulkCancelDialog``.
+ *
+ * Focus lands on Cancel, not on the destructive button: an accidental
+ * Enter must not commit.
+ */
+export function ConfirmDialog({
+  isOpen,
+  title,
+  children,
+  confirmLabel,
+  busyLabel,
+  cancelLabel = "Cancel",
+  onConfirm,
+  onCancel,
+  destructive = false,
+  confirmDisabled = false,
+  busy = false,
+  error = null,
+  maxWidthClass = "max-w-md",
+}: ConfirmDialogProps) {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onCancel}
+      title={title}
+      maxWidthClass={maxWidthClass}
+      closeOnOverlay={!busy}
+    >
+      <div className="space-y-4">
+        {children}
+
+        {error && <ResultBanner tone="error">{error}</ResultBanner>}
+
+        <div className="flex justify-end gap-2">
+          <button
+            autoFocus
+            onClick={onCancel}
+            disabled={busy}
+            className="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={confirmDisabled || busy}
+            className={`rounded-md px-3 py-1.5 text-sm font-medium text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:focus-visible:ring-offset-gray-800 ${
+              destructive
+                ? "bg-red-600 hover:bg-red-700 focus-visible:ring-red-500"
+                : "bg-blue-600 hover:bg-blue-700 focus-visible:ring-blue-500"
+            }`}
+          >
+            {busy ? (busyLabel ?? `${confirmLabel}…`) : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/app/stardag-ui/src/components/ui/ConfirmDialog.tsx
+++ b/app/stardag-ui/src/components/ui/ConfirmDialog.tsx
@@ -81,7 +81,7 @@ export function ConfirmDialog({
                 : "bg-blue-600 hover:bg-blue-700 focus-visible:ring-blue-500"
             }`}
           >
-            {busy ? (busyLabel ?? `${confirmLabel}…`) : confirmLabel}
+            {busy ? busyLabel ?? `${confirmLabel}…` : confirmLabel}
           </button>
         </div>
       </div>

--- a/app/stardag-ui/src/components/ui/ResultBanner.tsx
+++ b/app/stardag-ui/src/components/ui/ResultBanner.tsx
@@ -1,0 +1,68 @@
+import type { ReactNode } from "react";
+
+export type ResultBannerTone = "success" | "error" | "warning" | "info";
+
+interface ResultBannerProps {
+  tone: ResultBannerTone;
+  children: ReactNode;
+  onDismiss?: () => void;
+  className?: string;
+}
+
+const TONE_STYLES: Record<ResultBannerTone, string> = {
+  success:
+    "border-green-200 bg-green-50 text-green-800 dark:border-green-900 dark:bg-green-900/20 dark:text-green-300",
+  error:
+    "border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-900/20 dark:text-red-400",
+  warning:
+    "border-amber-200 bg-amber-50 text-amber-800 dark:border-amber-900 dark:bg-amber-900/20 dark:text-amber-300",
+  info: "border-blue-200 bg-blue-50 text-blue-800 dark:border-blue-900 dark:bg-blue-900/20 dark:text-blue-300",
+};
+
+/**
+ * Inline outcome message — "cancelled 4 builds, released 11 claims", or
+ * the error that stopped it.
+ *
+ * Inline rather than a floating toast on purpose: the outcome of a bulk
+ * mutation belongs next to the data it changed, and stays put long enough
+ * to be read and cross-checked against the refreshed table.
+ *
+ * Errors are announced assertively; everything else politely.
+ */
+export function ResultBanner({
+  tone,
+  children,
+  onDismiss,
+  className = "",
+}: ResultBannerProps) {
+  return (
+    <div
+      role={tone === "error" ? "alert" : "status"}
+      aria-live={tone === "error" ? "assertive" : "polite"}
+      className={`flex items-start gap-3 rounded-md border px-3 py-2 text-sm ${TONE_STYLES[tone]} ${className}`}
+    >
+      <div className="min-w-0 flex-1">{children}</div>
+      {onDismiss && (
+        <button
+          onClick={onDismiss}
+          aria-label="Dismiss message"
+          className="-mr-1 rounded p-0.5 opacity-60 hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-current"
+        >
+          <svg
+            className="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/stardag-ui/src/context/EnvironmentContext.tsx
+++ b/app/stardag-ui/src/context/EnvironmentContext.tsx
@@ -177,7 +177,7 @@ export function EnvironmentProvider({ children }: EnvironmentProviderProps) {
             localStorage.removeItem(STORAGE_KEY_ENVIRONMENT);
           }
 
-          // Navigate to home page when switching workspaces to avoid
+          // Navigate to the builds list when switching workspaces to avoid
           // "not found" errors from workspace-specific resources (builds, tasks, etc.)
           window.history.pushState({}, "", "/");
           window.dispatchEvent(new PopStateEvent("popstate"));

--- a/app/stardag-ui/src/context/ThemeContext.tsx
+++ b/app/stardag-ui/src/context/ThemeContext.tsx
@@ -19,6 +19,13 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     localStorage.setItem("theme", theme);
     document.documentElement.classList.toggle("dark", theme === "dark");
+    // Tailwind's `dark:` variant only reaches what we style ourselves.
+    // Natively-rendered controls — checkbox and radio glyphs, select
+    // arrows, scrollbars, focus rings — are painted by the browser from
+    // `color-scheme`, which defaults to light no matter what class is on
+    // the root. Without this an unchecked checkbox is a white box on a
+    // dark table.
+    document.documentElement.style.colorScheme = theme;
   }, [theme]);
 
   const toggleTheme = () => setTheme((t) => (t === "light" ? "dark" : "light"));

--- a/app/stardag-ui/src/hooks/useRowSelection.ts
+++ b/app/stardag-ui/src/hooks/useRowSelection.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+export interface RowSelection {
+  /** Selected ids, in the order of ``visibleIds``. */
+  selectedIds: string[];
+  selectedCount: number;
+  isSelected: (id: string) => boolean;
+  toggle: (id: string, checked: boolean) => void;
+  /** Select/deselect every currently visible row (the header checkbox). */
+  toggleAllVisible: (checked: boolean) => void;
+  clear: () => void;
+  /** Every visible row is selected (false when there are no rows). */
+  allVisibleSelected: boolean;
+  /** At least one — but not every — visible row is selected. */
+  someVisibleSelected: boolean;
+}
+
+/**
+ * Row selection for a paginated table.
+ *
+ * **Selection is scoped to what is on screen.** Passing a ``resetKey``
+ * that changes whenever the visible set changes (page, filters,
+ * environment) clears the selection, and ``selectedIds`` is always
+ * intersected with ``visibleIds``. That is deliberate: silently carrying
+ * off-screen rows into a destructive bulk action is exactly the kind of
+ * hidden state that makes such an action untrustworthy. Clearing is
+ * honest and visible.
+ */
+export function useRowSelection(
+  visibleIds: string[],
+  resetKey?: string,
+): RowSelection {
+  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
+
+  useEffect(() => {
+    setSelected(new Set());
+  }, [resetKey]);
+
+  const selectedIds = useMemo(
+    () => visibleIds.filter((id) => selected.has(id)),
+    [visibleIds, selected],
+  );
+
+  const isSelected = useCallback((id: string) => selected.has(id), [selected]);
+
+  const toggle = useCallback((id: string, checked: boolean) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (checked) {
+        next.add(id);
+      } else {
+        next.delete(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const toggleAllVisible = useCallback(
+    (checked: boolean) => {
+      setSelected(() => (checked ? new Set(visibleIds) : new Set()));
+    },
+    [visibleIds],
+  );
+
+  const clear = useCallback(() => setSelected(new Set()), []);
+
+  return {
+    selectedIds,
+    selectedCount: selectedIds.length,
+    isSelected,
+    toggle,
+    toggleAllVisible,
+    clear,
+    allVisibleSelected: visibleIds.length > 0 && selectedIds.length === visibleIds.length,
+    someVisibleSelected:
+      selectedIds.length > 0 && selectedIds.length < visibleIds.length,
+  };
+}

--- a/app/stardag-ui/src/hooks/useRowSelection.ts
+++ b/app/stardag-ui/src/hooks/useRowSelection.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 export interface RowSelection {
   /** Selected ids, in the order of ``visibleIds``. */
@@ -15,26 +15,30 @@ export interface RowSelection {
   someVisibleSelected: boolean;
 }
 
+const EMPTY: ReadonlySet<string> = new Set();
+
 /**
  * Row selection for a paginated table.
  *
- * **Selection is scoped to what is on screen.** Passing a ``resetKey``
- * that changes whenever the visible set changes (page, filters,
- * environment) clears the selection, and ``selectedIds`` is always
- * intersected with ``visibleIds``. That is deliberate: silently carrying
- * off-screen rows into a destructive bulk action is exactly the kind of
- * hidden state that makes such an action untrustworthy. Clearing is
- * honest and visible.
+ * **Selection is scoped to what is on screen.** Pass a ``resetKey`` that
+ * changes whenever the visible set changes (page, filters, environment)
+ * and the selection empties; ``selectedIds`` is additionally intersected
+ * with ``visibleIds``. That is deliberate: silently carrying off-screen
+ * rows into a destructive bulk action is exactly the kind of hidden state
+ * that makes such an action untrustworthy. Clearing is honest.
+ *
+ * The reset is derived rather than performed in an effect — the selection
+ * is stored together with the key it was made under, and a selection made
+ * under a different key simply reads as empty. No cascading render, and no
+ * window in which a stale selection is observable.
  */
-export function useRowSelection(
-  visibleIds: string[],
-  resetKey?: string,
-): RowSelection {
-  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
+export function useRowSelection(visibleIds: string[], resetKey?: string): RowSelection {
+  const [stored, setStored] = useState<{
+    key: string | undefined;
+    ids: ReadonlySet<string>;
+  }>(() => ({ key: resetKey, ids: EMPTY }));
 
-  useEffect(() => {
-    setSelected(new Set());
-  }, [resetKey]);
+  const selected = stored.key === resetKey ? stored.ids : EMPTY;
 
   const selectedIds = useMemo(
     () => visibleIds.filter((id) => selected.has(id)),
@@ -43,26 +47,30 @@ export function useRowSelection(
 
   const isSelected = useCallback((id: string) => selected.has(id), [selected]);
 
-  const toggle = useCallback((id: string, checked: boolean) => {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (checked) {
-        next.add(id);
-      } else {
-        next.delete(id);
-      }
-      return next;
-    });
-  }, []);
+  const toggle = useCallback(
+    (id: string, checked: boolean) => {
+      setStored((prev) => {
+        const base = prev.key === resetKey ? prev.ids : EMPTY;
+        const next = new Set(base);
+        if (checked) {
+          next.add(id);
+        } else {
+          next.delete(id);
+        }
+        return { key: resetKey, ids: next };
+      });
+    },
+    [resetKey],
+  );
 
   const toggleAllVisible = useCallback(
     (checked: boolean) => {
-      setSelected(() => (checked ? new Set(visibleIds) : new Set()));
+      setStored({ key: resetKey, ids: checked ? new Set(visibleIds) : EMPTY });
     },
-    [visibleIds],
+    [resetKey, visibleIds],
   );
 
-  const clear = useCallback(() => setSelected(new Set()), []);
+  const clear = useCallback(() => setStored({ key: resetKey, ids: EMPTY }), [resetKey]);
 
   return {
     selectedIds,
@@ -71,7 +79,8 @@ export function useRowSelection(
     toggle,
     toggleAllVisible,
     clear,
-    allVisibleSelected: visibleIds.length > 0 && selectedIds.length === visibleIds.length,
+    allVisibleSelected:
+      visibleIds.length > 0 && selectedIds.length === visibleIds.length,
     someVisibleSelected:
       selectedIds.length > 0 && selectedIds.length < visibleIds.length,
   };

--- a/app/stardag-ui/src/types/task.ts
+++ b/app/stardag-ui/src/types/task.ts
@@ -72,6 +72,76 @@ export interface Build {
   // older API responses and null for builds without a recorded trigger
   // executor.
   executor_metadata?: ExecutorMetadata | null;
+  // Reactive-scheduling owner: the app whose ticks drive this build. Null
+  // for ordinary (resident) builds — its presence is the reactive marker.
+  reactive_app_name?: string | null;
+  // ---- Liveness. Two different numbers; do not confuse them. ----
+  //
+  // `last_active_at` is the column the API orders the build list by. It is
+  // bumped by build-level LIFECYCLE transitions only (resume, complete,
+  // fail, cancel, exit-early, roots appended) — never by task events — so
+  // it is NOT an activity signal: a build that has been running tasks for
+  // three days still reports its BUILD_STARTED timestamp here.
+  //
+  // `last_activity_at` is the activity signal: the newest of the build's
+  // whole event stream (task events included), its `last_active_at`, and
+  // any pending scheduler wake-up. This is what the stale-build reaper
+  // measures idleness against, so it is the one to show and filter on.
+  // Both are optional: absent on API responses predating them.
+  last_active_at?: string | null;
+  last_activity_at?: string | null;
+}
+
+// Response of POST /builds/{id}/cancel — a superset of Build. The cascade
+// fields are empty/zero unless the call passed cascade=true.
+export interface BuildCancelResult extends Build {
+  cascaded_task_ids: string[];
+  cascaded_task_count: number;
+}
+
+// Why bulk-cancel did not act on an explicitly requested build id. Kept as
+// a union of the reasons the API documents today, widened to `string` at
+// the response boundary so an unknown future reason still renders.
+export type BulkCancelSkipReason =
+  | "not_found"
+  | "not_running"
+  | "reactive"
+  | "not_idle"
+  | "limit_reached";
+
+// Body of POST /builds/bulk-cancel. At least one of `build_ids` /
+// `idle_for_seconds` is required — the API answers 422 otherwise.
+export interface BulkCancelBuildsRequest {
+  build_ids?: string[];
+  // Idleness measured against `last_activity_at`, not `last_active_at`.
+  idle_for_seconds?: number;
+  reactive_app_name?: string | null;
+  include_reactive?: boolean;
+  // Also cancel the build's RUNNING/SUSPENDED tasks, releasing the
+  // execution claims and concurrency slots they hold.
+  cascade?: boolean;
+  dry_run?: boolean;
+  limit?: number;
+  reason?: string | null;
+}
+
+export interface CancelledBuildRef {
+  build_id: string;
+  name: string;
+  last_activity_at: string | null;
+  reactive_app_name: string | null;
+  cascaded_task_ids: string[];
+}
+
+export interface BulkCancelBuildsResponse {
+  dry_run: boolean;
+  builds: CancelledBuildRef[];
+  build_count: number;
+  task_count: number;
+  // build_id -> reason (see BulkCancelSkipReason).
+  skipped: Record<string, string>;
+  // More builds matched the filter than `limit` allowed; call again.
+  truncated: boolean;
 }
 
 export interface BuildListResponse {

--- a/app/stardag-ui/src/utils/time.test.ts
+++ b/app/stardag-ui/src/utils/time.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { formatAbsoluteTime, formatDuration, formatRelativeTime } from "./time";
+
+// Fixed local instant, so the assertions below read as wall-clock time in
+// whatever zone the suite happens to run in.
+const NOW = new Date(2026, 7, 9, 14, 32, 7); // 2026-08-09 14:32:07 local
+
+function at(offsetMs: number): string {
+  return new Date(NOW.getTime() - offsetMs).toISOString();
+}
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function freeze() {
+  vi.useFakeTimers();
+  vi.setSystemTime(NOW);
+}
+
+describe("formatDuration", () => {
+  it("breaks out days once an interval passes 24h", () => {
+    freeze();
+    // The case that motivated this: a build abandoned two weeks ago used
+    // to render as "371h 41m".
+    expect(formatDuration(at(15 * DAY + 11 * HOUR + 41 * MINUTE), null)).toBe(
+      "15d 11h 41m",
+    );
+  });
+
+  it("keeps the finer units below a day", () => {
+    freeze();
+    expect(formatDuration(at(45_000), null)).toBe("45s");
+    expect(formatDuration(at(12 * MINUTE + 3_000), null)).toBe("12m 3s");
+    expect(formatDuration(at(2 * HOUR + 7 * MINUTE), null)).toBe("2h 07m");
+  });
+
+  it("switches units exactly at the day boundary", () => {
+    freeze();
+    expect(formatDuration(at(DAY - MINUTE), null)).toBe("23h 59m");
+    expect(formatDuration(at(DAY), null)).toBe("1d 0h 00m");
+  });
+});
+
+describe("date rendering", () => {
+  it("uses YYYY-MM-DD rather than a locale-dependent order", () => {
+    freeze();
+    expect(formatRelativeTime(at(30 * DAY))).toBe("2026-07-10");
+  });
+
+  it("renders absolute timestamps as YYYY-MM-DD HH:MM:SS", () => {
+    expect(formatAbsoluteTime(NOW.toISOString())).toBe("2026-08-09 14:32:07");
+  });
+
+  it("dates in the viewer's timezone, not UTC", () => {
+    // 23:30 local on the 9th is the 10th in UTC for anyone east of
+    // Greenwich; the date shown must be the one on the viewer's wall.
+    const lateEvening = new Date(2026, 7, 9, 23, 30, 0);
+    expect(formatAbsoluteTime(lateEvening.toISOString())).toBe("2026-08-09 23:30:00");
+  });
+
+  it("still prefers relative wording inside a week", () => {
+    freeze();
+    expect(formatRelativeTime(at(3 * DAY))).toBe("3d ago");
+    expect(formatRelativeTime(at(5 * HOUR))).toBe("5h ago");
+  });
+
+  it("has one rendering for a missing timestamp", () => {
+    expect(formatRelativeTime(null)).toBe("—");
+    expect(formatAbsoluteTime(null)).toBeUndefined();
+  });
+});

--- a/app/stardag-ui/src/utils/time.ts
+++ b/app/stardag-ui/src/utils/time.ts
@@ -1,0 +1,75 @@
+/**
+ * Timestamp formatting shared by list views.
+ *
+ * Relative time is what an operator scans ("3d ago"); the absolute time
+ * belongs in a `title` next to it, because "3d ago" is useless the moment
+ * anyone needs to correlate with a log.
+ */
+
+const MISSING = "—";
+
+/** "just now" / "12m ago" / "5h ago" / "3d ago" / a locale date beyond a week. */
+export function formatRelativeTime(dateString: string | null | undefined): string {
+  if (!dateString) return MISSING;
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return MISSING;
+
+  const diffSecs = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (diffSecs < 0) return "just now";
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+  const diffDays = Math.floor(diffHours / 24);
+
+  if (diffSecs < 60) return "just now";
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  if (diffDays < 7) return `${diffDays}d ago`;
+  return date.toLocaleDateString();
+}
+
+/** Full local timestamp for a `title` attribute; undefined when unknown. */
+export function formatAbsoluteTime(
+  dateString: string | null | undefined,
+): string | undefined {
+  if (!dateString) return undefined;
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return undefined;
+  return date.toLocaleString();
+}
+
+/** Seconds since `dateString`, or null when it is missing/unparseable. */
+export function secondsSince(dateString: string | null | undefined): number | null {
+  if (!dateString) return null;
+  const ms = new Date(dateString).getTime();
+  if (Number.isNaN(ms)) return null;
+  return Math.floor((Date.now() - ms) / 1000);
+}
+
+/** "45s" / "12m 3s" / "2h 07m" — elapsed time between two instants. */
+export function formatDuration(
+  startedAt: string | null | undefined,
+  completedAt: string | null | undefined,
+): string {
+  if (!startedAt) return MISSING;
+  const start = new Date(startedAt);
+  if (Number.isNaN(start.getTime())) return MISSING;
+  const end = completedAt ? new Date(completedAt) : new Date();
+  const diffSecs = Math.max(0, Math.floor((end.getTime() - start.getTime()) / 1000));
+  const diffMins = Math.floor(diffSecs / 60);
+  const diffHours = Math.floor(diffMins / 60);
+
+  if (diffSecs < 60) return `${diffSecs}s`;
+  if (diffMins < 60) return `${diffMins}m ${diffSecs % 60}s`;
+  return `${diffHours}h ${String(diffMins % 60).padStart(2, "0")}m`;
+}
+
+/**
+ * Humanise an idleness threshold in seconds: "1h", "24h", "7d".
+ * Used in filter labels and in the bulk-cleanup confirmation copy.
+ */
+export function formatIdleThreshold(seconds: number): string {
+  if (seconds % 86400 === 0) return `${seconds / 86400}d`;
+  if (seconds % 3600 === 0) return `${seconds / 3600}h`;
+  if (seconds % 60 === 0) return `${seconds / 60}m`;
+  return `${seconds}s`;
+}

--- a/app/stardag-ui/src/utils/time.ts
+++ b/app/stardag-ui/src/utils/time.ts
@@ -65,9 +65,13 @@ export function formatDuration(
 
 /**
  * Humanise an idleness threshold in seconds: "1h", "24h", "7d".
- * Used in filter labels and in the bulk-cleanup confirmation copy.
+ * Used in filter summaries and in the bulk-cleanup confirmation copy.
+ *
+ * Hours are kept up to two days so a threshold the user picked as
+ * "24 hours" is not echoed back at them as "1d".
  */
 export function formatIdleThreshold(seconds: number): string {
+  if (seconds % 3600 === 0 && seconds < 48 * 3600) return `${seconds / 3600}h`;
   if (seconds % 86400 === 0) return `${seconds / 86400}d`;
   if (seconds % 3600 === 0) return `${seconds / 3600}h`;
   if (seconds % 60 === 0) return `${seconds / 60}m`;

--- a/app/stardag-ui/src/utils/time.ts
+++ b/app/stardag-ui/src/utils/time.ts
@@ -8,7 +8,23 @@
 
 const MISSING = "—";
 
-/** "just now" / "12m ago" / "5h ago" / "3d ago" / a locale date beyond a week. */
+const pad = (n: number) => String(n).padStart(2, "0");
+
+/**
+ * `YYYY-MM-DD` in the **viewer's** timezone.
+ *
+ * Not `toISOString().slice(0, 10)`, which is UTC and would show the wrong
+ * day for anyone west of Greenwich for part of their evening. Not
+ * `toLocaleDateString()` either: that renders `8/9/2026` or `9/8/2026`
+ * depending on the browser's locale, and a timestamp whose meaning depends
+ * on who is reading it is worse than useless when two people compare
+ * notes on the same incident.
+ */
+function isoDate(date: Date): string {
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
+}
+
+/** "just now" / "12m ago" / "5h ago" / "3d ago" / "2026-08-09" beyond a week. */
 export function formatRelativeTime(dateString: string | null | undefined): string {
   if (!dateString) return MISSING;
   const date = new Date(dateString);
@@ -24,17 +40,19 @@ export function formatRelativeTime(dateString: string | null | undefined): strin
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 7) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
+  return isoDate(date);
 }
 
-/** Full local timestamp for a `title` attribute; undefined when unknown. */
+/** "2026-08-09 14:32:07" — full local timestamp for a `title` attribute. */
 export function formatAbsoluteTime(
   dateString: string | null | undefined,
 ): string | undefined {
   if (!dateString) return undefined;
   const date = new Date(dateString);
   if (Number.isNaN(date.getTime())) return undefined;
-  return date.toLocaleString();
+  return `${isoDate(date)} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(
+    date.getSeconds(),
+  )}`;
 }
 
 /** Seconds since `dateString`, or null when it is missing/unparseable. */
@@ -45,7 +63,7 @@ export function secondsSince(dateString: string | null | undefined): number | nu
   return Math.floor((Date.now() - ms) / 1000);
 }
 
-/** "45s" / "12m 3s" / "2h 07m" — elapsed time between two instants. */
+/** "45s" / "12m 3s" / "2h 07m" / "15d 11h 41m" — elapsed time. */
 export function formatDuration(
   startedAt: string | null | undefined,
   completedAt: string | null | undefined,
@@ -60,7 +78,10 @@ export function formatDuration(
 
   if (diffSecs < 60) return `${diffSecs}s`;
   if (diffMins < 60) return `${diffMins}m ${diffSecs % 60}s`;
-  return `${diffHours}h ${String(diffMins % 60).padStart(2, "0")}m`;
+  if (diffHours < 24) return `${diffHours}h ${pad(diffMins % 60)}m`;
+  // Past a day, hours alone stop being readable: a build abandoned two
+  // weeks ago reads "371h 41m", which nobody converts in their head.
+  return `${Math.floor(diffHours / 24)}d ${diffHours % 24}h ${pad(diffMins % 60)}m`;
 }
 
 /**

--- a/integration-tests/tests/test_browser.py
+++ b/integration-tests/tests/test_browser.py
@@ -204,8 +204,10 @@ class TestUISidebarNavigation:
         expect(collapse_btn).to_be_visible()
 
         # Test navigation items exist
-        home_btn = logged_in_page.get_by_text("Home", exact=True)
-        expect(home_btn).to_be_visible()
+        # Scoped to the sidebar button: the breadcrumb also reads "Builds",
+        # so a bare text locator matches two elements and trips strict mode.
+        builds_btn = logged_in_page.locator("button[title='Builds']")
+        expect(builds_btn).to_be_visible()
 
         # Test collapse/expand
         collapse_btn.click()
@@ -481,8 +483,9 @@ class TestUIBuildViewDAG:
         """Test DAG toggle exists on build page and collapse/expand works."""
         self._go_to_home(logged_in_page, docker_services)
 
-        # Navigate to Home (builds list)
-        logged_in_page.get_by_text("Home", exact=True).click()
+        # Navigate to the builds list (sidebar button — see above on why this
+        # is not a text locator).
+        logged_in_page.locator("button[title='Builds']").click()
         logged_in_page.wait_for_load_state("networkidle")
 
         # Check if there are any builds to click on

--- a/integration-tests/tests/test_browser.py
+++ b/integration-tests/tests/test_browser.py
@@ -497,28 +497,30 @@ class TestUIBuildViewDAG:
             logged_in_page.wait_for_load_state("networkidle")
             logged_in_page.wait_for_timeout(500)
 
-            # Should have DAG View toggle button
-            dag_button = logged_in_page.get_by_text("DAG View", exact=False)
+            # Should have a DAG View disclosure toggle.
+            #
+            # This block asserted on button text ("Click to expand" /
+            # "Click to collapse") that has never existed in this UI — the
+            # toggle expresses its state with a rotated chevron and the
+            # panel's presence. It went unnoticed because the guard above
+            # matched nothing while the builds list was a list of buttons
+            # rather than a table, so the body never ran. It runs now, and
+            # asserts against aria-expanded, which is both the accessible
+            # contract and a stable hook.
+            dag_button = logged_in_page.locator(
+                "button[aria-controls='build-dag-panel']"
+            )
             expect(dag_button).to_be_visible()
+            expect(dag_button).to_have_attribute("aria-expanded", "true")
+            expect(logged_in_page.locator("#build-dag-panel")).to_be_visible()
 
-            # Test collapse/expand
-            dag_button = logged_in_page.locator("button:has-text('DAG View')")
-            if dag_button.is_visible():
-                dag_button.click()
-                logged_in_page.wait_for_timeout(300)
+            dag_button.click()
+            expect(dag_button).to_have_attribute("aria-expanded", "false")
+            expect(logged_in_page.locator("#build-dag-panel")).to_have_count(0)
 
-                collapsed_text = dag_button.inner_text()
-                assert "Click to expand" in collapsed_text, (
-                    f"After collapse, expected 'Click to expand', got: {collapsed_text}"
-                )
-
-                dag_button.click()
-                logged_in_page.wait_for_timeout(300)
-
-                expanded_text = dag_button.inner_text()
-                assert "Click to collapse" in expanded_text, (
-                    f"After expand, expected 'Click to collapse', got: {expanded_text}"
-                )
+            dag_button.click()
+            expect(dag_button).to_have_attribute("aria-expanded", "true")
+            expect(logged_in_page.locator("#build-dag-panel")).to_be_visible()
 
 
 class TestUIResponsiveness:

--- a/integration-tests/uv.lock
+++ b/integration-tests/uv.lock
@@ -627,9 +627,11 @@ requires-dist = [
     { name = "boto3", marker = "extra == 's3'", specifier = ">=1.34" },
     { name = "boto3-stubs", extras = ["s3"], marker = "extra == 's3'" },
     { name = "botocore", marker = "extra == 's3'", specifier = ">=1.36" },
+    { name = "cryptography", marker = "extra == 'selfhost'", specifier = ">=42.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx-retries", specifier = ">=0.1.0" },
     { name = "modal", marker = "extra == 'modal'", specifier = ">=1.0.0" },
+    { name = "modal", marker = "extra == 'selfhost'", specifier = ">=1.0.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=2.1.0" },
     { name = "prefect", marker = "extra == 'prefect'", specifier = ">=3.0.3" },
     { name = "pydantic", specifier = ">=2.8.2" },
@@ -640,7 +642,7 @@ requires-dist = [
     { name = "types-aioboto3", extras = ["s3"], marker = "extra == 's3'" },
     { name = "uuid6", specifier = ">=2022.6.25" },
 ]
-provides-extras = ["modal", "pandas", "prefect", "s3"]
+provides-extras = ["modal", "pandas", "prefect", "s3", "selfhost"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Frontend half of the stale-build cleanup work in #208 — the operator side
of **B3** (nothing terminates abandoned builds, and there is no bulk
operation) and the build-list part of **B5** (the UI cannot explain a
stalled build). Builds on the API branch it targets.

The motivating shape of the problem: an environment accumulated dozens of
builds left `RUNNING` forever by orchestrators that died without emitting
a terminal event, each still holding the execution claims and
concurrency-limit slots its tasks had when it vanished. Nothing in the UI
showed which builds those were, and cleaning up meant hand-rolled API
calls.

## What changed

**"Home" is now "Builds".** The nav item said "Home" but the view has
always been a builds list — its own breadcrumb reads "Builds", and
`NavItem` already carried an unused `"builds"` member. Label, nav id and
`HomePage` renamed; `/` is unchanged as the route.

**The builds list is a real table.** Columns: selection, status, build
(with the short-commit chip as before, plus a reactive-app chip that
doubles as a filter shortcut), description, duration, last activity,
created. Three filters — `status`, `reactive_app_name` and
`idle_for_seconds` — all server-side, all visible in the toolbar, all
clearable. The empty state distinguishes "no builds yet" from "no builds
match these filters".

**`last_activity_at`, not `last_active_at`.** These are two different
numbers and the difference matters here. `last_active_at` is what orders
the list by default, but it is bumped by build-level *lifecycle*
transitions only — task events deliberately skip it — so a build that has
been running tasks for three days still reports its `BUILD_STARTED`
timestamp. Surfacing it would tell an operator that a busy build is idle.
The table shows and filters on `last_activity_at`: the newest of the
build's whole event stream, its `last_active_at`, and any pending
scheduler wake-up — exactly what the reaper measures. Rendered as a
relative time with the absolute time in a `title`, and running builds
quiet for over a day are flagged in place without any filter being set.

**Idleness is filtered by the server, with the reaper's own predicate.**
`GET /builds?idle_for_seconds=` and `POST /builds/bulk-cancel` share one
SQL predicate on the API side, so the set this table shows and the set
"Clean up idle builds" acts on are the same by construction rather than
because two implementations happen to agree. `total` is an exact `COUNT`
and pagination is unbounded, so there is no scan-window caveat to make.
Ordering also comes from the server — stalest-first with the filter,
most-recently-active-first without — and the page is rendered as
returned, never re-sorted client-side.

One honesty note carried into the UI rather than hidden: the server sorts
stalest-first on `last_active_at`, an index-backed proxy for the composed
`last_activity_at` the column renders. They nearly always agree, so the
column runs *close to* — not strictly — oldest-first, and the "Last
activity" tooltip says exactly that.

`idle_for_seconds` alongside any status but `running` is a 422 (only
RUNNING has a SQL predicate). That combination is unreachable from both
directions rather than left to fail: incompatible status options are
disabled, and labelled "n/a with an idle filter", while an idle filter is
set; the idle select is disabled while an incompatible status is
selected. Both carry a tooltip explaining why, and neither control
silently rewrites the other.

**Bulk cancel shows its consequences before committing.** Selecting rows
reveals a bulk bar; confirming opens a dialog that immediately issues the
endpoint's `dry_run` and reports what a real call would do — how many
builds, how many task claims a cascade would release, and every build the
server will skip *with the reason spelled out in prose* (`not_running`,
`reactive`, `not_idle`, `limit_reached`, `not_found`), plus `truncated`.
The dry run re-runs whenever cascade or include-reactive changes, so
"3 builds skipped: reactive" is actionable rather than a dead end. Only
then does the confirm button apply the identical filter with
`dry_run: false`, and the outcome lands in a banner above the refreshed
table.

"Clean up idle builds…" runs the same dialog in `idle_for_seconds` mode,
enabled only once the threshold is explicit in the filters — so the
destructive action is always tied to a visible number, and to the exact
set the table is already showing.

**Single-build cascade.** `POST /builds/{id}/cancel` now takes `cascade`,
so the build view's override menu gains a second entry, "Cancel & Release
Claims", next to the untouched plain Cancel. Separate action rather than a
changed default: existing behaviour is preserved and the difference — one
writes a build event, the other actually releases the claims — is visible
in the menu. It reports how many claims were released.

**Selection across pagination:** scoped to the visible page, cleared on
page, filter or environment change. Carrying off-screen rows into a bulk
cancel is exactly the kind of hidden state that makes a destructive action
untrustworthy, so the hook stores the selection together with the key it
was made under and a selection made under a different key reads as empty.

**Admin gating:** bulk cancel requires the workspace admin role on the JWT
path (same gate as concurrency-limit eviction), so non-admins get no
selection column and no dead buttons, with a note in the toolbar saying
why. Filters and navigation are unchanged for everyone.

## Shared primitives

The codebase had no checkbox anywhere, no shared selection, and no
confirmation beyond `window.confirm` plus an inline red div. Introduced
once, small, no new dependency, and deliberately generic so the follow-up
work on this issue can reuse them:

| Primitive | Purpose |
| --- | --- |
| `ui/Checkbox` | The one checkbox, with the indeterminate state a "select all on page" header needs and a required accessible name. |
| `hooks/useRowSelection` | Selection for a paginated table; derived reset, no effect. |
| `ui/BulkActionBar` | Appears only when a selection exists; announces the count via `aria-live`. |
| `ui/ConfirmDialog` | Composed from the existing `Modal` (which gains an optional `maxWidthClass`), free-form body so a bulk action can render its preview inside the dialog that commits it. Focus lands on Cancel. |
| `ui/ResultBanner` | Inline outcome/error, `role=status` or `role=alert` by tone. |
| `utils/time` | The relative/absolute/duration formatting that was private to `BuildsList`, plus `secondsSince`. |

Existing `window.confirm` call sites are left alone; the dialog is used
only for the new destructive actions.

## Notes

Every new surface carries explicit `dark:` pairs. Rows are `<tr>`s with a
whole-row click for the mouse, but the build name is a real `<button>`, so
the row stays keyboard-reachable and accessibly named now that it is no
longer a full-width `<button>`; a click anywhere in the checkbox cell
selects and never navigates. Data fetching follows the existing
conventions — `useCallback` loader plus `useEffect`, refetch after mutate,
the epoch-ref stale-response guard on both the list and the dry run, and
the pre-existing `lastFetchedEnvIdRef` environment-change guard is
preserved. Types and API calls added by hand as usual, including a helper
that surfaces FastAPI's `detail` rather than "Unprocessable Entity".

`Modal` picks up a `TODO(a11y)` naming its missing focus trap — Escape
closes and the body is scroll-locked, but Tab walks out of the dialog and
focus is not restored on close. Shared behaviour inherited by every
caller, so it wants its own change rather than riding along here.

## Tests

22 new cases (`BuildsList.test.tsx`, `ui/Checkbox.test.tsx`): the
activity-vs-lifecycle distinction (asserting the lifecycle timestamp is
*not* rendered), filter round-trips including `idle_for_seconds`, proof
that the page is neither re-sorted nor re-filtered locally, the
status-plus-idleness pair being unreachable in both directions, selection
/ select-all / indeterminate header, the checkbox-does-not-navigate rule,
keyboard activation of a row, selection clearing across pagination, the
dry-run-then-apply flow including "nothing written yet", skip reasons and
truncation, the cascade toggle re-running the preview, admin gating, and
the empty/error states. `Sidebar.test.tsx` updated for the rename.

```
npx vitest run   → 12 files, 118 tests passed (96 before)
npx tsc -b       → clean
npx eslint src/  → clean
uvx pre-commit run --files <all changed>  → prettier / eslint / tsc pass
npx vite build   → clean
```

## Not in scope

The "why is this build not progressing?" panel, blocker visibility on the
build detail view, and the task-explorer claim work are a follow-up; the
primitives above are shaped for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NyR9Kc9ZP5Ko7dVndhi3Y
