### PR TITLE
refactor(api): denormalise build status so it is filterable, exact and computed once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,12 +91,9 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   predicate, not a second implementation) — so a client can list what the
   reaper would cancel before cancelling it. Because it is a real SQL
   predicate, `total` is an exact `COUNT(*)` and pagination is server-side
-  and unbounded, unlike the derived-`status` filter's bounded window.
-  Ordering flips to stalest-first when it is given. `status=running` is
-  accepted alongside it and then also resolves in SQL, so the
-  abandoned-build query stays exact past the 500-candidate scan cap; any
-  other `status` value combined with `idle_for_seconds` is rejected with
-  422 rather than served an approximate total that looks exact.
+  and unbounded. Ordering flips to stalest-first when it is given. It
+  combines with any `status` value — see the denormalisation entry below,
+  which made that true for the non-`running` ones too.
 - **Optional unattended sweep** (`STARDAG_API_REAPER_ENABLED`, off by
   default) runs the same operation on a timer inside the API process. Note
   that every replica runs its own timer with no leader election; cancellation
@@ -153,6 +150,42 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
     since — and those still need an operator (cancel, retry, evict) to
     release. Executor probing is unaffected and remains the better evidence
     where it is available.
+- **Build status is now a column, so `GET /builds?status=` is exact for
+  every status** ([#208](https://github.com/stardag-dev/stardag/issues/208)).
+  It was derived by replaying the build's build-level events on every read,
+  which had three consequences, all now gone: every `BuildResponse` cost an
+  event scan; the `status` filter could not run in SQL, so it scanned the 500
+  most-recently-active candidates, filtered in Python, and returned a `total`
+  that was **the matches within that window** while looking like an exact
+  count; and anything needing an unbounded "is this build RUNNING?" — the
+  stale-build reaper — had to carry a second SQL encoding of the same rule,
+  which disagreed with the replay when a terminal event shared a timestamp
+  with a start/resume.
+
+  Five denormalised columns on `builds` (`latest_status`,
+  `latest_started_at`, `latest_completed_at`,
+  `latest_status_triggered_by_user_id`, `latest_is_resumed`) now hold exactly
+  what the replay returned, folded in-transaction by every build lifecycle
+  path — the same pattern already used for `tasks.latest_*`. Backed by a new
+  `(environment_id, latest_status, last_active_at)` index. Migration
+  backfills existing builds by replaying their events, so no build changes
+  status across the upgrade.
+
+  - `status` filtering is a plain column predicate: exact `COUNT(*)`,
+    server-side pagination, no window and no cap, for every status.
+  - `status` combined with `idle_for_seconds` **no longer 422s** for
+    non-`running` statuses. That restriction existed only because `running`
+    was the sole value with a SQL predicate; "failed, and idle for a week" is
+    now a real query.
+  - **Tie-break:** two build-level events sharing a `created_at` resolve in
+    _arrival_ order — the order the server committed them — because the fold
+    shares a transaction with the event insert. Equal timestamps mean the
+    timestamp lost information the commit order still has, and both previous
+    implementations were guessing (the replay arbitrarily, the reaper by
+    always reading a tie as "not running"). The reaper is unaffected in
+    practice: it still only touches builds that are RUNNING _and_ have been
+    silent for at least `idle_for_seconds`.
+  - No response field changed shape or meaning.
 
 ### SDK
 

--- a/app/stardag-api/migrations/versions/20260807_235511_denormalised_build_status_columns_with_.py
+++ b/app/stardag-api/migrations/versions/20260807_235511_denormalised_build_status_columns_with_.py
@@ -54,33 +54,77 @@ _TERMINAL_BUILD_STATUS = {
 _USER_TRIGGERABLE = ("build_completed", "build_failed", "build_cancelled")
 
 
-def _backfill_build_status(connection: sa.engine.Connection) -> None:
-    """Replay every build-level event into the latest_* columns on its build."""
-    states: dict[str, dict] = {}
+_UPDATE_BATCH = 500
 
+
+def _fresh_state() -> dict:
+    return {
+        "status": "pending",
+        "started_at": None,
+        "completed_at": None,
+        "triggered_by": None,
+        "is_resumed": False,
+    }
+
+
+def _backfill_build_status(connection: sa.engine.Connection) -> None:
+    """Replay every build-level event into the latest_* columns on its build.
+
+    Streamed per build rather than accumulated: this runs at upgrade time on
+    installations whose event tables are the biggest thing they own, and a
+    dict keyed by every build that ever existed is a poor thing to require
+    of the machine running the migration.
+
+    Ordering by ``build_id`` first is what makes that possible, and is safe
+    because the replay only ever depends on the order of events *within* one
+    build — the global interleaving carries no information here. When the
+    build id changes, the previous build's state is final and can be
+    flushed.
+    """
+    update_stmt = sa.text(
+        """
+        UPDATE builds
+        SET latest_status = :status,
+            latest_started_at = :started_at,
+            latest_completed_at = :completed_at,
+            latest_status_triggered_by_user_id = :triggered_by,
+            latest_is_resumed = :is_resumed
+        WHERE id = :build_id
+        """
+    )
+    pending_updates: list[dict] = []
+
+    def flush(force: bool = False) -> None:
+        if pending_updates and (force or len(pending_updates) >= _UPDATE_BATCH):
+            connection.execute(update_stmt, pending_updates)
+            pending_updates.clear()
+
+    # Statement-level, NOT `connection.execution_options(...)`: that mutates
+    # the connection Alembic is running the whole migration on, and a
+    # streaming connection reports rowcount -1 — which Alembic reads as "the
+    # version-table update matched no row" and aborts every upgrade.
     events = connection.execute(
         sa.text(
             """
             SELECT id, build_id, event_type, created_at, event_metadata
             FROM events
             WHERE task_id IS NULL
-            ORDER BY created_at ASC, id ASC
+            ORDER BY build_id ASC, created_at ASC, id ASC
             """
-        )
+        ).execution_options(stream_results=True)
     )
+
+    current_id: str | None = None
+    state = _fresh_state()
 
     for row in events:
         build_id = str(row.build_id)
-        state = states.setdefault(
-            build_id,
-            {
-                "status": "pending",
-                "started_at": None,
-                "completed_at": None,
-                "triggered_by": None,
-                "is_resumed": False,
-            },
-        )
+        if build_id != current_id:
+            if current_id is not None:
+                pending_updates.append({"build_id": current_id, **state})
+                flush()
+            current_id = build_id
+            state = _fresh_state()
 
         et = row.event_type
         meta = row.event_metadata or {}
@@ -114,19 +158,9 @@ def _backfill_build_status(connection: sa.engine.Connection) -> None:
             )
         # Any other build-level event type is status-neutral.
 
-    update_stmt = sa.text(
-        """
-        UPDATE builds
-        SET latest_status = :status,
-            latest_started_at = :started_at,
-            latest_completed_at = :completed_at,
-            latest_status_triggered_by_user_id = :triggered_by,
-            latest_is_resumed = :is_resumed
-        WHERE id = :build_id
-        """
-    )
-    for build_id, state in states.items():
-        connection.execute(update_stmt, {"build_id": build_id, **state})
+    if current_id is not None:
+        pending_updates.append({"build_id": current_id, **state})
+    flush(force=True)
 
 
 def upgrade() -> None:

--- a/app/stardag-api/migrations/versions/20260807_235511_denormalised_build_status_columns_with_.py
+++ b/app/stardag-api/migrations/versions/20260807_235511_denormalised_build_status_columns_with_.py
@@ -1,0 +1,195 @@
+"""denormalised build status columns with backfill
+
+Revision ID: e87efdab31ca
+Revises: f6a5873c30fb
+Create Date: 2026-08-07 23:55:11.594802
+
+Adds five ``latest_*`` columns on ``builds`` holding exactly what the
+``get_build_status`` event replay used to return, then backfills them by
+replaying every existing build-level event in order.
+
+Motivation: build status was not a column, so every ``BuildResponse`` cost a
+scan of the build's event stream, ``GET /builds?status=`` could not filter in
+SQL (it scanned a bounded window of candidates and reported the matches
+*within that window* as ``total``), and the stale-build reaper needed a
+second, independent SQL encoding of the same rule to get an exact answer.
+The columns are kept up to date in-transaction whenever a build-level event
+is created (see ``services.status.apply_event_to_build``).
+
+Backfill strategy: one Python loop over build-level events (``task_id IS
+NULL``) ordered ``created_at ASC, id ASC``, applying the same rules as the
+in-process ``apply_event_to_build``. This reproduces what ``get_build_status``
+answered for every build, so no build changes status across the migration.
+
+The ``id`` tiebreaker matters for exactly one case: two build-level events of
+the same build sharing a ``created_at``. ``get_build_status`` ordered on the
+timestamp alone and let the index decide; ``id`` is a UUID7, so ordering by
+it is ordering by creation — the same arrival order the live fold applies
+events in. A tie therefore resolves the same way before and after the
+migration, which the timestamp alone could not guarantee.
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "e87efdab31ca"
+down_revision: Union[str, Sequence[str], None] = "f6a5873c30fb"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ----- Backfill logic (mirrors services.status.apply_event_to_build)
+
+_TERMINAL_BUILD_STATUS = {
+    "build_completed": "completed",
+    "build_failed": "failed",
+    "build_cancelled": "cancelled",
+    "build_exit_early": "exit_early",
+}
+# build_exit_early is excluded: the SDK emits it, never a user.
+_USER_TRIGGERABLE = ("build_completed", "build_failed", "build_cancelled")
+
+
+def _backfill_build_status(connection: sa.engine.Connection) -> None:
+    """Replay every build-level event into the latest_* columns on its build."""
+    states: dict[str, dict] = {}
+
+    events = connection.execute(
+        sa.text(
+            """
+            SELECT id, build_id, event_type, created_at, event_metadata
+            FROM events
+            WHERE task_id IS NULL
+            ORDER BY created_at ASC, id ASC
+            """
+        )
+    )
+
+    for row in events:
+        build_id = str(row.build_id)
+        state = states.setdefault(
+            build_id,
+            {
+                "status": "pending",
+                "started_at": None,
+                "completed_at": None,
+                "triggered_by": None,
+                "is_resumed": False,
+            },
+        )
+
+        et = row.event_type
+        meta = row.event_metadata or {}
+
+        if et == "build_started":
+            state.update(
+                status="running",
+                started_at=row.created_at,
+                triggered_by=None,
+                is_resumed=False,
+            )
+        elif et == "build_resumed":
+            # Keeps started_at — the build started when it first started —
+            # and clears completed_at so no stale "completed at" survives.
+            state.update(
+                status="running",
+                completed_at=None,
+                triggered_by=None,
+                is_resumed=True,
+            )
+        elif et in _TERMINAL_BUILD_STATUS:
+            state.update(
+                status=_TERMINAL_BUILD_STATUS[et],
+                completed_at=row.created_at,
+                is_resumed=False,
+                triggered_by=(
+                    meta.get("triggered_by_user_id")
+                    if et in _USER_TRIGGERABLE
+                    else None
+                ),
+            )
+        # Any other build-level event type is status-neutral.
+
+    update_stmt = sa.text(
+        """
+        UPDATE builds
+        SET latest_status = :status,
+            latest_started_at = :started_at,
+            latest_completed_at = :completed_at,
+            latest_status_triggered_by_user_id = :triggered_by,
+            latest_is_resumed = :is_resumed
+        WHERE id = :build_id
+        """
+    )
+    for build_id, state in states.items():
+        connection.execute(update_stmt, {"build_id": build_id, **state})
+
+
+def upgrade() -> None:
+    """Upgrade schema and backfill latest_* columns from build-level events."""
+    # The two NOT NULL columns get a server_default so the ALTER succeeds on
+    # existing rows; it is dropped again after the backfill so the
+    # application owns the columns from then on. The defaults are also the
+    # correct values for a build with no build-level events at all, which the
+    # backfill loop never visits.
+    op.add_column(
+        "builds",
+        sa.Column(
+            "latest_status",
+            sa.String(length=32),
+            nullable=False,
+            server_default="pending",
+        ),
+    )
+    op.add_column(
+        "builds",
+        sa.Column("latest_started_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "builds",
+        sa.Column("latest_completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "builds",
+        sa.Column(
+            "latest_status_triggered_by_user_id", sa.String(length=255), nullable=True
+        ),
+    )
+    op.add_column(
+        "builds",
+        sa.Column(
+            "latest_is_resumed",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.create_index(
+        "ix_builds_environment_status",
+        "builds",
+        ["environment_id", "latest_status", "last_active_at"],
+        unique=False,
+    )
+
+    _backfill_build_status(op.get_bind())
+
+    op.alter_column("builds", "latest_status", server_default=None)
+    op.alter_column("builds", "latest_is_resumed", server_default=None)
+
+
+def downgrade() -> None:
+    """Downgrade schema.
+
+    Lossless: every column dropped here is derivable from the events table,
+    which this migration never touched.
+    """
+    op.drop_index("ix_builds_environment_status", table_name="builds")
+    op.drop_column("builds", "latest_is_resumed")
+    op.drop_column("builds", "latest_status_triggered_by_user_id")
+    op.drop_column("builds", "latest_completed_at")
+    op.drop_column("builds", "latest_started_at")
+    op.drop_column("builds", "latest_status")

--- a/app/stardag-api/src/stardag_api/models/build.py
+++ b/app/stardag-api/src/stardag_api/models/build.py
@@ -6,11 +6,21 @@ from datetime import datetime
 from typing import TYPE_CHECKING
 from uuid import UUID
 
-from sqlalchemy import DateTime, ForeignKey, Index, JSON, String, Text, Uuid
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    JSON,
+    String,
+    Text,
+    Uuid,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from stardag_api.models.base import Base, TimestampMixin, generate_uuid7, utc_now
+from stardag_api.models.enums import BuildStatus
 
 if TYPE_CHECKING:
     from stardag_api.models.event import Event
@@ -21,8 +31,8 @@ if TYPE_CHECKING:
 class Build(Base, TimestampMixin):
     """Represents execution of sd.build() for a DAG/set of tasks.
 
-    Status is derived from events (no stored status field).
-    Timestamps (started_at, completed_at) are derived from events.
+    Status is a fold of the build's build-level events, denormalised onto
+    the row (the ``latest_*`` columns below) exactly as ``Task`` does it.
     """
 
     __tablename__ = "builds"
@@ -31,6 +41,25 @@ class Build(Base, TimestampMixin):
         Index(
             "ix_builds_environment_last_active",
             "environment_id",
+            "last_active_at",
+        ),
+        # Serves ``GET /builds?status=`` — "builds in THIS environment with
+        # status X, most recently active first" — and the reaper's
+        # "RUNNING builds, stalest first". Same shape, and the same reasoning,
+        # as ix_tasks_environment_status: the single-environment filter and
+        # the status filter are useless apart (RUNNING spans every tenant;
+        # the environment-keyed composites don't mention status), and the
+        # distribution is badly skewed — a mature environment is almost all
+        # terminal builds with a handful RUNNING.
+        #
+        # ``last_active_at`` is the third column, not a separate index, so
+        # the ORDER BY of a single-status page resolves from the index alone
+        # in either direction (newest-first for the default listing,
+        # stalest-first for a staleness query).
+        Index(
+            "ix_builds_environment_status",
+            "environment_id",
+            "latest_status",
             "last_active_at",
         ),
     )
@@ -138,6 +167,52 @@ class Build(Base, TimestampMixin):
     reactive_tick_kwargs: Mapped[dict | None] = mapped_column(
         JSON().with_variant(JSONB(), "postgresql"),
         nullable=True,
+    )
+
+    # ------------------------------------------------------------------
+    # Denormalised build-status columns.
+    #
+    # Maintained in-transaction whenever a build-level event is created
+    # (see services.status.apply_event_to_build, called by every build
+    # lifecycle path). They hold exactly what the historical
+    # ``get_build_status`` event replay returned, so a read is a column
+    # read rather than a scan of the build's whole event stream.
+    #
+    # They exist for three reasons, in increasing order of importance:
+    # every BuildResponse used to cost one event scan; ``GET /builds?status=``
+    # could not filter in SQL and so scanned a bounded window of candidates
+    # and reported a `total` that was only the matches *within that window*;
+    # and the stale-build reaper needed an exact, unbounded "is this build
+    # RUNNING?", which meant a second SQL encoding of the same rule that
+    # disagreed with the replay on timestamp ties. One column, one answer.
+    # ------------------------------------------------------------------
+    latest_status: Mapped[BuildStatus] = mapped_column(
+        String(32),
+        nullable=False,
+        default=BuildStatus.PENDING,
+    )
+    # First BUILD_STARTED. A resume does *not* move it — the build started
+    # when it first started; resuming is a separate concept, flagged by
+    # ``latest_is_resumed``.
+    latest_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+    )
+    # The terminal event that produced ``latest_status``; cleared by a
+    # resume so the UI doesn't keep showing a stale "completed at".
+    latest_completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+    )
+    # ``external_id`` of the user who triggered the current status, when it
+    # came from a manual UI override (the ``triggered_by_user_id`` key in
+    # the event metadata). NULL for the machine-driven transitions —
+    # start/resume/exit-early are never user-triggered.
+    latest_status_triggered_by_user_id: Mapped[str | None] = mapped_column(String(255))
+    # True iff the event that produced the current status was BUILD_RESUMED,
+    # i.e. the build was picked up again after finishing/failing and is
+    # RUNNING under resume semantics. The UI surfaces this as
+    # "running (resumed)".
+    latest_is_resumed: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False
     )
 
     # Relationships

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -80,11 +80,10 @@ from stardag_api.schemas import (
     TaskResponse,
     TaskWithStatusResponse,
 )
-from stardag_api.services import generate_build_slug, get_build_status
+from stardag_api.services import generate_build_slug
 from stardag_api.services.build_cleanup import (
     CASCADE_CANCEL_STATUSES,
     STALEST_FIRST_ORDER,
-    build_is_running,
     cancel_builds,
     cascade_cancel_build_tasks,
     idle_filters,
@@ -93,6 +92,7 @@ from stardag_api.services.build_cleanup import (
 )
 from stardag_api.services.claims import claim_is_live, live_claim_filter
 from stardag_api.services.status import (
+    apply_event_to_build,
     apply_event_to_task,
     get_all_task_global_statuses,
     get_task_status_in_build,
@@ -236,20 +236,20 @@ async def _build_to_response(
     build: Build,
     last_event_at: datetime | None = None,
 ) -> BuildResponse:
-    """Assemble a BuildResponse with derived status for a build row.
+    """Assemble a BuildResponse from a build row.
+
+    Status and its timestamps come straight off the denormalised
+    ``latest_*`` columns, maintained in-transaction by
+    :func:`~stardag_api.services.status.apply_event_to_build`. This used to
+    replay the build's whole build-level event stream on every response.
 
     ``last_event_at`` short-circuits the per-build activity lookup when the
     caller already fetched it in bulk. Passing None for a build that has
     events simply costs one extra index lookup, never a wrong answer.
     """
-    (
-        status,
-        started_at,
-        completed_at,
-        triggered_by_id,
-        is_resumed,
-    ) = await get_build_status(db, build.id)
-    triggered_by_user = await _get_triggered_by_user(db, triggered_by_id)
+    triggered_by_user = await _get_triggered_by_user(
+        db, build.latest_status_triggered_by_user_id
+    )
     if last_event_at is None:
         last_event_at = await _last_event_at(db, build.id)
     return BuildResponse(
@@ -264,11 +264,11 @@ async def _build_to_response(
         executor_metadata=build.executor_metadata,
         reactive_app_name=build.reactive_app_name,
         reactive_tick_kwargs=build.reactive_tick_kwargs,
-        status=status,
-        started_at=started_at,
-        completed_at=completed_at,
+        status=build.latest_status,
+        started_at=build.latest_started_at,
+        completed_at=build.latest_completed_at,
         status_triggered_by_user=triggered_by_user,
-        is_resumed=is_resumed,
+        is_resumed=build.latest_is_resumed,
         last_active_at=build.last_active_at,
         last_activity_at=last_activity_at(build, last_event_at),
     )
@@ -291,6 +291,53 @@ async def _get_triggered_by_user(
         email=user.email or "",
         display_name=user.display_name,
     )
+
+
+async def _get_build_for_update(
+    build_id: UUID, db: AsyncSession, auth: SdkAuth
+) -> Build:
+    """Fetch a build for a lifecycle transition, with its row locked.
+
+    ``SELECT ... FOR UPDATE``, for the same reason ``_get_build_and_task``
+    takes it on the task row: writing the denormalised status columns is a
+    read-modify-write (see ``services.status.apply_event_to_build``), and
+    without the lock two concurrent lifecycle calls on the same build can
+    each read the pre-state, apply different events, and leave a row that is
+    a mixture of the two — e.g. a COMPLETED build still carrying the
+    ``is_resumed`` flag and the NULL ``completed_at`` of a racing resume.
+    Every path that folds an event must go through here; the lock releases on
+    commit, so request duration governs hold time. On SQLite the clause is
+    silently dropped — fine, the test suite runs single-connection.
+
+    A build is always locked *before* any task rows it cascades to, so this
+    and ``_create_task_event`` acquire in one consistent order.
+
+    Read-only paths (``GET /builds``, ``/{id}``, the frontier) deliberately
+    don't take it — they just read the columns.
+    """
+    build = (
+        await db.execute(select(Build).where(Build.id == build_id).with_for_update())
+    ).scalar_one_or_none()
+    if not build:
+        raise HTTPException(status_code=404, detail="Build not found")
+    if build.environment_id != auth.environment_id:
+        raise HTTPException(
+            status_code=403, detail="Build does not belong to this environment"
+        )
+    return build
+
+
+async def _record_build_event(db: AsyncSession, build: Build, event: Event) -> None:
+    """Add a build-level event and fold it into the build's status columns.
+
+    The two halves are one operation and must stay in one transaction — an
+    event without its fold silently desynchronises the row, and every read
+    (and the reaper's selection) trusts the row. The flush is what populates
+    ``event.created_at`` before the fold reads it.
+    """
+    db.add(event)
+    await db.flush()
+    apply_event_to_build(build, event)
 
 
 async def _get_build_and_task(
@@ -526,7 +573,9 @@ async def create_build(
     db.add(db_build)
     await db.flush()  # Get the build ID
 
-    # Create BUILD_STARTED event
+    # Create BUILD_STARTED event, and fold it — this is what puts the fresh
+    # build in RUNNING with a started_at. No row lock: the build row is not
+    # visible to any other transaction until this one commits.
     start_event = Event(
         build_id=db_build.id,
         task_id=None,
@@ -535,7 +584,7 @@ async def create_build(
         if build.executor_metadata is not None
         else None,
     )
-    db.add(start_event)
+    await _record_build_event(db, db_build, start_event)
 
     await db.commit()
     await db.refresh(db_build)
@@ -545,15 +594,6 @@ async def create_build(
 
     # Build response with derived status
     return await _build_to_response(db, db_build)
-
-
-# When a derived-status filter is applied, build status can't be filtered
-# in SQL (it's computed from events, not stored), so we scan the most-
-# recently-active candidates and filter in Python. This caps that scan so
-# the cost stays bounded; the intended use — "RUNNING reactive builds owned
-# by app X" (reactive_app_name filter) — narrows the candidate set well
-# below this. Truncation is logged.
-_STATUS_FILTER_SCAN_CAP = 500
 
 
 @router.get("", response_model=BuildListResponse)
@@ -589,16 +629,15 @@ async def list_builds(
     - ``reactive_app_name``: only builds reactively scheduled by the named
       app (``reactive_app_name`` column). A server-side filter — the
       watchdog's real question is "RUNNING reactive builds owned by app X".
-    - ``status``: only builds with the given derived status (e.g.
-      ``running``). Because build status is derived from events (not a
-      column), it generally can't be paginated in SQL: matching candidates
-      are scanned up to a bounded cap and filtered in Python, so ``total``
-      means "matches within the scanned window". Intended to be combined
-      with ``reactive_app_name``, which keeps the candidate set small.
-    - ``idle_for_seconds``: only builds that are **still running** and have
-      been idle for at least that long. **A real SQL predicate**, so
+    - ``status``: only builds with the given status. A plain predicate on the
+      denormalised ``builds.latest_status`` column, for **every** status, so
       ``total`` is an exact ``COUNT(*)`` and pagination is server-side and
-      unbounded — no scan cap, nothing silently dropped.
+      unbounded. (It used to derive status in Python over the 500
+      most-recently-active candidates and report the matches within that
+      window as ``total``.)
+    - ``idle_for_seconds``: only builds that are **still running** and have
+      been idle for at least that long. Also a real SQL predicate, on the
+      same terms.
 
     Idleness implies RUNNING because that is the only state in which it
     means anything. A finished build has no activity by definition, so
@@ -606,6 +645,8 @@ async def list_builds(
     that ever completed, ordered by how long ago — which is a history
     listing wearing a cleanup query's clothes. The word this filter exists
     to express is *abandoned*, and only a running build can be abandoned.
+    Now that every status is a real predicate, that is a deliberate
+    semantic choice rather than a limitation of what SQL could express.
 
     Idleness is the same definition the stale-build reaper uses
     (:func:`~stardag_api.services.build_cleanup.idle_filters`), deliberately
@@ -647,17 +688,16 @@ async def list_builds(
     filters = [Build.environment_id == environment_id]
     if reactive_app_name is not None:
         filters.append(Build.reactive_app_name == reactive_app_name)
-
-    # Both filters below are exact SQL, so the derived-status Python scan is
-    # skipped entirely when they cover the request.
-    sql_filtered = idle_for_seconds is not None
+    if status is not None:
+        filters.append(Build.latest_status == status)
     if idle_for_seconds is not None:
         filters.extend(idle_filters(utc_now() - timedelta(seconds=idle_for_seconds)))
         # Unconditionally, not just when status=running was asked for: this
         # endpoint is the preview for POST /builds/bulk-cancel, which only
-        # ever acts on running builds. A preview that lists rows the action
-        # will not touch is worse than no preview.
-        filters.append(build_is_running())
+        # ever acts on running builds (`select_cancellable_builds` opens with
+        # this same predicate). A preview that lists rows the action will not
+        # touch is worse than no preview.
+        filters.append(Build.latest_status == BuildStatus.RUNNING)
 
     # Sort by last_active_at so a resumed build (BUILD_RESUMED touches this
     # column) jumps back to the top of the list. ``Build.id`` is a UUID7
@@ -677,41 +717,17 @@ async def list_builds(
         )
     )
 
-    if status is None or sql_filtered:
-        count_query = select(func.count()).select_from(Build).where(*filters)
-        total = (await db.execute(count_query)).scalar() or 0
-        result = await db.execute(
-            ordered.offset((page - 1) * page_size).limit(page_size)
-        )
-        page_builds = list(result.scalars().all())
-        # One grouped query for the page's activity timestamps rather than
-        # one per build.
-        last_events = await _last_event_at_map(db, [b.id for b in page_builds])
-        build_responses = [
-            await _build_to_response(db, build, last_events.get(build.id))
-            for build in page_builds
-        ]
-    else:
-        # Derived-status filter: scan bounded candidates, compute status,
-        # filter, then paginate the matches in Python.
-        scanned = (
-            (await db.execute(ordered.limit(_STATUS_FILTER_SCAN_CAP))).scalars().all()
-        )
-        if len(scanned) >= _STATUS_FILTER_SCAN_CAP:
-            logger.warning(
-                "list_builds status filter: scan hit the %d-candidate cap; "
-                "older matching builds (if any) are not included.",
-                _STATUS_FILTER_SCAN_CAP,
-            )
-        last_events = await _last_event_at_map(db, [b.id for b in scanned])
-        matched = []
-        for build in scanned:
-            response = await _build_to_response(db, build, last_events.get(build.id))
-            if response.status == status:
-                matched.append(response)
-        total = len(matched)
-        offset = (page - 1) * page_size
-        build_responses = matched[offset : offset + page_size]
+    count_query = select(func.count()).select_from(Build).where(*filters)
+    total = (await db.execute(count_query)).scalar() or 0
+    result = await db.execute(ordered.offset((page - 1) * page_size).limit(page_size))
+    page_builds = list(result.scalars().all())
+    # One grouped query for the page's activity timestamps rather than one
+    # per build.
+    last_events = await _last_event_at_map(db, [b.id for b in page_builds])
+    build_responses = [
+        await _build_to_response(db, build, last_events.get(build.id))
+        for build in page_builds
+    ]
 
     return BuildListResponse(
         builds=build_responses,
@@ -762,20 +778,17 @@ async def bulk_cancel_builds(
     ``include_reactive`` (or ``reactive_app_name``) when you know the owning
     app is gone.
 
-    Beyond that: only builds whose derived status is RUNNING are ever
-    touched, so the call is idempotent — safe to retry, and safe for two
-    replicas to run concurrently (duplicated work, not double cancellation).
-    ``dry_run`` reports the exact same selection and writes nothing.
+    Beyond that: only builds whose status is RUNNING are ever touched, so
+    the call is idempotent — safe to retry, and safe for two replicas to run
+    concurrently (duplicated work, not double cancellation). ``dry_run``
+    reports the exact same selection and writes nothing.
 
-    **Cost.** The RUNNING test is a SQL predicate (two correlated aggregates
-    over ``ix_events_build_created``), *not* the bounded Python scan that
-    ``GET /builds?status=`` uses — a reaper that inherited that 500-candidate
-    cap would systematically miss the oldest stale builds, which are exactly
-    the ones it exists to find. The idle filter puts an index-backed
-    ``last_active_at`` conjunct in front of the aggregates (sound because the
-    real signal is a max() over that column among others), so the aggregates
-    run only for builds already known to be quiet. Writes are capped by
-    ``limit``; the scan is not.
+    **Cost.** The RUNNING test is a predicate on ``builds.latest_status``,
+    served by ``ix_builds_environment_status`` — the same column, and the
+    same answer, as ``GET /builds?status=running``, so the preview an
+    operator runs cannot disagree with what this cancels. The idle filter's
+    correlated aggregates then run only for builds already known to be
+    RUNNING. Writes are capped by ``limit``; the scan is not.
 
     Auth: destructive, so the JWT/UI path requires the workspace ADMIN role
     (API keys, being environment-scoped machine credentials, are
@@ -1080,15 +1093,7 @@ async def complete_build(
         )
     )
 
-    build = await db.get(Build, build_id)
-    if not build:
-        raise HTTPException(status_code=404, detail="Build not found")
-
-    # Verify build belongs to authenticated environment
-    if build.environment_id != auth.environment_id:
-        raise HTTPException(
-            status_code=403, detail="Build does not belong to this environment"
-        )
+    build = await _get_build_for_update(build_id, db, auth)
 
     event = Event(
         build_id=build_id,
@@ -1096,7 +1101,7 @@ async def complete_build(
         event_type=EventType.BUILD_COMPLETED,
         event_metadata=_build_event_metadata(commit_hash, triggered_by_user_id),
     )
-    db.add(event)
+    await _record_build_event(db, build, event)
     await _touch_build_last_active(db, build_id)
     await db.commit()
 
@@ -1129,15 +1134,7 @@ async def fail_build(
         )
     )
 
-    build = await db.get(Build, build_id)
-    if not build:
-        raise HTTPException(status_code=404, detail="Build not found")
-
-    # Verify build belongs to authenticated environment
-    if build.environment_id != auth.environment_id:
-        raise HTTPException(
-            status_code=403, detail="Build does not belong to this environment"
-        )
+    build = await _get_build_for_update(build_id, db, auth)
 
     event = Event(
         build_id=build_id,
@@ -1146,7 +1143,7 @@ async def fail_build(
         error_message=error_message,
         event_metadata=_build_event_metadata(commit_hash, triggered_by_user_id),
     )
-    db.add(event)
+    await _record_build_event(db, build, event)
     await _touch_build_last_active(db, build_id)
     await db.commit()
 
@@ -1217,15 +1214,9 @@ async def cancel_build(
         )
     )
 
-    build = await db.get(Build, build_id)
-    if not build:
-        raise HTTPException(status_code=404, detail="Build not found")
-
-    # Verify build belongs to authenticated environment
-    if build.environment_id != auth.environment_id:
-        raise HTTPException(
-            status_code=403, detail="Build does not belong to this environment"
-        )
+    # Locked before the cascade below takes its task locks — build then
+    # tasks, the order every path uses.
+    build = await _get_build_for_update(build_id, db, auth)
 
     metadata = _build_event_metadata(commit_hash, triggered_by_user_id)
     cascaded_task_ids: list[str] = []
@@ -1258,7 +1249,7 @@ async def cancel_build(
         event_type=EventType.BUILD_CANCELLED,
         event_metadata=metadata,
     )
-    db.add(event)
+    await _record_build_event(db, build, event)
     await _touch_build_last_active(db, build_id)
     # One transaction: the build and the claims it held go terminal together,
     # so a failure here cannot leave a cancelled build still holding claims.
@@ -1292,15 +1283,7 @@ async def exit_early(
         )
     )
 
-    build = await db.get(Build, build_id)
-    if not build:
-        raise HTTPException(status_code=404, detail="Build not found")
-
-    # Verify build belongs to authenticated environment
-    if build.environment_id != auth.environment_id:
-        raise HTTPException(
-            status_code=403, detail="Build does not belong to this environment"
-        )
+    build = await _get_build_for_update(build_id, db, auth)
 
     event = Event(
         build_id=build_id,
@@ -1309,7 +1292,7 @@ async def exit_early(
         error_message=reason,  # Reuse error_message field for the reason
         event_metadata=_build_event_metadata(commit_hash),
     )
-    db.add(event)
+    await _record_build_event(db, build, event)
     await _touch_build_last_active(db, build_id)
     await db.commit()
 
@@ -1330,8 +1313,8 @@ async def resume_build(
 
     Called by the SDK when ``sd.build(resume_build_id=...)`` reuses an
     existing build that may have already terminated. Emits a
-    ``BUILD_RESUMED`` event so ``get_build_status`` flips the build back
-    to RUNNING and the UI shows a "running (resumed)" affordance.
+    ``BUILD_RESUMED`` event, which flips the build back to RUNNING with
+    ``is_resumed`` set so the UI shows a "running (resumed)" affordance.
 
     A build with no recorded activity beyond its ``BUILD_STARTED`` event
     is "fresh" — attaching to it is not a resume (e.g. a build id minted
@@ -1358,15 +1341,7 @@ async def resume_build(
         )
     )
 
-    build = await db.get(Build, build_id)
-    if not build:
-        raise HTTPException(status_code=404, detail="Build not found")
-
-    # Verify build belongs to authenticated environment
-    if build.environment_id != auth.environment_id:
-        raise HTTPException(
-            status_code=403, detail="Build does not belong to this environment"
-        )
+    build = await _get_build_for_update(build_id, db, auth)
 
     has_activity = (
         await db.execute(
@@ -1399,7 +1374,7 @@ async def resume_build(
             event_type=EventType.BUILD_RESUMED,
             event_metadata=event_metadata or None,
         )
-        db.add(event)
+        await _record_build_event(db, build, event)
         await _touch_build_last_active(db, build_id)
         needs_commit = True
 
@@ -1845,8 +1820,6 @@ async def get_build_frontier(
             .all()
         )
 
-    build_status, _, _, _, _ = await get_build_status(db, build.id)
-
     def _ref(t: Task) -> FrontierTaskRef:
         return FrontierTaskRef(
             task_id=t.task_id,
@@ -1866,7 +1839,7 @@ async def get_build_frontier(
 
     return BuildFrontierResponse(
         build_id=build_id,
-        build_status=build_status,
+        build_status=build.latest_status,
         needs_tick=build.needs_tick_at is not None,
         root_task_ids=root_task_ids,
         roots=[_ref(t) for t in roots],

--- a/app/stardag-api/src/stardag_api/services/__init__.py
+++ b/app/stardag-api/src/stardag_api/services/__init__.py
@@ -14,16 +14,19 @@ from stardag_api.services.lock import (
     renew_lock,
 )
 from stardag_api.services.slug import generate_build_slug
-from stardag_api.services.status import get_build_status, get_task_status_in_build
+from stardag_api.services.status import (
+    apply_event_to_build,
+    get_task_status_in_build,
+)
 
 __all__ = [
     "LockAcquisitionResult",
     "LockAcquisitionStatus",
     "acquire_lock",
+    "apply_event_to_build",
     "check_task_completed_in_registry",
     "cleanup_expired_locks",
     "generate_build_slug",
-    "get_build_status",
     "get_lock",
     "get_task_status_in_build",
     "get_environment_lock_count",

--- a/app/stardag-api/src/stardag_api/services/build_cleanup.py
+++ b/app/stardag-api/src/stardag_api/services/build_cleanup.py
@@ -1,12 +1,11 @@
 """Terminating abandoned builds and releasing the claims their tasks hold.
 
-Build status is derived from build-level events, so a build whose
-orchestrator died without emitting a terminal event stays RUNNING forever:
-interrupted local builds, crashed CI runs and failed triggers accumulate
-permanently. Worse, cancelling a build has never cascaded to its tasks, so
-a task left RUNNING keeps denying its execution claim — ``latest_status`` is
-environment-global — to every future build that needs it, and keeps
-occupying its concurrency-limit slots.
+A build whose orchestrator died without emitting a terminal event stays
+RUNNING forever: interrupted local builds, crashed CI runs and failed
+triggers accumulate permanently. Worse, cancelling a build has never
+cascaded to its tasks, so a task left RUNNING keeps denying its execution
+claim — ``latest_status`` is environment-global — to every future build that
+needs it, and keeps occupying its concurrency-limit slots.
 
 This module is the shared machinery for fixing that: selecting builds that
 are genuinely abandoned, and cancelling a build together with the claims it
@@ -27,25 +26,14 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from uuid import UUID
 
-from sqlalchemy import ColumnElement, func, or_, select, update
+from sqlalchemy import ColumnElement, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from stardag_api.models import Build, Event, EventType, Task, TaskStatus
+from stardag_api.models import Build, BuildStatus, Event, EventType, Task, TaskStatus
 from stardag_api.models.base import as_utc, utc_now
-from stardag_api.services.status import apply_event_to_task
+from stardag_api.services.status import apply_event_to_build, apply_event_to_task
 
 logger = logging.getLogger(__name__)
-
-# Build-level events that end a build, and the two that (re)start it. A
-# build's derived status is decided by whichever of these came last — see
-# services.status.get_build_status.
-_TERMINAL_BUILD_EVENTS = (
-    EventType.BUILD_COMPLETED,
-    EventType.BUILD_FAILED,
-    EventType.BUILD_CANCELLED,
-    EventType.BUILD_EXIT_EARLY,
-)
-_ACTIVE_BUILD_EVENTS = (EventType.BUILD_STARTED, EventType.BUILD_RESUMED)
 
 # Task statuses a build cancel cascades to. RUNNING holds the execution
 # claim and the concurrency-limit slots — that is the whole point. SUSPENDED
@@ -62,56 +50,6 @@ _ACTIVE_BUILD_EVENTS = (EventType.BUILD_STARTED, EventType.BUILD_RESUMED)
 # apart). Cancelling a build must not fail somebody else's. Use
 # POST /builds/{id}/skip-blocked, or the per-task cancel, for pending work.
 CASCADE_CANCEL_STATUSES = (TaskStatus.RUNNING, TaskStatus.SUSPENDED)
-
-
-def build_is_running() -> ColumnElement[bool]:
-    """SQL predicate: the correlated ``Build`` row's derived status is RUNNING.
-
-    Build status is not a column, and the existing ``GET /builds?status=``
-    filter therefore derives it in Python over a bounded scan
-    (``_STATUS_FILTER_SCAN_CAP``). A reaper must not inherit that cap: its
-    job is to find *every* stale RUNNING build, and the ones that matter are
-    precisely the oldest — the ones a "most recently active first, first 500"
-    scan drops first.
-
-    So the rule is expressed in SQL. RUNNING means the most recent
-    build-level event is BUILD_STARTED or BUILD_RESUMED, i.e.::
-
-        max(created_at) over start/resume events  >  max(...) over terminals
-
-    with a missing terminal max meaning "never ended". Two correlated
-    aggregates over ``ix_events_build_created``; build-level events are a
-    handful per build, and callers put a cheap index-backed filter in front
-    (see :func:`select_cancellable_builds`).
-
-    A tie — a terminal event sharing a timestamp with a start/resume — is
-    read as NOT running, so a reaper leaves it alone. ``get_build_status``
-    replays in timestamp order and would resolve the tie arbitrarily; when
-    the two disagree, the conservative reading has to win.
-    """
-    latest_active = (
-        select(func.max(Event.created_at))
-        .where(
-            Event.build_id == Build.id,
-            Event.task_id.is_(None),
-            Event.event_type.in_(_ACTIVE_BUILD_EVENTS),
-        )
-        .correlate(Build)
-        .scalar_subquery()
-    )
-    latest_terminal = (
-        select(func.max(Event.created_at))
-        .where(
-            Event.build_id == Build.id,
-            Event.task_id.is_(None),
-            Event.event_type.in_(_TERMINAL_BUILD_EVENTS),
-        )
-        .correlate(Build)
-        .scalar_subquery()
-    )
-    return latest_active.is_not(None) & or_(
-        latest_terminal.is_(None), latest_terminal < latest_active
-    )
 
 
 def last_event_at_subquery() -> ColumnElement[datetime]:
@@ -226,12 +164,20 @@ async def select_cancellable_builds(
     ``limit``. ``environment_id=None`` spans every environment (the
     in-process sweep; the HTTP endpoint always scopes to the caller's).
 
+    "RUNNING" is a plain column predicate on the denormalised
+    ``Build.latest_status`` — the same column ``GET /builds?status=running``
+    filters on, so the preview and the action cannot disagree, and neither is
+    bounded by a scan window. (Before the column existed this was two
+    correlated aggregates over the event stream, which had to be a *second*
+    encoding of the status rule and disagreed with the event replay on
+    timestamp ties; see ``services.status.apply_event_to_build``.)
+
     Ordered stalest-first by :data:`STALEST_FIRST_ORDER` — see there for why
     the sort key is a proxy rather than the full signal. Correctness comes
     from the filter; convergence comes from cancellation itself, since a
     reaped build stops being RUNNING and drops out of the next call.
     """
-    filters: list[ColumnElement[bool]] = [build_is_running()]
+    filters: list[ColumnElement[bool]] = [Build.latest_status == BuildStatus.RUNNING]
     if environment_id is not None:
         filters.append(Build.environment_id == environment_id)
     if build_ids is not None:
@@ -327,6 +273,13 @@ async def cancel_builds(
     does, and a crash mid-sweep leaves no build cancelled without its
     cascade. Re-running afterwards picks up exactly the builds that are
     still RUNNING.
+
+    Each build row is re-selected ``FOR UPDATE`` before it is folded, for the
+    same reason ``_create_task_event`` locks the task: writing the
+    denormalised status is a read-modify-write, and the lock is what stops a
+    concurrent lifecycle call on the same build from interleaving with it.
+    The build is always locked *before* the tasks it cascades to, matching
+    the order every route handler uses, so the two cannot deadlock.
     """
     event_metadata: dict = {"cancelled_by": source}
     if reason:
@@ -337,27 +290,33 @@ async def cancel_builds(
     results: list[CancelledBuild] = []
     now = utc_now()
     for build, last_event_at in rows:
+        locked = (
+            await db.execute(
+                select(Build).where(Build.id == build.id).with_for_update()
+            )
+        ).scalar_one()
         cancelled_tasks: list[Task] = []
         if cascade:
             cancelled_tasks = await cascade_cancel_build_tasks(
                 db, build.id, event_metadata=event_metadata
             )
-        db.add(
-            Event(
-                build_id=build.id,
-                task_id=None,
-                event_type=EventType.BUILD_CANCELLED,
-                error_message=reason,
-                event_metadata=event_metadata,
-            )
+        event = Event(
+            build_id=build.id,
+            task_id=None,
+            event_type=EventType.BUILD_CANCELLED,
+            error_message=reason,
+            event_metadata=event_metadata,
         )
+        db.add(event)
+        # Flush so event.created_at exists before the fold reads it (same
+        # pattern as the task path).
+        await db.flush()
+        apply_event_to_build(locked, event)
         # Same bookkeeping the single-build cancel endpoint does. Note this
         # moves the build to the top of the last_active_at ordering — correct:
         # its status just changed, and it can no longer be re-selected
-        # (build_is_running() is now false for it).
-        await db.execute(
-            update(Build).where(Build.id == build.id).values(last_active_at=now)
-        )
+        # (its latest_status is no longer RUNNING).
+        locked.last_active_at = now
         results.append(
             CancelledBuild(
                 build=build,

--- a/app/stardag-api/src/stardag_api/services/status.py
+++ b/app/stardag-api/src/stardag_api/services/status.py
@@ -6,7 +6,7 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from stardag_api.models import BuildStatus, Event, EventType, Task, TaskStatus
+from stardag_api.models import Build, BuildStatus, Event, EventType, Task, TaskStatus
 from stardag_api.services.claims import claim_expires_at
 
 # Statuses TASK_RETRIED resets to PENDING. Shared by the denormalised path
@@ -201,94 +201,109 @@ def apply_event_to_task(task: Task, event: Event) -> None:
     # (the global semantics treat it as a no-op).
 
 
-async def get_build_status(
-    db: AsyncSession, build_id: UUID
-) -> tuple[BuildStatus, datetime | None, datetime | None, str | None, bool]:
-    """Get derived build status from events.
+# The build-level statuses a terminal event produces, keyed by event type.
+# BUILD_STARTED / BUILD_RESUMED are handled separately: they are the only
+# two that move a build *back* into RUNNING, and they differ from each other
+# (and from the terminals) in which fields they touch.
+_TERMINAL_BUILD_STATUS = {
+    EventType.BUILD_COMPLETED: BuildStatus.COMPLETED,
+    EventType.BUILD_FAILED: BuildStatus.FAILED,
+    EventType.BUILD_CANCELLED: BuildStatus.CANCELLED,
+    EventType.BUILD_EXIT_EARLY: BuildStatus.EXIT_EARLY,
+}
 
-    Returns:
-        Tuple of (status, started_at, completed_at,
-                  status_triggered_by_user_id, is_resumed).
+# Terminals that can carry a "this was a manual override from the UI"
+# attribution. BUILD_EXIT_EARLY is excluded because it is emitted by the
+# SDK itself ("everything left is running in another build") and is never
+# user-triggered — it has no ``triggered_by_user_id`` to read.
+_USER_TRIGGERABLE_BUILD_EVENTS = (
+    EventType.BUILD_COMPLETED,
+    EventType.BUILD_FAILED,
+    EventType.BUILD_CANCELLED,
+)
 
-    ``is_resumed`` is True iff the build has at least one BUILD_RESUMED
-    event AND that event is more recent than any terminal event — i.e. the
-    build was picked up again after finishing/failing and is currently
-    treated as RUNNING under the resume semantics. The UI uses this to
-    surface a "running (resumed)" affordance.
+
+def apply_event_to_build(build: Build, event: Event) -> None:
+    """Mutate a Build's denormalised ``latest_*`` columns for a new event.
+
+    The build-level counterpart of :func:`apply_event_to_task`, and the sole
+    definition of what a build's status is. It implements the same rules the
+    historical ``get_build_status`` event replay did, applied incrementally:
+
+      - BUILD_STARTED / BUILD_RESUMED assert RUNNING. A start records
+        ``latest_started_at``; a resume deliberately does not, because the
+        build started when it first started, and instead clears
+        ``latest_completed_at`` so the UI stops showing a stale "completed
+        at" from the terminal it superseded.
+
+        Note this differs from ``apply_event_to_task``, where a start only
+        fills ``latest_started_at`` if it is unset. A build emits exactly one
+        BUILD_STARTED (at creation), so the two rules can only diverge on a
+        hand-inserted event stream — and there, matching what the replay this
+        replaces would have said is the right default for a refactor.
+      - The four terminals (COMPLETED / FAILED / CANCELLED / EXIT_EARLY) set
+        the status and ``latest_completed_at``, and record the triggering
+        user when the event carries one.
+      - ``latest_is_resumed`` is true only immediately after a BUILD_RESUMED;
+        anything else — including a later BUILD_STARTED — clears it.
+      - Task-level events are no-ops.
+
+    **There is no stickiness here, and that is the difference from tasks.**
+    A completed task cannot un-complete: COMPLETED means the target exists.
+    A build genuinely can go COMPLETED → RUNNING, because
+    ``sd.build(resume_build_id=...)`` picking a finished build back up is a
+    supported operation, so the fold is plain last-event-wins.
+
+    **Tie-break.** "Last" means *arrival* order — the order the server
+    committed the events — not ``created_at`` order. That is not a choice so
+    much as a consequence of folding at write time: the event insert and this
+    mutation share a transaction, so two events are strictly ordered by their
+    commits even when their timestamps collide. It also resolves a
+    disagreement the two previous implementations had: the replay ordered by
+    ``created_at`` and broke ties arbitrarily (whatever the index returned),
+    while the reaper's SQL predicate read a tie as *not* running. Both were
+    guessing, because equal timestamps mean the proxy lost the information
+    the arrival order still has.
+
+    The reaper is unaffected in practice: it can only act on a build whose
+    column says RUNNING *and* which has then been silent for at least
+    ``idle_for_seconds`` (floor: 60 s). A build whose last committed
+    lifecycle event was a start or resume is running by every available
+    reading, and a build that is running and has since gone quiet for the
+    idle window is exactly what the reaper exists to find.
+
+    The caller is responsible for persisting the Build — this function only
+    mutates the in-memory ORM instance — and for holding the row lock that
+    makes the read-modify-write safe (see ``_get_build_for_update``).
     """
-    # Get build-level events (task_id is NULL)
-    result = await db.execute(
-        select(Event)
-        .where(Event.build_id == build_id)
-        .where(Event.task_id.is_(None))
-        .order_by(Event.created_at.desc())
-    )
-    events = result.scalars().all()
+    et = event.event_type
+    metadata = event.event_metadata or {}
 
-    status = BuildStatus.PENDING
-    started_at: datetime | None = None
-    completed_at: datetime | None = None
-    status_triggered_by_user_id: str | None = None
-    is_resumed = False
-
-    # Process events from oldest to newest to build final state
-    for event in reversed(events):
-        if event.event_type == EventType.BUILD_STARTED:
-            status = BuildStatus.RUNNING
-            started_at = event.created_at
-            status_triggered_by_user_id = None  # Not user-triggered
-            # Reset is_resumed so the flag stays consistent with its
-            # documented semantic (latest build-level event is
-            # BUILD_RESUMED). The SDK never emits BUILD_STARTED after a
-            # BUILD_RESUMED in normal flow, but the replay shouldn't rely
-            # on event ordering — admin/manual event inserts could
-            # produce any sequence.
-            is_resumed = False
-        elif event.event_type == EventType.BUILD_RESUMED:
-            # Treat like BUILD_STARTED, but flip the is_resumed flag and
-            # clear completed_at so the UI doesn't keep showing a stale
-            # "completed at" from the previous terminal event.
-            status = BuildStatus.RUNNING
-            completed_at = None
-            status_triggered_by_user_id = None
-            is_resumed = True
-            # Don't overwrite started_at — the build started when it first
-            # started; resume is a separate concept.
-        elif event.event_type == EventType.BUILD_COMPLETED:
-            status = BuildStatus.COMPLETED
-            completed_at = event.created_at
-            is_resumed = False
-            # Check if this was user-triggered (manual override)
-            status_triggered_by_user_id = (
-                event.event_metadata.get("triggered_by_user_id")
-                if event.event_metadata
-                else None
-            )
-        elif event.event_type == EventType.BUILD_FAILED:
-            status = BuildStatus.FAILED
-            completed_at = event.created_at
-            is_resumed = False
-            status_triggered_by_user_id = (
-                event.event_metadata.get("triggered_by_user_id")
-                if event.event_metadata
-                else None
-            )
-        elif event.event_type == EventType.BUILD_CANCELLED:
-            status = BuildStatus.CANCELLED
-            completed_at = event.created_at
-            is_resumed = False
-            status_triggered_by_user_id = (
-                event.event_metadata.get("triggered_by_user_id")
-                if event.event_metadata
-                else None
-            )
-        elif event.event_type == EventType.BUILD_EXIT_EARLY:
-            status = BuildStatus.EXIT_EARLY
-            completed_at = event.created_at
-            is_resumed = False
-            status_triggered_by_user_id = None  # Not user-triggered
-
-    return status, started_at, completed_at, status_triggered_by_user_id, is_resumed
+    if et == EventType.BUILD_STARTED:
+        build.latest_status = BuildStatus.RUNNING
+        build.latest_started_at = event.created_at
+        build.latest_status_triggered_by_user_id = None  # never user-triggered
+        # Clear the flag rather than leave it: the SDK never emits
+        # BUILD_STARTED after a BUILD_RESUMED, but the fold shouldn't depend
+        # on that — a manual/admin event insert could produce any sequence,
+        # and "resumed" must keep meaning "the event that put this build in
+        # its current status was a resume".
+        build.latest_is_resumed = False
+    elif et == EventType.BUILD_RESUMED:
+        build.latest_status = BuildStatus.RUNNING
+        build.latest_completed_at = None
+        build.latest_status_triggered_by_user_id = None
+        build.latest_is_resumed = True
+    elif et in _TERMINAL_BUILD_STATUS:
+        build.latest_status = _TERMINAL_BUILD_STATUS[et]
+        build.latest_completed_at = event.created_at
+        build.latest_is_resumed = False
+        build.latest_status_triggered_by_user_id = (
+            metadata.get("triggered_by_user_id")
+            if et in _USER_TRIGGERABLE_BUILD_EVENTS
+            else None
+        )
+    # Task-level events never affect build status.
 
 
 async def get_task_status_in_build(

--- a/app/stardag-api/tests/test_build_cleanup.py
+++ b/app/stardag-api/tests/test_build_cleanup.py
@@ -56,9 +56,9 @@ async def _backdate(
     event it owns. Returns the timestamp used.
 
     Event timestamps are rewritten one microsecond apart in their original
-    order rather than all set to the same instant — build status is derived
-    from *which build-level event came last*, so collapsing them would
-    change the build's status, not just its age.
+    order rather than all set to the same instant. Status no longer depends
+    on this — it lives on the build row — but the event stream stays a
+    faithful history, and ``last_activity_at`` is a max over it.
     """
     when = datetime.now(timezone.utc) - age
     pk = UUID(build_id)
@@ -910,23 +910,17 @@ async def test_list_builds_idle_filter_environment_isolation(
 
 
 @pytest.mark.asyncio
-async def test_list_builds_running_and_idle_is_exact_beyond_the_scan_cap(
-    client: AsyncClient, async_session, monkeypatch
+async def test_list_builds_running_and_idle_is_exact_and_unbounded(
+    client: AsyncClient, async_session
 ):
-    """`status=running` alone derives status in Python over the 500
-    most-recently-active candidates. Combined with `idle_for_seconds` that
-    cap would drop precisely the oldest builds — the ones the query exists
-    to find — so the pair uses the SQL RUNNING predicate instead.
+    """ "Running, and idle for a day" — the abandoned-build query — is served
+    entirely in SQL: an exact `COUNT(*)` and a server-side page.
 
-    The cap is monkeypatched down (as the existing truncation test does)
-    rather than building 500 rows.
+    This used to be the one status combination with a SQL predicate, bolted
+    on beside a Python scan of the 500 most-recently-active candidates that
+    would have dropped precisely the oldest builds. With `latest_status` a
+    column there is no window and no cap to escape.
     """
-    from stardag_api.routes import builds as builds_routes
-
-    monkeypatch.setattr(builds_routes, "_STATUS_FILTER_SCAN_CAP", 2)
-
-    # Three old RUNNING builds and one old terminal one. With a cap of 2,
-    # a window scan could see at most two of them.
     old_running = []
     for days in (10, 9, 8):
         build_id = await _new_build(client)
@@ -936,8 +930,8 @@ async def test_list_builds_running_and_idle_is_exact_beyond_the_scan_cap(
     await client.post(f"/api/v1/builds/{old_done}/complete")
     await _backdate(async_session, old_done, age=timedelta(days=7))
 
-    # Two fresh RUNNING builds, which is what the most-recently-active
-    # window would be full of.
+    # Fresh RUNNING builds, which is what a most-recently-active window
+    # would have been full of.
     for _ in range(2):
         await _new_build(client)
 
@@ -951,10 +945,9 @@ async def test_list_builds_running_and_idle_is_exact_beyond_the_scan_cap(
     assert [b["id"] for b in body["builds"]] == old_running  # stalest first
     assert all(b["status"] == "running" for b in body["builds"])
 
-    # The bare status filter is unchanged — still window-scanned, still
-    # truncating at the (patched) cap.
+    # The bare status filter counts every running build, fresh ones included.
     capped = (await client.get("/api/v1/builds", params={"status": "running"})).json()
-    assert capped["total"] <= 2
+    assert capped["total"] == 5
 
 
 @pytest.mark.asyncio

--- a/app/stardag-api/tests/test_build_cleanup.py
+++ b/app/stardag-api/tests/test_build_cleanup.py
@@ -913,7 +913,7 @@ async def test_list_builds_idle_filter_environment_isolation(
 async def test_list_builds_running_and_idle_is_exact_and_unbounded(
     client: AsyncClient, async_session
 ):
-    """ "Running, and idle for a day" — the abandoned-build query — is served
+    """The abandoned-build query — running, and idle for a day — is served
     entirely in SQL: an exact `COUNT(*)` and a server-side page.
 
     This used to be the one status combination with a SQL predicate, bolted

--- a/app/stardag-api/tests/test_build_status_denormalisation.py
+++ b/app/stardag-api/tests/test_build_status_denormalisation.py
@@ -1,0 +1,575 @@
+"""Tests for the denormalised ``Build.latest_*`` columns.
+
+Build status used to be recomputed from the build's event stream on every
+read, which meant ``GET /builds?status=`` could not filter in SQL and the
+stale-build reaper needed a second, independent SQL encoding of the same
+rule. These tests pin down that there is now one rule, on the row:
+
+- ``apply_event_to_build`` encodes what the historical event replay did.
+- Every build lifecycle endpoint folds its event into the columns — miss one
+  and the row silently drifts from the event log.
+- The columns are what reads, filters, pagination and the reaper all consult,
+  so they cannot disagree.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from uuid import UUID
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from stardag_api.models import Build, BuildStatus, Event, EventType
+from stardag_api.models.base import generate_uuid7
+from stardag_api.services.status import apply_event_to_build
+from tests.conftest import DEFAULT_ENVIRONMENT_ID
+
+T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+def _new_build() -> Build:
+    return Build(
+        id=generate_uuid7(),
+        environment_id=DEFAULT_ENVIRONMENT_ID,
+        name="b1",
+        root_task_ids=[],
+        latest_status=BuildStatus.PENDING,
+        latest_is_resumed=False,
+    )
+
+
+def _event(
+    et: EventType,
+    *,
+    offset_seconds: int = 0,
+    metadata: dict | None = None,
+) -> Event:
+    return Event(
+        id=generate_uuid7(),
+        build_id=generate_uuid7(),
+        task_id=None,
+        event_type=et,
+        created_at=T0 + timedelta(seconds=offset_seconds),
+        event_metadata=metadata,
+    )
+
+
+async def _db_build(session: AsyncSession, build_id: str) -> Build:
+    session.expire_all()
+    row = await session.get(Build, UUID(build_id))
+    assert row is not None
+    return row
+
+
+# ---------------------------------------------------------------------------
+# apply_event_to_build — the rule itself
+# ---------------------------------------------------------------------------
+
+
+class TestApplyEventToBuild:
+    def test_started_asserts_running_with_started_at(self) -> None:
+        build = _new_build()
+        apply_event_to_build(build, _event(EventType.BUILD_STARTED))
+        assert build.latest_status == BuildStatus.RUNNING
+        assert build.latest_started_at == T0
+        assert build.latest_completed_at is None
+        assert build.latest_is_resumed is False
+
+    @pytest.mark.parametrize(
+        ("event_type", "status"),
+        [
+            (EventType.BUILD_COMPLETED, BuildStatus.COMPLETED),
+            (EventType.BUILD_FAILED, BuildStatus.FAILED),
+            (EventType.BUILD_CANCELLED, BuildStatus.CANCELLED),
+            (EventType.BUILD_EXIT_EARLY, BuildStatus.EXIT_EARLY),
+        ],
+    )
+    def test_terminals_set_status_and_completed_at(
+        self, event_type: EventType, status: BuildStatus
+    ) -> None:
+        build = _new_build()
+        apply_event_to_build(build, _event(EventType.BUILD_STARTED))
+        apply_event_to_build(build, _event(event_type, offset_seconds=10))
+        assert build.latest_status == status
+        assert build.latest_completed_at == T0 + timedelta(seconds=10)
+        assert build.latest_started_at == T0  # untouched by the terminal
+        assert build.latest_is_resumed is False
+
+    @pytest.mark.parametrize(
+        "event_type",
+        [
+            EventType.BUILD_COMPLETED,
+            EventType.BUILD_FAILED,
+            EventType.BUILD_CANCELLED,
+        ],
+    )
+    def test_terminals_record_the_triggering_user(self, event_type: EventType) -> None:
+        build = _new_build()
+        apply_event_to_build(
+            build, _event(event_type, metadata={"triggered_by_user_id": "u-7"})
+        )
+        assert build.latest_status_triggered_by_user_id == "u-7"
+
+    def test_exit_early_is_never_user_triggered(self) -> None:
+        """The SDK emits it ("everything left is running elsewhere"), so it
+        carries no attribution even if metadata sneaks one in."""
+        build = _new_build()
+        apply_event_to_build(
+            build,
+            _event(
+                EventType.BUILD_EXIT_EARLY,
+                metadata={"triggered_by_user_id": "u-7"},
+            ),
+        )
+        assert build.latest_status_triggered_by_user_id is None
+
+    def test_resume_reasserts_running_and_clears_completed_at(self) -> None:
+        build = _new_build()
+        apply_event_to_build(build, _event(EventType.BUILD_STARTED))
+        apply_event_to_build(
+            build,
+            _event(
+                EventType.BUILD_FAILED,
+                offset_seconds=10,
+                metadata={"triggered_by_user_id": "u-9"},
+            ),
+        )
+        apply_event_to_build(build, _event(EventType.BUILD_RESUMED, offset_seconds=20))
+
+        assert build.latest_status == BuildStatus.RUNNING
+        assert build.latest_is_resumed is True
+        # Cleared, so no stale "completed at" survives the resume...
+        assert build.latest_completed_at is None
+        assert build.latest_status_triggered_by_user_id is None
+        # ...but the build still started when it first started.
+        assert build.latest_started_at == T0
+
+    def test_a_terminal_after_a_resume_clears_the_resumed_flag(self) -> None:
+        build = _new_build()
+        apply_event_to_build(build, _event(EventType.BUILD_RESUMED))
+        apply_event_to_build(
+            build, _event(EventType.BUILD_COMPLETED, offset_seconds=10)
+        )
+        assert build.latest_status == BuildStatus.COMPLETED
+        assert build.latest_is_resumed is False
+
+    def test_a_start_after_a_resume_clears_the_resumed_flag(self) -> None:
+        """The SDK never emits this sequence, but the fold must not depend on
+        that — ``is_resumed`` means "the event that produced the current
+        status was a resume", full stop."""
+        build = _new_build()
+        apply_event_to_build(build, _event(EventType.BUILD_RESUMED))
+        apply_event_to_build(build, _event(EventType.BUILD_STARTED, offset_seconds=10))
+        assert build.latest_status == BuildStatus.RUNNING
+        assert build.latest_is_resumed is False
+
+    def test_no_stickiness_a_completed_build_can_resume(self) -> None:
+        """Unlike a task, where COMPLETED means "the target exists" and is
+        sticky, a build genuinely goes COMPLETED → RUNNING:
+        ``sd.build(resume_build_id=...)`` on a finished build is supported."""
+        build = _new_build()
+        apply_event_to_build(build, _event(EventType.BUILD_COMPLETED))
+        apply_event_to_build(build, _event(EventType.BUILD_RESUMED, offset_seconds=10))
+        assert build.latest_status == BuildStatus.RUNNING
+
+    def test_task_events_are_no_ops(self) -> None:
+        build = _new_build()
+        apply_event_to_build(build, _event(EventType.BUILD_STARTED))
+        for et in (
+            EventType.TASK_STARTED,
+            EventType.TASK_FAILED,
+            EventType.TASK_COMPLETED,
+        ):
+            apply_event_to_build(build, _event(et, offset_seconds=10))
+        assert build.latest_status == BuildStatus.RUNNING
+        assert build.latest_completed_at is None
+
+    def test_ties_resolve_in_arrival_order_not_timestamp_order(self) -> None:
+        """Two events sharing a ``created_at`` are still applied one after the
+        other, and the later-applied one wins.
+
+        This is the tie-break decision. The event replay this fold replaces
+        ordered on ``created_at`` and let the index settle ties; the reaper's
+        separate SQL predicate read a tie as *not* running. Folding at write
+        time removes the question: the commits are strictly ordered even when
+        the timestamps collide, so "last" means what the server actually saw
+        last.
+        """
+        cancelled_last = _new_build()
+        apply_event_to_build(cancelled_last, _event(EventType.BUILD_RESUMED))
+        apply_event_to_build(cancelled_last, _event(EventType.BUILD_CANCELLED))
+        assert cancelled_last.latest_status == BuildStatus.CANCELLED
+
+        resumed_last = _new_build()
+        apply_event_to_build(resumed_last, _event(EventType.BUILD_CANCELLED))
+        apply_event_to_build(resumed_last, _event(EventType.BUILD_RESUMED))
+        assert resumed_last.latest_status == BuildStatus.RUNNING
+        assert resumed_last.latest_is_resumed is True
+
+
+# ---------------------------------------------------------------------------
+# Every lifecycle endpoint folds its event into the row.
+#
+# These assert on the ``builds`` row itself, not on the response body: a
+# handler that forgot the fold but still recomputed the response some other
+# way would pass an endpoint test and leave the row — which the list filter
+# and the reaper both trust — permanently wrong.
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycleEndpointsUpdateTheRow:
+    async def test_create_build_starts_running(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+        row = await _db_build(async_session, build_id)
+        assert row.latest_status == BuildStatus.RUNNING
+        assert row.latest_started_at is not None
+        assert row.latest_completed_at is None
+        assert row.latest_is_resumed is False
+
+    @pytest.mark.parametrize(
+        ("path", "status"),
+        [
+            ("complete", BuildStatus.COMPLETED),
+            ("fail", BuildStatus.FAILED),
+            ("cancel", BuildStatus.CANCELLED),
+            ("exit-early", BuildStatus.EXIT_EARLY),
+        ],
+    )
+    async def test_terminal_endpoints(
+        self,
+        client: AsyncClient,
+        async_session: AsyncSession,
+        path: str,
+        status: BuildStatus,
+    ) -> None:
+        build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+        response = await client.post(f"/api/v1/builds/{build_id}/{path}")
+        assert response.status_code == 200
+
+        row = await _db_build(async_session, build_id)
+        assert row.latest_status == status
+        assert row.latest_completed_at is not None
+        assert row.latest_started_at is not None  # the start is not lost
+        # The row and the response cannot disagree — they are the same data.
+        assert response.json()["status"] == status.value
+
+    async def test_terminal_endpoints_record_triggered_by_user(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+        await client.post(
+            f"/api/v1/builds/{build_id}/cancel",
+            params={"triggered_by_user_id": "default-local-user"},
+        )
+        row = await _db_build(async_session, build_id)
+        assert row.latest_status_triggered_by_user_id == "default-local-user"
+
+        body = (await client.get(f"/api/v1/builds/{build_id}")).json()
+        assert body["status_triggered_by_user"]["id"] == "default-local-user"
+
+    async def test_cascading_cancel_folds_the_build_too(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        """The cascade takes task row locks; the build must still be folded,
+        and must be locked first so the two orders can't deadlock."""
+        build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+        await client.post(
+            f"/api/v1/builds/{build_id}/tasks",
+            json={
+                "task_id": "casc-t",
+                "task_namespace": "",
+                "task_name": "T",
+                "task_data": {},
+                "dependency_task_ids": [],
+            },
+        )
+        await client.post(f"/api/v1/builds/{build_id}/tasks/casc-t/start")
+
+        response = await client.post(
+            f"/api/v1/builds/{build_id}/cancel", params={"cascade": "true"}
+        )
+        assert response.json()["cascaded_task_ids"] == ["casc-t"]
+        row = await _db_build(async_session, build_id)
+        assert row.latest_status == BuildStatus.CANCELLED
+
+    async def test_bulk_cancel_folds_every_build_it_cancels(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        build_ids = [
+            (await client.post("/api/v1/builds", json={})).json()["id"]
+            for _ in range(3)
+        ]
+        response = await client.post(
+            "/api/v1/builds/bulk-cancel", json={"build_ids": build_ids}
+        )
+        assert response.json()["build_count"] == 3
+        for build_id in build_ids:
+            row = await _db_build(async_session, build_id)
+            assert row.latest_status == BuildStatus.CANCELLED
+            assert row.latest_completed_at is not None
+
+    async def test_resume_preserves_started_at_and_clears_completed_at(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+        started_at = (await _db_build(async_session, build_id)).latest_started_at
+
+        await client.post(f"/api/v1/builds/{build_id}/fail")
+        failed = await _db_build(async_session, build_id)
+        assert failed.latest_completed_at is not None
+
+        body = (await client.post(f"/api/v1/builds/{build_id}/resume")).json()
+        assert body["status"] == "running"
+        assert body["is_resumed"] is True
+        assert body["completed_at"] is None
+
+        row = await _db_build(async_session, build_id)
+        assert row.latest_status == BuildStatus.RUNNING
+        assert row.latest_is_resumed is True
+        assert row.latest_completed_at is None
+        assert row.latest_started_at == started_at
+
+    async def test_no_op_resume_of_a_fresh_build_leaves_the_row_alone(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        """No BUILD_RESUMED event is recorded for a build with no activity
+        beyond its start, so nothing is folded either."""
+        build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+        body = (await client.post(f"/api/v1/builds/{build_id}/resume")).json()
+        assert body["is_resumed"] is False
+
+        row = await _db_build(async_session, build_id)
+        assert row.latest_status == BuildStatus.RUNNING
+        assert row.latest_is_resumed is False
+
+    async def test_the_row_matches_a_replay_of_the_whole_lifecycle(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        """End to end: drive a build through every transition, then fold its
+        recorded events from scratch and check the two agree. The row is the
+        event stream, not an approximation of it."""
+        build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+        await client.post(f"/api/v1/builds/{build_id}/fail")
+        await client.post(
+            f"/api/v1/builds/{build_id}/tasks",
+            json={
+                "task_id": "replay-t",
+                "task_namespace": "",
+                "task_name": "T",
+                "task_data": {},
+                "dependency_task_ids": [],
+            },
+        )
+        await client.post(f"/api/v1/builds/{build_id}/resume")
+        await client.post(
+            f"/api/v1/builds/{build_id}/complete",
+            params={"triggered_by_user_id": "default-local-user"},
+        )
+
+        events = (
+            (
+                await async_session.execute(
+                    select(Event)
+                    .where(Event.build_id == UUID(build_id))
+                    .where(Event.task_id.is_(None))
+                    .order_by(Event.created_at.asc(), Event.id.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
+        replayed = _new_build()
+        for event in events:
+            apply_event_to_build(replayed, event)
+
+        row = await _db_build(async_session, build_id)
+        assert row.latest_status == replayed.latest_status == BuildStatus.COMPLETED
+        assert row.latest_started_at == replayed.latest_started_at
+        assert row.latest_completed_at == replayed.latest_completed_at
+        assert row.latest_is_resumed == replayed.latest_is_resumed is False
+        assert (
+            row.latest_status_triggered_by_user_id
+            == replayed.latest_status_triggered_by_user_id
+            == "default-local-user"
+        )
+
+
+# ---------------------------------------------------------------------------
+# GET /builds?status= — exact and unbounded, for every status.
+# ---------------------------------------------------------------------------
+
+
+class TestStatusFilterIsExact:
+    async def test_total_is_a_true_count_and_pages_partition_it(
+        self, client: AsyncClient
+    ) -> None:
+        """Not "matches within the scanned window". The old implementation
+        scanned the 500 most-recently-active candidates, filtered in Python
+        and paginated the survivors in memory."""
+        failed = []
+        for _ in range(5):
+            build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+            await client.post(f"/api/v1/builds/{build_id}/fail")
+            failed.append(build_id)
+        for _ in range(3):
+            await client.post("/api/v1/builds", json={})
+
+        seen: list[str] = []
+        for page in (1, 2, 3):
+            body = (
+                await client.get(
+                    "/api/v1/builds",
+                    params={"status": "failed", "page_size": 2, "page": page},
+                )
+            ).json()
+            assert body["total"] == 5
+            seen.extend(b["id"] for b in body["builds"])
+        assert len(seen) == len(set(seen)) == 5
+        assert set(seen) == set(failed)
+
+        # ...and the page really was cut server-side.
+        first = (
+            await client.get(
+                "/api/v1/builds", params={"status": "failed", "page_size": 2}
+            )
+        ).json()
+        assert len(first["builds"]) == 2
+
+    @pytest.mark.parametrize(
+        ("path", "status"),
+        [
+            ("complete", "completed"),
+            ("fail", "failed"),
+            ("cancel", "cancelled"),
+            ("exit-early", "exit_early"),
+        ],
+    )
+    async def test_every_status_filters_in_sql(
+        self, client: AsyncClient, path: str, status: str
+    ) -> None:
+        match = (await client.post("/api/v1/builds", json={})).json()["id"]
+        await client.post(f"/api/v1/builds/{match}/{path}")
+        other = (await client.post("/api/v1/builds", json={})).json()["id"]
+
+        body = (await client.get("/api/v1/builds", params={"status": status})).json()
+        assert body["total"] == 1
+        assert [b["id"] for b in body["builds"]] == [match]
+
+        running = (
+            await client.get("/api/v1/builds", params={"status": "running"})
+        ).json()
+        assert [b["id"] for b in running["builds"]] == [other]
+
+    async def test_pending_builds_are_filterable(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        """A build row with no build-level events at all — reachable only by
+        direct insertion, but it is a status the enum has and the filter must
+        answer for."""
+        build = _new_build()
+        async_session.add(build)
+        await async_session.commit()
+        await client.post("/api/v1/builds", json={})
+
+        body = (await client.get("/api/v1/builds", params={"status": "pending"})).json()
+        assert body["total"] == 1
+        assert [b["id"] for b in body["builds"]] == [str(build.id)]
+
+
+# ---------------------------------------------------------------------------
+# The reaper reads the same column.
+# ---------------------------------------------------------------------------
+
+
+class TestReaperSelectsFromTheColumn:
+    async def _stale(self, client: AsyncClient, session: AsyncSession) -> str:
+        build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+        when = datetime.now(timezone.utc) - timedelta(days=2)
+        row = await _db_build(session, build_id)
+        row.last_active_at = when
+        for event in (
+            (
+                await session.execute(
+                    select(Event).where(Event.build_id == UUID(build_id))
+                )
+            )
+            .scalars()
+            .all()
+        ):
+            event.created_at = when
+        await session.commit()
+        return build_id
+
+    async def test_only_running_builds_are_selected(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        running = await self._stale(client, async_session)
+        done = await self._stale(client, async_session)
+        await client.post(f"/api/v1/builds/{done}/complete")
+
+        preview = (
+            await client.post(
+                "/api/v1/builds/bulk-cancel",
+                json={"idle_for_seconds": 3600, "dry_run": True},
+            )
+        ).json()
+        assert [b["build_id"] for b in preview["builds"]] == [running]
+
+        # And the list endpoint, filtering on the same column, agrees.
+        listed = (
+            await client.get(
+                "/api/v1/builds",
+                params={"status": "running", "idle_for_seconds": 3600},
+            )
+        ).json()
+        assert [b["id"] for b in listed["builds"]] == [running]
+
+    async def test_a_resume_that_arrived_last_makes_a_build_reapable(
+        self, client: AsyncClient, async_session: AsyncSession
+    ) -> None:
+        """The tie-break, where it costs money.
+
+        A terminal event and a resume sharing a ``created_at`` used to be read
+        as "not running" by the reaper's own SQL predicate, deliberately, and
+        arbitrarily by the status replay — the two disagreed. Now both read
+        the column, which records the order the events actually arrived: the
+        resume landed last, so the build is running, and a build that is
+        running and has since been silent for the idle window is exactly what
+        the reaper is for.
+        """
+        build_id = await self._stale(client, async_session)
+        await client.post(f"/api/v1/builds/{build_id}/cancel")
+        await client.post(f"/api/v1/builds/{build_id}/resume")
+
+        # Collapse every event onto one instant: the timestamps now tie, and
+        # the row still says what arrived last.
+        when = datetime.now(timezone.utc) - timedelta(days=2)
+        row = await _db_build(async_session, build_id)
+        row.last_active_at = when
+        for event in (
+            (
+                await async_session.execute(
+                    select(Event).where(Event.build_id == UUID(build_id))
+                )
+            )
+            .scalars()
+            .all()
+        ):
+            event.created_at = when
+        await async_session.commit()
+
+        assert (await _db_build(async_session, build_id)).latest_status == (
+            BuildStatus.RUNNING
+        )
+        preview = (
+            await client.post(
+                "/api/v1/builds/bulk-cancel",
+                json={"idle_for_seconds": 3600, "dry_run": True},
+            )
+        ).json()
+        assert [b["build_id"] for b in preview["builds"]] == [build_id]

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -199,8 +199,8 @@ async def test_resume_build_complete_clears_resumed_flag(client: AsyncClient):
     """A resumed build that subsequently completes shows is_resumed=False.
 
     Once a terminal event lands after BUILD_RESUMED, the resumed-flag
-    semantic is gone — get_build_status only flags is_resumed when the
-    most recent build-level event is BUILD_RESUMED.
+    semantic is gone — is_resumed is only set when the event that produced
+    the build's current status was a BUILD_RESUMED.
     """
     response = await client.post("/api/v1/builds", json={})
     build_id = response.json()["id"]

--- a/app/stardag-api/tests/test_status_denormalisation_concurrency.py
+++ b/app/stardag-api/tests/test_status_denormalisation_concurrency.py
@@ -1,4 +1,9 @@
-"""Postgres-only concurrency tests for the denormalised Task.latest_* columns.
+"""Postgres-only concurrency tests for the denormalised ``latest_*`` columns.
+
+Both ``Task`` and ``Build`` carry a status folded in-transaction from the
+event that produced it, and both folds are read-modify-writes that need the
+row lock to be safe. The task groups come first; the build ones mirror them
+at the end of the file.
 
 Two complementary test groups:
 
@@ -29,6 +34,7 @@ from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker
 from stardag_api.auth.dependencies import SdkAuth
 from stardag_api.models import (
     Build,
+    BuildStatus,
     Environment,
     Event,
     EventType,
@@ -36,8 +42,14 @@ from stardag_api.models import (
     TaskStatus,
 )
 from stardag_api.models.base import generate_uuid7
-from stardag_api.routes.builds import _create_task_event
-from stardag_api.services.status import apply_event_to_task
+from stardag_api.routes.builds import (
+    _create_task_event,
+    cancel_build,
+    complete_build,
+    fail_build,
+    resume_build,
+)
+from stardag_api.services.status import apply_event_to_build, apply_event_to_task
 from tests.conftest import (
     DEFAULT_ENVIRONMENT_ID,
     DEFAULT_WORKSPACE_ID,
@@ -330,3 +342,195 @@ async def test_with_lock_completed_stays_sticky(
         row = await final.get(Task, task_pk)
         assert row is not None
         assert row.latest_status == TaskStatus.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# The same story for Build.latest_*.
+#
+# The build fold is last-event-wins rather than sticky (a resume legitimately
+# takes a COMPLETED build back to RUNNING), so the failure mode the lock
+# prevents is not a lost terminal — it is a *torn* row. Each session's UPDATE
+# carries only the columns it changed, so two writers that both read the
+# pre-state can each land half of their transition and leave a combination no
+# single event could produce.
+# ---------------------------------------------------------------------------
+
+
+async def _seed_running_build(pg_engine: AsyncEngine, name: str):
+    """Insert a RUNNING build with its BUILD_STARTED event; return its id."""
+    sm = async_sessionmaker(pg_engine, expire_on_commit=False)
+    async with sm() as setup:
+        build = Build(
+            id=generate_uuid7(),
+            environment_id=DEFAULT_ENVIRONMENT_ID,
+            user_id=None,
+            name=name,
+            description=None,
+            commit_hash=None,
+            root_task_ids=[],
+            latest_status=BuildStatus.PENDING,
+            latest_is_resumed=False,
+        )
+        setup.add(build)
+        await setup.flush()
+        event = Event(
+            id=generate_uuid7(),
+            build_id=build.id,
+            task_id=None,
+            event_type=EventType.BUILD_STARTED,
+            created_at=datetime.now(timezone.utc),
+        )
+        setup.add(event)
+        await setup.flush()
+        apply_event_to_build(build, event)
+        # A second event so the resume endpoint sees "activity" and actually
+        # records a BUILD_RESUMED rather than no-opping.
+        setup.add(
+            Event(
+                id=generate_uuid7(),
+                build_id=build.id,
+                task_id=None,
+                event_type=EventType.BUILD_FAILED,
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        await setup.commit()
+        return build.id
+
+
+def _is_coherent(build: Build) -> bool:
+    """Every field combination a single event could have produced."""
+    if build.latest_status == BuildStatus.RUNNING:
+        # A start or a resume: nothing has completed since.
+        return build.latest_completed_at is None
+    # A terminal: it stamped completed_at and cleared the resumed flag.
+    return build.latest_completed_at is not None and not build.latest_is_resumed
+
+
+async def _force_overlapping_build_selects(
+    pg_engine: AsyncEngine, build_id, *, use_for_update: bool
+) -> None:
+    """Two read-modify-writes on one build, both SELECTing before either
+    COMMITs: BUILD_COMPLETED from A, BUILD_RESUMED from B, A committing first.
+    """
+    sm = async_sessionmaker(pg_engine, expire_on_commit=False)
+    async with sm() as s_a, sm() as s_b:
+        stmt = select(Build).where(Build.id == build_id)
+        if use_for_update:
+            stmt = stmt.with_for_update()
+
+        async def apply(session, build, event_type) -> None:
+            event = Event(
+                id=generate_uuid7(),
+                build_id=build.id,
+                task_id=None,
+                event_type=event_type,
+                created_at=datetime.now(timezone.utc),
+            )
+            session.add(event)
+            await session.flush()
+            apply_event_to_build(build, event)
+
+        if use_for_update:
+            # A holds the lock, so B's SELECT blocks until A commits —
+            # gathering them would just deadlock on that lock.
+            b_a = (await s_a.execute(stmt)).scalar_one()
+            await apply(s_a, b_a, EventType.BUILD_COMPLETED)
+            await s_a.commit()
+
+            b_b = (await s_b.execute(stmt)).scalar_one()
+            await apply(s_b, b_b, EventType.BUILD_RESUMED)
+            await s_b.commit()
+        else:
+            r_a, r_b = await asyncio.gather(s_a.execute(stmt), s_b.execute(stmt))
+            b_a, b_b = r_a.scalar_one(), r_b.scalar_one()
+            await apply(s_a, b_a, EventType.BUILD_COMPLETED)
+            await apply(s_b, b_b, EventType.BUILD_RESUMED)
+            await s_a.commit()
+            await s_b.commit()
+
+
+async def test_without_lock_the_build_row_tears(pg_engine: AsyncEngine) -> None:
+    """Without ``SELECT ... FOR UPDATE`` the two writers each land only the
+    columns they changed relative to the *pre*-state, and the row ends as a
+    combination no event could produce: COMPLETED — with a completed_at — yet
+    flagged as resumed. This pins down the bug the production lock fixes."""
+    build_id = await _seed_running_build(pg_engine, "build-race-no-lock")
+
+    await _force_overlapping_build_selects(pg_engine, build_id, use_for_update=False)
+
+    sm = async_sessionmaker(pg_engine, expire_on_commit=False)
+    async with sm() as final:
+        row = await final.get(Build, build_id)
+        assert row is not None
+        assert row.latest_status == BuildStatus.COMPLETED
+        assert row.latest_is_resumed is True  # ...from the resume that lost
+        assert not _is_coherent(row)
+
+
+async def test_with_lock_the_build_row_stays_coherent(pg_engine: AsyncEngine) -> None:
+    """With the lock the second writer observes the first writer's committed
+    state, so the resume applies to a COMPLETED build and produces the whole
+    resume transition: RUNNING, resumed, completed_at cleared."""
+    build_id = await _seed_running_build(pg_engine, "build-race-locked")
+
+    await _force_overlapping_build_selects(pg_engine, build_id, use_for_update=True)
+
+    sm = async_sessionmaker(pg_engine, expire_on_commit=False)
+    async with sm() as final:
+        row = await final.get(Build, build_id)
+        assert row is not None
+        assert row.latest_status == BuildStatus.RUNNING
+        assert row.latest_is_resumed is True
+        assert row.latest_completed_at is None
+        assert _is_coherent(row)
+
+
+async def _call_lifecycle(pg_engine: AsyncEngine, handler, build_id, auth) -> None:
+    """Invoke a production build-lifecycle handler on its own session."""
+    sm = async_sessionmaker(pg_engine, expire_on_commit=False)
+    async with sm() as session:
+        await handler(build_id, session, auth)
+
+
+async def test_production_lifecycle_handlers_never_tear_the_row(
+    pg_engine: AsyncEngine,
+) -> None:
+    """Stress the real handlers — which all go through
+    ``_get_build_for_update`` — with complete/fail/cancel/resume racing on one
+    build. Whichever commits last, the row must be exactly what that one event
+    produces. If anyone drops the lock from a lifecycle path, this starts
+    failing flakily."""
+    build_id = await _seed_running_build(pg_engine, "build-race-stress")
+    auth = await _make_sdk_auth(pg_engine)
+
+    coros = []
+    for _ in range(10):
+        for handler in (complete_build, fail_build, cancel_build, resume_build):
+            coros.append(_call_lifecycle(pg_engine, handler, build_id, auth))
+    await asyncio.gather(*coros)
+
+    sm = async_sessionmaker(pg_engine, expire_on_commit=False)
+    async with sm() as final:
+        row = await final.get(Build, build_id)
+        assert row is not None
+        assert _is_coherent(row)
+        # And the status is one an event actually asserted.
+        types = set(
+            (
+                await final.execute(
+                    select(Event.event_type)
+                    .where(Event.build_id == build_id)
+                    .where(Event.task_id.is_(None))
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert EventType.BUILD_RESUMED in types
+        assert row.latest_status in {
+            BuildStatus.RUNNING,
+            BuildStatus.COMPLETED,
+            BuildStatus.FAILED,
+            BuildStatus.CANCELLED,
+        }

--- a/app/stardag-api/tests/test_status_denormalisation_concurrency.py
+++ b/app/stardag-api/tests/test_status_denormalisation_concurrency.py
@@ -385,12 +385,32 @@ async def _seed_running_build(pg_engine: AsyncEngine, name: str):
         apply_event_to_build(build, event)
         # A second event so the resume endpoint sees "activity" and actually
         # records a BUILD_RESUMED rather than no-opping.
+        #
+        # A *task*-level event, deliberately. A build-level terminal event
+        # here would leave this build's event stream disagreeing with its
+        # own `latest_*` columns — a state the denormalisation makes
+        # impossible in production, and one that would mask exactly the
+        # bugs these tests exist to catch (code consulting the stream where
+        # it should consult the columns).
+        activity_task = Task(
+            id=generate_uuid7(),
+            task_id=f"{name}-activity",
+            environment_id=DEFAULT_ENVIRONMENT_ID,
+            task_namespace="",
+            task_name=f"{name}-activity",
+            task_data={},
+            is_phantom=False,
+            latest_status=TaskStatus.PENDING,
+            latest_waiting_for_lock=False,
+        )
+        setup.add(activity_task)
+        await setup.flush()
         setup.add(
             Event(
                 id=generate_uuid7(),
                 build_id=build.id,
-                task_id=None,
-                event_type=EventType.BUILD_FAILED,
+                task_id=activity_task.id,
+                event_type=EventType.TASK_STARTED,
                 created_at=datetime.now(timezone.utc),
             )
         )


### PR DESCRIPTION
Build status was not a column. `get_build_status` replayed every build-level
event on every read, and `_build_to_response` called it per build. Three
things followed from that, and this PR removes all three.

## What moved

Five denormalised columns on `builds`, holding exactly what the replay
returned:

| column | was |
| --- | --- |
| `latest_status` | `status` |
| `latest_started_at` | `started_at` |
| `latest_completed_at` | `completed_at` |
| `latest_status_triggered_by_user_id` | `status_triggered_by_user_id` |
| `latest_is_resumed` | `is_resumed` |

Plus `ix_builds_environment_status` on `(environment_id, latest_status,
last_active_at)` — same shape and same reasoning as `ix_tasks_environment_status`,
so a single-status page resolves its `ORDER BY` from the index in either
direction.

They are maintained by `apply_event_to_build`, which mirrors
`apply_event_to_task`: applied in the transaction that inserts the event,
on a row locked by `_get_build_for_update`. Every path that creates a
build-level event goes through it — `create_build`, `/complete`, `/fail`,
`/cancel`, `/exit-early`, `/resume`, and `cancel_builds` (bulk cancel and
the reaper). The build is always locked *before* any task rows a cascade
touches, so the lock order is consistent with `_create_task_event`.

One structural difference from the task fold, and it is deliberate: there
is no stickiness. A completed task cannot un-complete, but a build
genuinely goes COMPLETED → RUNNING, because `sd.build(resume_build_id=...)`
on a finished build is supported. So the build fold is plain
last-event-wins.

## The tie-break

The two previous implementations disagreed when a terminal event shared a
`created_at` with a start/resume: the replay ordered on the timestamp and
let the index settle ties; `build_is_running()` read a tie as *not*
running, on purpose, so the reaper would leave it alone.

**The new rule is arrival order** — the order the server committed the
events. That is less a choice than a consequence of folding at write time:
the event insert and the fold share a transaction, so two events are
strictly ordered by their commits even when their timestamps collide.
Equal timestamps mean the proxy lost information the commit order still
has; both old implementations were guessing.

The reaper's conservatism is **consciously changed, and preserved where it
matters**. It can only act on a build whose column says RUNNING *and*
which has since been silent for at least `idle_for_seconds` (floor 60s). A
build whose last committed lifecycle event was a start or resume is
running by every available reading; a build that is running and has gone
quiet for the idle window is precisely what the reaper exists to find. The
case is covered by a test that reproduces the tie and asserts the build is
now selected.

## What was deleted

- `_STATUS_FILTER_SCAN_CAP = 500` and the Python filter path in
  `GET /builds`, along with the `total` that counted matches *within the
  scanned window* while looking like an exact count.
- `build_is_running()` in `services/build_cleanup.py` — a second SQL
  encoding of the same rule — and its call sites, which become
  `Build.latest_status == BuildStatus.RUNNING`. `_TERMINAL_BUILD_EVENTS`
  and `_ACTIVE_BUILD_EVENTS` went with it.
- `get_build_status` itself, rather than leaving a thin wrapper: the whole
  point is that there is one way to get the answer.
- The per-response event scan behind every `BuildResponse`.

## `status` is now exact for every value — but the idle restriction stays

`status` filtering is exact and unbounded for **every** status: true
`COUNT(*)`, server-side pagination, no window. That part of the original
motivation stands.

What did **not** happen is lifting the `status` + `idle_for_seconds`
restriction. An earlier revision of this PR removed the 422 on the grounds
that "only `running` has a SQL predicate" was no longer true. It was
reinstated, because the reason for the restriction turned out not to be the
implementation at all:

An idle filter means **abandoned**, and only a running build can be
abandoned. A finished build satisfies "no activity for N seconds"
trivially and permanently, so a bare staleness query returned every build
that ever completed — sorted stalest-first, which put the oldest completed
builds *above* the running ones an operator is looking for. It also broke
parity with `POST /builds/bulk-cancel`, which only ever cascades over
running builds: the listing is that endpoint's preview, and a preview that
offers rows the action will never touch is worse than none.

So `idle_for_seconds` implies RUNNING, and pairing it with any other status
is a contradiction rather than a narrower query — answered with 422 instead
of the empty result the predicates would produce. Verified against a live
deployment: the query went from 4 builds (2 terminal, sorted top) to 2,
matching the reaper's dry run exactly.

## Migration

`e87efdab31ca`, autogenerated, with the backfill added deliberately: one
pass over build-level events ordered `(created_at, id)`, applying the same
rules as `apply_event_to_build`. The `id` tiebreaker is what makes ties
resolve the same way before and after — `id` is a UUID7, so ordering by it
is ordering by arrival. The two NOT NULL columns take a `server_default`
so the ALTER succeeds on existing rows, dropped again afterwards.

Verified against Postgres 16: `upgrade head` → `downgrade -1` →
`upgrade head`, then `alembic check` clean. Eleven seeded event streams —
every terminal, resume-then-terminal, start-after-resume, both tie
orderings, and a build with no events at all — compared field by field
against the old replay; all matched.

## Tests

`app/stardag-api/tests/test_build_status_denormalisation.py` (new) covers
`apply_event_to_build` including the tie-break, every lifecycle endpoint
asserted **against the `builds` row** rather than the response body (a
handler that forgot the fold but recomputed the response some other way
would pass an endpoint test and leave the row wrong), a full-lifecycle
row-versus-replay check, exact `total` and server-side pagination for
non-`running` statuses, and the reaper selecting from the column.
`test_status_denormalisation_concurrency.py` gains the build mirror of the
task race tests, including a deterministic demonstration of the torn row
the lock prevents (COMPLETED, with a `completed_at`, yet flagged resumed)
and a 40-way stress test through the real handlers.

The two tests that asserted the approximate `total` and the 422 are
rewritten to assert the exact behaviour that replaced them.

`478 passed, 1 skipped` (SQLite + Postgres); pyright and the pre-commit
hooks clean.

## Net lines

`src/`: +347 / -342 — net **+5**, and much of the addition is the comment
explaining the tie-break and the lock. `tests/`: +842 / -41. Migration and
CHANGELOG: +234 / -6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NyR9Kc9ZP5Ko7dVndhi3Y
