### PR TITLE
feat(ui): explain stalled builds — cross-build blockers, claim holders, tick reasoning (#208 B5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,46 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   that every replica runs its own timer with no leader election; cancellation
   is idempotent, so concurrent sweeps are wasteful rather than wrong.
 
+### UI
+
+- **A Builds view, replacing "Home".** Builds are listed with status,
+  duration, last activity and the reactive app that owns them, and can be
+  filtered by status, by owning app, and by how long they have been idle.
+  The idle filter means _abandoned_, so it implies Running: a finished
+  build has no activity by definition, and including terminal builds would
+  fill a staleness listing with history sorted oldest-first.
+
+- **Bulk cleanup of abandoned builds**, admin-gated to match the API. Rows
+  are selectable per page, and "Clean up idle builds…" sweeps the whole
+  environment on the server rather than the visible page. Both paths open a
+  confirmation showing a **dry run of the real query** — the same selection
+  `POST /builds/bulk-cancel` will act on, including the per-build reasons
+  anything was skipped — because a preview that disagrees with the action
+  is worse than no preview.
+
+- **A build that is not progressing now says why.** When nothing is
+  actionable and nothing is running, the build view names each blocking
+  upstream, its status, how long it has been held, and which build owns it
+  — including blockers that are not part of the build at all, which are
+  otherwise invisible from it. Each carries the remedy (release the claim,
+  or reset the task to pending) addressed to the owning build. Behind a
+  disclosure: the scheduler's own tick trail, with runs of identical ticks
+  collapsed ("lease held ×20") and counters that stayed at zero dropped, so
+  a stalled build's repetition reads as a diagnosis instead of a log.
+
+- **Claim triage in the task explorer.** Lists the tasks holding an
+  execution claim, longest-held first, with the build that owns each one,
+  and releases them in bulk. Only tasks actually holding a claim are
+  selectable, and every release reads the resulting status back — a task
+  that finished between listing and acting is reported as such rather than
+  counted as released.
+
+- **Fixed:** unchecked checkboxes rendered as white boxes in dark mode
+  (`color-scheme` was never set, so every native control used the light
+  theme); durations past a day read as `371h 41m` instead of `15d 11h 41m`;
+  dates rendered in the browser's locale order (`8/9/2026` or `9/8/2026`
+  depending on the reader) rather than `YYYY-MM-DD`.
+
 ### SDK
 
 - **Reactive builds now discover the DAG inside Modal, not on the machine

--- a/app/stardag-ui/src/api/tasks.ts
+++ b/app/stardag-ui/src/api/tasks.ts
@@ -1,8 +1,10 @@
 import type {
   Build,
   BuildCancelResult,
+  BuildFrontier,
   BuildListResponse,
   BuildStatus,
+  BuildTickSummaryListResponse,
   BulkCancelBuildsRequest,
   BulkCancelBuildsResponse,
   Task,
@@ -99,6 +101,57 @@ export async function fetchBuild(
   return response.json();
 }
 
+/**
+ * The build's scheduling frontier — what a reactive scheduler tick sees.
+ *
+ * This is the endpoint that answers "why is this build not progressing?":
+ * it reports what is actionable, what is running, and — when neither is —
+ * which upstreams outside the build are holding it back. See
+ * ``BuildFrontier.blocked_by_external`` for the one ambiguity that matters:
+ * an empty blocker list means "not blocked, OR not stalled".
+ */
+export async function fetchBuildFrontier(
+  buildId: string,
+  environmentId: string,
+): Promise<BuildFrontier> {
+  const params = new URLSearchParams();
+  params.set("environment_id", environmentId);
+
+  const url = `${API_BASE}/builds/${buildId}/frontier?${params.toString()}`;
+  const response = await fetchWithAuth(url);
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, "Failed to fetch build frontier"));
+  }
+  return response.json();
+}
+
+/**
+ * The build's recent reactive-scheduler tick summaries, newest first.
+ *
+ * Returns ``null`` when the server does not have the endpoint (404) — it
+ * postdates the frontier, so a UI pointed at an older API must degrade to
+ * "no tick history" rather than to an error. A missing *build* would have
+ * failed the frontier fetch first, so treating 404 as "unavailable" does
+ * not hide a real problem.
+ */
+export async function fetchBuildTickSummaries(
+  buildId: string,
+  environmentId: string,
+  limit?: number,
+): Promise<BuildTickSummaryListResponse | null> {
+  const params = new URLSearchParams();
+  params.set("environment_id", environmentId);
+  if (limit) params.set("limit", String(limit));
+
+  const url = `${API_BASE}/builds/${buildId}/tick-summaries?${params.toString()}`;
+  const response = await fetchWithAuth(url);
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, "Failed to fetch tick summaries"));
+  }
+  return response.json();
+}
+
 // Task API (build-scoped)
 
 export interface TaskFilters {
@@ -190,8 +243,29 @@ export interface GlobalTaskFilters {
   page_size?: number;
   task_name?: string;
   environment_id?: string;
+  /**
+   * Filter by the task's *global* (environment-wide) status. Repeatable —
+   * `["running", "suspended"]` matches either. This is how "which tasks are
+   * holding an execution claim?" is asked.
+   */
+  status?: TaskStatus[];
+  /**
+   * Only tasks whose current status was recorded strictly before this
+   * ISO-8601 instant. An absolute timestamp rather than a duration so a
+   * paged scan cannot drift between requests. Tasks with no recorded
+   * status timestamp never match.
+   */
+  status_older_than?: string;
 }
 
+/**
+ * List tasks in an environment.
+ *
+ * With a status or staleness filter the server orders **oldest claim
+ * first** (the task RUNNING longest is the most likely to be abandoned and
+ * the most expensive to leave holding a claim); otherwise newest-first by
+ * registration time.
+ */
 export async function fetchTasks(
   filters: GlobalTaskFilters = {},
 ): Promise<{ tasks: Task[]; total: number; page: number; page_size: number }> {
@@ -200,6 +274,9 @@ export async function fetchTasks(
   if (filters.page_size) params.set("page_size", String(filters.page_size));
   if (filters.task_name) params.set("task_name", filters.task_name);
   if (filters.environment_id) params.set("environment_id", filters.environment_id);
+  for (const status of filters.status ?? []) params.append("status", status);
+  if (filters.status_older_than)
+    params.set("status_older_than", filters.status_older_than);
 
   const url = `${API_BASE}/tasks?${params.toString()}`;
   const response = await fetchWithAuth(url);
@@ -347,6 +424,15 @@ export async function failBuild(
 
 // Task actions (build-scoped)
 
+/**
+ * Cancel a task under a build, releasing the execution claim and any
+ * concurrency-limit slot it holds.
+ *
+ * ``buildId`` addresses the *owning* build — the one whose event produced
+ * the task's current status (``latest_status_build_id``) — which is not
+ * necessarily the build the user is looking at. A task's status is
+ * environment-global, so releasing a claim is inherently a cross-build act.
+ */
 export async function cancelTask(
   buildId: string,
   taskId: string,
@@ -358,7 +444,31 @@ export async function cancelTask(
   const url = `${API_BASE}/builds/${buildId}/tasks/${taskId}/cancel?${params.toString()}`;
   const response = await fetchWithAuth(url, { method: "POST" });
   if (!response.ok) {
-    throw new Error(`Failed to cancel task: ${response.statusText}`);
+    throw new Error(await errorMessage(response, "Failed to cancel task"));
+  }
+}
+
+/**
+ * Reset a failed / cancelled / skipped / **suspended** task to pending.
+ *
+ * Suspended is included: a task suspended for dynamic dependencies is not
+ * executing, so one whose orchestrator died has no path forward except
+ * running again from scratch. RUNNING tasks are deliberately unaffected —
+ * they hold a live claim, and releasing that is `cancelTask`, not a retry.
+ * COMPLETED is sticky. Same ``buildId`` rule as `cancelTask`.
+ */
+export async function retryTask(
+  buildId: string,
+  taskId: string,
+  environmentId?: string,
+): Promise<void> {
+  const params = new URLSearchParams();
+  if (environmentId) params.set("environment_id", environmentId);
+
+  const url = `${API_BASE}/builds/${buildId}/tasks/${taskId}/retry?${params.toString()}`;
+  const response = await fetchWithAuth(url, { method: "POST" });
+  if (!response.ok) {
+    throw new Error(await errorMessage(response, "Failed to retry task"));
   }
 }
 

--- a/app/stardag-ui/src/api/tasks.ts
+++ b/app/stardag-ui/src/api/tasks.ts
@@ -437,7 +437,7 @@ export async function cancelTask(
   buildId: string,
   taskId: string,
   environmentId?: string,
-): Promise<void> {
+): Promise<TaskStatus> {
   const params = new URLSearchParams();
   if (environmentId) params.set("environment_id", environmentId);
 
@@ -446,6 +446,13 @@ export async function cancelTask(
   if (!response.ok) {
     throw new Error(await errorMessage(response, "Failed to cancel task"));
   }
+  // The resulting status, which is not always `cancelled`: the server
+  // records the event unconditionally — that is what makes a cancel racing
+  // a completion benign — but COMPLETED is sticky and wins. A caller that
+  // reports "released" without looking is lying in exactly the case the
+  // user most needs told about.
+  const body: unknown = await response.json();
+  return (body as { status: TaskStatus }).status;
 }
 
 /**

--- a/app/stardag-ui/src/api/tasks.ts
+++ b/app/stardag-ui/src/api/tasks.ts
@@ -446,13 +446,18 @@ export async function cancelTask(
   if (!response.ok) {
     throw new Error(await errorMessage(response, "Failed to cancel task"));
   }
-  // The resulting status, which is not always `cancelled`: the server
-  // records the event unconditionally — that is what makes a cancel racing
-  // a completion benign — but COMPLETED is sticky and wins. A caller that
-  // reports "released" without looking is lying in exactly the case the
-  // user most needs told about.
-  const body: unknown = await response.json();
-  return (body as { status: TaskStatus }).status;
+  // `latest_status`, NOT `status`. `status` is the task's status *within
+  // this build*, so cancelling a task that another build already completed
+  // comes back "cancelled" — this build did cancel it — while the claim was
+  // never held and nothing was released. `latest_status` is the
+  // environment-global answer, which is what "did the release work?" means.
+  // Older servers omit it; fall back rather than reporting a failure that
+  // did not happen.
+  const body = (await response.json()) as {
+    status: TaskStatus;
+    latest_status?: TaskStatus | null;
+  };
+  return body.latest_status ?? body.status;
 }
 
 /**

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
@@ -1,0 +1,414 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  BuildFrontier,
+  BuildStatus,
+  BuildTickSummary,
+  FrontierExternalBlocker,
+} from "../types/task";
+import { schedulingPanelForm } from "../utils/claims";
+import { BuildSchedulingPanel } from "./BuildSchedulingPanel";
+
+let mockWorkspaceRole: "owner" | "admin" | "member" | null = "admin";
+vi.mock("../context/EnvironmentContext", () => ({
+  useEnvironment: () => ({
+    activeEnvironment: { id: "env-1", slug: "default", name: "default" },
+    activeWorkspaceRole: mockWorkspaceRole,
+  }),
+}));
+
+vi.mock("../api/tasks", () => ({
+  fetchBuildFrontier: vi.fn(),
+  fetchBuildTickSummaries: vi.fn(),
+  cancelTask: vi.fn(),
+  retryTask: vi.fn(),
+}));
+
+import {
+  cancelTask,
+  fetchBuildFrontier,
+  fetchBuildTickSummaries,
+  retryTask,
+} from "../api/tasks";
+
+// Obviously fictional ids: the build on screen, and the build that owns
+// the blocker.
+const VIEWED_BUILD = "99999999-aaaa-bbbb-cccc-dddddddddddd";
+const OWNER_BUILD = "11111111-2222-3333-4444-555555555555";
+
+const HOUR = 3600 * 1000;
+const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+function makeBlocker(
+  overrides: Partial<FrontierExternalBlocker> = {},
+): FrontierExternalBlocker {
+  return {
+    task_id: "tid-espresso-downstream",
+    blocking_task_id: "tid-grind-beans",
+    blocking_task_namespace: "",
+    blocking_task_name: "GrindBeans",
+    blocking_status: "running",
+    blocking_status_at: ago(3 * HOUR),
+    blocking_status_build_id: OWNER_BUILD,
+    blocking_in_build: false,
+    ...overrides,
+  };
+}
+
+function makeFrontier(overrides: Partial<BuildFrontier> = {}): BuildFrontier {
+  return {
+    build_id: VIEWED_BUILD,
+    build_status: "running",
+    needs_tick: false,
+    root_task_ids: ["tid-espresso-downstream"],
+    roots: [],
+    status_counts: { completed: 2, suspended: 1 },
+    actionable: [],
+    running: [],
+    blocked_by_external: [],
+    blocked_by_external_truncated: false,
+    reactive_app_name: "kettle-scheduler",
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<BuildTickSummary> = {}): BuildTickSummary {
+  return {
+    id: "tick-1",
+    build_id: VIEWED_BUILD,
+    outcome: "lingered_out",
+    summary: { spawned: 0, claim_denied: 3, iterations: 4 },
+    created_at: ago(60 * 1000),
+    ...overrides,
+  };
+}
+
+function renderPanel(
+  props: { buildStatus?: BuildStatus; onNavigate?: () => void } = {},
+) {
+  return render(
+    <BuildSchedulingPanel
+      buildId={VIEWED_BUILD}
+      environmentId="env-1"
+      buildStatus={props.buildStatus ?? "running"}
+      onNavigateToBuild={props.onNavigate}
+    />,
+  );
+}
+
+describe("schedulingPanelForm", () => {
+  it("flags a running build with nothing actionable and nothing running", () => {
+    expect(schedulingPanelForm(makeFrontier(), "running")).toBe("stalled");
+  });
+
+  it("stays quiet while a build is progressing", () => {
+    const progressing = makeFrontier({
+      actionable: [{ task_id: "tid-a", latest_status: "pending" }],
+    });
+    // Reactive builds keep a one-line strip; non-reactive ones render nothing.
+    expect(schedulingPanelForm(progressing, "running")).toBe("collapsed");
+    expect(
+      schedulingPanelForm({ ...progressing, reactive_app_name: null }, "running"),
+    ).toBe("hidden");
+  });
+
+  it("does not flag a build with no tasks at all", () => {
+    expect(schedulingPanelForm(makeFrontier({ status_counts: {} }), "pending")).toBe(
+      "collapsed",
+    );
+  });
+
+  it("never flags a completed or cancelled build", () => {
+    expect(schedulingPanelForm(makeFrontier(), "completed")).toBe("collapsed");
+    expect(schedulingPanelForm(makeFrontier(), "cancelled")).toBe("collapsed");
+  });
+
+  it("flags a failed build only when the failure has the stuck-build shape", () => {
+    // Build failed, yet nothing in it failed: the spurious-failure signature.
+    expect(
+      schedulingPanelForm(
+        makeFrontier({ status_counts: { completed: 2, suspended: 1 } }),
+        "failed",
+      ),
+    ).toBe("stalled");
+    // An ordinary DAG failure explains itself in the task table.
+    expect(
+      schedulingPanelForm(
+        makeFrontier({ status_counts: { completed: 2, failed: 1 } }),
+        "failed",
+      ),
+    ).toBe("collapsed");
+    // ...unless a blocker was reported anyway.
+    expect(
+      schedulingPanelForm(
+        makeFrontier({
+          status_counts: { completed: 2, failed: 1 },
+          blocked_by_external: [makeBlocker()],
+        }),
+        "failed",
+      ),
+    ).toBe("stalled");
+  });
+});
+
+describe("BuildSchedulingPanel", () => {
+  beforeEach(() => {
+    mockWorkspaceRole = "admin";
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(makeFrontier());
+    vi.mocked(fetchBuildTickSummaries).mockResolvedValue({
+      build_id: VIEWED_BUILD,
+      summaries: [makeSummary()],
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing for a healthy non-reactive build", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({
+        reactive_app_name: null,
+        actionable: [{ task_id: "tid-a", latest_status: "pending" }],
+      }),
+    );
+    const { container } = renderPanel();
+
+    await waitFor(() => expect(fetchBuildFrontier).toHaveBeenCalled());
+    expect(container).toBeEmptyDOMElement();
+    // No point paying for tick history nobody will read.
+    expect(fetchBuildTickSummaries).not.toHaveBeenCalled();
+  });
+
+  it("never claims 'no blockers' while the build is progressing", async () => {
+    // An empty `blocked_by_external` means "not blocked, OR not stalled" —
+    // the server only looks while a build is stalled. A progressing build
+    // must say the second thing, not the first.
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({
+        actionable: [{ task_id: "tid-a", latest_status: "pending" }],
+        running: [{ task_id: "tid-b", latest_status: "running" }],
+      }),
+    );
+    const user = userEvent.setup();
+    renderPanel();
+
+    expect(await screen.findByText("1 actionable · 1 running")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Why is this build not progressing/),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(/no upstream/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Scheduling" }));
+    expect(
+      await screen.findByText(/only looked for while a build is stalled/i),
+    ).toBeInTheDocument();
+    // Tick history is fetched on demand, not on every poll of a healthy build.
+    await waitFor(() => expect(fetchBuildTickSummaries).toHaveBeenCalledTimes(1));
+  });
+
+  it("names the blocker, how long it has been held, and links to the owning build", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({ blocked_by_external: [makeBlocker()] }),
+    );
+    const onNavigate = vi.fn();
+    const user = userEvent.setup();
+    renderPanel({ onNavigate });
+
+    expect(
+      await screen.findByText("Why is this build not progressing?"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("GrindBeans")).toBeInTheDocument();
+    expect(screen.getByText("running")).toBeInTheDocument();
+    expect(screen.getByText("for 3h 00m")).toBeInTheDocument();
+    expect(screen.getByText("tid-espresso-downstream")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: OWNER_BUILD.slice(0, 8) }));
+    expect(onNavigate).toHaveBeenCalledWith(OWNER_BUILD);
+  });
+
+  it("distinguishes a blocker outside this build from one inside it", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({
+        blocked_by_external: [makeBlocker({ blocking_in_build: false })],
+      }),
+    );
+    const { unmount } = renderPanel();
+    expect(await screen.findByText(/has never registered/i)).toBeInTheDocument();
+    unmount();
+
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({ blocked_by_external: [makeBlocker({ blocking_in_build: true })] }),
+    );
+    renderPanel();
+    expect(
+      await screen.findByText(/in this build's own task set/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/has never registered/i)).not.toBeInTheDocument();
+  });
+
+  it("says so when the blocker list was truncated", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({
+        blocked_by_external: [makeBlocker()],
+        blocked_by_external_truncated: true,
+      }),
+    );
+    renderPanel();
+    expect(
+      await screen.findByText(/More blockers were found than are listed here/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders tick counters it has never heard of rather than dropping them", async () => {
+    vi.mocked(fetchBuildTickSummaries).mockResolvedValue({
+      build_id: VIEWED_BUILD,
+      summaries: [
+        makeSummary({
+          summary: {
+            claim_denied: 3,
+            // A counter added by a newer SDK than this UI.
+            external_blockers_seen: 7,
+          },
+        }),
+      ],
+    });
+    renderPanel();
+
+    expect(await screen.findByText("lingered out")).toBeInTheDocument();
+    // Known key: rendered with its friendly label.
+    expect(screen.getByText("claim denied")).toBeInTheDocument();
+    // Unknown key: rendered anyway, underscores relaxed.
+    expect(screen.getByText("external blockers seen")).toBeInTheDocument();
+    expect(screen.getByText("7")).toBeInTheDocument();
+  });
+
+  it("degrades gracefully when the server has no tick-summaries endpoint", async () => {
+    vi.mocked(fetchBuildTickSummaries).mockResolvedValue(null);
+    renderPanel();
+
+    expect(
+      await screen.findByText(/does not record tick history/i),
+    ).toBeInTheDocument();
+    // The rest of the panel is unaffected.
+    expect(screen.getByText("Why is this build not progressing?")).toBeInTheDocument();
+  });
+
+  it("releases a claim under the owning build after confirmation, then refetches", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({ blocked_by_external: [makeBlocker()] }),
+    );
+    vi.mocked(cancelTask).mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(
+      await screen.findByRole("button", { name: "Release claim on GrindBeans" }),
+    );
+    // The dialog names the build the action is addressed to.
+    expect(
+      await screen.findByText("Release this task's execution claim"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/a different build from the one you are viewing/),
+    ).toBeInTheDocument();
+    expect(cancelTask).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Release claim" }));
+    await waitFor(() =>
+      // Addressed to the OWNING build, not the one on screen.
+      expect(cancelTask).toHaveBeenCalledWith(OWNER_BUILD, "tid-grind-beans", "env-1"),
+    );
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      /Released the claim on GrindBeans/,
+    );
+    await waitFor(() => expect(fetchBuildFrontier).toHaveBeenCalledTimes(2));
+  });
+
+  it("offers a reset, not a release, for a blocker that is not running", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({
+        blocked_by_external: [makeBlocker({ blocking_status: "failed" })],
+      }),
+    );
+    vi.mocked(retryTask).mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    renderPanel();
+
+    expect(
+      await screen.findByRole("button", { name: "Reset to pending on GrindBeans" }),
+    ).toBeInTheDocument();
+    // A failed task holds no claim, so there is nothing to release.
+    expect(
+      screen.queryByRole("button", { name: "Release claim on GrindBeans" }),
+    ).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole("button", { name: "Reset to pending on GrindBeans" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Reset to pending" }));
+    await waitFor(() =>
+      expect(retryTask).toHaveBeenCalledWith(OWNER_BUILD, "tid-grind-beans", "env-1"),
+    );
+  });
+
+  it("offers no remedy when the owning build was never recorded", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({
+        blocked_by_external: [makeBlocker({ blocking_status_build_id: null })],
+      }),
+    );
+    renderPanel();
+
+    expect(await screen.findByText(/owning build not recorded/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/there is nothing to address a cancel or retry to/),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Release claim on/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides cross-build remedies from non-admin members", async () => {
+    mockWorkspaceRole = "member";
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({ blocked_by_external: [makeBlocker()] }),
+    );
+    renderPanel();
+
+    // The diagnosis is for everyone...
+    expect(await screen.findByText("GrindBeans")).toBeInTheDocument();
+    // ...the destructive cross-build remedy is not.
+    expect(
+      screen.queryByRole("button", { name: /Release claim on/ }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/requires the\s+workspace admin role/)).toBeInTheDocument();
+  });
+
+  it("reports a frontier read failure instead of failing silently", async () => {
+    vi.mocked(fetchBuildFrontier).mockRejectedValue(new Error("Build not found"));
+    renderPanel();
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      /Could not read this build.s scheduler state.*Build not found/,
+    );
+  });
+
+  it("says what is pending when a stalled build still has a wake-up queued", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(makeFrontier({ needs_tick: true }));
+    renderPanel();
+
+    expect(await screen.findByText("wake-up pending")).toBeInTheDocument();
+    expect(
+      screen.getByText(/A scheduler wake-up is pending, so the next tick may still/),
+    ).toBeInTheDocument();
+  });
+
+  it("says nothing will happen when a stalled reactive build has no wake-up queued", async () => {
+    renderPanel();
+    expect(
+      await screen.findByText(/Nothing is going to happen without intervention/),
+    ).toBeInTheDocument();
+  });
+});

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
@@ -216,16 +216,68 @@ describe("BuildSchedulingPanel", () => {
     const user = userEvent.setup();
     renderPanel({ onNavigate });
 
-    expect(
-      await screen.findByText("Why is this build not progressing?"),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("Not progressing")).toBeInTheDocument();
     expect(screen.getByText("GrindBeans")).toBeInTheDocument();
     expect(screen.getByText("running")).toBeInTheDocument();
-    expect(screen.getByText("for 3h 00m")).toBeInTheDocument();
-    expect(screen.getByText("tid-espresso-downstream")).toBeInTheDocument();
+    expect(screen.getByText("3h 00m")).toBeInTheDocument();
+    // The blocked task is identified by a short id with the whole thing in
+    // a title — the full id is 60 characters of noise on a summary line.
+    expect(
+      screen.getByTitle("This build's task tid-espresso-downstream"),
+    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: OWNER_BUILD.slice(0, 8) }));
     expect(onNavigate).toHaveBeenCalledWith(OWNER_BUILD);
+  });
+
+  it("stays compact until asked to explain itself", async () => {
+    // The panel sits above the DAG and the task table. Everything that is
+    // explanation rather than answer has to be behind a disclosure, or the
+    // build view is unusable on the builds this panel exists to diagnose.
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({ blocked_by_external: [makeBlocker()] }),
+    );
+    const user = userEvent.setup();
+    renderPanel();
+
+    // Visible: the headline and the blocker itself, with its remedy.
+    expect(await screen.findByText("Not progressing")).toBeInTheDocument();
+    expect(
+      screen.getByText(/1 task blocked by 1 upstream held outside this build/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Release claim on GrindBeans" }),
+    ).toBeInTheDocument();
+
+    // Hidden: the prose, the status breakdown, and the tick trail — which
+    // is not even fetched until someone asks for it.
+    expect(screen.queryByText(/Nothing in this build is actionable/)).toBeNull();
+    expect(screen.queryByText("completed")).toBeNull();
+    expect(screen.queryByText("Recent scheduler ticks")).toBeNull();
+    expect(fetchBuildTickSummaries).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: /3 tasks · details/ }));
+
+    expect(
+      await screen.findByText(/Nothing in this build is actionable/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("completed")).toBeInTheDocument();
+    expect(screen.getByText("Recent scheduler ticks")).toBeInTheDocument();
+    await waitFor(() => expect(fetchBuildTickSummaries).toHaveBeenCalledTimes(1));
+  });
+
+  it("suppresses task statuses that nothing is in", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({ status_counts: { completed: 2, failed: 0, skipped: 0 } }),
+    );
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(await screen.findByRole("button", { name: /2 tasks · details/ }));
+    expect(await screen.findByText("completed")).toBeInTheDocument();
+    // "failed 0" is not information about this build.
+    expect(screen.queryByText("failed")).toBeNull();
+    expect(screen.queryByText("skipped")).toBeNull();
   });
 
   it("distinguishes a blocker outside this build from one inside it", async () => {
@@ -234,7 +286,14 @@ describe("BuildSchedulingPanel", () => {
         blocked_by_external: [makeBlocker({ blocking_in_build: false })],
       }),
     );
+    const user = userEvent.setup();
     const { unmount } = renderPanel();
+    // Visible without expanding anything: a blocker that is not part of
+    // this build at all is the case with no local remedy.
+    expect(await screen.findByText("outside this build")).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Explain why GrindBeans is blocking" }),
+    );
     expect(await screen.findByText(/has never registered/i)).toBeInTheDocument();
     unmount();
 
@@ -242,6 +301,11 @@ describe("BuildSchedulingPanel", () => {
       makeFrontier({ blocked_by_external: [makeBlocker({ blocking_in_build: true })] }),
     );
     renderPanel();
+    expect(await screen.findByText("GrindBeans")).toBeInTheDocument();
+    expect(screen.queryByText("outside this build")).toBeNull();
+    await user.click(
+      screen.getByRole("button", { name: "Explain why GrindBeans is blocking" }),
+    );
     expect(
       await screen.findByText(/in this build's own task set/i),
     ).toBeInTheDocument();
@@ -255,7 +319,9 @@ describe("BuildSchedulingPanel", () => {
         blocked_by_external_truncated: true,
       }),
     );
+    const user = userEvent.setup();
     renderPanel();
+    await user.click(await screen.findByRole("button", { name: /3 tasks · details/ }));
     expect(
       await screen.findByText(/More blockers were found than are listed here/),
     ).toBeInTheDocument();
@@ -274,7 +340,9 @@ describe("BuildSchedulingPanel", () => {
         }),
       ],
     });
+    const user = userEvent.setup();
     renderPanel();
+    await user.click(await screen.findByRole("button", { name: /3 tasks · details/ }));
 
     expect(await screen.findByText("lingered out")).toBeInTheDocument();
     // Known key: rendered with its friendly label.
@@ -284,22 +352,49 @@ describe("BuildSchedulingPanel", () => {
     expect(screen.getByText("7")).toBeInTheDocument();
   });
 
+  it("collapses a run of identical ticks, and drops the counters that stayed at zero", async () => {
+    // What a stalled build actually produces: the same tick, over and over.
+    vi.mocked(fetchBuildTickSummaries).mockResolvedValue({
+      build_id: VIEWED_BUILD,
+      summaries: [
+        makeSummary({ id: "t1", summary: { spawned: 0, claim_denied: 3 } }),
+        makeSummary({ id: "t2", summary: { spawned: 0, claim_denied: 3 } }),
+        makeSummary({ id: "t3", summary: { spawned: 0, claim_denied: 3 } }),
+        // A different outcome breaks the run rather than merging into it.
+        makeSummary({ id: "t4", outcome: "lease_held", summary: { spawned: 0 } }),
+      ],
+    });
+    const user = userEvent.setup();
+    renderPanel();
+    await user.click(await screen.findByRole("button", { name: /3 tasks · details/ }));
+
+    expect(await screen.findByText("×3")).toBeInTheDocument();
+    expect(screen.getByText("claim denied")).toBeInTheDocument();
+    // "spawned 0" is the tick saying nothing happened; it is not a finding.
+    expect(screen.queryByText("spawned")).toBeNull();
+    // The run that follows is still its own row.
+    expect(screen.getByText("lease held")).toBeInTheDocument();
+    expect(screen.getByText("Nothing happened on this tick.")).toBeInTheDocument();
+  });
+
   it("degrades gracefully when the server has no tick-summaries endpoint", async () => {
     vi.mocked(fetchBuildTickSummaries).mockResolvedValue(null);
+    const user = userEvent.setup();
     renderPanel();
+    await user.click(await screen.findByRole("button", { name: /3 tasks · details/ }));
 
     expect(
       await screen.findByText(/does not record tick history/i),
     ).toBeInTheDocument();
     // The rest of the panel is unaffected.
-    expect(screen.getByText("Why is this build not progressing?")).toBeInTheDocument();
+    expect(screen.getByText("Not progressing")).toBeInTheDocument();
   });
 
   it("releases a claim under the owning build after confirmation, then refetches", async () => {
     vi.mocked(fetchBuildFrontier).mockResolvedValue(
       makeFrontier({ blocked_by_external: [makeBlocker()] }),
     );
-    vi.mocked(cancelTask).mockResolvedValue(undefined);
+    vi.mocked(cancelTask).mockResolvedValue("cancelled");
     const user = userEvent.setup();
     renderPanel();
 
@@ -359,15 +454,19 @@ describe("BuildSchedulingPanel", () => {
         blocked_by_external: [makeBlocker({ blocking_status_build_id: null })],
       }),
     );
+    const user = userEvent.setup();
     renderPanel();
 
-    expect(await screen.findByText(/owning build not recorded/)).toBeInTheDocument();
-    expect(
-      screen.getByText(/there is nothing to address a cancel or retry to/),
-    ).toBeInTheDocument();
+    expect(await screen.findByText("no owning build")).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /Release claim on/ }),
     ).not.toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Explain why GrindBeans is blocking" }),
+    );
+    expect(
+      await screen.findByText(/there is nothing to address a cancel or retry to/),
+    ).toBeInTheDocument();
   });
 
   it("hides cross-build remedies from non-admin members", async () => {
@@ -377,13 +476,19 @@ describe("BuildSchedulingPanel", () => {
     );
     renderPanel();
 
+    const user = userEvent.setup();
     // The diagnosis is for everyone...
     expect(await screen.findByText("GrindBeans")).toBeInTheDocument();
     // ...the destructive cross-build remedy is not.
     expect(
       screen.queryByRole("button", { name: /Release claim on/ }),
     ).not.toBeInTheDocument();
-    expect(screen.getByText(/requires the\s+workspace admin role/)).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", { name: "Explain why GrindBeans is blocking" }),
+    );
+    expect(
+      await screen.findByText(/requires the\s+workspace admin role/),
+    ).toBeInTheDocument();
   });
 
   it("reports a frontier read failure instead of failing silently", async () => {
@@ -397,16 +502,32 @@ describe("BuildSchedulingPanel", () => {
 
   it("says what is pending when a stalled build still has a wake-up queued", async () => {
     vi.mocked(fetchBuildFrontier).mockResolvedValue(makeFrontier({ needs_tick: true }));
+    const user = userEvent.setup();
     renderPanel();
 
+    // The headline says it without being expanded — it is the difference
+    // between "wait" and "intervene".
     expect(await screen.findByText("wake-up pending")).toBeInTheDocument();
     expect(
-      screen.getByText(/A scheduler wake-up is pending, so the next tick may still/),
+      screen.getByText(/Nothing runnable — a scheduler wake-up is still pending/),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /3 tasks · details/ }));
+    expect(
+      await screen.findByText(
+        /A scheduler wake-up is pending, so the next tick may still/,
+      ),
     ).toBeInTheDocument();
   });
 
   it("says nothing will happen when a stalled reactive build has no wake-up queued", async () => {
+    const user = userEvent.setup();
     renderPanel();
+    expect(
+      await screen.findByText(/no wake-up pending — needs intervention/),
+    ).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /3 tasks · details/ }));
     expect(
       await screen.findByText(/Nothing is going to happen without intervention/),
     ).toBeInTheDocument();

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
@@ -29,6 +29,10 @@ import { ResultBanner } from "./ui/ResultBanner";
 // turning the panel into a log viewer.
 const TICK_LIMIT = 20;
 
+// Blockers shown before the panel has to be expanded. Two is enough to
+// see whether they share a cause; past that it is a work queue.
+const COMPACT_BLOCKERS = 2;
+
 // Order the status chips read in, rather than whatever order the server's
 // GROUP BY produced. Unknown statuses (a newer SDK) are appended.
 const STATUS_ORDER: TaskStatus[] = [
@@ -96,6 +100,7 @@ function BlockerCard({
   onNavigateToBuild,
   onAct,
 }: BlockerCardProps) {
+  const [open, setOpen] = useState(false);
   const ownerBuildId = blocker.blocking_status_build_id ?? null;
   const ownedByThisBuild = ownerBuildId === buildId;
   const held = heldFor(blocker.blocking_status_at);
@@ -118,58 +123,73 @@ function BlockerCard({
   }
 
   return (
-    <li className="rounded-md border border-amber-200 bg-white/70 p-2.5 dark:border-amber-900/60 dark:bg-gray-800/60">
-      <p className="text-xs text-gray-600 dark:text-gray-400">
-        This build&rsquo;s task{" "}
-        <code
-          title={blocker.task_id}
-          className="rounded bg-gray-100 px-1 py-0.5 font-mono text-gray-800 dark:bg-gray-700 dark:text-gray-200"
+    <li className="border-t border-amber-200/70 first:border-t-0 dark:border-amber-900/50">
+      {/* The whole blocker on one line: which task, waiting on what, in
+          what status, for how long, under whose build — and the remedy.
+          Everything that explains *why* sits behind the disclosure, since
+          it is the same three sentences every time and this panel shares
+          the viewport with the DAG and the task table. */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 py-1 text-xs">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          aria-label={`Explain why ${blocker.blocking_task_name} is blocking`}
+          className="rounded text-amber-900/70 hover:text-amber-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-amber-200/70 dark:hover:text-amber-100"
         >
-          {blocker.task_id}
-        </code>{" "}
-        is waiting on:
-      </p>
-      <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
-        <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+          <svg
+            className={`h-3 w-3 transition-transform ${open ? "rotate-90" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        </button>
+        <code
+          title={`This build's task ${blocker.task_id}`}
+          className="rounded bg-amber-100/60 px-1 py-0.5 font-mono text-[11px] text-gray-700 dark:bg-gray-700/60 dark:text-gray-200"
+        >
+          {shortId(blocker.task_id)}
+        </code>
+        <span className="text-gray-600 dark:text-gray-400">waits on</span>
+        <span
+          title={blocker.blocking_task_id}
+          className="max-w-[18rem] truncate font-medium text-gray-900 dark:text-gray-100"
+        >
           {qualifiedName}
         </span>
         <StatusBadge status={blocker.blocking_status} />
-        {held ? (
+        {held && (
           <span
-            className="text-xs text-gray-600 dark:text-gray-400"
+            className="text-gray-600 dark:text-gray-400"
             title={formatAbsoluteTime(blocker.blocking_status_at)}
           >
-            for {held}
-          </span>
-        ) : (
-          <span className="text-xs text-gray-500 dark:text-gray-400">
-            since an unrecorded time
+            {held}
           </span>
         )}
         {ownerBuildId ? (
-          <span className="text-xs text-gray-600 dark:text-gray-400">
-            held by build{" "}
-            <BuildLink buildId={ownerBuildId} onNavigateToBuild={onNavigateToBuild} />
-            {ownedByThisBuild ? " (this build)" : ""}
-          </span>
+          <BuildLink buildId={ownerBuildId} onNavigateToBuild={onNavigateToBuild} />
         ) : (
-          <span className="text-xs text-gray-500 dark:text-gray-400">
-            owning build not recorded
+          <span className="text-gray-500 dark:text-gray-400">no owning build</span>
+        )}
+        {!blocker.blocking_in_build && (
+          <span
+            title="The blocking task is not part of this build at all"
+            className="rounded bg-amber-100 px-1 py-0.5 text-[11px] text-amber-900 dark:bg-amber-900/40 dark:text-amber-200"
+          >
+            outside this build
           </span>
         )}
-      </div>
-      <p className="mt-1.5 text-xs text-gray-600 dark:text-gray-400">{explanation}</p>
-      <p
-        className="mt-1 truncate font-mono text-[11px] text-gray-500 dark:text-gray-500"
-        title={blocker.blocking_task_id}
-      >
-        {blocker.blocking_task_id}
-      </p>
-
-      {actions.length > 0 && (
-        <div className="mt-2 flex flex-wrap items-center gap-2">
-          {isAdmin && ownerBuildId ? (
-            actions.map((action) => (
+        {actions.length > 0 && isAdmin && ownerBuildId && (
+          <span className="ml-auto flex items-center gap-1.5">
+            {actions.map((action) => (
               <button
                 key={action}
                 type="button"
@@ -178,21 +198,35 @@ function BlockerCard({
                 // Several identical-looking buttons can sit in this list,
                 // so each names its target rather than just its verb.
                 aria-label={`${CLAIM_ACTION_LABELS[action]} on ${blocker.blocking_task_name}`}
-                className="rounded-md border border-red-300 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+                className="rounded border border-red-300 px-1.5 py-0.5 font-medium text-red-700 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
               >
                 {CLAIM_ACTION_LABELS[action]}
               </button>
-            ))
-          ) : !ownerBuildId ? (
-            <span className="text-xs text-gray-500 dark:text-gray-400">
+            ))}
+          </span>
+        )}
+      </div>
+
+      {open && (
+        <div className="pb-1.5 pl-5 text-xs text-gray-600 dark:text-gray-400">
+          <p>{explanation}</p>
+          <p className="mt-1 font-mono text-[11px] text-gray-500 dark:text-gray-500">
+            {blocker.task_id} → {blocker.blocking_task_id}
+          </p>
+          {ownedByThisBuild && (
+            <p className="mt-1">This build owns the blocking status itself.</p>
+          )}
+          {actions.length > 0 && !ownerBuildId && (
+            <p className="mt-1">
               No remedy can be offered: the build that set this status was not recorded,
               so there is nothing to address a cancel or retry to.
-            </span>
-          ) : (
-            <span className="text-xs text-gray-500 dark:text-gray-400">
+            </p>
+          )}
+          {actions.length > 0 && ownerBuildId && !isAdmin && (
+            <p className="mt-1">
               Releasing or resetting another build&rsquo;s task requires the workspace
               admin role.
-            </span>
+            </p>
           )}
         </div>
       )}
@@ -244,9 +278,14 @@ export function BuildSchedulingPanel({
   const [ticksUnavailable, setTicksUnavailable] = useState(false);
   const [ticksError, setTicksError] = useState<string | null>(null);
 
-  // Collapsed-form disclosure. Only meaningful in the "collapsed" form;
-  // the stalled form is always open.
+  // Collapsed-form disclosure.
   const [stripOpen, setStripOpen] = useState(false);
+  // Stalled-form disclosure. The verdict, the task-status breakdown and
+  // the scheduler's tick trail are all *explanation*; the headline and the
+  // blockers themselves are the answer. Only the answer is on screen by
+  // default — this panel sits above the DAG and the task table, and at
+  // full height it pushed both off the viewport.
+  const [detailsOpen, setDetailsOpen] = useState(false);
 
   // In-flight remedy.
   const [pending, setPending] = useState<{
@@ -292,6 +331,7 @@ export function BuildSchedulingPanel({
     setTicksUnavailable(false);
     setTicksError(null);
     setStripOpen(false);
+    setDetailsOpen(false);
     setNotice(null);
     setActionError(null);
   }, [buildId]);
@@ -299,7 +339,8 @@ export function BuildSchedulingPanel({
   const form = frontier ? schedulingPanelForm(frontier, buildStatus) : "hidden";
   // Tick history is fetched only when it will actually be read: always for
   // a stalled build, and on demand behind the collapsed form's disclosure.
-  const wantTicks = form === "stalled" || (form === "collapsed" && stripOpen);
+  const wantTicks =
+    (form === "stalled" && detailsOpen) || (form === "collapsed" && stripOpen);
 
   useEffect(() => {
     if (!wantTicks || !buildId || !environmentId) return;
@@ -343,7 +384,21 @@ export function BuildSchedulingPanel({
     setActionError(null);
     try {
       if (action === "release") {
-        await cancelTask(ownerBuildId, blocker.blocking_task_id, environmentId);
+        const resulting = await cancelTask(
+          ownerBuildId,
+          blocker.blocking_task_id,
+          environmentId,
+        );
+        // See TaskDetail: the event is recorded whatever the task's status,
+        // but only a task that was actually holding the claim ends up
+        // CANCELLED. Reporting a release that did not happen would send
+        // someone off looking for a second cause.
+        if (resulting !== "cancelled") {
+          setActionError(
+            `${blocker.blocking_task_name} is already ${resulting}, so there was no claim to release. If this build is still stuck, something else is holding it.`,
+          );
+          return;
+        }
       } else {
         await retryTask(ownerBuildId, blocker.blocking_task_id, environmentId);
       }
@@ -383,11 +438,15 @@ export function BuildSchedulingPanel({
   if (!frontier || form === "hidden") return null;
 
   const blockers = frontier.blocked_by_external;
-  const counts = Object.entries(frontier.status_counts).sort((a, b) => {
-    const ai = STATUS_ORDER.indexOf(a[0] as TaskStatus);
-    const bi = STATUS_ORDER.indexOf(b[0] as TaskStatus);
-    return (ai < 0 ? STATUS_ORDER.length : ai) - (bi < 0 ? STATUS_ORDER.length : bi);
-  });
+  const totalTasks = Object.values(frontier.status_counts).reduce((a, b) => a + b, 0);
+  // A status nothing is in is not information about this build.
+  const counts = Object.entries(frontier.status_counts)
+    .filter(([, count]) => count > 0)
+    .sort((a, b) => {
+      const ai = STATUS_ORDER.indexOf(a[0] as TaskStatus);
+      const bi = STATUS_ORDER.indexOf(b[0] as TaskStatus);
+      return (ai < 0 ? STATUS_ORDER.length : ai) - (bi < 0 ? STATUS_ORDER.length : bi);
+    });
 
   const countChips = (
     <div className="flex flex-wrap items-center gap-1">
@@ -480,6 +539,25 @@ export function BuildSchedulingPanel({
   const blockedTaskCount = new Set(blockers.map((b) => b.task_id)).size;
   const externalCount = blockers.filter((b) => !b.blocking_in_build).length;
 
+  // One line that says what is wrong. The paragraph-length version is
+  // still below, behind the disclosure, for when the headline is not
+  // enough — but the headline is what has to survive being read at a
+  // glance above a DAG.
+  let headline: string;
+  if (blockers.length > 0) {
+    headline =
+      `${blockedTaskCount} task${blockedTaskCount === 1 ? "" : "s"} blocked by ` +
+      `${blockers.length} upstream${blockers.length === 1 ? "" : "s"} ` +
+      `held outside this build` +
+      (externalCount > 0 ? `, ${externalCount} not part of it` : "");
+  } else if (frontier.needs_tick) {
+    headline = "Nothing runnable — a scheduler wake-up is still pending";
+  } else if (frontier.reactive_app_name) {
+    headline = "Nothing runnable, and no wake-up pending — needs intervention";
+  } else {
+    headline = "Nothing runnable — this build is not reactively scheduled";
+  }
+
   let verdict: string;
   if (blockers.length > 0) {
     verdict =
@@ -510,11 +588,18 @@ export function BuildSchedulingPanel({
   }
 
   return (
-    <div className="border-b border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900/60 dark:bg-amber-950/30">
-      <div className="flex flex-wrap items-center gap-2">
-        <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-200">
-          Why is this build not progressing?
+    <div className="border-b border-amber-200 bg-amber-50 px-4 py-1.5 dark:border-amber-900/60 dark:bg-amber-950/30">
+      {/* Headline row: the answer, plus the way to the reasoning. */}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+        <span aria-hidden="true" className="text-amber-700 dark:text-amber-400">
+          ⚠
+        </span>
+        <h3 className="text-xs font-semibold text-amber-900 dark:text-amber-200">
+          Not progressing
         </h3>
+        <span className="text-xs text-amber-900/90 dark:text-amber-100/90">
+          — {headline}
+        </span>
         {appChip}
         {frontier.needs_tick && (
           <span
@@ -524,34 +609,53 @@ export function BuildSchedulingPanel({
             wake-up pending
           </span>
         )}
+        <button
+          type="button"
+          onClick={() => setDetailsOpen((v) => !v)}
+          aria-expanded={detailsOpen}
+          className="ml-auto flex items-center gap-1 rounded text-xs font-medium text-amber-900/80 hover:text-amber-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-amber-200/80 dark:hover:text-amber-100"
+        >
+          <svg
+            className={`h-3 w-3 transition-transform ${detailsOpen ? "rotate-90" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+          {totalTasks} task{totalTasks === 1 ? "" : "s"} · details
+        </button>
       </div>
 
-      <p className="mt-1 text-sm text-amber-900/90 dark:text-amber-100/90">{verdict}</p>
-
-      <div className="mt-2">{countChips}</div>
-
       {notice && (
-        <ResultBanner tone="success" className="mt-2" onDismiss={() => setNotice(null)}>
+        <ResultBanner tone="success" className="mt-1" onDismiss={() => setNotice(null)}>
           {notice}
         </ResultBanner>
       )}
       {actionError && !pending && (
         <ResultBanner
           tone="error"
-          className="mt-2"
+          className="mt-1"
           onDismiss={() => setActionError(null)}
         >
           {actionError}
         </ResultBanner>
       )}
 
+      {/* Blockers stay visible: they carry the remedy, which is the whole
+          point of noticing a stalled build. Only a couple are shown until
+          the panel is expanded — past two, it is a list to work through
+          rather than something to read in place. */}
       {blockers.length > 0 && (
-        <div className="mt-3">
-          <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-amber-900/80 dark:text-amber-200/80">
-            Blocked by upstreams outside this build ({blockers.length})
-          </h4>
-          <ul className="space-y-2">
-            {blockers.map((blocker) => (
+        <ul className="mt-1">
+          {(detailsOpen ? blockers : blockers.slice(0, COMPACT_BLOCKERS)).map(
+            (blocker) => (
               <BlockerCard
                 key={`${blocker.task_id}->${blocker.blocking_task_id}`}
                 blocker={blocker}
@@ -561,24 +665,40 @@ export function BuildSchedulingPanel({
                 onNavigateToBuild={onNavigateToBuild}
                 onAct={handleAct}
               />
-            ))}
-          </ul>
+            ),
+          )}
+        </ul>
+      )}
+      {!detailsOpen && blockers.length > COMPACT_BLOCKERS && (
+        <button
+          type="button"
+          onClick={() => setDetailsOpen(true)}
+          className="rounded text-xs text-blue-700 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-300"
+        >
+          Show {blockers.length - COMPACT_BLOCKERS} more blocker
+          {blockers.length - COMPACT_BLOCKERS === 1 ? "" : "s"}
+        </button>
+      )}
+
+      {detailsOpen && (
+        <div className="mt-2 space-y-2 border-t border-amber-200/70 pt-2 dark:border-amber-900/50">
+          <p className="text-xs text-amber-900/90 dark:text-amber-100/90">{verdict}</p>
+          {countChips}
           {frontier.blocked_by_external_truncated && (
-            <p className="mt-1.5 text-xs text-amber-900/80 dark:text-amber-200/80">
+            <p className="text-xs text-amber-900/80 dark:text-amber-200/80">
               More blockers were found than are listed here — the list is capped because
               it is a diagnostic, not a work queue. Clearing the ones shown will reveal
               the rest.
             </p>
           )}
+          <div>
+            <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-amber-900/80 dark:text-amber-200/80">
+              Recent scheduler ticks
+            </h4>
+            {tickTrail}
+          </div>
         </div>
       )}
-
-      <div className="mt-3">
-        <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-amber-900/80 dark:text-amber-200/80">
-          Recent scheduler ticks
-        </h4>
-        {tickTrail}
-      </div>
 
       {pending && pending.blocker.blocking_status_build_id && (
         <ClaimActionDialog

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
@@ -337,8 +337,10 @@ export function BuildSchedulingPanel({
   }, [buildId]);
 
   const form = frontier ? schedulingPanelForm(frontier, buildStatus) : "hidden";
-  // Tick history is fetched only when it will actually be read: always for
-  // a stalled build, and on demand behind the collapsed form's disclosure.
+  // Tick history is fetched only when it will actually be read, which in
+  // both forms now means "the disclosure is open" — the stalled form keeps
+  // its trail behind `details` so the panel stays short enough to leave the
+  // DAG and the task table on screen.
   const wantTicks =
     (form === "stalled" && detailsOpen) || (form === "collapsed" && stripOpen);
 

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
@@ -1,0 +1,602 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  cancelTask,
+  fetchBuildFrontier,
+  fetchBuildTickSummaries,
+  retryTask,
+} from "../api/tasks";
+import { useEnvironment } from "../context/EnvironmentContext";
+import type {
+  BuildFrontier,
+  BuildStatus,
+  BuildTickSummary,
+  FrontierExternalBlocker,
+  TaskStatus,
+} from "../types/task";
+import {
+  availableClaimActions,
+  CLAIM_ACTION_LABELS,
+  schedulingPanelForm,
+  type ClaimAction,
+} from "../utils/claims";
+import { formatAbsoluteTime, formatDuration } from "../utils/time";
+import { ClaimActionDialog } from "./ClaimActionDialog";
+import { StatusBadge } from "./StatusBadge";
+import { TickSummaryTrail } from "./TickSummaryTrail";
+import { ResultBanner } from "./ui/ResultBanner";
+
+// How many ticks to pull. Enough to see a repeating outcome without
+// turning the panel into a log viewer.
+const TICK_LIMIT = 20;
+
+// Order the status chips read in, rather than whatever order the server's
+// GROUP BY produced. Unknown statuses (a newer SDK) are appended.
+const STATUS_ORDER: TaskStatus[] = [
+  "running",
+  "suspended",
+  "pending",
+  "failed",
+  "cancelled",
+  "skipped",
+  "unregistered",
+  "completed",
+];
+
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+/** "for 3h 12m", or nothing when the timestamp was never recorded. */
+function heldFor(since: string | null | undefined): string | null {
+  if (!since) return null;
+  const duration = formatDuration(since, null);
+  return duration === "—" ? null : duration;
+}
+
+function BuildLink({
+  buildId,
+  onNavigateToBuild,
+}: {
+  buildId: string;
+  onNavigateToBuild?: (buildId: string) => void;
+}) {
+  if (!onNavigateToBuild) {
+    return (
+      <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+        {shortId(buildId)}
+      </code>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => onNavigateToBuild(buildId)}
+      title={`Go to build ${buildId}`}
+      className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs text-blue-700 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:bg-gray-700 dark:text-blue-300"
+    >
+      {shortId(buildId)}
+    </button>
+  );
+}
+
+interface BlockerCardProps {
+  blocker: FrontierExternalBlocker;
+  buildId: string;
+  isAdmin: boolean;
+  busyAction: boolean;
+  onNavigateToBuild?: (buildId: string) => void;
+  onAct: (blocker: FrontierExternalBlocker, action: ClaimAction) => void;
+}
+
+function BlockerCard({
+  blocker,
+  buildId,
+  isAdmin,
+  busyAction,
+  onNavigateToBuild,
+  onAct,
+}: BlockerCardProps) {
+  const ownerBuildId = blocker.blocking_status_build_id ?? null;
+  const ownedByThisBuild = ownerBuildId === buildId;
+  const held = heldFor(blocker.blocking_status_at);
+  const actions = availableClaimActions(blocker.blocking_status);
+  const qualifiedName = blocker.blocking_task_namespace
+    ? `${blocker.blocking_task_namespace}/${blocker.blocking_task_name}`
+    : blocker.blocking_task_name;
+
+  // The remedy differs by ownership, so the copy has to as well.
+  let explanation: string;
+  if (!blocker.blocking_in_build) {
+    explanation =
+      "This build has never registered the blocking task, so it will never schedule it — it can only wait for whoever owns it.";
+  } else if (ownedByThisBuild) {
+    explanation =
+      "The blocking task is in this build's own task set and this build put it into that status, but it is not actionable, so nothing here will move it on.";
+  } else {
+    explanation =
+      "The blocking task is in this build's own task set — it is in the table below — but another build set its current status, so this build will not advance it.";
+  }
+
+  return (
+    <li className="rounded-md border border-amber-200 bg-white/70 p-2.5 dark:border-amber-900/60 dark:bg-gray-800/60">
+      <p className="text-xs text-gray-600 dark:text-gray-400">
+        This build&rsquo;s task{" "}
+        <code
+          title={blocker.task_id}
+          className="rounded bg-gray-100 px-1 py-0.5 font-mono text-gray-800 dark:bg-gray-700 dark:text-gray-200"
+        >
+          {blocker.task_id}
+        </code>{" "}
+        is waiting on:
+      </p>
+      <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1">
+        <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+          {qualifiedName}
+        </span>
+        <StatusBadge status={blocker.blocking_status} />
+        {held ? (
+          <span
+            className="text-xs text-gray-600 dark:text-gray-400"
+            title={formatAbsoluteTime(blocker.blocking_status_at)}
+          >
+            for {held}
+          </span>
+        ) : (
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            since an unrecorded time
+          </span>
+        )}
+        {ownerBuildId ? (
+          <span className="text-xs text-gray-600 dark:text-gray-400">
+            held by build{" "}
+            <BuildLink buildId={ownerBuildId} onNavigateToBuild={onNavigateToBuild} />
+            {ownedByThisBuild ? " (this build)" : ""}
+          </span>
+        ) : (
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            owning build not recorded
+          </span>
+        )}
+      </div>
+      <p className="mt-1.5 text-xs text-gray-600 dark:text-gray-400">{explanation}</p>
+      <p
+        className="mt-1 truncate font-mono text-[11px] text-gray-500 dark:text-gray-500"
+        title={blocker.blocking_task_id}
+      >
+        {blocker.blocking_task_id}
+      </p>
+
+      {actions.length > 0 && (
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          {isAdmin && ownerBuildId ? (
+            actions.map((action) => (
+              <button
+                key={action}
+                type="button"
+                disabled={busyAction}
+                onClick={() => onAct(blocker, action)}
+                // Several identical-looking buttons can sit in this list,
+                // so each names its target rather than just its verb.
+                aria-label={`${CLAIM_ACTION_LABELS[action]} on ${blocker.blocking_task_name}`}
+                className="rounded-md border border-red-300 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+              >
+                {CLAIM_ACTION_LABELS[action]}
+              </button>
+            ))
+          ) : !ownerBuildId ? (
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              No remedy can be offered: the build that set this status was not recorded,
+              so there is nothing to address a cancel or retry to.
+            </span>
+          ) : (
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              Releasing or resetting another build&rsquo;s task requires the workspace
+              admin role.
+            </span>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+interface BuildSchedulingPanelProps {
+  buildId: string;
+  environmentId: string;
+  buildStatus: BuildStatus;
+  /**
+   * Bumped by the parent on every refresh. The panel refetches in step
+   * with the build view rather than running its own timer, so the 5s
+   * auto-refresh does not end up issuing two independent request streams.
+   */
+  refreshToken?: number;
+  onNavigateToBuild?: (buildId: string) => void;
+  /** Called after a remedy changed server state, so the parent refetches. */
+  onChanged?: () => void;
+}
+
+/**
+ * "Why is this build not progressing?" — the scheduler's view of a build.
+ *
+ * Answers the question the task table cannot: which of this build's tasks
+ * are held back, by *which* task, in what status, for how long, and under
+ * whose build — plus what the reactive scheduler itself thought it was
+ * doing on each of its recent ticks.
+ *
+ * See `schedulingPanelForm` for when it renders.
+ */
+export function BuildSchedulingPanel({
+  buildId,
+  environmentId,
+  buildStatus,
+  refreshToken = 0,
+  onNavigateToBuild,
+  onChanged,
+}: BuildSchedulingPanelProps) {
+  const { activeWorkspaceRole } = useEnvironment();
+  const isAdmin = activeWorkspaceRole === "owner" || activeWorkspaceRole === "admin";
+
+  const [frontier, setFrontier] = useState<BuildFrontier | null>(null);
+  const [frontierError, setFrontierError] = useState<string | null>(null);
+
+  const [summaries, setSummaries] = useState<BuildTickSummary[]>([]);
+  const [ticksLoading, setTicksLoading] = useState(false);
+  const [ticksUnavailable, setTicksUnavailable] = useState(false);
+  const [ticksError, setTicksError] = useState<string | null>(null);
+
+  // Collapsed-form disclosure. Only meaningful in the "collapsed" form;
+  // the stalled form is always open.
+  const [stripOpen, setStripOpen] = useState(false);
+
+  // In-flight remedy.
+  const [pending, setPending] = useState<{
+    blocker: FrontierExternalBlocker;
+    action: ClaimAction;
+  } | null>(null);
+  const [acting, setActing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+  // Bumped locally after a remedy so the panel refreshes even when the
+  // parent does not pass a refreshToken.
+  const [localNonce, setLocalNonce] = useState(0);
+
+  // Stale-response guards: a slow response from a previous build or
+  // environment must not overwrite the current one's state.
+  const frontierEpochRef = useRef(0);
+  const ticksEpochRef = useRef(0);
+
+  useEffect(() => {
+    if (!buildId || !environmentId) return;
+    const epoch = ++frontierEpochRef.current;
+    const fresh = () => frontierEpochRef.current === epoch;
+    fetchBuildFrontier(buildId, environmentId)
+      .then((data) => {
+        if (!fresh()) return;
+        setFrontier(data);
+        setFrontierError(null);
+      })
+      .catch((err: unknown) => {
+        if (!fresh()) return;
+        setFrontierError(
+          err instanceof Error ? err.message : "Failed to read scheduler state",
+        );
+      });
+  }, [buildId, environmentId, refreshToken, localNonce]);
+
+  // Reset per-build state when navigating between builds, so a previous
+  // build's blockers/ticks never show under a new one's header.
+  useEffect(() => {
+    setFrontier(null);
+    setFrontierError(null);
+    setSummaries([]);
+    setTicksUnavailable(false);
+    setTicksError(null);
+    setStripOpen(false);
+    setNotice(null);
+    setActionError(null);
+  }, [buildId]);
+
+  const form = frontier ? schedulingPanelForm(frontier, buildStatus) : "hidden";
+  // Tick history is fetched only when it will actually be read: always for
+  // a stalled build, and on demand behind the collapsed form's disclosure.
+  const wantTicks = form === "stalled" || (form === "collapsed" && stripOpen);
+
+  useEffect(() => {
+    if (!wantTicks || !buildId || !environmentId) return;
+    const epoch = ++ticksEpochRef.current;
+    const fresh = () => ticksEpochRef.current === epoch;
+    setTicksLoading(true);
+    fetchBuildTickSummaries(buildId, environmentId, TICK_LIMIT)
+      .then((data) => {
+        if (!fresh()) return;
+        // A null response means the server has no such endpoint (404).
+        setTicksUnavailable(data === null);
+        setSummaries(data?.summaries ?? []);
+        setTicksError(null);
+      })
+      .catch((err: unknown) => {
+        if (!fresh()) return;
+        setTicksError(
+          err instanceof Error ? err.message : "Failed to load tick history",
+        );
+      })
+      .finally(() => {
+        if (fresh()) setTicksLoading(false);
+      });
+  }, [wantTicks, buildId, environmentId, refreshToken, localNonce]);
+
+  const handleAct = useCallback(
+    (blocker: FrontierExternalBlocker, action: ClaimAction) => {
+      setActionError(null);
+      setNotice(null);
+      setPending({ blocker, action });
+    },
+    [],
+  );
+
+  const handleConfirm = useCallback(async () => {
+    if (!pending) return;
+    const { blocker, action } = pending;
+    const ownerBuildId = blocker.blocking_status_build_id;
+    if (!ownerBuildId) return;
+    setActing(true);
+    setActionError(null);
+    try {
+      if (action === "release") {
+        await cancelTask(ownerBuildId, blocker.blocking_task_id, environmentId);
+      } else {
+        await retryTask(ownerBuildId, blocker.blocking_task_id, environmentId);
+      }
+      setPending(null);
+      setNotice(
+        action === "release"
+          ? `Released the claim on ${blocker.blocking_task_name} under build ${shortId(
+              ownerBuildId,
+            )}.`
+          : `Reset ${blocker.blocking_task_name} to pending under build ${shortId(
+              ownerBuildId,
+            )}.`,
+      );
+      setLocalNonce((n) => n + 1);
+      onChanged?.();
+    } catch (err) {
+      setActionError(err instanceof Error ? err.message : "Action failed");
+    } finally {
+      setActing(false);
+    }
+  }, [pending, environmentId, onChanged]);
+
+  // The first load renders nothing rather than a placeholder: this panel is
+  // an answer, and on a healthy build there is no question — flashing a
+  // "checking…" box on every build open would be worse than the ~200ms of
+  // nothing. A *failed* read is different, and does render (below).
+  if (frontierError) {
+    return (
+      <div className="border-b border-gray-200 px-4 py-2 dark:border-gray-700">
+        <ResultBanner tone="warning">
+          Could not read this build&rsquo;s scheduler state, so the panel that explains
+          a stalled build is unavailable: {frontierError}
+        </ResultBanner>
+      </div>
+    );
+  }
+  if (!frontier || form === "hidden") return null;
+
+  const blockers = frontier.blocked_by_external;
+  const counts = Object.entries(frontier.status_counts).sort((a, b) => {
+    const ai = STATUS_ORDER.indexOf(a[0] as TaskStatus);
+    const bi = STATUS_ORDER.indexOf(b[0] as TaskStatus);
+    return (ai < 0 ? STATUS_ORDER.length : ai) - (bi < 0 ? STATUS_ORDER.length : bi);
+  });
+
+  const countChips = (
+    <div className="flex flex-wrap items-center gap-1">
+      {counts.map(([status, count]) => (
+        <span
+          key={status}
+          className="inline-flex items-baseline gap-1 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+        >
+          <span>{status}</span>
+          <span className="font-medium">{count}</span>
+        </span>
+      ))}
+    </div>
+  );
+
+  const appChip = frontier.reactive_app_name ? (
+    <span
+      className="rounded bg-indigo-100 px-1.5 py-0.5 text-xs text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-300"
+      title="The reactive app whose scheduler ticks drive this build"
+    >
+      ⚡ {frontier.reactive_app_name}
+    </span>
+  ) : null;
+
+  const tickTrail = (
+    <TickSummaryTrail
+      summaries={summaries}
+      loading={ticksLoading && summaries.length === 0}
+      unavailable={ticksUnavailable}
+      error={ticksError}
+    />
+  );
+
+  if (form === "collapsed") {
+    // A progressing reactive build: one line, never an empty box. It must
+    // not imply anything about blockers — the server does not look for
+    // them while a build is moving.
+    return (
+      <div className="border-b border-gray-200 bg-gray-50 px-4 py-1.5 dark:border-gray-700 dark:bg-gray-800/50">
+        <div className="flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setStripOpen((v) => !v)}
+            aria-expanded={stripOpen}
+            className="flex items-center gap-1.5 rounded text-xs font-medium text-gray-700 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-300 dark:hover:text-gray-100"
+          >
+            <svg
+              className={`h-3 w-3 transition-transform ${stripOpen ? "rotate-90" : ""}`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 5l7 7-7 7"
+              />
+            </svg>
+            Scheduling
+          </button>
+          {appChip}
+          <span className="text-xs text-gray-600 dark:text-gray-400">
+            {frontier.actionable.length} actionable · {frontier.running.length} running
+            {frontier.needs_tick ? " · wake-up pending" : ""}
+          </span>
+        </div>
+        {stripOpen && (
+          <div className="mt-2 space-y-2 pb-1">
+            {countChips}
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              Upstreams owned by other builds are only looked for while a build is
+              stalled, so nothing here says whether this build has any.
+            </p>
+            <div>
+              <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400">
+                Recent scheduler ticks
+              </h4>
+              {tickTrail}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  // --- Stalled form ---
+
+  const blockedTaskCount = new Set(blockers.map((b) => b.task_id)).size;
+  const externalCount = blockers.filter((b) => !b.blocking_in_build).length;
+
+  let verdict: string;
+  if (blockers.length > 0) {
+    verdict =
+      `Nothing in this build is actionable and nothing is running. ` +
+      `${blockedTaskCount} of its task${blockedTaskCount === 1 ? " is" : "s are"} ` +
+      `held back by ${blockers.length} upstream${blockers.length === 1 ? "" : "s"} ` +
+      `whose status ${blockers.length === 1 ? "was" : "were"} set outside this build` +
+      (externalCount > 0
+        ? ` — ${externalCount} of which ${
+            externalCount === 1 ? "is" : "are"
+          } not even part of this build.`
+        : ".");
+  } else if (frontier.needs_tick) {
+    verdict =
+      "Nothing in this build is actionable and nothing is running, and no upstream " +
+      "outside the build is holding it back. A scheduler wake-up is pending, so the " +
+      "next tick may still move it.";
+  } else if (frontier.reactive_app_name) {
+    verdict =
+      "Nothing in this build is actionable and nothing is running, no upstream " +
+      "outside the build is holding it back, and no scheduler wake-up is pending. " +
+      "Nothing is going to happen without intervention.";
+  } else {
+    verdict =
+      "Nothing in this build is actionable and nothing is running, and no upstream " +
+      "outside the build is holding it back. This build is not reactively scheduled, " +
+      "so nothing will advance it on its own.";
+  }
+
+  return (
+    <div className="border-b border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900/60 dark:bg-amber-950/30">
+      <div className="flex flex-wrap items-center gap-2">
+        <h3 className="text-sm font-semibold text-amber-900 dark:text-amber-200">
+          Why is this build not progressing?
+        </h3>
+        {appChip}
+        {frontier.needs_tick && (
+          <span
+            className="rounded bg-blue-100 px-1.5 py-0.5 text-xs text-blue-800 dark:bg-blue-900/40 dark:text-blue-300"
+            title="The scheduler has a wake-up queued for this build"
+          >
+            wake-up pending
+          </span>
+        )}
+      </div>
+
+      <p className="mt-1 text-sm text-amber-900/90 dark:text-amber-100/90">{verdict}</p>
+
+      <div className="mt-2">{countChips}</div>
+
+      {notice && (
+        <ResultBanner tone="success" className="mt-2" onDismiss={() => setNotice(null)}>
+          {notice}
+        </ResultBanner>
+      )}
+      {actionError && !pending && (
+        <ResultBanner
+          tone="error"
+          className="mt-2"
+          onDismiss={() => setActionError(null)}
+        >
+          {actionError}
+        </ResultBanner>
+      )}
+
+      {blockers.length > 0 && (
+        <div className="mt-3">
+          <h4 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-amber-900/80 dark:text-amber-200/80">
+            Blocked by upstreams outside this build ({blockers.length})
+          </h4>
+          <ul className="space-y-2">
+            {blockers.map((blocker) => (
+              <BlockerCard
+                key={`${blocker.task_id}->${blocker.blocking_task_id}`}
+                blocker={blocker}
+                buildId={buildId}
+                isAdmin={isAdmin}
+                busyAction={acting}
+                onNavigateToBuild={onNavigateToBuild}
+                onAct={handleAct}
+              />
+            ))}
+          </ul>
+          {frontier.blocked_by_external_truncated && (
+            <p className="mt-1.5 text-xs text-amber-900/80 dark:text-amber-200/80">
+              More blockers were found than are listed here — the list is capped because
+              it is a diagnostic, not a work queue. Clearing the ones shown will reveal
+              the rest.
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="mt-3">
+        <h4 className="mb-1 text-xs font-semibold uppercase tracking-wide text-amber-900/80 dark:text-amber-200/80">
+          Recent scheduler ticks
+        </h4>
+        {tickTrail}
+      </div>
+
+      {pending && pending.blocker.blocking_status_build_id && (
+        <ClaimActionDialog
+          action={pending.action}
+          taskName={pending.blocker.blocking_task_name}
+          taskId={pending.blocker.blocking_task_id}
+          ownerBuildId={pending.blocker.blocking_status_build_id}
+          currentBuildId={buildId}
+          status={pending.blocker.blocking_status}
+          busy={acting}
+          error={actionError}
+          onConfirm={handleConfirm}
+          onCancel={() => {
+            setPending(null);
+            setActionError(null);
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -25,6 +25,7 @@ import type {
   TaskWithContext,
 } from "../types/task";
 import { isExtendedResponse } from "../types/task";
+import { BuildSchedulingPanel } from "./BuildSchedulingPanel";
 import { BuildStatusBadge } from "./BuildStatusBadge";
 import { BuildExecutorChips } from "./ExecutorBadge";
 import { DagControls, type DagControlsState } from "./DagControls";
@@ -88,6 +89,10 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
   // Refresh state
   const [refreshing, setRefreshing] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(false);
+  // Bumped on every build refresh (manual, auto or post-mutation). The
+  // scheduling panel refetches off this rather than running its own timer,
+  // so the 5s auto-refresh drives one request stream, not two.
+  const [refreshToken, setRefreshToken] = useState(0);
   const autoRefreshRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastClickRef = useRef<number>(0);
 
@@ -163,6 +168,7 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
   // Refresh handler
   const handleRefresh = useCallback(async () => {
     setRefreshing(true);
+    setRefreshToken((token) => token + 1);
     await loadBuild();
     setRefreshing(false);
   }, [loadBuild]);
@@ -592,6 +598,20 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
                   )}
                 </div>
               </div>
+
+              {/* Scheduler state. Renders itself only when it has something
+                  to say — see `schedulingPanelForm`. Placed above the DAG so
+                  a stalled build's explanation is the first thing read. */}
+              {activeEnvironment?.id && (
+                <BuildSchedulingPanel
+                  buildId={buildId}
+                  environmentId={activeEnvironment.id}
+                  buildStatus={build.status}
+                  refreshToken={refreshToken}
+                  onNavigateToBuild={onNavigateToBuild}
+                  onChanged={handleRefresh}
+                />
+              )}
 
               {/* DAG header - always visible */}
               <div className="flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-700">

--- a/app/stardag-ui/src/components/ClaimActionDialog.tsx
+++ b/app/stardag-ui/src/components/ClaimActionDialog.tsx
@@ -1,0 +1,111 @@
+import type { TaskStatus } from "../types/task";
+import { ConfirmDialog } from "./ui/ConfirmDialog";
+import type { ClaimAction } from "../utils/claims";
+
+interface ClaimActionDialogProps {
+  action: ClaimAction | null;
+  taskName: string;
+  taskId: string;
+  /** The build whose event produced the task's current status. */
+  ownerBuildId: string;
+  /** The build the user is currently looking at, when there is one. */
+  currentBuildId?: string;
+  status: TaskStatus;
+  busy: boolean;
+  error: string | null;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Confirmation for a single cross-build claim remedy.
+ *
+ * The dialog names the build the action is addressed to, because that is
+ * the part a user cannot infer: a task's status is environment-global, so
+ * the build that owns the claim is frequently *not* the build on screen,
+ * and acting on it changes state outside what the current page shows.
+ */
+export function ClaimActionDialog({
+  action,
+  taskName,
+  taskId,
+  ownerBuildId,
+  currentBuildId,
+  status,
+  busy,
+  error,
+  onConfirm,
+  onCancel,
+}: ClaimActionDialogProps) {
+  const shortBuild = ownerBuildId.slice(0, 8);
+  const crossBuild = Boolean(currentBuildId && currentBuildId !== ownerBuildId);
+
+  const target = (
+    <>
+      <span className="font-medium text-gray-900 dark:text-gray-100">{taskName}</span>{" "}
+      <code className="rounded bg-gray-100 px-1 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+        {taskId}
+      </code>
+    </>
+  );
+
+  const addressed = (
+    <>
+      under build{" "}
+      <code className="rounded bg-gray-100 px-1 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200">
+        {shortBuild}
+      </code>
+      {crossBuild ? " — a different build from the one you are viewing" : ""}
+    </>
+  );
+
+  return (
+    <ConfirmDialog
+      isOpen={action !== null}
+      title={
+        action === "retry"
+          ? "Reset this task to pending"
+          : "Release this task's execution claim"
+      }
+      destructive
+      confirmLabel={action === "retry" ? "Reset to pending" : "Release claim"}
+      busyLabel={action === "retry" ? "Resetting…" : "Releasing…"}
+      cancelLabel="Close"
+      busy={busy}
+      error={error}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+      maxWidthClass="max-w-lg"
+    >
+      {action === "retry" ? (
+        <>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Records a retry for {target} {addressed}, moving it from <em>{status}</em>{" "}
+            back to <em>pending</em> so any build that needs it can run it again.
+          </p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            This does not start anything on its own — a scheduler tick or a new build
+            has to pick the task up.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Cancels {target} {addressed} — the build whose event put it into{" "}
+            <em>{status}</em>, and therefore the build that owns its claim.
+          </p>
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            A task&rsquo;s status is environment-wide, so this one task denies its
+            execution claim to <em>every</em> build that needs it until something
+            releases it. Releasing frees the claim and any concurrency-limit slot it
+            holds.
+          </p>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            The server cannot stop anything: a worker whose task is cancelled here keeps
+            going until it notices, and if it completes anyway, completed wins.
+          </p>
+        </>
+      )}
+    </ConfirmDialog>
+  );
+}

--- a/app/stardag-ui/src/components/ClaimTriage.test.tsx
+++ b/app/stardag-ui/src/components/ClaimTriage.test.tsx
@@ -202,6 +202,29 @@ describe("ClaimTriage", () => {
     });
   });
 
+  it("reads the global status, not this build's, when judging a release", async () => {
+    // The server reports both: `status` is what *this build* did (it did
+    // cancel), `latest_status` is what the claim says (COMPLETED is sticky,
+    // so nothing was held). Reading the former reports every no-op as a
+    // success — the bug this whole guard exists to prevent.
+    vi.mocked(cancelTask).mockResolvedValue("completed");
+    const user = userEvent.setup();
+    renderTriage();
+    await screen.findByText("GrindBeans");
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select all claims on this page" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Release claims" }));
+    await user.click(
+      screen.getAllByRole("button", { name: "Release claims" }).slice(-1)[0],
+    );
+
+    const banner = await screen.findByRole("status");
+    expect(banner).toHaveTextContent("Released 0 of 2 claims.");
+    expect(banner).toHaveTextContent(/already completed — no claim to release/);
+  });
+
   it("says so when a task finished before its claim could be released", async () => {
     // The race that survives the guard above: held when listed, finished
     // by the time the release lands. The write succeeds; COMPLETED is

--- a/app/stardag-ui/src/components/ClaimTriage.test.tsx
+++ b/app/stardag-ui/src/components/ClaimTriage.test.tsx
@@ -1,0 +1,226 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Task } from "../types/task";
+import { ClaimTriage } from "./ClaimTriage";
+
+let mockWorkspaceRole: "owner" | "admin" | "member" | null = "admin";
+vi.mock("../context/EnvironmentContext", () => ({
+  useEnvironment: () => ({
+    activeEnvironment: { id: "env-1", slug: "default", name: "default" },
+    activeWorkspaceRole: mockWorkspaceRole,
+  }),
+}));
+
+vi.mock("../api/tasks", () => ({
+  fetchTasks: vi.fn(),
+  cancelTask: vi.fn(),
+}));
+
+import { cancelTask, fetchTasks } from "../api/tasks";
+
+const HOUR = 3600 * 1000;
+const ago = (ms: number) => new Date(Date.now() - ms).toISOString();
+
+// Two obviously fictional claim holders owned by two different builds.
+const BUILD_A = "aaaaaaaa-1111-2222-3333-444444444444";
+const BUILD_B = "bbbbbbbb-5555-6666-7777-888888888888";
+
+function makeTask(
+  overrides: Partial<Task> & Pick<Task, "task_id" | "task_name">,
+): Task {
+  return {
+    id: `pk-${overrides.task_id}`,
+    environment_id: "env-1",
+    task_namespace: "",
+    task_data: {},
+    version: null,
+    output_uri: null,
+    created_at: ago(9 * HOUR),
+    status: "running",
+    started_at: ago(8 * HOUR),
+    completed_at: null,
+    error_message: null,
+    artifact_count: 0,
+    latest_status: "running",
+    latest_status_at: ago(8 * HOUR),
+    latest_status_build_id: BUILD_A,
+    ...overrides,
+  };
+}
+
+const grind = makeTask({ task_id: "tid-grind", task_name: "GrindBeans" });
+const steam = makeTask({
+  task_id: "tid-steam",
+  task_name: "SteamMilk",
+  latest_status: "suspended",
+  status: "suspended",
+  latest_status_at: ago(2 * HOUR),
+  latest_status_build_id: BUILD_B,
+});
+
+function response(tasks: Task[]) {
+  return { tasks, total: tasks.length, page: 1, page_size: 50 };
+}
+
+function renderTriage() {
+  return render(
+    <ClaimTriage
+      environmentId="env-1"
+      selectedTaskId={null}
+      onSelectTask={() => {}}
+      onNavigateToBuild={onNavigate}
+    />,
+  );
+}
+
+const onNavigate = vi.fn();
+
+describe("ClaimTriage", () => {
+  beforeEach(() => {
+    mockWorkspaceRole = "admin";
+    vi.mocked(fetchTasks).mockResolvedValue(response([grind, steam]));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("asks for claim-holding statuses and shows the holder of each", async () => {
+    const user = userEvent.setup();
+    renderTriage();
+
+    expect(await screen.findByText("GrindBeans")).toBeInTheDocument();
+    await waitFor(() =>
+      expect(fetchTasks).toHaveBeenCalledWith(
+        expect.objectContaining({
+          environment_id: "env-1",
+          status: ["running", "suspended"],
+          status_older_than: undefined,
+        }),
+      ),
+    );
+
+    expect(screen.getByText("8h 00m")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: BUILD_B.slice(0, 8) }));
+    expect(onNavigate).toHaveBeenCalledWith(BUILD_B);
+  });
+
+  it("turns a staleness choice into an absolute cutoff", async () => {
+    const user = userEvent.setup();
+    renderTriage();
+    await screen.findByText("GrindBeans");
+
+    await user.selectOptions(
+      screen.getByLabelText("Held for at least"),
+      String(6 * 3600),
+    );
+
+    await waitFor(() => {
+      const last = vi.mocked(fetchTasks).mock.calls.at(-1)![0]!;
+      expect(last.status_older_than).toBeTruthy();
+      // An absolute instant, not a duration: reproducible across pages.
+      const cutoff = new Date(last.status_older_than!).getTime();
+      expect(Date.now() - cutoff).toBeGreaterThanOrEqual(6 * HOUR - 5000);
+      expect(Date.now() - cutoff).toBeLessThan(6 * HOUR + 5000);
+    });
+  });
+
+  it("releases each selected claim under its own owning build", async () => {
+    vi.mocked(cancelTask).mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    renderTriage();
+    await screen.findByText("GrindBeans");
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select all claims on this page" }),
+    );
+    expect(screen.getByText("2 claims selected")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Release claims" }));
+    expect(await screen.findByText("Release 2 execution claims")).toBeInTheDocument();
+    await user.click(
+      screen.getAllByRole("button", { name: "Release claims" }).slice(-1)[0],
+    );
+
+    await waitFor(() => expect(cancelTask).toHaveBeenCalledTimes(2));
+    expect(cancelTask).toHaveBeenCalledWith(BUILD_A, "tid-grind", "env-1");
+    expect(cancelTask).toHaveBeenCalledWith(BUILD_B, "tid-steam", "env-1");
+    // Refetched after mutating.
+    await waitFor(() => expect(fetchTasks).toHaveBeenCalledTimes(2));
+  });
+
+  it("reports partial failure per task rather than as one error", async () => {
+    // A task can complete between being listed and being acted on, so a
+    // mixed result is the normal case, not an exception.
+    vi.mocked(cancelTask).mockImplementation(async (buildId: string) => {
+      if (buildId === BUILD_B) throw new Error("Task not found");
+    });
+    const user = userEvent.setup();
+    renderTriage();
+    await screen.findByText("GrindBeans");
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select all claims on this page" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Release claims" }));
+    await user.click(
+      screen.getAllByRole("button", { name: "Release claims" }).slice(-1)[0],
+    );
+
+    const banner = await screen.findByRole("status");
+    expect(banner).toHaveTextContent("Released 1 of 2 claims.");
+    // The task that failed is named, with the server's own reason.
+    expect(banner).toHaveTextContent("SteamMilk");
+    expect(banner).toHaveTextContent("Task not found");
+    expect(banner).not.toHaveTextContent("GrindBeans");
+  });
+
+  it("does not let a task with no recorded owning build be selected", async () => {
+    vi.mocked(fetchTasks).mockResolvedValue(
+      response([grind, makeTask({ ...steam, latest_status_build_id: null })]),
+    );
+    renderTriage();
+    await screen.findByText("SteamMilk");
+
+    expect(screen.getByText("not recorded")).toBeInTheDocument();
+    expect(
+      screen.getByRole("checkbox", {
+        name: /SteamMilk cannot be selected/,
+      }),
+    ).toBeDisabled();
+  });
+
+  it("gives non-admin members the view but no selection and no bulk action", async () => {
+    mockWorkspaceRole = "member";
+    renderTriage();
+
+    expect(await screen.findByText("GrindBeans")).toBeInTheDocument();
+    expect(screen.queryAllByRole("checkbox", { name: /^Select / })).toHaveLength(0);
+    expect(
+      screen.queryByRole("button", { name: "Release claims" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Releasing claims requires the workspace admin role."),
+    ).toBeInTheDocument();
+  });
+
+  it("distinguishes 'nothing holds a claim' from 'nothing matches the filters'", async () => {
+    vi.mocked(fetchTasks).mockResolvedValue(response([]));
+    const user = userEvent.setup();
+    renderTriage();
+
+    expect(await screen.findByText(/nothing is holding a claim/i)).toBeInTheDocument();
+
+    await user.selectOptions(screen.getByLabelText("Held for at least"), "3600");
+    expect(
+      await screen.findByText(/Widen the filters to see every claim/),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a load failure", async () => {
+    vi.mocked(fetchTasks).mockRejectedValue(new Error("Service unavailable"));
+    renderTriage();
+    expect(await screen.findByRole("alert")).toHaveTextContent("Service unavailable");
+  });
+});

--- a/app/stardag-ui/src/components/ClaimTriage.test.tsx
+++ b/app/stardag-ui/src/components/ClaimTriage.test.tsx
@@ -127,7 +127,7 @@ describe("ClaimTriage", () => {
   });
 
   it("releases each selected claim under its own owning build", async () => {
-    vi.mocked(cancelTask).mockResolvedValue(undefined);
+    vi.mocked(cancelTask).mockResolvedValue("cancelled");
     const user = userEvent.setup();
     renderTriage();
     await screen.findByText("GrindBeans");
@@ -150,11 +150,89 @@ describe("ClaimTriage", () => {
     await waitFor(() => expect(fetchTasks).toHaveBeenCalledTimes(2));
   });
 
+  it("will not offer to release a claim a task is not holding", async () => {
+    // Reachable by unchecking both status boxes, which used to drop the
+    // status filter entirely and list every task in the environment.
+    // Cancelling a completed task is not an error — the server records the
+    // event and COMPLETED stays — so it reported a cheerful "released 1 of
+    // 1 claims" having released nothing.
+    vi.mocked(fetchTasks).mockResolvedValue({
+      tasks: [
+        makeTask({ task_id: "tid-grind", task_name: "GrindBeans" }),
+        makeTask({
+          task_id: "tid-done",
+          task_name: "PourWater",
+          status: "completed",
+          latest_status: "completed",
+        }),
+      ],
+      total: 2,
+      page: 1,
+      page_size: 25,
+    });
+    const user = userEvent.setup();
+    renderTriage();
+    await screen.findByText("PourWater");
+
+    expect(
+      screen.getByRole("checkbox", {
+        name: /PourWater cannot be selected: it is completed and holds no claim/,
+      }),
+    ).toBeDisabled();
+
+    // Select-all takes the claim holder and leaves the finished task.
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select all claims on this page" }),
+    );
+    expect(screen.getByText("1 claim selected")).toBeInTheDocument();
+  });
+
+  it("keeps listing claim holders when every status box is unchecked", async () => {
+    const user = userEvent.setup();
+    renderTriage();
+    await screen.findByText("GrindBeans");
+
+    await user.click(screen.getByRole("checkbox", { name: "Running" }));
+    await user.click(screen.getByRole("checkbox", { name: "Suspended" }));
+
+    await waitFor(() => {
+      const last = vi.mocked(fetchTasks).mock.calls.at(-1)![0]!;
+      // Not `undefined`, which would list every task in the environment.
+      expect(last.status).toEqual(["running", "suspended"]);
+    });
+  });
+
+  it("says so when a task finished before its claim could be released", async () => {
+    // The race that survives the guard above: held when listed, finished
+    // by the time the release lands. The write succeeds; COMPLETED is
+    // sticky, so nothing was actually released.
+    vi.mocked(cancelTask).mockImplementation(async (buildId: string) =>
+      buildId === BUILD_B ? "completed" : "cancelled",
+    );
+    const user = userEvent.setup();
+    renderTriage();
+    await screen.findByText("GrindBeans");
+
+    await user.click(
+      screen.getByRole("checkbox", { name: "Select all claims on this page" }),
+    );
+    await user.click(screen.getByRole("button", { name: "Release claims" }));
+    await user.click(
+      screen.getAllByRole("button", { name: "Release claims" }).slice(-1)[0],
+    );
+
+    const banner = await screen.findByRole("status");
+    expect(banner).toHaveTextContent("Released 1 of 2 claims.");
+    expect(banner).toHaveTextContent("SteamMilk");
+    expect(banner).toHaveTextContent(/already completed — no claim to release/);
+  });
+
   it("reports partial failure per task rather than as one error", async () => {
     // A task can complete between being listed and being acted on, so a
     // mixed result is the normal case, not an exception.
     vi.mocked(cancelTask).mockImplementation(async (buildId: string) => {
       if (buildId === BUILD_B) throw new Error("Task not found");
+      return "cancelled";
     });
     const user = userEvent.setup();
     renderTriage();

--- a/app/stardag-ui/src/components/ClaimTriage.tsx
+++ b/app/stardag-ui/src/components/ClaimTriage.tsx
@@ -1,0 +1,524 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { cancelTask, fetchTasks } from "../api/tasks";
+import { useEnvironment } from "../context/EnvironmentContext";
+import type { Task, TaskStatus } from "../types/task";
+import { CLAIM_HOLDING_STATUSES } from "../utils/claims";
+import { formatAbsoluteTime, formatDuration } from "../utils/time";
+import { useRowSelection } from "../hooks/useRowSelection";
+import { StatusBadge } from "./StatusBadge";
+import { BulkActionBar } from "./ui/BulkActionBar";
+import { Checkbox } from "./ui/Checkbox";
+import { ConfirmDialog } from "./ui/ConfirmDialog";
+import { ResultBanner } from "./ui/ResultBanner";
+
+const PAGE_SIZE = 50;
+
+// Staleness cuts. The API takes an absolute ISO instant rather than a
+// duration (a duration would move the cutoff on every page request), so
+// these are converted at fetch time and the resulting instant is what the
+// request — and this page of results — is pinned to.
+const AGE_OPTIONS: { label: string; seconds: number }[] = [
+  { label: "Any age", seconds: 0 },
+  { label: "Older than 15m", seconds: 15 * 60 },
+  { label: "Older than 1h", seconds: 3600 },
+  { label: "Older than 6h", seconds: 6 * 3600 },
+  { label: "Older than 24h", seconds: 24 * 3600 },
+  { label: "Older than 7d", seconds: 7 * 24 * 3600 },
+];
+
+/** Per-task result of a bulk release; partial failure is the normal case. */
+interface ReleaseOutcome {
+  task: Task;
+  error: string | null;
+}
+
+function EyeIcon() {
+  return (
+    <svg
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+      />
+    </svg>
+  );
+}
+
+interface ClaimTriageProps {
+  environmentId: string;
+  selectedTaskId: string | null;
+  onSelectTask: (task: Task) => void;
+  onNavigateToBuild?: (buildId: string) => void;
+}
+
+/**
+ * "Which tasks are holding an execution claim, and who owns them?"
+ *
+ * A separate mode rather than another filter chip on the generic task
+ * search, for a reason that is not cosmetic: `/tasks/search` reports a
+ * task's status but neither *when* it entered it nor *which build* put it
+ * there, and it evaluates a status filter in Python over the whole
+ * unpaginated match set. `/tasks?status=…&status_older_than=…` carries
+ * `latest_status_at` and `latest_status_build_id`, filters in SQL, and
+ * orders oldest-claim-first — which is the triage order. The generic
+ * search is untouched.
+ */
+export function ClaimTriage({
+  environmentId,
+  selectedTaskId,
+  onSelectTask,
+  onNavigateToBuild,
+}: ClaimTriageProps) {
+  const { activeWorkspaceRole } = useEnvironment();
+  const isAdmin = activeWorkspaceRole === "owner" || activeWorkspaceRole === "admin";
+
+  const [statuses, setStatuses] = useState<TaskStatus[]>(CLAIM_HOLDING_STATUSES);
+  const [ageSeconds, setAgeSeconds] = useState(0);
+  const [page, setPage] = useState(1);
+
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadNonce, setReloadNonce] = useState(0);
+
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [releasing, setReleasing] = useState(false);
+  const [releaseError, setReleaseError] = useState<string | null>(null);
+  const [outcomes, setOutcomes] = useState<ReleaseOutcome[] | null>(null);
+
+  // Stale-response guard: a slow response from a previous environment or
+  // filter must not overwrite the current one's results.
+  const epochRef = useRef(0);
+
+  const statusKey = statuses.join(",");
+
+  useEffect(() => {
+    if (!environmentId) return;
+    const epoch = ++epochRef.current;
+    const fresh = () => epochRef.current === epoch;
+    setLoading(true);
+    setError(null);
+    fetchTasks({
+      environment_id: environmentId,
+      page,
+      page_size: PAGE_SIZE,
+      status: statuses.length > 0 ? statuses : undefined,
+      status_older_than:
+        ageSeconds > 0
+          ? new Date(Date.now() - ageSeconds * 1000).toISOString()
+          : undefined,
+    })
+      .then((response) => {
+        if (!fresh()) return;
+        setTasks(response.tasks);
+        setTotal(response.total);
+      })
+      .catch((err: unknown) => {
+        if (!fresh()) return;
+        setError(err instanceof Error ? err.message : "Failed to load tasks");
+        setTasks([]);
+        setTotal(0);
+      })
+      .finally(() => {
+        if (fresh()) setLoading(false);
+      });
+    // `statuses` is covered by the derived `statusKey`; listing the array
+    // itself would refetch on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [environmentId, page, statusKey, ageSeconds, reloadNonce]);
+
+  // Reset to page 1 when the filters change under the user.
+  useEffect(() => {
+    setPage(1);
+  }, [environmentId, statusKey, ageSeconds]);
+
+  // Only a task whose owning build is known can be acted on — the cancel
+  // endpoint is addressed to a build. Rows without one stay visible (they
+  // are still claim holders worth seeing) but are not selectable.
+  const actionableTasks = useMemo(
+    () => tasks.filter((task) => Boolean(task.latest_status_build_id)),
+    [tasks],
+  );
+  const selectableIds = useMemo(
+    () => actionableTasks.map((task) => task.task_id),
+    [actionableTasks],
+  );
+  const {
+    selectedIds,
+    selectedCount,
+    isSelected,
+    toggle,
+    toggleAllVisible,
+    clear,
+    allVisibleSelected,
+    someVisibleSelected,
+  } = useRowSelection(
+    selectableIds,
+    `${environmentId}|${page}|${statusKey}|${ageSeconds}`,
+  );
+
+  const selectedTasks = useMemo(
+    () => actionableTasks.filter((task) => selectedIds.includes(task.task_id)),
+    [actionableTasks, selectedIds],
+  );
+
+  const handleRelease = useCallback(async () => {
+    setReleasing(true);
+    setReleaseError(null);
+    // Each task is cancelled under *its own* owning build. A single
+    // failure is expected rather than exceptional — a task may well have
+    // completed between listing and acting — so every result is kept and
+    // reported per task instead of collapsing into one error.
+    const results = await Promise.allSettled(
+      selectedTasks.map((task) =>
+        cancelTask(task.latest_status_build_id!, task.task_id, environmentId),
+      ),
+    );
+    const collected: ReleaseOutcome[] = selectedTasks.map((task, i) => {
+      const result = results[i];
+      if (result.status === "fulfilled") return { task, error: null };
+      const reason: unknown = result.reason;
+      return {
+        task,
+        error: reason instanceof Error ? reason.message : "Failed to release claim",
+      };
+    });
+    setOutcomes(collected);
+    setReleasing(false);
+    setConfirmOpen(false);
+    clear();
+    setReloadNonce((n) => n + 1);
+  }, [selectedTasks, environmentId, clear]);
+
+  const totalPages = Math.ceil(total / PAGE_SIZE);
+  const filtersActive = statuses.length !== 2 || ageSeconds > 0;
+  const failedCount = outcomes?.filter((o) => o.error).length ?? 0;
+  const releasedCount = (outcomes?.length ?? 0) - failedCount;
+
+  const toggleStatus = (status: TaskStatus, checked: boolean) => {
+    setStatuses((prev) =>
+      checked ? [...prev, status] : prev.filter((s) => s !== status),
+    );
+  };
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Toolbar */}
+      <div className="border-b border-gray-200 bg-white px-4 py-2 dark:border-gray-700 dark:bg-gray-800">
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          A task left running or suspended holds its execution claim environment-wide:
+          every build that needs it waits until something releases it. Longest-held
+          first.
+        </p>
+        <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2">
+          <Checkbox
+            checked={statuses.includes("running")}
+            onChange={(checked) => toggleStatus("running", checked)}
+            label="Running"
+            labelHidden={false}
+          />
+          <Checkbox
+            checked={statuses.includes("suspended")}
+            onChange={(checked) => toggleStatus("suspended", checked)}
+            label="Suspended"
+            labelHidden={false}
+          />
+          <label className="flex items-center gap-1.5 text-sm text-gray-700 dark:text-gray-300">
+            <span className="sr-only">Held for at least</span>
+            <select
+              value={ageSeconds}
+              onChange={(e) => setAgeSeconds(Number(e.target.value))}
+              aria-label="Held for at least"
+              className="rounded-md border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-200"
+            >
+              {AGE_OPTIONS.map((option) => (
+                <option key={option.seconds} value={option.seconds}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button
+            type="button"
+            onClick={() => setReloadNonce((n) => n + 1)}
+            className="rounded-md border border-gray-300 px-2 py-1 text-sm text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+          >
+            Refresh
+          </button>
+          <span className="ml-auto text-xs text-gray-500 dark:text-gray-400">
+            {loading ? "Loading…" : `${total} claim${total === 1 ? "" : "s"}`}
+          </span>
+          {!isAdmin && (
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              Releasing claims requires the workspace admin role.
+            </span>
+          )}
+        </div>
+      </div>
+
+      {outcomes && (
+        <div className="border-b border-gray-200 px-4 py-2 dark:border-gray-700">
+          <ResultBanner
+            tone={failedCount === 0 ? "success" : "warning"}
+            onDismiss={() => setOutcomes(null)}
+          >
+            <p>
+              Released {releasedCount} of {outcomes.length} claim
+              {outcomes.length === 1 ? "" : "s"}.
+            </p>
+            {failedCount > 0 && (
+              <ul className="mt-1 list-disc space-y-0.5 pl-4">
+                {outcomes
+                  .filter((outcome) => outcome.error)
+                  .map((outcome) => (
+                    <li key={outcome.task.task_id}>
+                      <span className="font-medium">{outcome.task.task_name}</span>:{" "}
+                      {outcome.error}
+                    </li>
+                  ))}
+              </ul>
+            )}
+          </ResultBanner>
+        </div>
+      )}
+
+      {/* Results */}
+      <div className="flex-1 overflow-auto">
+        {loading && tasks.length === 0 ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+          </div>
+        ) : error ? (
+          <div className="flex h-full items-center justify-center px-4 text-red-500">
+            <p role="alert">{error}</p>
+          </div>
+        ) : tasks.length === 0 ? (
+          <div className="flex h-full flex-col items-center justify-center px-4 text-center text-gray-500 dark:text-gray-400">
+            <p className="text-lg font-medium">No claims held</p>
+            <p className="mt-1 text-sm">
+              {filtersActive
+                ? "No task matches these statuses and this age. Widen the filters to see every claim."
+                : "No task in this environment is running or suspended, so nothing is holding a claim."}
+            </p>
+          </div>
+        ) : (
+          <table className="w-full table-fixed">
+            <thead className="sticky top-0 bg-gray-50 dark:bg-gray-800">
+              <tr>
+                {isAdmin && (
+                  <th className="w-10 border-b border-gray-200 px-3 py-1.5 dark:border-gray-700">
+                    <Checkbox
+                      checked={allVisibleSelected}
+                      indeterminate={someVisibleSelected}
+                      onChange={toggleAllVisible}
+                      label="Select all claims on this page"
+                      disabled={selectableIds.length === 0}
+                    />
+                  </th>
+                )}
+                {["Task", "Namespace", "Status", "Held for", "Claim holder"].map(
+                  (label) => (
+                    <th
+                      key={label}
+                      className="border-b border-gray-200 px-3 py-1.5 text-left text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:border-gray-700 dark:text-gray-400"
+                    >
+                      {label}
+                    </th>
+                  ),
+                )}
+                <th className="w-12 border-b border-gray-200 px-3 py-1.5 dark:border-gray-700">
+                  <span className="sr-only">Actions</span>
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200 bg-white dark:divide-gray-700 dark:bg-gray-800">
+              {tasks.map((task) => {
+                const holderBuildId = task.latest_status_build_id ?? null;
+                const status = task.latest_status ?? task.status;
+                const held = task.latest_status_at
+                  ? formatDuration(task.latest_status_at, null)
+                  : "—";
+                return (
+                  <tr
+                    key={task.task_id}
+                    className={`hover:bg-gray-50 dark:hover:bg-gray-700/50 ${
+                      selectedTaskId === task.task_id
+                        ? "bg-blue-50 dark:bg-blue-900/20"
+                        : ""
+                    }`}
+                  >
+                    {isAdmin && (
+                      <td className="px-3 py-1.5">
+                        <Checkbox
+                          checked={isSelected(task.task_id)}
+                          onChange={(checked) => toggle(task.task_id, checked)}
+                          disabled={!holderBuildId}
+                          label={
+                            holderBuildId
+                              ? `Select ${task.task_name}`
+                              : `${task.task_name} cannot be selected: its owning build was not recorded`
+                          }
+                        />
+                      </td>
+                    )}
+                    <td className="overflow-hidden text-ellipsis whitespace-nowrap px-3 py-1.5 text-xs text-gray-900 dark:text-gray-100">
+                      <span title={task.task_id}>{task.task_name}</span>
+                    </td>
+                    <td className="overflow-hidden text-ellipsis whitespace-nowrap px-3 py-1.5 text-xs text-gray-500 dark:text-gray-400">
+                      {task.task_namespace || "—"}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-1.5">
+                      <StatusBadge status={status} />
+                    </td>
+                    <td
+                      className="whitespace-nowrap px-3 py-1.5 text-xs text-gray-700 dark:text-gray-300"
+                      title={formatAbsoluteTime(task.latest_status_at)}
+                    >
+                      {held}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-1.5 text-xs">
+                      {holderBuildId ? (
+                        onNavigateToBuild ? (
+                          <button
+                            type="button"
+                            onClick={() => onNavigateToBuild(holderBuildId)}
+                            title={`Go to build ${holderBuildId}`}
+                            className="rounded font-mono text-blue-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-400"
+                          >
+                            {holderBuildId.slice(0, 8)}
+                          </button>
+                        ) : (
+                          <span className="font-mono text-gray-700 dark:text-gray-300">
+                            {holderBuildId.slice(0, 8)}
+                          </span>
+                        )
+                      ) : (
+                        <span
+                          className="text-gray-400 dark:text-gray-500"
+                          title="Recorded before the owning build was denormalised onto the task"
+                        >
+                          not recorded
+                        </span>
+                      )}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-1.5">
+                      <button
+                        type="button"
+                        onClick={() => onSelectTask(task)}
+                        aria-label={`View details for ${task.task_name}`}
+                        className="rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
+                      >
+                        <EyeIcon />
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      <BulkActionBar
+        count={selectedCount}
+        noun="claim"
+        onClear={clear}
+        note="Selection covers this page only."
+      >
+        <button
+          type="button"
+          onClick={() => {
+            setReleaseError(null);
+            setConfirmOpen(true);
+          }}
+          className="rounded-md bg-red-600 px-2.5 py-1 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+        >
+          Release claims
+        </button>
+      </BulkActionBar>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between border-t border-gray-200 bg-white px-4 py-1.5 dark:border-gray-700 dark:bg-gray-800">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {(page - 1) * PAGE_SIZE + 1}-{Math.min(page * PAGE_SIZE, total)} of {total}
+          </span>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => setPage(Math.max(1, page - 1))}
+              disabled={page === 1}
+              className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              Prev
+            </button>
+            <span className="text-xs text-gray-500 dark:text-gray-400">
+              {page}/{totalPages}
+            </span>
+            <button
+              onClick={() => setPage(Math.min(totalPages, page + 1))}
+              disabled={page === totalPages}
+              className="rounded border border-gray-300 px-2 py-0.5 text-xs text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      <ConfirmDialog
+        isOpen={confirmOpen}
+        title={`Release ${selectedCount} execution claim${
+          selectedCount === 1 ? "" : "s"
+        }`}
+        destructive
+        confirmLabel="Release claims"
+        busyLabel="Releasing…"
+        cancelLabel="Close"
+        busy={releasing}
+        error={releaseError}
+        onConfirm={handleRelease}
+        onCancel={() => setConfirmOpen(false)}
+        maxWidthClass="max-w-lg"
+      >
+        <p className="text-sm text-gray-600 dark:text-gray-400">
+          Cancels each selected task{" "}
+          <em>under the build that put it into its current status</em> — one request per
+          task, addressed to a different build each time. That frees the execution
+          claims and any concurrency-limit slots they hold.
+        </p>
+        <ul className="max-h-40 space-y-1 overflow-auto text-xs text-gray-600 dark:text-gray-400">
+          {selectedTasks.map((task) => (
+            <li key={task.task_id} className="flex items-center gap-2">
+              <span className="truncate font-medium text-gray-800 dark:text-gray-200">
+                {task.task_name}
+              </span>
+              <span>{task.latest_status ?? task.status}</span>
+              <code className="rounded bg-gray-100 px-1 font-mono dark:bg-gray-700">
+                {task.latest_status_build_id?.slice(0, 8)}
+              </code>
+            </li>
+          ))}
+        </ul>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          Some may fail — a task can complete between this list being drawn and the
+          request landing. Every outcome is reported per task, and the server cannot
+          stop a worker that is still running: if it completes anyway, completed wins.
+        </p>
+      </ConfirmDialog>
+    </div>
+  );
+}

--- a/app/stardag-ui/src/components/ClaimTriage.tsx
+++ b/app/stardag-ui/src/components/ClaimTriage.tsx
@@ -116,7 +116,10 @@ export function ClaimTriage({
       environment_id: environmentId,
       page,
       page_size: PAGE_SIZE,
-      status: statuses.length > 0 ? statuses : undefined,
+      // Unchecking both boxes means "either kind of claim", not "every
+      // task in the environment" — this view only has an opinion about
+      // tasks that hold a claim.
+      status: statuses.length > 0 ? statuses : CLAIM_HOLDING_STATUSES,
       status_older_than:
         ageSeconds > 0
           ? new Date(Date.now() - ageSeconds * 1000).toISOString()
@@ -146,11 +149,23 @@ export function ClaimTriage({
     setPage(1);
   }, [environmentId, statusKey, ageSeconds]);
 
-  // Only a task whose owning build is known can be acted on — the cancel
-  // endpoint is addressed to a build. Rows without one stay visible (they
-  // are still claim holders worth seeing) but are not selectable.
+  // Two conditions, both of which leave the row visible but unselectable:
+  //
+  // - the task must actually hold a claim. Releasing one it does not hold
+  //   changes nothing — the server records the event (deliberately: that
+  //   is what makes a cancel racing a completion safe) but COMPLETED and
+  //   the other terminal statuses do not move. Offering the action anyway
+  //   produced a "released 1 of 1 claims" for a task that was already
+  //   finished, which is worse than offering nothing.
+  // - the owning build must be known, because the cancel endpoint is
+  //   addressed to a build.
   const actionableTasks = useMemo(
-    () => tasks.filter((task) => Boolean(task.latest_status_build_id)),
+    () =>
+      tasks.filter(
+        (task) =>
+          Boolean(task.latest_status_build_id) &&
+          CLAIM_HOLDING_STATUSES.includes(task.latest_status ?? task.status),
+      ),
     [tasks],
   );
   const selectableIds = useMemo(
@@ -190,7 +205,16 @@ export function ClaimTriage({
     );
     const collected: ReleaseOutcome[] = selectedTasks.map((task, i) => {
       const result = results[i];
-      if (result.status === "fulfilled") return { task, error: null };
+      if (result.status === "fulfilled") {
+        // A released claim leaves the task CANCELLED. Anything else means
+        // the event was recorded but did not take: the claim was held when
+        // the page was fetched, and between then and now the task reached
+        // a terminal status of its own — COMPLETED is sticky and wins.
+        // The request succeeded; the release did not.
+        return result.value === "cancelled"
+          ? { task, error: null }
+          : { task, error: `already ${result.value} — no claim to release` };
+      }
       const reason: unknown = result.reason;
       return {
         task,
@@ -349,6 +373,8 @@ export function ClaimTriage({
               {tasks.map((task) => {
                 const holderBuildId = task.latest_status_build_id ?? null;
                 const status = task.latest_status ?? task.status;
+                const holdsClaim = CLAIM_HOLDING_STATUSES.includes(status);
+                const selectable = holdsClaim && Boolean(holderBuildId);
                 const held = task.latest_status_at
                   ? formatDuration(task.latest_status_at, null)
                   : "—";
@@ -366,11 +392,13 @@ export function ClaimTriage({
                         <Checkbox
                           checked={isSelected(task.task_id)}
                           onChange={(checked) => toggle(task.task_id, checked)}
-                          disabled={!holderBuildId}
+                          disabled={!selectable}
                           label={
-                            holderBuildId
+                            selectable
                               ? `Select ${task.task_name}`
-                              : `${task.task_name} cannot be selected: its owning build was not recorded`
+                              : !holdsClaim
+                                ? `${task.task_name} cannot be selected: it is ${status} and holds no claim to release`
+                                : `${task.task_name} cannot be selected: its owning build was not recorded`
                           }
                         />
                       </td>

--- a/app/stardag-ui/src/components/TaskDetail.test.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.test.tsx
@@ -1,7 +1,25 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it } from "vitest";
-import { ModalExecutionCallRef, ModalExecutionDetails } from "./TaskDetail";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Task } from "../types/task";
+
+let mockWorkspaceRole: "owner" | "admin" | "member" | null = "admin";
+vi.mock("../context/EnvironmentContext", () => ({
+  useEnvironment: () => ({
+    activeEnvironment: { id: "env-1", slug: "default", name: "default" },
+    activeWorkspaceRole: mockWorkspaceRole,
+  }),
+}));
+
+vi.mock("../api/tasks", () => ({
+  cancelTask: vi.fn(),
+  retryTask: vi.fn(),
+  fetchTaskArtifacts: vi.fn().mockResolvedValue({ artifacts: [] }),
+  fetchTaskEvents: vi.fn().mockResolvedValue([]),
+}));
+
+import { cancelTask, retryTask } from "../api/tasks";
+import { ModalExecutionCallRef, ModalExecutionDetails, TaskDetail } from "./TaskDetail";
 
 const fullMetadata = {
   kind: "modal",
@@ -251,5 +269,150 @@ describe("ModalExecutionDetails", () => {
     });
     await user.click(copyButtons[copyButtons.length - 1]);
     expect(await window.navigator.clipboard.readText()).toBe("fc-789");
+  });
+});
+
+// ---- Claim holder ----
+
+const VIEWED_BUILD = "99999999-aaaa-bbbb-cccc-dddddddddddd";
+const HOLDER_BUILD = "11111111-2222-3333-4444-555555555555";
+const HOUR = 3600 * 1000;
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "pk-1",
+    task_id: "tid-grind-beans",
+    environment_id: "env-1",
+    task_namespace: "",
+    task_name: "GrindBeans",
+    task_data: {},
+    version: null,
+    output_uri: null,
+    created_at: new Date(Date.now() - 5 * HOUR).toISOString(),
+    status: "running",
+    started_at: new Date(Date.now() - 4 * HOUR).toISOString(),
+    completed_at: null,
+    error_message: null,
+    artifact_count: 0,
+    latest_status: "running",
+    latest_status_at: new Date(Date.now() - 4 * HOUR).toISOString(),
+    latest_status_build_id: HOLDER_BUILD,
+    ...overrides,
+  };
+}
+
+describe("TaskDetail claim holder", () => {
+  beforeEach(() => {
+    mockWorkspaceRole = "admin";
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("says in words that another build holds the claim, and for how long", async () => {
+    const onStatusBuildClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <TaskDetail
+        task={makeTask()}
+        buildId={VIEWED_BUILD}
+        onClose={() => {}}
+        onStatusBuildClick={onStatusBuildClick}
+      />,
+    );
+
+    expect(
+      screen.getByText("Execution claim held by another build"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/for 4h 00m/)).toBeInTheDocument();
+    expect(screen.getByText(/not the build you are viewing/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: HOLDER_BUILD.slice(0, 8) }));
+    expect(onStatusBuildClick).toHaveBeenCalledWith(HOLDER_BUILD);
+  });
+
+  it("addresses the release to the holding build, not the one on screen", async () => {
+    vi.mocked(cancelTask).mockResolvedValue(undefined);
+    const onTaskCancelled = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <TaskDetail
+        task={makeTask()}
+        buildId={VIEWED_BUILD}
+        onClose={() => {}}
+        onTaskCancelled={onTaskCancelled}
+      />,
+    );
+
+    // The plain Cancel button stands down: it would address the wrong build.
+    expect(screen.queryByRole("button", { name: "Cancel" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Release claim" }));
+    expect(
+      await screen.findByText("Release this task's execution claim"),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getAllByRole("button", { name: "Release claim" }).slice(-1)[0],
+    );
+
+    await waitFor(() =>
+      expect(cancelTask).toHaveBeenCalledWith(HOLDER_BUILD, "tid-grind-beans", "env-1"),
+    );
+    expect(onTaskCancelled).toHaveBeenCalled();
+  });
+
+  it("offers a reset as well for a suspended task, and retries under the holder", async () => {
+    vi.mocked(retryTask).mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(
+      <TaskDetail
+        task={makeTask({ status: "suspended", latest_status: "suspended" })}
+        buildId={VIEWED_BUILD}
+        onClose={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Reset to pending" }));
+    await user.click(
+      screen.getAllByRole("button", { name: "Reset to pending" }).slice(-1)[0],
+    );
+    await waitFor(() =>
+      expect(retryTask).toHaveBeenCalledWith(HOLDER_BUILD, "tid-grind-beans", "env-1"),
+    );
+  });
+
+  it("hides the remedies from non-admin members but keeps the diagnosis", async () => {
+    mockWorkspaceRole = "member";
+    render(<TaskDetail task={makeTask()} buildId={VIEWED_BUILD} onClose={() => {}} />);
+
+    expect(
+      await screen.findByText("Execution claim held by another build"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Release claim" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Releasing a claim requires the workspace admin role."),
+    ).toBeInTheDocument();
+  });
+
+  it("says nothing about claims for a task that holds none", async () => {
+    render(
+      <TaskDetail
+        task={makeTask({ status: "completed", latest_status: "completed" })}
+        buildId={VIEWED_BUILD}
+        onClose={() => {}}
+      />,
+    );
+    expect(await screen.findByText("GrindBeans")).toBeInTheDocument();
+    expect(screen.queryByText(/execution claim/i)).not.toBeInTheDocument();
+  });
+
+  it("reports the holder without cross-build wording when no build is in view", async () => {
+    // The task explorer renders this panel with no build context.
+    render(<TaskDetail task={makeTask()} onClose={() => {}} />);
+    expect(await screen.findByText("Holding an execution claim")).toBeInTheDocument();
+    expect(screen.queryByText(/not the build you are viewing/)).not.toBeInTheDocument();
   });
 });

--- a/app/stardag-ui/src/components/TaskDetail.test.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.test.tsx
@@ -333,7 +333,7 @@ describe("TaskDetail claim holder", () => {
   });
 
   it("addresses the release to the holding build, not the one on screen", async () => {
-    vi.mocked(cancelTask).mockResolvedValue(undefined);
+    vi.mocked(cancelTask).mockResolvedValue("cancelled");
     const onTaskCancelled = vi.fn();
     const user = userEvent.setup();
     render(

--- a/app/stardag-ui/src/components/TaskDetail.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.tsx
@@ -378,7 +378,21 @@ export function TaskDetail({
       setCancelError(null);
       try {
         if (action === "release") {
-          await cancelTask(targetBuildId, task.task_id, task.environment_id);
+          const resulting = await cancelTask(
+            targetBuildId,
+            task.task_id,
+            task.environment_id,
+          );
+          // The write always succeeds; the release does not. A task that
+          // completed since this panel loaded keeps COMPLETED, and saying
+          // "released" would send the user away believing the claim is
+          // free when it never was theirs to free.
+          if (resulting !== "cancelled") {
+            setCancelError(
+              `This task is already ${resulting}, so there was no claim to release.`,
+            );
+            return false;
+          }
         } else {
           await retryTask(targetBuildId, task.task_id, task.environment_id);
         }

--- a/app/stardag-ui/src/components/TaskDetail.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.tsx
@@ -1,5 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
-import { cancelTask, fetchTaskArtifacts, fetchTaskEvents } from "../api/tasks";
+import {
+  cancelTask,
+  fetchTaskArtifacts,
+  fetchTaskEvents,
+  retryTask,
+} from "../api/tasks";
+import { useEnvironment } from "../context/EnvironmentContext";
 import type {
   Task,
   TaskArtifact,
@@ -8,13 +14,20 @@ import type {
   ExecutorMetadata,
 } from "../types/task";
 import {
+  availableClaimActions,
+  CLAIM_ACTION_LABELS,
+  type ClaimAction,
+} from "../utils/claims";
+import {
   isModalMetadata,
   modalAppUrl,
   modalEnvironmentUrl,
   modalFunctionCallUrl,
   modalFunctionUrl,
 } from "../utils/modalLinks";
+import { formatAbsoluteTime, formatDuration } from "../utils/time";
 import { ArtifactList, ExpandButton } from "./ArtifactViewer";
+import { ClaimActionDialog } from "./ClaimActionDialog";
 import { ExecutorBadge } from "./ExecutorBadge";
 import { FullscreenModal } from "./FullscreenModal";
 import { StatusBadge } from "./StatusBadge";
@@ -306,8 +319,37 @@ export function TaskDetail({
   const [eventsLoading, setEventsLoading] = useState(false);
   const [cancelling, setCancelling] = useState(false);
   const [cancelError, setCancelError] = useState<string | null>(null);
+  const [claimAction, setClaimAction] = useState<ClaimAction | null>(null);
+  const [claimNotice, setClaimNotice] = useState<string | null>(null);
 
-  const canCancel = buildId && (task.status === "pending" || task.status === "running");
+  const { activeWorkspaceRole } = useEnvironment();
+  const isAdmin = activeWorkspaceRole === "owner" || activeWorkspaceRole === "admin";
+
+  // ---- Claim holder ----
+  //
+  // A task's status is environment-global, so a task left RUNNING (or
+  // SUSPENDED) by some build denies its execution claim to every build
+  // that needs it, indefinitely. `StatusBadge` already hints at a
+  // cross-build status with an icon; that is not enough to act on, so
+  // when the holder is a *different* build from the one being viewed we
+  // say it in words, with the elapsed time and the remedies.
+  const holderBuildId = task.latest_status_build_id ?? task.status_build_id ?? null;
+  const globalStatus = task.latest_status ?? task.status;
+  const holdsClaim = globalStatus === "running" || globalStatus === "suspended";
+  // In the task explorer there is no build in view, so every holder is
+  // "elsewhere" — which is exactly the claim-holder question being asked
+  // there. The copy below adapts rather than the condition.
+  const crossBuild = Boolean(holderBuildId && buildId && holderBuildId !== buildId);
+  const showClaimHolder = holdsClaim && Boolean(holderBuildId);
+  const claimSince =
+    task.latest_status_at ?? (globalStatus === "running" ? task.started_at : null);
+  const heldFor = claimSince ? formatDuration(claimSince, null) : null;
+
+  // The plain Cancel button addresses the *viewed* build. When the claim
+  // is held by a different one, that is the wrong build to address, so the
+  // claim callout below owns the action instead of offering two.
+  const canCancel =
+    buildId && !crossBuild && (task.status === "pending" || task.status === "running");
 
   const loadEvents = useCallback(async () => {
     setEventsLoading(true);
@@ -327,6 +369,36 @@ export function TaskDetail({
     loadEvents();
   }, [loadEvents]);
 
+  // The one place a task mutation is issued from this panel. `targetBuildId`
+  // is whichever build the action belongs to: the viewed build for the plain
+  // Cancel, the *claim holder* for a cross-build release/reset.
+  const runTaskAction = useCallback(
+    async (action: ClaimAction, targetBuildId: string) => {
+      setCancelling(true);
+      setCancelError(null);
+      try {
+        if (action === "release") {
+          await cancelTask(targetBuildId, task.task_id, task.environment_id);
+        } else {
+          await retryTask(targetBuildId, task.task_id, task.environment_id);
+        }
+        return true;
+      } catch (err) {
+        setCancelError(
+          err instanceof Error
+            ? err.message
+            : action === "release"
+              ? "Failed to cancel task"
+              : "Failed to retry task",
+        );
+        return false;
+      } finally {
+        setCancelling(false);
+      }
+    },
+    [task.task_id, task.environment_id],
+  );
+
   const handleCancel = async () => {
     if (!buildId || !canCancel) return;
 
@@ -335,17 +407,23 @@ export function TaskDetail({
     );
     if (!confirmed) return;
 
-    setCancelling(true);
-    setCancelError(null);
-    try {
-      await cancelTask(buildId, task.task_id, task.environment_id);
+    if (await runTaskAction("release", buildId)) {
       onTaskCancelled?.();
-    } catch (err) {
-      setCancelError(err instanceof Error ? err.message : "Failed to cancel task");
-    } finally {
-      setCancelling(false);
     }
   };
+
+  const handleClaimAction = useCallback(async () => {
+    if (!claimAction || !holderBuildId) return;
+    if (await runTaskAction(claimAction, holderBuildId)) {
+      setClaimNotice(
+        claimAction === "release"
+          ? `Released the claim under build ${holderBuildId.slice(0, 8)}.`
+          : `Reset to pending under build ${holderBuildId.slice(0, 8)}.`,
+      );
+      setClaimAction(null);
+      onTaskCancelled?.();
+    }
+  }, [claimAction, holderBuildId, runTaskAction, onTaskCancelled]);
 
   useEffect(() => {
     let cancelled = false;
@@ -444,8 +522,74 @@ export function TaskDetail({
               </button>
             )}
           </div>
-          {cancelError && (
+          {cancelError && !claimAction && (
             <p className="mt-1 text-xs text-red-600 dark:text-red-400">{cancelError}</p>
+          )}
+          {claimNotice && (
+            <p
+              role="status"
+              className="mt-1 text-xs text-green-700 dark:text-green-400"
+            >
+              {claimNotice}
+            </p>
+          )}
+
+          {/* Claim holder: who is sitting on this task, and for how long. */}
+          {showClaimHolder && holderBuildId && (
+            <div className="mt-2 rounded-md border border-amber-200 bg-amber-50 p-2.5 dark:border-amber-900/60 dark:bg-amber-950/30">
+              <p className="text-xs font-semibold text-amber-900 dark:text-amber-200">
+                {crossBuild
+                  ? "Execution claim held by another build"
+                  : "Holding an execution claim"}
+              </p>
+              <p className="mt-1 text-xs text-amber-900/90 dark:text-amber-100/90">
+                This task has been <em>{globalStatus}</em>
+                {heldFor && heldFor !== "—" ? (
+                  <span title={formatAbsoluteTime(claimSince)}> for {heldFor}</span>
+                ) : null}{" "}
+                under build{" "}
+                {onStatusBuildClick ? (
+                  <button
+                    type="button"
+                    onClick={() => onStatusBuildClick(holderBuildId)}
+                    title={`Go to build ${holderBuildId}`}
+                    className="rounded bg-amber-100 px-1 py-0.5 font-mono text-blue-700 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:bg-amber-900/40 dark:text-blue-300"
+                  >
+                    {holderBuildId.slice(0, 8)}
+                  </button>
+                ) : (
+                  <code className="rounded bg-amber-100 px-1 py-0.5 font-mono dark:bg-amber-900/40">
+                    {holderBuildId.slice(0, 8)}
+                  </code>
+                )}
+                {crossBuild ? ", not the build you are viewing." : "."} A task&rsquo;s
+                status is environment-wide, so until this claim is released every build
+                that needs this task waits on it.
+              </p>
+              <div className="mt-2 flex flex-wrap items-center gap-2">
+                {isAdmin ? (
+                  availableClaimActions(globalStatus).map((action) => (
+                    <button
+                      key={action}
+                      type="button"
+                      disabled={cancelling}
+                      onClick={() => {
+                        setCancelError(null);
+                        setClaimNotice(null);
+                        setClaimAction(action);
+                      }}
+                      className="rounded-md border border-red-300 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-red-500 disabled:opacity-50 dark:border-red-800 dark:text-red-300 dark:hover:bg-red-900/30"
+                    >
+                      {CLAIM_ACTION_LABELS[action]}
+                    </button>
+                  ))
+                ) : (
+                  <span className="text-xs text-amber-900/80 dark:text-amber-200/80">
+                    Releasing a claim requires the workspace admin role.
+                  </span>
+                )}
+              </div>
+            </div>
           )}
         </div>
 
@@ -605,6 +749,24 @@ export function TaskDetail({
           <ArtifactList artifacts={artifacts} />
         )}
       </div>
+
+      {holderBuildId && (
+        <ClaimActionDialog
+          action={claimAction}
+          taskName={task.task_name}
+          taskId={task.task_id}
+          ownerBuildId={holderBuildId}
+          currentBuildId={buildId}
+          status={globalStatus}
+          busy={cancelling}
+          error={cancelError}
+          onConfirm={handleClaimAction}
+          onCancel={() => {
+            setClaimAction(null);
+            setCancelError(null);
+          }}
+        />
+      )}
 
       {/* Task Parameters Fullscreen Modal */}
       <FullscreenModal

--- a/app/stardag-ui/src/components/TaskExplorer.tsx
+++ b/app/stardag-ui/src/components/TaskExplorer.tsx
@@ -27,6 +27,7 @@ import {
   type AvailableColumn,
   type ColumnConfig,
 } from "./ColumnManagerModal";
+import { ClaimTriage } from "./ClaimTriage";
 import { DagControls, type DagControlsState } from "./DagControls";
 import { DagGraph } from "./DagGraph";
 import {
@@ -129,9 +130,18 @@ function formatFilterForInput(filter: FilterCondition): string {
   return `${filter.key} ${filter.operator} ${quoteValue(filter.value)}`;
 }
 
+// The explorer answers two different questions with two different
+// backends. "search" is the generic `/tasks/search` filtering that has
+// always been here. "claims" is the operational question — which tasks
+// are holding an execution claim — which `/tasks/search` cannot answer:
+// it reports a status but neither when the task entered it nor which
+// build put it there. See `ClaimTriage`.
+type ExplorerMode = "search" | "claims";
+
 export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
   const { activeEnvironment } = useEnvironment();
   const { setItems: setBreadcrumb } = useBreadcrumb();
+  const [mode, setMode] = useState<ExplorerMode>("search");
 
   // Search state
   const [filters, setFilters] = useState<FilterCondition[]>([]);
@@ -156,12 +166,15 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
     const items: { label: string; onClick?: () => void }[] = [
       { label: "Task Explorer" },
     ];
+    if (mode === "claims") {
+      items.push({ label: "Claims" });
+    }
     if (selectedTask) {
       items.push({ label: selectedTask.task_id });
     }
     setBreadcrumb(items);
     return () => setBreadcrumb([]);
-  }, [selectedTask, setBreadcrumb]);
+  }, [selectedTask, setBreadcrumb, mode]);
 
   // DAG view state
   const [userPrefersShowDag, setUserPrefersShowDag] = useState(true);
@@ -834,157 +847,203 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
           {/* Left panel - search, filters, DAG, results */}
           <Panel defaultSize={selectedTask ? 70 : 100} minSize={40}>
             <div className="flex h-full flex-col">
-              {/* Search bar */}
-              <TaskExplorerSearch
-                searchText={searchText}
-                onSearchInput={handleSearchInput}
-                onSearchSubmit={handleSearchSubmit}
-                onKeyDown={handleKeyDown}
-                onFocus={() => searchText && handleSearchInput(searchText)}
-                onBlur={() => setTimeout(() => setShowAutocomplete(false), 150)}
-                filters={filters}
-                onEditFilter={editFilter}
-                onRemoveFilter={removeFilter}
-                onClearAllFilters={() => setFilters([])}
-                onShowColumnManager={() => setShowColumnManager(true)}
-                showAutocomplete={showAutocomplete}
-                autocompleteOptions={autocompleteOptions}
-                autocompleteMode={autocompleteMode}
-                autocompleteKey={autocompleteKey}
-                selectedIndex={selectedIndex}
-                onAutocompleteSelect={handleAutocompleteSelect}
-                onSelectedIndexChange={setSelectedIndex}
-                inputRef={inputRef}
-              />
-
-              {/* DAG header - always visible */}
-              <div className="flex items-center justify-between border-b border-gray-200 px-4 py-1.5 dark:border-gray-700">
-                <button
-                  onClick={() => canShowDag && handleToggleDag()}
-                  disabled={!canShowDag}
-                  className={`flex items-center gap-2 text-sm ${
-                    canShowDag
-                      ? "cursor-pointer text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
-                      : "cursor-not-allowed text-gray-400 dark:text-gray-500"
-                  }`}
-                >
-                  <svg
-                    className={`h-4 w-4 transition-transform ${
-                      showDag ? "rotate-90" : ""
+              {/* Mode tabs */}
+              <div
+                role="tablist"
+                aria-label="Task explorer mode"
+                className="flex items-center gap-1 border-b border-gray-200 bg-white px-4 py-1 dark:border-gray-700 dark:bg-gray-800"
+              >
+                {(
+                  [
+                    ["search", "Search"],
+                    ["claims", "Claims"],
+                  ] as const
+                ).map(([value, label]) => (
+                  <button
+                    key={value}
+                    role="tab"
+                    aria-selected={mode === value}
+                    onClick={() => setMode(value)}
+                    className={`rounded-md px-2.5 py-1 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 ${
+                      mode === value
+                        ? "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300"
+                        : "text-gray-600 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-700"
                     }`}
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
+                    title={
+                      value === "claims"
+                        ? "Tasks holding an execution claim, and the builds that own them"
+                        : "Search and filter every task in this environment"
+                    }
                   >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 5l7 7-7 7"
-                    />
-                  </svg>
-                  <span className="font-medium">DAG View</span>
-                  {!canShowDag && (
-                    <span className="text-xs text-gray-400 dark:text-gray-500">
-                      {tasks.length === 0 ? "(No tasks)" : "(Limit: 500 tasks)"}
-                    </span>
-                  )}
-                </button>
-                {showDag && canShowDag && (
-                  <div className="flex items-center gap-2">
-                    <DagControls
-                      value={dagControls}
-                      onChange={setDagControls}
-                      primaryCount={tasks.length}
-                      upstreamCount={extendedDagGraph?.total_upstream_count ?? 0}
-                      downstreamCount={extendedDagGraph?.total_downstream_count ?? 0}
-                      groupCount={extendedDagGraph?.groups.length ?? 0}
-                      truncated={extendedDagGraph?.truncated ?? false}
-                    />
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              {mode === "claims" ? (
+                <ClaimTriage
+                  environmentId={activeEnvironment.id}
+                  selectedTaskId={selectedTask?.task_id ?? null}
+                  onSelectTask={(task) => setSelectedTask(task as TaskSearchResult)}
+                  onNavigateToBuild={onNavigateToBuild}
+                />
+              ) : (
+                <>
+                  {/* Search bar */}
+                  <TaskExplorerSearch
+                    searchText={searchText}
+                    onSearchInput={handleSearchInput}
+                    onSearchSubmit={handleSearchSubmit}
+                    onKeyDown={handleKeyDown}
+                    onFocus={() => searchText && handleSearchInput(searchText)}
+                    onBlur={() => setTimeout(() => setShowAutocomplete(false), 150)}
+                    filters={filters}
+                    onEditFilter={editFilter}
+                    onRemoveFilter={removeFilter}
+                    onClearAllFilters={() => setFilters([])}
+                    onShowColumnManager={() => setShowColumnManager(true)}
+                    showAutocomplete={showAutocomplete}
+                    autocompleteOptions={autocompleteOptions}
+                    autocompleteMode={autocompleteMode}
+                    autocompleteKey={autocompleteKey}
+                    selectedIndex={selectedIndex}
+                    onAutocompleteSelect={handleAutocompleteSelect}
+                    onSelectedIndexChange={setSelectedIndex}
+                    inputRef={inputRef}
+                  />
+
+                  {/* DAG header - always visible */}
+                  <div className="flex items-center justify-between border-b border-gray-200 px-4 py-1.5 dark:border-gray-700">
                     <button
-                      onClick={() => setDagFullscreen(true)}
-                      className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-                      title="Fullscreen DAG"
+                      onClick={() => canShowDag && handleToggleDag()}
+                      disabled={!canShowDag}
+                      className={`flex items-center gap-2 text-sm ${
+                        canShowDag
+                          ? "cursor-pointer text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100"
+                          : "cursor-not-allowed text-gray-400 dark:text-gray-500"
+                      }`}
                     >
                       <svg
-                        className="h-4 w-4"
+                        className={`h-4 w-4 transition-transform ${
+                          showDag ? "rotate-90" : ""
+                        }`}
                         fill="none"
                         stroke="currentColor"
                         viewBox="0 0 24 24"
-                        strokeWidth={2}
                       >
                         <path
                           strokeLinecap="round"
                           strokeLinejoin="round"
-                          d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"
+                          strokeWidth={2}
+                          d="M9 5l7 7-7 7"
                         />
                       </svg>
+                      <span className="font-medium">DAG View</span>
+                      {!canShowDag && (
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
+                          {tasks.length === 0 ? "(No tasks)" : "(Limit: 500 tasks)"}
+                        </span>
+                      )}
                     </button>
-                  </div>
-                )}
-              </div>
-
-              {/* DAG + Results with resizable split */}
-              <PanelGroup direction="vertical" className="flex-1">
-                {/* Collapsible DAG section */}
-                <Panel
-                  ref={dagPanelRef}
-                  defaultSize={50}
-                  minSize={0}
-                  collapsible
-                  onCollapse={() => setShowDag(false)}
-                  onExpand={() => setShowDag(true)}
-                >
-                  {showDag && canShowDag && !dagFullscreen && (
-                    <div className="h-full bg-gray-50 dark:bg-gray-900">
-                      {dagLoading ? (
-                        <div className="flex h-full items-center justify-center">
-                          <div className="h-6 w-6 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
-                        </div>
-                      ) : dagGraph ? (
-                        <DagGraph
-                          tasks={tasksWithContext}
-                          graph={dagGraph}
-                          selectedTaskId={selectedTask?.task_id ?? null}
-                          onTaskClick={handleDagTaskClick}
-                          direction={dagDirection}
-                          onDirectionChange={setDagDirection}
-                          positionCache={dagPositionCacheRef}
+                    {showDag && canShowDag && (
+                      <div className="flex items-center gap-2">
+                        <DagControls
+                          value={dagControls}
+                          onChange={setDagControls}
+                          primaryCount={tasks.length}
+                          upstreamCount={extendedDagGraph?.total_upstream_count ?? 0}
+                          downstreamCount={
+                            extendedDagGraph?.total_downstream_count ?? 0
+                          }
+                          groupCount={extendedDagGraph?.groups.length ?? 0}
+                          truncated={extendedDagGraph?.truncated ?? false}
                         />
-                      ) : (
-                        <div className="flex h-full items-center justify-center text-gray-500 dark:text-gray-400">
-                          <p>Failed to load DAG</p>
+                        <button
+                          onClick={() => setDagFullscreen(true)}
+                          className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+                          title="Fullscreen DAG"
+                        >
+                          <svg
+                            className="h-4 w-4"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            strokeWidth={2}
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5v-4m0 4h-4m4 0l-5-5"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* DAG + Results with resizable split */}
+                  <PanelGroup direction="vertical" className="flex-1">
+                    {/* Collapsible DAG section */}
+                    <Panel
+                      ref={dagPanelRef}
+                      defaultSize={50}
+                      minSize={0}
+                      collapsible
+                      onCollapse={() => setShowDag(false)}
+                      onExpand={() => setShowDag(true)}
+                    >
+                      {showDag && canShowDag && !dagFullscreen && (
+                        <div className="h-full bg-gray-50 dark:bg-gray-900">
+                          {dagLoading ? (
+                            <div className="flex h-full items-center justify-center">
+                              <div className="h-6 w-6 animate-spin rounded-full border-2 border-blue-500 border-t-transparent" />
+                            </div>
+                          ) : dagGraph ? (
+                            <DagGraph
+                              tasks={tasksWithContext}
+                              graph={dagGraph}
+                              selectedTaskId={selectedTask?.task_id ?? null}
+                              onTaskClick={handleDagTaskClick}
+                              direction={dagDirection}
+                              onDirectionChange={setDagDirection}
+                              positionCache={dagPositionCacheRef}
+                            />
+                          ) : (
+                            <div className="flex h-full items-center justify-center text-gray-500 dark:text-gray-400">
+                              <p>Failed to load DAG</p>
+                            </div>
+                          )}
                         </div>
                       )}
-                    </div>
-                  )}
-                </Panel>
+                    </Panel>
 
-                <PanelResizeHandle className="h-1 cursor-row-resize bg-gray-200 transition-colors hover:bg-blue-400 dark:bg-gray-700 dark:hover:bg-blue-500" />
+                    <PanelResizeHandle className="h-1 cursor-row-resize bg-gray-200 transition-colors hover:bg-blue-400 dark:bg-gray-700 dark:hover:bg-blue-500" />
 
-                {/* Results table */}
-                <Panel defaultSize={50} minSize={20}>
-                  <TaskExplorerTable
-                    tasks={tasks}
-                    loading={loading}
-                    error={error}
-                    visibleColumns={visibleColumns}
-                    selectedTaskId={selectedTask?.task_id ?? null}
-                    sortBy={sortBy}
-                    sortDir={sortDir}
-                    onSort={handleSort}
-                    onCellClick={handleCellClick}
-                    onSelectTask={setSelectedTask}
-                    onNavigateToBuild={onNavigateToBuild}
-                    onResizeStart={handleResizeStart}
-                    page={page}
-                    pageSize={pageSize}
-                    total={total}
-                    totalPages={totalPages}
-                    onPageChange={setPage}
-                  />
-                </Panel>
-              </PanelGroup>
+                    {/* Results table */}
+                    <Panel defaultSize={50} minSize={20}>
+                      <TaskExplorerTable
+                        tasks={tasks}
+                        loading={loading}
+                        error={error}
+                        visibleColumns={visibleColumns}
+                        selectedTaskId={selectedTask?.task_id ?? null}
+                        sortBy={sortBy}
+                        sortDir={sortDir}
+                        onSort={handleSort}
+                        onCellClick={handleCellClick}
+                        onSelectTask={setSelectedTask}
+                        onNavigateToBuild={onNavigateToBuild}
+                        onResizeStart={handleResizeStart}
+                        page={page}
+                        pageSize={pageSize}
+                        total={total}
+                        totalPages={totalPages}
+                        onPageChange={setPage}
+                      />
+                    </Panel>
+                  </PanelGroup>
+                </>
+              )}
             </div>
           </Panel>
 

--- a/app/stardag-ui/src/components/TickSummaryTrail.tsx
+++ b/app/stardag-ui/src/components/TickSummaryTrail.tsx
@@ -1,0 +1,272 @@
+import { useState } from "react";
+import type { BuildTickSummary } from "../types/task";
+import { formatAbsoluteTime, formatRelativeTime } from "../utils/time";
+
+// What each tick outcome means, in the words an operator needs. Unknown
+// outcomes (a newer SDK) fall through to the raw value with no gloss —
+// better a bare word than a wrong explanation.
+const OUTCOMES: Record<string, { label: string; help: string; tone: string }> = {
+  not_reactive: {
+    label: "not reactive",
+    help: "The build carries no reactive-app marker, so the tick did not drive it. Nothing will advance this build on a schedule.",
+    tone: "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300",
+  },
+  lease_held: {
+    label: "lease held",
+    help: "Another tick already held this build's lease, so this one exited without acting. Normal under overlapping wake-ups.",
+    tone: "bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300",
+  },
+  terminal: {
+    label: "terminal",
+    help: "The build was already in a terminal state when the tick ran.",
+    tone: "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300",
+  },
+  lingered_out: {
+    label: "lingered out",
+    help: "The tick waited for work to become actionable and gave up without anything appearing. Repeated on every tick, this is the signature of a stalled build.",
+    tone: "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300",
+  },
+  foreign_app: {
+    label: "foreign app",
+    help: "The build is owned by a different reactive app than the one that ticked, so this tick declined to drive it.",
+    tone: "bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300",
+  },
+};
+
+// Counters this UI knows how to explain. Everything else in `summary` is
+// rendered generically — see `summaryEntries`. Deliberately a lookup and
+// not an exhaustive union: the SDK adds counters continuously (external
+// blocker counts are the current example) and a summary key must never be
+// dropped just because this build of the UI predates it.
+const COUNTERS: Record<string, { label: string; help: string }> = {
+  spawned: { label: "spawned", help: "Executions this tick started." },
+  self_healed: {
+    label: "self-healed",
+    help: "Tasks recorded complete after their detached execution was found finished.",
+  },
+  failed_recorded: {
+    label: "failures recorded",
+    help: "Tasks whose detached execution was found failed.",
+  },
+  cancelled_refs: {
+    label: "executions cancelled",
+    help: "Detached executions cancelled by this tick.",
+  },
+  iterations: { label: "iterations", help: "Scheduling passes within this tick." },
+  limit_denied: {
+    label: "concurrency-limit denied",
+    help: "Spawns refused because a named concurrency limit was full. The build is waiting for a slot, not stuck.",
+  },
+  claim_denied: {
+    label: "claim denied",
+    help: "Spawns refused because another build already holds the task's execution claim. The claim holder must finish or be released.",
+  },
+  skipped: { label: "skipped", help: "Tasks skipped because an upstream failed." },
+  terminal_status: {
+    label: "terminal status",
+    help: "The status the tick moved the build to.",
+  },
+};
+
+/** "claim_denied" -> "claim denied"; used for keys we have no gloss for. */
+function humanise(key: string): string {
+  return key.replace(/_/g, " ");
+}
+
+interface Entry {
+  key: string;
+  label: string;
+  help?: string;
+  value: string;
+  /** Numeric zero / empty: rendered muted, since it is context not signal. */
+  muted: boolean;
+  known: boolean;
+}
+
+/**
+ * One renderable chip per key of a tick summary.
+ *
+ * Known keys get a label and a tooltip; unknown ones get the key with its
+ * underscores relaxed. Numbers, strings and booleans render inline;
+ * anything structured renders as compact JSON with the full value in a
+ * `title`. Nothing is dropped — a counter this UI has never heard of is
+ * exactly the counter most likely to explain a new failure mode.
+ */
+function summaryEntries(summary: Record<string, unknown>): Entry[] {
+  return Object.entries(summary).map(([key, value]) => {
+    const known = COUNTERS[key];
+    let text: string;
+    let muted = false;
+    if (typeof value === "number") {
+      text = String(value);
+      muted = value === 0;
+    } else if (typeof value === "string") {
+      text = value;
+      muted = value === "";
+    } else if (typeof value === "boolean") {
+      text = value ? "yes" : "no";
+      muted = !value;
+    } else if (value === null || value === undefined) {
+      text = "—";
+      muted = true;
+    } else {
+      text = JSON.stringify(value);
+      muted = text === "{}" || text === "[]";
+    }
+    return {
+      key,
+      label: known?.label ?? humanise(key),
+      help: known?.help,
+      value: text,
+      muted,
+      known: Boolean(known),
+    };
+  });
+}
+
+function SummaryChips({ summary }: { summary: Record<string, unknown> }) {
+  const entries = summaryEntries(summary);
+  if (entries.length === 0) {
+    return (
+      <span className="text-xs text-gray-500 dark:text-gray-400">
+        No counters reported.
+      </span>
+    );
+  }
+  return (
+    <div className="flex flex-wrap gap-1">
+      {entries.map((entry) => (
+        <span
+          key={entry.key}
+          title={entry.help ?? `${entry.key}: ${entry.value}`}
+          className={`inline-flex items-baseline gap-1 rounded px-1.5 py-0.5 text-xs ${
+            entry.muted
+              ? "bg-gray-50 text-gray-400 dark:bg-gray-800 dark:text-gray-500"
+              : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
+          }`}
+        >
+          <span>{entry.label}</span>
+          <span
+            className={
+              entry.muted ? "" : "font-medium text-gray-900 dark:text-gray-100"
+            }
+          >
+            {entry.value}
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function OutcomeBadge({ outcome }: { outcome: string }) {
+  const known = OUTCOMES[outcome];
+  return (
+    <span
+      title={known?.help ?? `Tick outcome reported by the scheduler: ${outcome}`}
+      className={`inline-flex flex-shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+        known?.tone ?? "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+      }`}
+    >
+      {known?.label ?? humanise(outcome)}
+    </span>
+  );
+}
+
+function SummaryRow({ summary }: { summary: BuildTickSummary }) {
+  return (
+    <li className="space-y-1 py-1.5">
+      <div className="flex items-center gap-2">
+        <OutcomeBadge outcome={summary.outcome} />
+        <span
+          className="text-xs text-gray-500 dark:text-gray-400"
+          title={formatAbsoluteTime(summary.created_at)}
+        >
+          {formatRelativeTime(summary.created_at)}
+        </span>
+      </div>
+      <SummaryChips summary={summary.summary} />
+    </li>
+  );
+}
+
+interface TickSummaryTrailProps {
+  summaries: BuildTickSummary[];
+  loading: boolean;
+  /** True when the server has no tick-summaries endpoint (404). */
+  unavailable: boolean;
+  error: string | null;
+  /** Ticks shown before the "show earlier" disclosure. */
+  compactCount?: number;
+}
+
+/**
+ * The scheduler's own account of what it did, newest first.
+ *
+ * A stalled build repeats the same outcome tick after tick, so the trail
+ * reads far better than a single row: "lingered out ×6, claim denied 3
+ * every time" is a diagnosis, while one row of it is an anecdote. Kept to
+ * the two most recent by default and expandable from there.
+ */
+export function TickSummaryTrail({
+  summaries,
+  loading,
+  unavailable,
+  error,
+  compactCount = 2,
+}: TickSummaryTrailProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (loading) {
+    return (
+      <p className="text-xs text-gray-500 dark:text-gray-400">Loading tick history…</p>
+    );
+  }
+  if (unavailable) {
+    return (
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        This server does not record tick history, so the scheduler&rsquo;s own reasoning
+        is not available here — it is in the scheduler&rsquo;s logs.
+      </p>
+    );
+  }
+  if (error) {
+    return (
+      <p role="alert" className="text-xs text-red-600 dark:text-red-400">
+        {error}
+      </p>
+    );
+  }
+  if (summaries.length === 0) {
+    return (
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        No ticks recorded for this build yet.
+      </p>
+    );
+  }
+
+  const shown = expanded ? summaries : summaries.slice(0, compactCount);
+  const hidden = summaries.length - shown.length;
+
+  return (
+    <div>
+      <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+        {shown.map((summary) => (
+          <SummaryRow key={summary.id} summary={summary} />
+        ))}
+      </ul>
+      {(hidden > 0 || expanded) && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          className="mt-1 rounded text-xs text-blue-600 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-blue-400"
+        >
+          {expanded
+            ? "Show fewer ticks"
+            : `Show ${hidden} earlier tick${hidden === 1 ? "" : "s"}`}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/stardag-ui/src/components/TickSummaryTrail.tsx
+++ b/app/stardag-ui/src/components/TickSummaryTrail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { BuildTickSummary } from "../types/task";
 import { formatAbsoluteTime, formatRelativeTime } from "../utils/time";
 
@@ -124,12 +124,23 @@ function summaryEntries(summary: Record<string, unknown>): Entry[] {
   });
 }
 
-function SummaryChips({ summary }: { summary: Record<string, unknown> }) {
-  const entries = summaryEntries(summary);
+/**
+ * The counters worth reading: the ones that are not zero.
+ *
+ * A tick reports its whole counter set every time, so most of a summary is
+ * "this did not happen" — `spawned 0, skipped 0, claim denied 0` on every
+ * row, drowning the one counter that moved. What a tick *did* is the
+ * signal; what it did not do is the absence of one.
+ */
+function signalEntries(summary: Record<string, unknown>): Entry[] {
+  return summaryEntries(summary).filter((entry) => !entry.muted);
+}
+
+function SummaryChips({ entries }: { entries: Entry[] }) {
   if (entries.length === 0) {
     return (
       <span className="text-xs text-gray-500 dark:text-gray-400">
-        No counters reported.
+        Nothing happened on this tick.
       </span>
     );
   }
@@ -139,18 +150,10 @@ function SummaryChips({ summary }: { summary: Record<string, unknown> }) {
         <span
           key={entry.key}
           title={entry.help ?? `${entry.key}: ${entry.value}`}
-          className={`inline-flex items-baseline gap-1 rounded px-1.5 py-0.5 text-xs ${
-            entry.muted
-              ? "bg-gray-50 text-gray-400 dark:bg-gray-800 dark:text-gray-500"
-              : "bg-gray-100 text-gray-700 dark:bg-gray-700 dark:text-gray-200"
-          }`}
+          className="inline-flex items-baseline gap-1 rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-700 dark:bg-gray-700 dark:text-gray-200"
         >
           <span>{entry.label}</span>
-          <span
-            className={
-              entry.muted ? "" : "font-medium text-gray-900 dark:text-gray-100"
-            }
-          >
+          <span className="font-medium text-gray-900 dark:text-gray-100">
             {entry.value}
           </span>
         </span>
@@ -173,19 +176,85 @@ function OutcomeBadge({ outcome }: { outcome: string }) {
   );
 }
 
-function SummaryRow({ summary }: { summary: BuildTickSummary }) {
+interface TickGroup {
+  id: string;
+  outcome: string;
+  entries: Entry[];
+  count: number;
+  /** Newest tick in the group. */
+  latest: string;
+  /** Oldest tick in the group; equal to `latest` for a group of one. */
+  earliest: string;
+}
+
+/** The identity a run of ticks is collapsed on: same outcome, same signal. */
+function groupKey(summary: BuildTickSummary, entries: Entry[]): string {
+  return [summary.outcome, ...entries.map((e) => `${e.key}=${e.value}`)].join("|");
+}
+
+/**
+ * Collapse consecutive ticks that reported the same thing.
+ *
+ * A stalled build is stalled *repetitively*: the same outcome with the
+ * same counters, every few seconds, for as long as it has been stuck.
+ * Twenty rows of "lease held" is twenty ways of saying one thing. Grouped,
+ * the repetition becomes the diagnosis — "lingered out ×6, claim denied 3
+ * every time" — and it fits on one line.
+ *
+ * Only *consecutive* runs collapse, so the order in which outcomes
+ * alternated is still visible; this is a summary of the trail, not a
+ * histogram over it.
+ */
+function groupTicks(summaries: BuildTickSummary[]): TickGroup[] {
+  const groups: TickGroup[] = [];
+  let key: string | null = null;
+  for (const summary of summaries) {
+    const entries = signalEntries(summary.summary);
+    const thisKey = groupKey(summary, entries);
+    const last = groups[groups.length - 1];
+    if (last && thisKey === key) {
+      last.count += 1;
+      last.earliest = summary.created_at;
+      continue;
+    }
+    key = thisKey;
+    groups.push({
+      id: summary.id,
+      outcome: summary.outcome,
+      entries,
+      count: 1,
+      latest: summary.created_at,
+      earliest: summary.created_at,
+    });
+  }
+  return groups;
+}
+
+function SummaryRow({ group }: { group: TickGroup }) {
   return (
-    <li className="space-y-1 py-1.5">
-      <div className="flex items-center gap-2">
-        <OutcomeBadge outcome={summary.outcome} />
+    <li className="flex flex-wrap items-center gap-x-2 gap-y-1 py-1">
+      <OutcomeBadge outcome={group.outcome} />
+      {group.count > 1 && (
         <span
-          className="text-xs text-gray-500 dark:text-gray-400"
-          title={formatAbsoluteTime(summary.created_at)}
+          className="text-xs font-medium text-gray-700 dark:text-gray-300"
+          title={`${group.count} consecutive ticks reported this`}
         >
-          {formatRelativeTime(summary.created_at)}
+          ×{group.count}
         </span>
-      </div>
-      <SummaryChips summary={summary.summary} />
+      )}
+      <span
+        className="text-xs text-gray-500 dark:text-gray-400"
+        title={
+          group.count > 1
+            ? `${formatAbsoluteTime(group.earliest)} — ${formatAbsoluteTime(
+                group.latest,
+              )}`
+            : formatAbsoluteTime(group.latest)
+        }
+      >
+        {formatRelativeTime(group.latest)}
+      </span>
+      <SummaryChips entries={group.entries} />
     </li>
   );
 }
@@ -196,7 +265,7 @@ interface TickSummaryTrailProps {
   /** True when the server has no tick-summaries endpoint (404). */
   unavailable: boolean;
   error: string | null;
-  /** Ticks shown before the "show earlier" disclosure. */
+  /** Tick *groups* shown before the "show earlier" disclosure. */
   compactCount?: number;
 }
 
@@ -205,8 +274,10 @@ interface TickSummaryTrailProps {
  *
  * A stalled build repeats the same outcome tick after tick, so the trail
  * reads far better than a single row: "lingered out ×6, claim denied 3
- * every time" is a diagnosis, while one row of it is an anecdote. Kept to
- * the two most recent by default and expandable from there.
+ * every time" is a diagnosis, while one row of it is an anecdote. Runs of
+ * identical ticks are collapsed into one row each (see `groupTicks`), and
+ * only the counters that actually moved are shown, so the repetition reads
+ * as a count rather than as twenty rows of noise.
  */
 export function TickSummaryTrail({
   summaries,
@@ -216,6 +287,7 @@ export function TickSummaryTrail({
   compactCount = 2,
 }: TickSummaryTrailProps) {
   const [expanded, setExpanded] = useState(false);
+  const groups = useMemo(() => groupTicks(summaries), [summaries]);
 
   if (loading) {
     return (
@@ -245,14 +317,14 @@ export function TickSummaryTrail({
     );
   }
 
-  const shown = expanded ? summaries : summaries.slice(0, compactCount);
-  const hidden = summaries.length - shown.length;
+  const shown = expanded ? groups : groups.slice(0, compactCount);
+  const hidden = groups.length - shown.length;
 
   return (
     <div>
       <ul className="divide-y divide-gray-200 dark:divide-gray-700">
-        {shown.map((summary) => (
-          <SummaryRow key={summary.id} summary={summary} />
+        {shown.map((group) => (
+          <SummaryRow key={group.id} group={group} />
         ))}
       </ul>
       {(hidden > 0 || expanded) && (
@@ -264,7 +336,7 @@ export function TickSummaryTrail({
         >
           {expanded
             ? "Show fewer ticks"
-            : `Show ${hidden} earlier tick${hidden === 1 ? "" : "s"}`}
+            : `Show ${hidden} earlier outcome${hidden === 1 ? "" : "s"}`}
         </button>
       )}
     </div>

--- a/app/stardag-ui/src/types/task.ts
+++ b/app/stardag-ui/src/types/task.ts
@@ -151,6 +151,108 @@ export interface BuildListResponse {
   page_size: number;
 }
 
+// ---- Build frontier: what a scheduler tick sees ----
+
+// A task in a build's scheduling frontier. Statuses are the task's *global*
+// (environment-wide) status, not "its status in this build".
+export interface FrontierTaskRef {
+  task_id: string;
+  latest_status: TaskStatus;
+  latest_executor?: string | null;
+  latest_executor_ref?: string | null;
+  latest_executor_metadata?: ExecutorMetadata | null;
+  latest_status_at?: string | null;
+}
+
+/**
+ * An upstream *outside* this build that holds one of its tasks back.
+ *
+ * Task rows and their dependency edges are per environment, not per build,
+ * so an upstream left non-COMPLETED by some other build still gates this
+ * build's downstream tasks — silently, since such an upstream need not be
+ * part of this build's task set at all.
+ */
+export interface FrontierExternalBlocker {
+  // The blocked task — always a member of THIS build's task set.
+  task_id: string;
+  // The blocker. Identity is spelled out because the viewer may never have
+  // seen this task. `blocking_task_namespace` is "" for the default namespace.
+  blocking_task_id: string;
+  blocking_task_namespace: string;
+  blocking_task_name: string;
+  // Never "completed" (a completed upstream does not gate anything).
+  blocking_status: TaskStatus;
+  // When the blocker entered that status, and the build whose event put it
+  // there. The build id is null only for rows predating status
+  // denormalisation — with it, there is nothing to address a remedy to.
+  blocking_status_at?: string | null;
+  blocking_status_build_id?: string | null;
+  // Whether the blocker is also part of THIS build's task set. False is the
+  // pathological case: this build has never registered it and can only wait
+  // for whoever owns it. True still blocks, but the task is at least visible
+  // in this build's own table.
+  blocking_in_build: boolean;
+}
+
+export interface BuildFrontier {
+  build_id: string;
+  build_status: BuildStatus;
+  // A scheduler wake-up is pending for this build.
+  needs_tick: boolean;
+  root_task_ids: string[];
+  roots: FrontierTaskRef[];
+  // Global status -> count, over every task the build has events for.
+  status_counts: Record<string, number>;
+  actionable: FrontierTaskRef[];
+  running: FrontierTaskRef[];
+  /**
+   * **Populated only when the build has nothing actionable and nothing
+   * running** — i.e. only when it already looks stalled, which is the only
+   * state in which the answer matters and keeps a per-edge sort off the hot
+   * path of every healthy build's poll.
+   *
+   * So an empty list means *"not externally blocked, OR not stalled"*. Never
+   * render it as "no blockers" while the build is still progressing.
+   */
+  blocked_by_external: FrontierExternalBlocker[];
+  // The blocker list is capped (it is a diagnostic, not a work queue — a
+  // truncated list still proves "waiting, not stuck").
+  blocked_by_external_truncated: boolean;
+  reactive_app_name?: string | null;
+  reactive_tick_kwargs?: Record<string, unknown> | null;
+}
+
+// ---- Persisted reactive-scheduler tick summaries ----
+
+// Why a tick did (or did not) do anything. Widened to `string` at the
+// response boundary so an outcome a newer server adds still renders.
+export type TickOutcome =
+  | "not_reactive"
+  | "lease_held"
+  | "terminal"
+  | "lingered_out"
+  | "foreign_app";
+
+export interface BuildTickSummary {
+  id: string;
+  build_id: string;
+  // A TickOutcome value; typed wide on purpose (see above).
+  outcome: string;
+  /**
+   * The tick's own summary, verbatim and **deliberately open**: the SDK
+   * grows counters (`spawned`, `claim_denied`, `limit_denied`, …) faster
+   * than this UI ships. Render known keys with a label and unknown ones
+   * generically — never drop what you don't recognise.
+   */
+  summary: Record<string, unknown>;
+  created_at: string;
+}
+
+export interface BuildTickSummaryListResponse {
+  build_id: string;
+  summaries: BuildTickSummary[];
+}
+
 // Task with status (from build context)
 export interface Task {
   id: string;
@@ -186,6 +288,27 @@ export interface Task {
   latest_executor?: string | null;
   latest_executor_ref?: string | null;
   latest_executor_metadata?: ExecutorMetadata | null;
+  // ---- Global (environment-wide) status, i.e. "who holds the claim". ----
+  //
+  // A task row is unique per (environment_id, task_id), so `latest_status`
+  // is NOT "the status within some build": a task left RUNNING by any build
+  // denies the execution claim to every other build that needs it, until
+  // something moves it. These three answer "who is holding this claim, and
+  // since when":
+  //
+  //   latest_status          — the environment-wide status.
+  //   latest_status_at       — when it entered that status ("running since").
+  //   latest_status_build_id — the build whose event produced it: the claim
+  //                            holder. Null only on rows predating status
+  //                            denormalisation.
+  //
+  // `GET /tasks` returns these; `GET /tasks/search` does not (it reports the
+  // same status under `status` / `status_build_id` and has no timestamp), so
+  // claim triage reads the former. All optional — purely additive over the
+  // older response shape.
+  latest_status?: TaskStatus | null;
+  latest_status_at?: string | null;
+  latest_status_build_id?: string | null;
 }
 
 export interface TaskListResponse {

--- a/app/stardag-ui/src/utils/claims.ts
+++ b/app/stardag-ui/src/utils/claims.ts
@@ -1,0 +1,97 @@
+import type { BuildFrontier, BuildStatus, TaskStatus } from "../types/task";
+
+/**
+ * The two ways a stuck task gets unstuck.
+ *
+ * - `release` cancels it, freeing the execution claim and any
+ *   concurrency-limit slot it holds. The remedy for a task left RUNNING.
+ * - `retry` resets it to pending so it can be scheduled again. The remedy
+ *   for a task left failed / cancelled / skipped / suspended. It does
+ *   nothing to a RUNNING task by design — that would invite a second,
+ *   concurrent execution of the same task.
+ */
+export type ClaimAction = "release" | "retry";
+
+export const CLAIM_ACTION_LABELS: Record<ClaimAction, string> = {
+  release: "Release claim",
+  retry: "Reset to pending",
+};
+
+/**
+ * Which remedies the server will actually honour for a given status.
+ *
+ * Offering a button the server would treat as a no-op is worse than
+ * offering nothing, so this mirrors the API's own rules: COMPLETED is
+ * sticky, RUNNING is cancel-only, and PENDING/UNREGISTERED have nothing
+ * to release and nothing a reset would change.
+ */
+export function availableClaimActions(status: TaskStatus): ClaimAction[] {
+  switch (status) {
+    case "running":
+      return ["release"];
+    case "suspended":
+      return ["release", "retry"];
+    case "failed":
+    case "cancelled":
+    case "skipped":
+      return ["retry"];
+    default:
+      return [];
+  }
+}
+
+/** A task whose global status is one of these is holding an execution claim. */
+export const CLAIM_HOLDING_STATUSES: TaskStatus[] = ["running", "suspended"];
+
+export type SchedulingPanelForm = "hidden" | "collapsed" | "stalled";
+
+/**
+ * When — and how loudly — the build scheduling panel has something to say.
+ *
+ * `"stalled"` (full, prominent) requires the build to have tasks, nothing
+ * actionable and nothing running. That is not an arbitrary heuristic: it
+ * is *exactly* the condition under which the server computes
+ * `blocked_by_external`, and exactly the condition the SDK reads as "this
+ * build cannot progress" — the read that fails a build with "No runnable
+ * or running tasks left but roots are not complete" even when an upstream
+ * owned by another build is legitimately holding it up.
+ *
+ * Terminal states are qualified rather than blanket-included:
+ *
+ * - `completed` / `cancelled`: never. The build is not "not progressing",
+ *   it is done, or a user stopped it on purpose.
+ * - `failed`: only when the failure has the stuck-build shape — an
+ *   external blocker was reported, or the build failed while *nothing in
+ *   it failed*. An ordinary DAG failure (a task raised) explains itself
+ *   in the task table and does not need a scheduler post-mortem.
+ *
+ * `"collapsed"` is a single quiet line for a reactive build the rule does
+ * not flag: the live counts, plus access to the tick trail, which exists
+ * nowhere else in the UI. `"hidden"` is everything else — a healthy
+ * non-reactive build has no scheduler to reason about, and a permanently
+ * empty box is worse than no box.
+ */
+export function schedulingPanelForm(
+  frontier: BuildFrontier,
+  buildStatus: BuildStatus,
+): SchedulingPanelForm {
+  const totalTasks = Object.values(frontier.status_counts).reduce((a, b) => a + b, 0);
+  const stalledShape =
+    totalTasks > 0 && frontier.actionable.length === 0 && frontier.running.length === 0;
+
+  let stalled = false;
+  if (stalledShape) {
+    if (buildStatus === "completed" || buildStatus === "cancelled") {
+      stalled = false;
+    } else if (buildStatus === "failed") {
+      stalled =
+        frontier.blocked_by_external.length > 0 ||
+        (frontier.status_counts.failed ?? 0) === 0;
+    } else {
+      stalled = true;
+    }
+  }
+
+  if (stalled) return "stalled";
+  return frontier.reactive_app_name ? "collapsed" : "hidden";
+}

--- a/app/stardag-ui/src/utils/claims.ts
+++ b/app/stardag-ui/src/utils/claims.ts
@@ -56,10 +56,13 @@ export type SchedulingPanelForm = "hidden" | "collapsed" | "stalled";
  * or running tasks left but roots are not complete" even when an upstream
  * owned by another build is legitimately holding it up.
  *
- * Terminal states are qualified rather than blanket-included:
+ * Terminal states are qualified rather than blanket-included. Note this
+ * whole paragraph is about the **`"stalled"`** form only — a terminal
+ * reactive build still gets the quiet `"collapsed"` strip, which is the
+ * one route to its tick trail and says nothing about blockers:
  *
- * - `completed` / `cancelled`: never. The build is not "not progressing",
- *   it is done, or a user stopped it on purpose.
+ * - `completed` / `cancelled`: never *stalled*. The build is not "not
+ *   progressing", it is done, or a user stopped it on purpose.
  * - `failed`: only when the failure has the stuck-build shape — an
  *   external blocker was reported, or the build failed while *nothing in
  *   it failed*. An ordinary DAG failure (a task raised) explains itself


### PR DESCRIPTION
Second frontend piece of **B5** in #208 — the "UI cannot explain a stalled
or spuriously failed build" half. Builds on the branch it targets.

## The incident this makes diagnosable

A reactive build failed within seconds of being triggered with:

```
No runnable or running tasks left but roots are not complete
(status counts: {'completed': 2, 'suspended': 1})
```

Nothing in the DAG was wrong. The real cause was a task left `RUNNING` by
a **different** build, holding an environment-global execution claim —
`latest_status` is denormalised per `(environment_id, task_id)`, so an
upstream any build leaves non-completed gates every downstream task in
every other build, while contributing nothing to *this* build's `running`
count. The UI showed a failed build, a task table with nothing obviously
wrong, and no way to find the task that was actually in the way.

Every fact needed to explain that is already in the API. This PR renders it.

## 1. "Why is this build not progressing?" on the build view

`GET /builds/{id}/frontier` has existed since reactive scheduling shipped
and the UI has never called it. It now drives a panel above the DAG.

**Show/hide rule** (`schedulingPanelForm`, unit-tested):

- **Prominent and expanded** when the build looks stalled: it has tasks,
  nothing actionable, and nothing running. Not a heuristic — that is
  *exactly* the condition under which the server computes
  `blocked_by_external`, and exactly the condition the SDK reads as "this
  build cannot progress", i.e. the read that produced the error above.
- Terminal states are qualified rather than blanket-included. Never for
  `completed`/`cancelled` (the build is done, or someone stopped it on
  purpose). For `failed`, only when the failure has the stuck-build
  shape: a blocker was reported, **or the build failed while nothing in
  it failed**. An ordinary DAG failure explains itself in the task table
  and does not need a scheduler post-mortem.
- **One quiet line** for a reactive build the rule does not flag, carrying
  the live counts and a disclosure onto the tick trail (which exists
  nowhere else in the UI).
- **Nothing at all** otherwise. A healthy non-reactive build has no
  scheduler to reason about, and a permanently empty box is worse than no
  box.

**The `blocked_by_external` ambiguity.** The server populates that list
only when the build has nothing actionable and nothing running, so an
empty list means *"not externally blocked, **or** not stalled"*. The panel
only ever says "no upstream outside the build is holding it back" from
inside the stalled branch, where the server did look. The progressing form
says the opposite explicitly — "upstreams owned by other builds are only
looked for while a build is stalled, so nothing here says whether this
build has any" — and there is a test asserting the progressing form makes
no no-blockers claim.

**Blockers.** Each entry names the blocked task of this build, the
blocking task (namespace-qualified — the viewer may never have seen it),
its status, how long it has been in it, and links to the build that put it
there. #208 calls that link "the single most useful piece of information
for the whole class of cross-build blocking problems". The copy splits on
`blocking_in_build`, because so does the remedy: a blocker inside this
build's own task set is at least visible in the table below, while one
outside it will never be scheduled here at all and can only be waited on.
`blocked_by_external_truncated` is stated rather than swallowed.

**Tick reasoning.** `GET /builds/{id}/tick-summaries`, newest first, two
deep with a "show N earlier ticks" disclosure. A stalled build repeats the
same outcome, so a trail reads as a diagnosis where one row reads as an
anecdote. Outcomes and known counters (`limit_denied`, `claim_denied`,
`self_healed`, …) get a label and a tooltip explaining what they imply;
**unknown keys render generically rather than being dropped**, because
`summary` is an open blob by design and the counter this UI has never
heard of is the one most likely to explain a new failure mode. A server
without the endpoint (404) degrades to "this server does not record tick
history", not an error.

## 2. Claim holder on the task detail panel

`StatusBadge` already hinted at a cross-build status with an icon. That is
enough to notice something, not enough to act. When a task's global status
is `RUNNING`/`SUSPENDED` under a build other than the one being viewed,
the panel now says "Execution claim held by another build", for how long,
with a link to the holder and the consequence spelled out.

Cancel logic is extended, not duplicated: the existing `window.confirm`
Cancel and the new dialog-confirmed release both go through one
`runTaskAction(action, targetBuildId)`. The plain Cancel button stands
down while another build holds the claim — it addresses the *viewed*
build, which is the wrong one, and two buttons that cancel the same task
under different builds is a trap rather than a choice.

## 3. Claim triage in the task explorer

A "Claims" mode beside the existing Search. The generic `/tasks/search`
filtering is untouched; this is a separate view because it needs a
different endpoint, and not for cosmetic reasons: `/tasks/search` reports
a task's status but neither *when* it entered it nor *which build* put it
there, and evaluates a status filter in Python over the whole unpaginated
match set. `/tasks?status=…&status_older_than=…` carries
`latest_status_at` and `latest_status_build_id`, filters in SQL, and
orders oldest-claim-first — the triage order.

Running/suspended toggles, a staleness cut (converted to an absolute
instant per request, since a duration would move the cutoff between
pages), a claim-holder column linking to the owning build, page-scoped
selection, and a bulk release that issues one cancel per task **under
that task's own owning build**. Partial failure is the normal case here
rather than an exception — a task can complete between the list being
drawn and the request landing — so the banner reports "released X of N"
and names each failure with the server's own reason instead of collapsing
into a single "failed". A task whose owning build was never recorded still
shows (it is a claim holder worth seeing) but is not selectable, because a
cancel has to be addressed to a build.

## Remedies and gating

`release` (cancel) for `RUNNING`/`SUSPENDED`, `retry` (reset to pending)
for `failed`/`cancelled`/`skipped`/`suspended` — mirroring what the server
will actually honour, since a button the API treats as a no-op is worse
than no button. Every one is addressed to the owning build and says which
in the confirmation. All are gated on `role === "owner" || "admin"`, the
same convention as concurrency-limit eviction and bulk build cancel;
non-admins keep the whole diagnosis and get a note instead of dead
buttons. Everything refetches after mutating.

## Notes

Data fetching follows the established idioms: no react-query, epoch-guarded
loads, and a refresh token from the build view so the 5s auto-refresh
drives one request stream rather than two. Tick history is fetched only
where it will be read. Every new surface carries explicit `dark:` pairs;
checkboxes and the repeated blocker action buttons carry accessible names
that identify their target.

## Tests

37 new tests (151 total, all green), covering: the show/hide rule across
running / progressing / no-tasks / completed / cancelled / failed-with-a-
failure / failed-with-none; an external blocker rendering with a working
owning-build link; `blocking_in_build` true vs false copy; the empty-list-
while-progressing case making no no-blockers claim; truncation; an unknown
tick-summary counter key surviving; a 404 from tick-summaries degrading
gracefully; a frontier read failure surfacing; release/retry confirming and
addressing the owning build then refetching; admin gating on all three
surfaces; the claim query's statuses and absolute staleness cutoff; a
non-selectable row with no recorded owning build; and bulk release
reporting partial failure per task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NyR9Kc9ZP5Ko7dVndhi3Y
