### PR TITLE
feat(api): expose per-build task attempt counts so schedulers can retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,12 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   tick is short-lived and cannot remember what it already tried.
 
   `attempt_count` is how many times execution has been started for a task
-  **in that build**, exposed on `FrontierTaskRef` (all of `actionable`,
-  `running` and `roots`), on `GET /builds/{id}/tasks`, and on every task
-  lifecycle event response so a caller that has just recorded a failure or
-  won a claiming start can apply its budget without a second round-trip.
+  **since its build's most recent `BUILD_RESUMED` event** — since the
+  build began, if it never was. Exposed on `FrontierTaskRef` (all of
+  `actionable`, `running` and `roots`), on `GET /builds/{id}/tasks`, and on
+  every task lifecycle event response so a caller that has just recorded a
+  failure or won a claiming start can apply its budget without a second
+  round-trip. Always populated wherever it is declared.
 
   Three things it is easy to assume and get wrong:
 
@@ -37,17 +39,28 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   - **The scope is the build, not the environment** — unlike the
     `latest_*` fields it travels with. A task that spent two attempts in
     an earlier build arrives in a fresh trigger with a full budget.
-  - **A retry does not reset it.** A scheduler retries a failed task
-    _through_ `POST .../retry`, so a resetting counter would be cleared by
-    every enforcement of the budget it defines. Within one build the
-    number is a lifetime budget; a re-trigger gets a new build.
+  - **A resume resets it; a retry does not.** `build_trigger(...,
+build_id=<existing>, reactive=True)` is the recommended way to pick a
+    failed reactive build back up, and it does _not_ mint a new build: it
+    resumes this one and retries the failed tasks in it. Counting over a
+    build's whole history would therefore leave the budget spent the
+    moment the user asked for another go, and resuming would mean also
+    raising `max_attempts`. `BUILD_RESUMED` is the durable marker of
+    "another round was asked for" — and the server already skips it for a
+    build with no activity beyond `BUILD_STARTED`, so a first trigger is
+    unaffected. `TASK_RETRIED` on its own does not reset, because a
+    scheduler retries _through_ that endpoint: a counter cleared by it
+    would be cleared by every enforcement of the budget it defines. So a
+    bare retry against a spent budget is a real "this round is out of
+    attempts", and resuming is the answer to it.
 
   Derived from the event log rather than denormalised — attempts are
-  per-build and there is no per-(build, task) row to hang a column on — as
-  one grouped query bounded to the tasks being reported. No migration; the
-  frontier costs exactly one extra query, and none at all when it has no
-  tasks to report. Purely additive: every existing field keeps its exact
-  semantics.
+  per-build, per-round, and there is no per-(build, task) row to hang a
+  column on — as one grouped query bounded to the tasks being reported,
+  with the round cutoff riding along as a correlated subquery. No
+  migration; the frontier costs exactly one extra query, and none at all
+  when it has no tasks to report. Purely additive: every existing field
+  keeps its exact semantics.
 
 - **Reactive scheduler tick summaries are now persisted per build**
   (`POST`/`GET /builds/{build_id}/tick-summaries`). A reactive build is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,47 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### Registry API
 
+- **Task refs now carry `attempt_count`, so a scheduler can run a retry
+  policy** ([#208](https://github.com/stardag-dev/stardag/issues/208)).
+  Reactive scheduling records a failed execution and never respawns it —
+  retries are the execution backend's job — but a backend's function-level
+  retries only cover exceptions raised _inside_ a container that started.
+  A spawn that failed before the container existed, an OOM kill, a
+  preemption, or a worker that died after writing partial output are
+  invisible to them, so under fail-fast a single transient failure killed
+  the whole build. Deciding otherwise needs a _durable_ attempt count: a
+  tick is short-lived and cannot remember what it already tried.
+
+  `attempt_count` is how many times execution has been started for a task
+  **in that build**, exposed on `FrontierTaskRef` (all of `actionable`,
+  `running` and `roots`), on `GET /builds/{id}/tasks`, and on every task
+  lifecycle event response so a caller that has just recorded a failure or
+  won a claiming start can apply its budget without a second round-trip.
+
+  Three things it is easy to assume and get wrong:
+
+  - **It counts attempts, not `TASK_STARTED` events.** Engines emit
+    several starts per execution — an acquiring start for the claim /
+    limit slot before the spawn (no executor ref), a second carrying the
+    ref, plus the worker's own start when the executor self-reports
+    lifecycle. A run of consecutive starts collapses to the one execution
+    it describes, which makes the number the same whichever engine and
+    executor ran the task.
+  - **The scope is the build, not the environment** — unlike the
+    `latest_*` fields it travels with. A task that spent two attempts in
+    an earlier build arrives in a fresh trigger with a full budget.
+  - **A retry does not reset it.** A scheduler retries a failed task
+    _through_ `POST .../retry`, so a resetting counter would be cleared by
+    every enforcement of the budget it defines. Within one build the
+    number is a lifetime budget; a re-trigger gets a new build.
+
+  Derived from the event log rather than denormalised — attempts are
+  per-build and there is no per-(build, task) row to hang a column on — as
+  one grouped query bounded to the tasks being reported. No migration; the
+  frontier costs exactly one extra query, and none at all when it has no
+  tasks to report. Purely additive: every existing field keeps its exact
+  semantics.
+
 - **Reactive scheduler tick summaries are now persisted per build**
   (`POST`/`GET /builds/{build_id}/tick-summaries`). A reactive build is
   driven by many short-lived scheduler ticks, each in its own container,

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1642,11 +1642,13 @@ async def get_build_frontier(
     :class:`FrontierExternalBlocker`.
 
     ``attempt_count`` on every task ref is the one field here that is
-    scoped to **this build** rather than the environment — deliberately,
-    because "how many times has this build tried" is the retry-relevant
-    number, and a task that failed twice in an earlier build must not
-    arrive here with its budget already spent. It also counts *attempts*,
-    not TASK_STARTED events; see :class:`FrontierTaskRef`.
+    scoped to **this build**, and to its current round, rather than to the
+    environment — deliberately, because "how many times has this build
+    tried since it was last resumed" is the retry-relevant number. A task
+    that failed twice in an earlier build must not arrive here with its
+    budget already spent, and neither must one whose build the user has
+    just re-triggered. It also counts *attempts*, not TASK_STARTED events;
+    see :class:`FrontierTaskRef`.
     """
     _raise_if_limit_exceeded(check_rate_limit(auth.workspace_id, limits_settings))
     build = await _get_build_checked(build_id, db, auth)
@@ -1834,11 +1836,12 @@ async def get_build_frontier(
             .all()
         )
 
-    # Execution attempts per task, for the scheduler's retry policy (see
-    # FrontierTaskRef.attempt_count). Derived rather than denormalised:
-    # attempts are per *build*, and there is no per-(build, task) row to
-    # denormalise onto — inventing one would cost a table, a fold on every
-    # start path and a backfill, to replace this.
+    # Execution attempts per task in this build's current round, for the
+    # scheduler's retry policy (see FrontierTaskRef.attempt_count). Derived
+    # rather than denormalised: attempts are per *build* and per *round*,
+    # and there is no per-(build, task) row to denormalise onto — inventing
+    # one would cost a table, a fold on every start path and a backfill, to
+    # replace this.
     #
     # ONE grouped query for every task in the response — the frontier is
     # re-read on every linger poll (~3 s per active build), so a per-task
@@ -3111,9 +3114,10 @@ async def list_tasks_in_build(
 
     Statuses are global (events from all builds); ``attempt_count`` is
     per-build by construction — it answers "how many times did *this* build
-    try", which is what a UI or CLI showing a build wants, and what a
-    global count could not express. See ``FrontierTaskRef.attempt_count``
-    for the counting rule.
+    try since it was last resumed", which is what a UI or CLI showing a
+    build wants, and what a global count could not express. See
+    ``FrontierTaskRef.attempt_count`` for the counting rule and the round
+    window.
 
     Requires authentication via API key or JWT token with environment_id.
     """

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -95,6 +95,7 @@ from stardag_api.services.status import (
     apply_event_to_build,
     apply_event_to_task,
     get_all_task_global_statuses,
+    get_attempt_counts_in_build,
     get_task_status_in_build,
 )
 
@@ -516,12 +517,18 @@ async def _create_task_event(
 
     record_entity_created(auth.workspace_id, "events")
 
-    status, _, _, _ = await get_task_status_in_build(db, build_id, db_task.id)
+    # The attempt count comes out of the replay this call already performs,
+    # so every task-event response carries it at no extra query cost — see
+    # TaskEventResponse.attempt_count for why it is worth carrying.
+    status, _, _, _, attempt_count = await get_task_status_in_build(
+        db, build_id, db_task.id
+    )
 
     return TaskEventResponse(
         task_id=db_task.task_id,
         status=status,
         latest_status=db_task.latest_status,
+        attempt_count=attempt_count,
     )
 
 
@@ -1633,6 +1640,13 @@ async def get_build_frontier(
     dependency gating is environment-global, while ``running`` and
     ``status_counts`` cover only tasks this build has events for. See
     :class:`FrontierExternalBlocker`.
+
+    ``attempt_count`` on every task ref is the one field here that is
+    scoped to **this build** rather than the environment — deliberately,
+    because "how many times has this build tried" is the retry-relevant
+    number, and a task that failed twice in an earlier build must not
+    arrive here with its budget already spent. It also counts *attempts*,
+    not TASK_STARTED events; see :class:`FrontierTaskRef`.
     """
     _raise_if_limit_exceeded(check_rate_limit(auth.workspace_id, limits_settings))
     build = await _get_build_checked(build_id, db, auth)
@@ -1820,6 +1834,25 @@ async def get_build_frontier(
             .all()
         )
 
+    # Execution attempts per task, for the scheduler's retry policy (see
+    # FrontierTaskRef.attempt_count). Derived rather than denormalised:
+    # attempts are per *build*, and there is no per-(build, task) row to
+    # denormalise onto — inventing one would cost a table, a fold on every
+    # start path and a backfill, to replace this.
+    #
+    # ONE grouped query for every task in the response — the frontier is
+    # re-read on every linger poll (~3 s per active build), so a per-task
+    # aggregate would be N+1 on the hottest read in the system. Bounded to
+    # the tasks actually being reported, so the added scan is proportional
+    # to the response, not to the build's whole event history. Frontier
+    # query-count delta: +1, unconditionally.
+    attempt_task_pks = {t.id for t in actionable_tasks}
+    attempt_task_pks.update(t.id for t in running_tasks)
+    attempt_task_pks.update(t.id for t in roots)
+    attempt_counts = await get_attempt_counts_in_build(
+        db, build_id, list(attempt_task_pks)
+    )
+
     def _ref(t: Task) -> FrontierTaskRef:
         return FrontierTaskRef(
             task_id=t.task_id,
@@ -1835,6 +1868,9 @@ async def get_build_frontier(
             # expiry the server itself will hand the task to the next
             # claimant, so a scheduler can stop inferring from elapsed time.
             latest_status_expires_at=t.latest_status_expires_at,
+            # Absent from the map = no attempt recorded in this build. A
+            # root cached from an earlier build is the normal case.
+            attempt_count=attempt_counts.get(t.id, 0),
         )
 
     return BuildFrontierResponse(
@@ -3073,6 +3109,12 @@ async def list_tasks_in_build(
 ):
     """List all tasks in a build with their status.
 
+    Statuses are global (events from all builds); ``attempt_count`` is
+    per-build by construction — it answers "how many times did *this* build
+    try", which is what a UI or CLI showing a build wants, and what a
+    global count could not express. See ``FrontierTaskRef.attempt_count``
+    for the counting rule.
+
     Requires authentication via API key or JWT token with environment_id.
     """
     build = await db.get(Build, build_id)
@@ -3129,6 +3171,10 @@ async def list_tasks_in_build(
         )
         artifact_counts = {row[0]: row[1] for row in artifact_count_result.all()}
 
+    # One grouped query for the whole page, mirroring artifact_counts above
+    # (and never one per task).
+    attempt_counts = await get_attempt_counts_in_build(db, build_id, task_ids)
+
     responses = []
     for task in tasks:
         (
@@ -3165,6 +3211,7 @@ async def list_tasks_in_build(
                 waiting_for_lock=waiting_for_lock,
                 status_build_id=status_build_id,
                 commit_hash=commit_hash,
+                attempt_count=attempt_counts.get(task.id, 0),
             )
         )
 

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1848,7 +1848,8 @@ async def get_build_frontier(
     # aggregate would be N+1 on the hottest read in the system. Bounded to
     # the tasks actually being reported, so the added scan is proportional
     # to the response, not to the build's whole event history. Frontier
-    # query-count delta: +1, unconditionally.
+    # query-count delta: +1, or 0 when the frontier has no tasks to report
+    # (`get_attempt_counts_in_build` returns without touching the DB).
     attempt_task_pks = {t.id for t in actionable_tasks}
     attempt_task_pks.update(t.id for t in running_tasks)
     attempt_task_pks.update(t.id for t in roots)

--- a/app/stardag-api/src/stardag_api/routes/concurrency_limits.py
+++ b/app/stardag-api/src/stardag_api/routes/concurrency_limits.py
@@ -48,7 +48,7 @@ from stardag_api.schemas import (
     TaskEventResponse,
 )
 from stardag_api.services.claims import live_claim_filter
-from stardag_api.services.status import apply_event_to_task
+from stardag_api.services.status import apply_event_to_task, get_attempt_counts_in_build
 
 router = APIRouter(prefix="/concurrency-limits", tags=["concurrency-limits"])
 
@@ -389,10 +389,19 @@ async def evict_concurrency_limit_holder(
 
     record_entity_created(auth.workspace_id, "events")
 
-    # This surface has no build scope, so both fields carry the global
-    # status — see TaskEventResponse for why they are usually different.
+    # Attempts the evicted task made in the build the eviction was recorded
+    # against — one extra query, on an admin recovery path that runs at
+    # human frequency, so that the field is never null anywhere and an SDK
+    # can read it without a "was it computed here?" branch.
+    attempt_counts = await get_attempt_counts_in_build(
+        db, db_task.latest_status_build_id, [db_task.id]
+    )
+
+    # This surface has no build scope, so both status fields carry the
+    # global status — see TaskEventResponse for why they usually differ.
     return TaskEventResponse(
         task_id=db_task.task_id,
         status=db_task.latest_status,
         latest_status=db_task.latest_status,
+        attempt_count=attempt_counts.get(db_task.id, 0),
     )

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -314,6 +314,37 @@ class FrontierTaskRef(BaseModel):
     # to date it). Those need an operator to release; there is no timestamp
     # that would let a client conclude anything else.
     latest_status_expires_at: datetime | None = None
+    # How many times execution has been started for this task **in this
+    # build** — the input to a scheduler's own retry policy (a
+    # `max_attempts`), which the reactive engine has no other way to
+    # express: a tick is short-lived and cannot remember what it already
+    # tried, and the execution backend's own function-level retries only
+    # cover exceptions raised *inside* a container that started. A spawn
+    # that failed before the container existed, an OOM kill, a preemption,
+    # or a worker that died after writing partial output are all invisible
+    # to them and visible here.
+    #
+    # **Per build, unlike every other field on this ref.** The latest_*
+    # fields are environment-global because a completed task is completed
+    # for everyone; attempts are the opposite — a task that burned two
+    # attempts in an earlier build arrives in a new one with a full budget,
+    # which is what a fresh trigger means.
+    #
+    # Counts *attempts*, not TASK_STARTED events: engines emit several
+    # starts per execution (a claim/limit-acquiring start with no executor
+    # ref, then one carrying the ref, plus the worker's own start when the
+    # executor self-reports lifecycle), and consecutive starts collapse
+    # into the one attempt they describe.
+    #
+    # A retry (TASK_RETRIED) does NOT reset it: a scheduler retries a
+    # failed task *through* that endpoint, so a resetting counter would be
+    # cleared by the very act it is meant to bound. Within one build the
+    # number is therefore a lifetime budget; a re-trigger gets a new build
+    # and a fresh count.
+    #
+    # 0 means "not attempted in this build" — and is also what a server
+    # predating this field serialises, i.e. "unknown, don't enforce".
+    attempt_count: int = 0
 
 
 class FrontierExternalBlocker(BaseModel):
@@ -639,6 +670,14 @@ class TaskWithStatusResponse(TaskResponse):
     status_build_id: UUID | None = None
     # Git commit hash from the event that determined the current status
     commit_hash: str | None = None
+    # Execution attempts for this task in the build being listed — see
+    # ``FrontierTaskRef.attempt_count`` for the counting rule. Scoped to the
+    # build in the URL, NOT global like ``status`` above: this endpoint is
+    # the only consumer of this model, and it is per-build, which is what
+    # makes the field meaningful here. It deliberately does not appear on
+    # the environment-global task responses, where "how many attempts"
+    # would have no build to be about.
+    attempt_count: int = 0
 
 
 class TaskEventResponse(BaseModel):
@@ -657,6 +696,13 @@ class TaskEventResponse(BaseModel):
     # The environment-global denormalised status after this event — the
     # execution claim's own answer.
     latest_status: TaskStatus | None = None
+    # Execution attempts for this task in this build, *including the event
+    # just recorded* — so a caller that has recorded a failure, or won a
+    # claiming start, can apply its retry budget without a second
+    # round-trip to the frontier (and against a count that is authoritative
+    # rather than a snapshot some racing scheduler may have moved on from).
+    # Counting rule and per-build scoping: see ``FrontierTaskRef``.
+    attempt_count: int = 0
 
 
 class TaskListResponse(BaseModel):

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -314,21 +314,21 @@ class FrontierTaskRef(BaseModel):
     # to date it). Those need an operator to release; there is no timestamp
     # that would let a client conclude anything else.
     latest_status_expires_at: datetime | None = None
-    # How many times execution has been started for this task **in this
-    # build** — the input to a scheduler's own retry policy (a
-    # `max_attempts`), which the reactive engine has no other way to
-    # express: a tick is short-lived and cannot remember what it already
-    # tried, and the execution backend's own function-level retries only
-    # cover exceptions raised *inside* a container that started. A spawn
-    # that failed before the container existed, an OOM kill, a preemption,
-    # or a worker that died after writing partial output are all invisible
-    # to them and visible here.
+    # How many times execution has been started for this task **since this
+    # build's most recent BUILD_RESUMED event** (since the start of the
+    # build if it has never been resumed) — the input to a scheduler's own
+    # retry policy (a `max_attempts`), which the reactive engine has no
+    # other way to express: a tick is short-lived and cannot remember what
+    # it already tried, and the execution backend's own function-level
+    # retries only cover exceptions raised *inside* a container that
+    # started. A spawn that failed before the container existed, an OOM
+    # kill, a preemption, or a worker that died after writing partial
+    # output are all invisible to them and visible here.
     #
     # **Per build, unlike every other field on this ref.** The latest_*
     # fields are environment-global because a completed task is completed
     # for everyone; attempts are the opposite — a task that burned two
-    # attempts in an earlier build arrives in a new one with a full budget,
-    # which is what a fresh trigger means.
+    # attempts in an earlier build arrives in a new one with a full budget.
     #
     # Counts *attempts*, not TASK_STARTED events: engines emit several
     # starts per execution (a claim/limit-acquiring start with no executor
@@ -336,14 +336,26 @@ class FrontierTaskRef(BaseModel):
     # executor self-reports lifecycle), and consecutive starts collapse
     # into the one attempt they describe.
     #
-    # A retry (TASK_RETRIED) does NOT reset it: a scheduler retries a
-    # failed task *through* that endpoint, so a resetting counter would be
-    # cleared by the very act it is meant to bound. Within one build the
-    # number is therefore a lifetime budget; a re-trigger gets a new build
-    # and a fresh count.
+    # **A resume resets it; a retry does not.** The two look similar and
+    # the difference is the whole point:
     #
-    # 0 means "not attempted in this build" — and is also what a server
-    # predating this field serialises, i.e. "unknown, don't enforce".
+    #   - BUILD_RESUMED means a new round was asked for. Re-triggering an
+    #     existing build id is the recommended way to pick a failed
+    #     reactive build back up, and it does NOT mint a new build — so
+    #     without this the budget would already be spent the moment the
+    #     user asked to try again. The server skips the event for a build
+    #     with no activity beyond BUILD_STARTED, so a first trigger is
+    #     unaffected.
+    #   - TASK_RETRIED does not reset, because a scheduler retries a
+    #     failed task *through* that endpoint: a counter cleared by it
+    #     would be cleared by every enforcement of the budget it defines.
+    #     So a bare retry against a spent budget is a real "you asked, but
+    #     this round is out of attempts" — which is the signal to resume.
+    #
+    # 0 means "not attempted in this round". Note it is also what a server
+    # predating this field would mean if a client defaulted a missing key
+    # to 0 — don't: treat absence as "unknown, don't enforce". Every
+    # response of this API that declares the field always populates it.
     attempt_count: int = 0
 
 
@@ -670,13 +682,13 @@ class TaskWithStatusResponse(TaskResponse):
     status_build_id: UUID | None = None
     # Git commit hash from the event that determined the current status
     commit_hash: str | None = None
-    # Execution attempts for this task in the build being listed — see
-    # ``FrontierTaskRef.attempt_count`` for the counting rule. Scoped to the
-    # build in the URL, NOT global like ``status`` above: this endpoint is
-    # the only consumer of this model, and it is per-build, which is what
-    # makes the field meaningful here. It deliberately does not appear on
-    # the environment-global task responses, where "how many attempts"
-    # would have no build to be about.
+    # Execution attempts for this task in the current round of the build
+    # being listed — see ``FrontierTaskRef.attempt_count`` for the counting
+    # rule and the round window. Scoped to the build in the URL, NOT global
+    # like ``status`` above: this endpoint is the only consumer of this
+    # model, and it is per-build, which is what makes the field meaningful
+    # here. It deliberately does not appear on the environment-global task
+    # responses, where "how many attempts" would have no build to be about.
     attempt_count: int = 0
 
 
@@ -696,12 +708,14 @@ class TaskEventResponse(BaseModel):
     # The environment-global denormalised status after this event — the
     # execution claim's own answer.
     latest_status: TaskStatus | None = None
-    # Execution attempts for this task in this build, *including the event
-    # just recorded* — so a caller that has recorded a failure, or won a
-    # claiming start, can apply its retry budget without a second
-    # round-trip to the frontier (and against a count that is authoritative
-    # rather than a snapshot some racing scheduler may have moved on from).
-    # Counting rule and per-build scoping: see ``FrontierTaskRef``.
+    # Execution attempts for this task in the build's current round,
+    # *including the event just recorded* — so a caller that has recorded a
+    # failure, or won a claiming start, can apply its retry budget without
+    # a second round-trip to the frontier (and against a count that is
+    # authoritative rather than a snapshot some racing scheduler may have
+    # moved on from). Counting rule, round window and per-build scoping:
+    # see ``FrontierTaskRef``. Always populated, on every endpoint
+    # returning this model.
     attempt_count: int = 0
 
 

--- a/app/stardag-api/src/stardag_api/services/__init__.py
+++ b/app/stardag-api/src/stardag_api/services/__init__.py
@@ -16,6 +16,7 @@ from stardag_api.services.lock import (
 from stardag_api.services.slug import generate_build_slug
 from stardag_api.services.status import (
     apply_event_to_build,
+    get_attempt_counts_in_build,
     get_task_status_in_build,
 )
 
@@ -27,6 +28,7 @@ __all__ = [
     "check_task_completed_in_registry",
     "cleanup_expired_locks",
     "generate_build_slug",
+    "get_attempt_counts_in_build",
     "get_lock",
     "get_task_status_in_build",
     "get_environment_lock_count",

--- a/app/stardag-api/src/stardag_api/services/status.py
+++ b/app/stardag-api/src/stardag_api/services/status.py
@@ -126,6 +126,11 @@ def last_build_resumed_at(build_id: UUID) -> Select[tuple[datetime]]:
     """
     return select(func.max(Event.created_at)).where(
         Event.build_id == build_id,
+        # Explicit, even though only build-level events carry this type: it
+        # is what makes the index a seek on (build_id, NULL, 'build_resumed')
+        # rather than a scan over every event the build ever recorded, and
+        # the comment above claims exactly that.
+        Event.task_id.is_(None),
         Event.event_type == EventType.BUILD_RESUMED.value,
     )
 

--- a/app/stardag-api/src/stardag_api/services/status.py
+++ b/app/stardag-api/src/stardag_api/services/status.py
@@ -1,9 +1,10 @@
 """Status derivation from events."""
 
+from collections.abc import Sequence
 from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from stardag_api.models import Build, BuildStatus, Event, EventType, Task, TaskStatus
@@ -31,6 +32,140 @@ _RETRYABLE_STATUSES = (
     TaskStatus.SKIPPED,
     TaskStatus.SUSPENDED,
 )
+
+
+# --- Execution attempts -------------------------------------------------
+#
+# "How many times has execution been started for this task in this build?"
+# — the number a scheduler needs to decide whether a failure is worth
+# another go. It is NOT the number of TASK_STARTED events, and the gap is
+# not an edge case: engines routinely emit several starts per attempt.
+#
+#   reactive (_act_on_frontier):  an *acquiring* start (the atomic claim /
+#       limit-slot acquisition, before the spawn, with no executor ref)
+#       and then a second start carrying the ref once the spawn returned.
+#   resident (_concurrent):       the same claim-then-ref pair, and on top
+#       of it the worker's own self-reported start when the executor
+#       reports lifecycle — which lands minutes later under cold start, so
+#       three starts for one execution.
+#   sequential / unclaimed:       exactly one start.
+#
+# Counting events would therefore make the same task look like it had
+# 1, 2 or 3 attempts depending on which engine and which executor ran it,
+# and would exhaust any retry budget on the first try.
+#
+# The rule instead counts *transitions into RUNNING*: a start begins a new
+# attempt unless the previous status-affecting event was itself a start.
+# Consecutive starts are one execution re-recording itself, whatever the
+# engine's reason for re-recording. That is engine-agnostic by
+# construction — it needs no knowledge of who emits how many starts, only
+# that nothing else happened to the task in between.
+#
+# Status-neutral events are excluded from "previous" so one landing inside
+# an attempt's acquire→spawn window cannot split it in two. They can't
+# change status, so they can't end an attempt either.
+_ATTEMPT_ORDERING_EVENT_TYPES = (
+    EventType.TASK_STARTED,
+    EventType.TASK_RESUMED,
+    EventType.TASK_SUSPENDED,
+    EventType.TASK_RETRIED,
+    EventType.TASK_COMPLETED,
+    EventType.TASK_FAILED,
+    EventType.TASK_SKIPPED,
+    EventType.TASK_CANCELLED,
+)
+
+
+def starts_new_attempt(event_type: str | None, prev_event_type: str | None) -> bool:
+    """Whether ``event_type`` begins a new execution attempt.
+
+    ``prev_event_type`` is the preceding *status-affecting* event for the
+    same (build, task) — ``None`` for the first one. The single Python
+    definition of the rule described above; ``get_attempt_counts_in_build``
+    expresses the identical predicate in SQL, and the two must agree.
+    """
+    return (
+        event_type == EventType.TASK_STARTED
+        and prev_event_type != EventType.TASK_STARTED
+    )
+
+
+async def get_attempt_counts_in_build(
+    db: AsyncSession,
+    build_id: UUID,
+    task_db_ids: Sequence[UUID] | None = None,
+) -> dict[UUID, int]:
+    """Execution attempts per task **within one build**, keyed by task pk.
+
+    **Per build, deliberately** — unlike the denormalised ``Task.latest_*``
+    columns beside it, which are environment-global because a completed
+    task is completed for everyone. Attempts are not like that: the
+    retry-relevant question is "how many times has *this* build tried", and
+    a task that burned two attempts in an earlier build must not arrive in
+    a new one with its budget already spent. That is also why this cannot
+    live on the task row at all — there is no per-(build, task) row to
+    denormalise onto, and adding one would buy a fold on every start path
+    plus a backfill to replace a single grouped query over an index that
+    already exists (``ix_events_build_task_type``).
+
+    Tasks with no attempt in this build are simply absent from the result;
+    callers default them to 0.
+
+    ``task_db_ids`` bounds the scan to the tasks the caller will actually
+    report, so the cost tracks the size of the response rather than the
+    size of the build. Omit it for every task in the build.
+
+    One grouped query, never one per task: the frontier that consumes this
+    is re-read on every linger poll of every active build.
+    """
+    if task_db_ids is not None and not task_db_ids:
+        return {}
+
+    # LAG gives each event its predecessor within the task's own stream, so
+    # the attempt-boundary rule becomes a WHERE clause. Restricting the rows
+    # to the status-affecting types is safe *and* is what makes the rule
+    # right (see _ATTEMPT_ORDERING_EVENT_TYPES); restricting them to
+    # ``task_db_ids`` is safe because the window partitions by task, so a
+    # task's predecessor is never in another task's rows.
+    #
+    # (created_at, id) rather than created_at alone: task ids are UUID7, so
+    # id is a time-ordered tiebreak, and two starts of one attempt can share
+    # a timestamp at second/millisecond resolution.
+    ordered = (
+        select(
+            Event.task_id.label("task_id"),
+            Event.event_type.label("event_type"),
+            func.lag(Event.event_type)
+            .over(
+                partition_by=Event.task_id,
+                order_by=(Event.created_at, Event.id),
+            )
+            .label("prev_event_type"),
+        )
+        .where(
+            Event.build_id == build_id,
+            Event.task_id.is_not(None),
+            Event.event_type.in_([e.value for e in _ATTEMPT_ORDERING_EVENT_TYPES]),
+        )
+        .where(*([Event.task_id.in_(task_db_ids)] if task_db_ids is not None else []))
+        .subquery()
+    )
+    rows = (
+        await db.execute(
+            select(ordered.c.task_id, func.count())
+            .where(
+                ordered.c.event_type == EventType.TASK_STARTED.value,
+                # Null-safe: the first event in a stream has no predecessor
+                # and must still count as an attempt (renders IS DISTINCT
+                # FROM on Postgres, IS NOT on SQLite).
+                ordered.c.prev_event_type.is_distinct_from(
+                    EventType.TASK_STARTED.value
+                ),
+            )
+            .group_by(ordered.c.task_id)
+        )
+    ).all()
+    return {task_id: count for task_id, count in rows}
 
 
 def apply_event_to_task(task: Task, event: Event) -> None:
@@ -308,17 +443,27 @@ def apply_event_to_build(build: Build, event: Event) -> None:
 
 async def get_task_status_in_build(
     db: AsyncSession, build_id: UUID, task_db_id: UUID
-) -> tuple[TaskStatus, datetime | None, datetime | None, str | None]:
+) -> tuple[TaskStatus, datetime | None, datetime | None, str | None, int]:
     """Get derived task status from events for a specific build.
 
     Returns:
-        Tuple of (status, started_at, completed_at, error_message)
+        Tuple of (status, started_at, completed_at, error_message,
+        attempt_count)
+
+    ``attempt_count`` falls out of the replay this already does, so every
+    task-event response can carry the authoritative post-event count for
+    free — no second round-trip for a caller deciding whether to retry.
+    It applies the same rule as :func:`get_attempt_counts_in_build`, via
+    the same :func:`starts_new_attempt` predicate.
     """
     result = await db.execute(
         select(Event)
         .where(Event.build_id == build_id)
         .where(Event.task_id == task_db_id)
-        .order_by(Event.created_at.desc())
+        # id (UUID7) breaks created_at ties, matching the SQL attempt count.
+        # Without it, two same-timestamp events replay in whatever order the
+        # index returned, which the attempt rule is sensitive to.
+        .order_by(Event.created_at.desc(), Event.id.desc())
     )
     events = result.scalars().all()
 
@@ -326,9 +471,15 @@ async def get_task_status_in_build(
     started_at: datetime | None = None
     completed_at: datetime | None = None
     error_message: str | None = None
+    attempt_count = 0
+    prev_ordering_type: str | None = None
 
     # Process events from oldest to newest to build final state
     for event in reversed(events):
+        if event.event_type in _ATTEMPT_ORDERING_EVENT_TYPES:
+            if starts_new_attempt(event.event_type, prev_ordering_type):
+                attempt_count += 1
+            prev_ordering_type = event.event_type
         if event.event_type == EventType.TASK_PENDING:
             status = TaskStatus.PENDING
         elif event.event_type == EventType.TASK_REFERENCED:
@@ -368,7 +519,7 @@ async def get_task_status_in_build(
             status = TaskStatus.CANCELLED
             completed_at = event.created_at
 
-    return status, started_at, completed_at, error_message
+    return status, started_at, completed_at, error_message, attempt_count
 
 
 async def get_all_task_statuses_in_build(

--- a/app/stardag-api/src/stardag_api/services/status.py
+++ b/app/stardag-api/src/stardag_api/services/status.py
@@ -1,10 +1,10 @@
 """Status derivation from events."""
 
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import Select, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from stardag_api.models import Build, BuildStatus, Event, EventType, Task, TaskStatus
@@ -36,10 +36,11 @@ _RETRYABLE_STATUSES = (
 
 # --- Execution attempts -------------------------------------------------
 #
-# "How many times has execution been started for this task in this build?"
-# — the number a scheduler needs to decide whether a failure is worth
-# another go. It is NOT the number of TASK_STARTED events, and the gap is
-# not an edge case: engines routinely emit several starts per attempt.
+# "How many times has execution been started for this task in the build's
+# current round?" — the number a scheduler needs to decide whether a
+# failure is worth another go. It is NOT the number of TASK_STARTED
+# events, and the gap is not an edge case: engines routinely emit several
+# starts per attempt.
 #
 #   reactive (_act_on_frontier):  an *acquiring* start (the atomic claim /
 #       limit-slot acquisition, before the spawn, with no executor ref)
@@ -80,13 +81,52 @@ def starts_new_attempt(event_type: str | None, prev_event_type: str | None) -> b
     """Whether ``event_type`` begins a new execution attempt.
 
     ``prev_event_type`` is the preceding *status-affecting* event for the
-    same (build, task) — ``None`` for the first one. The single Python
-    definition of the rule described above; ``get_attempt_counts_in_build``
-    expresses the identical predicate in SQL, and the two must agree.
+    same (build, task) **within the current round** — ``None`` for the
+    first one, which is why the first start after a resume always counts
+    even if the last event before the resume was also a start. The single
+    Python definition of the rule described above;
+    ``get_attempt_counts_in_build`` expresses the identical predicate in
+    SQL, and the two must agree.
     """
     return (
         event_type == EventType.TASK_STARTED
         and prev_event_type != EventType.TASK_STARTED
+    )
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normalise a timestamp to aware UTC so two of them can be compared.
+
+    One event stream can hold both shapes at once: Postgres returns aware
+    values and SQLite returns naive ones, and on either backend an object
+    flushed earlier in *this* session still carries the aware value
+    ``utc_now()`` produced, never having round-tripped through the
+    database. Every one of them is UTC, so the only real work is putting
+    the tzinfo back on the ones that lost it — without which the round
+    comparison below raises on a mixed stream.
+    """
+    return value if value.tzinfo is not None else value.replace(tzinfo=timezone.utc)
+
+
+def last_build_resumed_at(build_id: UUID) -> Select[tuple[datetime]]:
+    """When this build was last resumed — NULL if it never was.
+
+    (The annotation is SQLAlchemy's column type; ``max`` over no rows
+    still yields NULL, so executing this returns ``datetime | None``.)
+
+    The start of the attempt-counting window (see
+    :func:`get_attempt_counts_in_build`). Factored out because the two
+    consumers need it in different forms — ``.scalar_subquery()`` inside
+    the grouped statement, executed directly beside the per-task replay,
+    which must still see the whole stream — and they must not drift.
+
+    Served by ``ix_events_build_task_type`` as a seek: build-level events
+    carry ``task_id IS NULL``, so ``(build_id, NULL, 'build_resumed')`` is
+    a point lookup rather than a scan of the build's events.
+    """
+    return select(func.max(Event.created_at)).where(
+        Event.build_id == build_id,
+        Event.event_type == EventType.BUILD_RESUMED.value,
     )
 
 
@@ -95,20 +135,49 @@ async def get_attempt_counts_in_build(
     build_id: UUID,
     task_db_ids: Sequence[UUID] | None = None,
 ) -> dict[UUID, int]:
-    """Execution attempts per task **within one build**, keyed by task pk.
+    """Execution attempts per task in a build's **current round**, by task pk.
+
+    A "round" starts at the build's most recent ``BUILD_RESUMED`` event, or
+    at the beginning of the build when it has never been resumed.
+
+    **Why the resume, and not simply the whole build.** A retry budget has
+    to have an escape hatch the user can reach, and re-triggering an
+    existing build id — ``build_trigger(..., build_id=<existing>,
+    reactive=True)`` — is the recommended way to pick a failed reactive
+    build back up. That path does NOT mint a new build: it resumes this
+    one and calls ``task_retry`` on the failed tasks *in it*. Counting
+    over the build's whole history would therefore leave the budget
+    already spent the moment the user asked for another round, so the one
+    action anybody reaches for after a failure would do nothing unless
+    they also raised ``max_attempts``.
+
+    ``BUILD_RESUMED`` is exactly the durable marker of "another round was
+    asked for": it already exists, it is already emitted on that path, and
+    the server skips it for a build with no activity beyond
+    ``BUILD_STARTED`` — so a *first* trigger is not a resume and the
+    window is simply the whole build. No new event type, column or marker.
+    Repeated re-triggers do hand out fresh budgets, but that is a user
+    deciding to try again, not a scheduler looping.
 
     **Per build, deliberately** — unlike the denormalised ``Task.latest_*``
     columns beside it, which are environment-global because a completed
     task is completed for everyone. Attempts are not like that: the
-    retry-relevant question is "how many times has *this* build tried", and
-    a task that burned two attempts in an earlier build must not arrive in
-    a new one with its budget already spent. That is also why this cannot
-    live on the task row at all — there is no per-(build, task) row to
-    denormalise onto, and adding one would buy a fold on every start path
-    plus a backfill to replace a single grouped query over an index that
-    already exists (``ix_events_build_task_type``).
+    retry-relevant question is "how many times has *this* build tried in
+    this round", and a task that burned two attempts in an earlier build
+    must not arrive in a new one with its budget already spent. That is
+    also why this cannot live on the task row at all — there is no
+    per-(build, task) row to denormalise onto, and adding one would buy a
+    fold on every start path plus a backfill to replace a single grouped
+    query over an index that already exists
+    (``ix_events_build_task_type``).
 
-    Tasks with no attempt in this build are simply absent from the result;
+    Note what a resume does NOT reset: ``TASK_RETRIED`` on its own never
+    resets the count. A scheduler retries a failed task *through* that
+    endpoint, so a counter cleared by it would be cleared by every
+    enforcement of the budget it defines. The distinction is the whole
+    point — a bare retry spends budget, a resume grants a new round.
+
+    Tasks with no attempt in this round are simply absent from the result;
     callers default them to 0.
 
     ``task_db_ids`` bounds the scan to the tasks the caller will actually
@@ -116,7 +185,9 @@ async def get_attempt_counts_in_build(
     size of the build. Omit it for every task in the build.
 
     One grouped query, never one per task: the frontier that consumes this
-    is re-read on every linger poll of every active build.
+    is re-read on every linger poll of every active build. The round
+    cutoff rides along as a correlated scalar subquery, so windowing costs
+    no extra round trip.
     """
     if task_db_ids is not None and not task_db_ids:
         return {}
@@ -128,9 +199,19 @@ async def get_attempt_counts_in_build(
     # ``task_db_ids`` is safe because the window partitions by task, so a
     # task's predecessor is never in another task's rows.
     #
-    # (created_at, id) rather than created_at alone: task ids are UUID7, so
-    # id is a time-ordered tiebreak, and two starts of one attempt can share
-    # a timestamp at second/millisecond resolution.
+    # The round cutoff is applied HERE, in the inner query, not to the
+    # outer count — so LAG never sees a pre-resume event and the first
+    # start of a new round has no predecessor and always counts. Filtering
+    # afterwards would instead let the last start of the *previous* round
+    # collapse the first start of this one, and a resumed build would
+    # report zero attempts however many times it tried.
+    #
+    # ``>=``, and the tie it admits is unreachable in practice: it would
+    # take a task event committed in the same microsecond as the resume,
+    # by a different request, to land on the wrong side. Counting such an
+    # event is also the conservative direction — it can only spend budget,
+    # never grant an unbounded loop.
+    resumed_at = last_build_resumed_at(build_id).scalar_subquery()
     ordered = (
         select(
             Event.task_id.label("task_id"),
@@ -146,6 +227,8 @@ async def get_attempt_counts_in_build(
             Event.build_id == build_id,
             Event.task_id.is_not(None),
             Event.event_type.in_([e.value for e in _ATTEMPT_ORDERING_EVENT_TYPES]),
+            # Never resumed → no cutoff → the window is the whole build.
+            or_(resumed_at.is_(None), Event.created_at >= resumed_at),
         )
         .where(*([Event.task_id.in_(task_db_ids)] if task_db_ids is not None else []))
         .subquery()
@@ -450,12 +533,24 @@ async def get_task_status_in_build(
         Tuple of (status, started_at, completed_at, error_message,
         attempt_count)
 
-    ``attempt_count`` falls out of the replay this already does, so every
-    task-event response can carry the authoritative post-event count for
-    free — no second round-trip for a caller deciding whether to retry.
-    It applies the same rule as :func:`get_attempt_counts_in_build`, via
-    the same :func:`starts_new_attempt` predicate.
+    ``attempt_count`` rides along on the replay this already does, so every
+    task-event response can carry the authoritative post-event count
+    without a second round-trip for a caller deciding whether to retry. It
+    applies the same rule as :func:`get_attempt_counts_in_build`, via the
+    same :func:`starts_new_attempt` predicate and the same round window.
+
+    The window cannot be pushed into the query the way it is for the
+    grouped path: the *status* fold has to see the whole stream (a task
+    completed before a resume is still completed), so only the attempt
+    tally is windowed. That costs one small indexed lookup for the round
+    cutoff.
     """
+    # The build's current round (see get_attempt_counts_in_build). Fetched
+    # rather than filtered on, because the status fold below needs every
+    # event regardless of round.
+    resumed_at = await db.scalar(last_build_resumed_at(build_id))
+    round_start = _as_utc(resumed_at) if resumed_at is not None else None
+
     result = await db.execute(
         select(Event)
         .where(Event.build_id == build_id)
@@ -476,7 +571,13 @@ async def get_task_status_in_build(
 
     # Process events from oldest to newest to build final state
     for event in reversed(events):
-        if event.event_type in _ATTEMPT_ORDERING_EVENT_TYPES:
+        # Pre-resume events are skipped for the tally *without* updating
+        # prev_ordering_type, so the first start of a new round still sees
+        # no predecessor and counts — mirroring the SQL path, where the
+        # cutoff is applied before LAG rather than after it.
+        if event.event_type in _ATTEMPT_ORDERING_EVENT_TYPES and (
+            round_start is None or _as_utc(event.created_at) >= round_start
+        ):
             if starts_new_attempt(event.event_type, prev_ordering_type):
                 attempt_count += 1
             prev_ordering_type = event.event_type

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -2838,6 +2838,7 @@ async def test_evict_holder_frees_slot(client: AsyncClient):
         "task_id": "ev-a",
         "status": "failed",
         "latest_status": "failed",
+        # The eviction ends the one attempt the holder made.
         "attempt_count": 1,
     }
 
@@ -3025,6 +3026,7 @@ async def test_evicted_then_worker_completes_sticky_completed(client: AsyncClien
         "task_id": "alive-ev",
         "status": "failed",
         "latest_status": "failed",
+        # The eviction ends the one attempt the holder made.
         "attempt_count": 1,
     }
 
@@ -3145,6 +3147,7 @@ async def test_evict_admin_allowed_and_records_admin_identity(client: AsyncClien
         "task_id": "admin-ev",
         "status": "failed",
         "latest_status": "failed",
+        # The eviction ends the one attempt the holder made.
         "attempt_count": 1,
     }
 

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -2838,6 +2838,7 @@ async def test_evict_holder_frees_slot(client: AsyncClient):
         "task_id": "ev-a",
         "status": "failed",
         "latest_status": "failed",
+        "attempt_count": 1,
     }
 
     # Failure recorded with the evictor identity (mocked auth user).
@@ -3024,6 +3025,7 @@ async def test_evicted_then_worker_completes_sticky_completed(client: AsyncClien
         "task_id": "alive-ev",
         "status": "failed",
         "latest_status": "failed",
+        "attempt_count": 1,
     }
 
     # The (still-alive) worker reports completion afterwards.
@@ -3143,6 +3145,7 @@ async def test_evict_admin_allowed_and_records_admin_identity(client: AsyncClien
         "task_id": "admin-ev",
         "status": "failed",
         "latest_status": "failed",
+        "attempt_count": 1,
     }
 
 

--- a/app/stardag-api/tests/test_task_attempts.py
+++ b/app/stardag-api/tests/test_task_attempts.py
@@ -1,0 +1,360 @@
+"""Per-build execution attempt counts (``attempt_count``).
+
+The number a scheduler needs to run its own retry policy: how many times
+has execution been started for this task *in this build*. Three properties
+carry the whole feature, and each is easy to break without noticing:
+
+- **An attempt is not a TASK_STARTED event.** Engines emit several starts
+  per execution — an acquiring start for the claim/limit slot before the
+  spawn (no executor ref), a second one once the spawn returns a ref, and,
+  when the executor self-reports lifecycle, the worker's own start minutes
+  later. Counting events would make one attempt look like two or three and
+  exhaust any budget on the first try. The tests below pin the reactive
+  (two starts) and resident (one, and three) shapes to the same answer.
+- **The scope is the build, not the environment.** Unlike the
+  denormalised ``latest_*`` fields it travels with, a count that spanned
+  builds would let a task that failed twice last week arrive in a fresh
+  trigger with no budget left.
+- **A retry does not reset it.** A scheduler retries a failed task
+  *through* ``POST .../retry``, so a resetting counter would be cleared by
+  the very act it exists to bound, and ``max_attempts`` would never bind.
+
+Postgres gets its own pass over the first and third: the derivation uses a
+window function and a null-safe inequality, which render differently on
+the two dialects.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+BUILDS = "/api/v1/builds"
+
+
+def _register(task_id: str, deps: list[str] | None = None) -> dict:
+    return {
+        "task_id": task_id,
+        "task_namespace": "",
+        "task_name": "T",
+        "task_data": {},
+        "dependency_task_ids": deps or [],
+    }
+
+
+async def _new_build(client: AsyncClient, roots: list[str] | None = None) -> str:
+    body = {"root_task_ids": roots} if roots else {}
+    return (await client.post(BUILDS, json=body)).json()["id"]
+
+
+async def _register_task(client: AsyncClient, build_id: str, task_id: str) -> None:
+    response = await client.post(f"{BUILDS}/{build_id}/tasks", json=_register(task_id))
+    assert response.status_code == 201, response.text
+
+
+async def _frontier_attempts(client: AsyncClient, build_id: str) -> dict[str, int]:
+    """``task_id -> attempt_count`` across every frontier list.
+
+    Merged deliberately: the three lists are populated by three different
+    code paths and a regression that drops the field from one of them
+    should not be able to hide behind the others.
+    """
+    frontier = (await client.get(f"{BUILDS}/{build_id}/frontier")).json()
+    return {
+        ref["task_id"]: ref["attempt_count"]
+        for key in ("actionable", "running", "roots")
+        for ref in frontier[key]
+    }
+
+
+async def _listed_attempts(client: AsyncClient, build_id: str) -> dict[str, int]:
+    tasks = (await client.get(f"{BUILDS}/{build_id}/tasks")).json()
+    return {t["task_id"]: t["attempt_count"] for t in tasks}
+
+
+# --- The double-start rule ----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reactive_acquire_then_spawn_is_one_attempt(client: AsyncClient):
+    """The reactive shape: a claiming start with no ref, then a start
+    carrying the ref once the spawn returned. Two events, one execution."""
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "react-1")
+
+    # Acquiring start: arbitration happens before the spawn, so there is
+    # nothing to reference yet.
+    acquiring = await client.post(
+        f"{BUILDS}/{build_id}/tasks/react-1/start", params={"claim": True}
+    )
+    assert acquiring.status_code == 200
+    assert acquiring.json()["attempt_count"] == 1
+
+    # Post-spawn start: same execution, now with a ref. NOT a claiming
+    # start — a second claim would be denied as already-running, which is
+    # exactly why the engine records the ref with a plain one.
+    with_ref = await client.post(
+        f"{BUILDS}/{build_id}/tasks/react-1/start",
+        params={"executor": "modal", "executor_ref": "fc-1"},
+    )
+    assert with_ref.status_code == 200
+    assert with_ref.json()["attempt_count"] == 1
+
+    assert await _frontier_attempts(client, build_id) == {"react-1": 1}
+
+
+@pytest.mark.asyncio
+async def test_resident_single_start_is_one_attempt(client: AsyncClient):
+    """The resident/sequential shape: one start, one attempt. The rule must
+    not assume starts come in pairs."""
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "resident-1")
+
+    response = await client.post(f"{BUILDS}/{build_id}/tasks/resident-1/start")
+    assert response.json()["attempt_count"] == 1
+    assert await _frontier_attempts(client, build_id) == {"resident-1": 1}
+
+
+@pytest.mark.asyncio
+async def test_resident_claim_spawn_and_worker_self_report_is_one_attempt(
+    client: AsyncClient,
+):
+    """The widest shape: claim start, engine's ref-carrying start, and then
+    the worker's own start once its container is finally up. Three events,
+    still one execution — the rule collapses a run of starts however long."""
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "resident-3")
+
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/resident-3/start", params={"claim": True}
+    )
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/resident-3/start",
+        params={"executor": "modal", "executor_ref": "fc-3"},
+    )
+    worker = await client.post(
+        f"{BUILDS}/{build_id}/tasks/resident-3/start",
+        params={"executor": "modal", "executor_ref": "fc-3"},
+    )
+    assert worker.json()["attempt_count"] == 1
+    assert await _frontier_attempts(client, build_id) == {"resident-3": 1}
+
+
+@pytest.mark.asyncio
+async def test_status_neutral_event_between_starts_does_not_split_the_attempt(
+    client: AsyncClient,
+):
+    """A status-neutral event landing in the acquire→spawn window must not
+    break the run of starts in two. It cannot change the task's status, so
+    it cannot end an execution either."""
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "neutral-1")
+
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/neutral-1/start", params={"claim": True}
+    )
+    await client.post(f"{BUILDS}/{build_id}/tasks/neutral-1/waiting-for-lock")
+    ref_start = await client.post(
+        f"{BUILDS}/{build_id}/tasks/neutral-1/start",
+        params={"executor": "modal", "executor_ref": "fc-n"},
+    )
+    assert ref_start.json()["attempt_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_second_execution_after_failure_is_a_second_attempt(
+    client: AsyncClient,
+):
+    """The rule collapses *consecutive* starts only — a start after a
+    terminal event is a genuinely new execution."""
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "fail-then-run")
+
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/fail-then-run/start", params={"claim": True}
+    )
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/fail-then-run/start",
+        params={"executor": "modal", "executor_ref": "fc-a"},
+    )
+    failed = await client.post(f"{BUILDS}/{build_id}/tasks/fail-then-run/fail")
+    # The failure ends attempt 1; it does not start attempt 2.
+    assert failed.json()["attempt_count"] == 1
+
+    await client.post(f"{BUILDS}/{build_id}/tasks/fail-then-run/retry")
+    second = await client.post(
+        f"{BUILDS}/{build_id}/tasks/fail-then-run/start", params={"claim": True}
+    )
+    assert second.json()["attempt_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_suspend_then_resume_counts_the_re_execution(client: AsyncClient):
+    """A task suspended for dynamic dependencies and then re-spawned really
+    did execute twice, and the count says so. Documented rather than
+    special-cased: ``attempt_count`` is executions, and a policy that wants
+    to charge only failures needs a different number."""
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "dyn-1")
+
+    await client.post(f"{BUILDS}/{build_id}/tasks/dyn-1/start", params={"claim": True})
+    await client.post(f"{BUILDS}/{build_id}/tasks/dyn-1/suspend")
+    resumed = await client.post(f"{BUILDS}/{build_id}/tasks/dyn-1/start")
+    assert resumed.json()["attempt_count"] == 2
+
+
+# --- Retry does not reset -----------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_does_not_reset_the_count(client: AsyncClient):
+    """``max_attempts`` is a per-build lifetime budget.
+
+    A scheduler enforcing one retries *through* this endpoint — a failed
+    task is not in the frontier's actionable set until something flips it
+    back to PENDING — so a count that reset here would be reset by every
+    enforcement of the budget it defines, and the build would loop forever.
+    """
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "budget-1")
+
+    for attempt in range(1, 4):
+        started = await client.post(
+            f"{BUILDS}/{build_id}/tasks/budget-1/start", params={"claim": True}
+        )
+        assert started.json()["attempt_count"] == attempt
+        await client.post(f"{BUILDS}/{build_id}/tasks/budget-1/fail")
+        retried = await client.post(f"{BUILDS}/{build_id}/tasks/budget-1/retry")
+        # The retry itself is not an attempt, and does not erase the ones
+        # already spent.
+        assert retried.json()["attempt_count"] == attempt
+
+    assert await _frontier_attempts(client, build_id) == {"budget-1": 3}
+
+
+# --- Per-build scoping --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_two_builds_over_one_task_keep_separate_counts(client: AsyncClient):
+    """The escape hatch a lifetime budget needs: a re-trigger is a new
+    build, and a new build starts the task's budget over. If this leaked
+    across builds, a task that exhausted its retries once would be
+    unschedulable in every future build in the environment."""
+    build_a = await _new_build(client)
+    await _register_task(client, build_a, "shared-1")
+    await client.post(
+        f"{BUILDS}/{build_a}/tasks/shared-1/start", params={"claim": True}
+    )
+    await client.post(
+        f"{BUILDS}/{build_a}/tasks/shared-1/start",
+        params={"executor": "modal", "executor_ref": "fc-a"},
+    )
+    await client.post(f"{BUILDS}/{build_a}/tasks/shared-1/fail")
+
+    # A fresh trigger: same task, new build.
+    build_b = await _new_build(client)
+    await _register_task(client, build_b, "shared-1")
+    await client.post(f"{BUILDS}/{build_b}/tasks/shared-1/retry")
+    started_b = await client.post(
+        f"{BUILDS}/{build_b}/tasks/shared-1/start", params={"claim": True}
+    )
+    assert started_b.json()["attempt_count"] == 1
+
+    # ...and build A's own record is untouched by build B's attempt.
+    assert await _listed_attempts(client, build_a) == {"shared-1": 1}
+    assert await _listed_attempts(client, build_b) == {"shared-1": 1}
+
+
+@pytest.mark.asyncio
+async def test_task_never_attempted_in_this_build_reports_zero(client: AsyncClient):
+    """A root cached from an earlier build shows the build's own count —
+    zero — not the global history that ``latest_status`` beside it
+    reflects."""
+    build_a = await _new_build(client)
+    await _register_task(client, build_a, "cached-1")
+    await client.post(
+        f"{BUILDS}/{build_a}/tasks/cached-1/start", params={"claim": True}
+    )
+    await client.post(f"{BUILDS}/{build_a}/tasks/cached-1/complete")
+
+    build_b = await _new_build(client, roots=["cached-1"])
+    frontier = (await client.get(f"{BUILDS}/{build_b}/frontier")).json()
+    root = frontier["roots"][0]
+    # Globally completed (that scope is unchanged)...
+    assert root["latest_status"] == "completed"
+    # ...but this build has attempted nothing.
+    assert root["attempt_count"] == 0
+
+
+# --- Frontier and listing exposure --------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_frontier_exposes_counts_on_actionable_running_and_roots(
+    client: AsyncClient,
+):
+    """All three ref lists carry the field, with the counts kept apart."""
+    build_id = await _new_build(client, roots=["front-root"])
+    await client.post(f"{BUILDS}/{build_id}/tasks", json=_register("front-dep"))
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks",
+        json=_register("front-root", deps=["front-dep"]),
+    )
+
+    # One attempt on the dep, recorded the reactive way (two starts).
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/front-dep/start", params={"claim": True}
+    )
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/front-dep/start",
+        params={"executor": "modal", "executor_ref": "fc-d"},
+    )
+
+    frontier = (await client.get(f"{BUILDS}/{build_id}/frontier")).json()
+    assert {t["task_id"]: t["attempt_count"] for t in frontier["actionable"]} == {
+        "front-dep": 1
+    }
+    assert {t["task_id"]: t["attempt_count"] for t in frontier["running"]} == {
+        "front-dep": 1
+    }
+    # The root is gated behind the running dep and has never been started.
+    assert {t["task_id"]: t["attempt_count"] for t in frontier["roots"]} == {
+        "front-root": 0
+    }
+
+    assert await _listed_attempts(client, build_id) == {
+        "front-dep": 1,
+        "front-root": 0,
+    }
+
+
+# --- Postgres parity ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_attempt_counts_on_postgres(pg_client: AsyncClient):
+    """The derivation is a LAG window function plus a null-safe inequality
+    (``IS DISTINCT FROM`` on Postgres, ``IS NOT`` on SQLite), so the
+    dialect the product actually runs on gets its own pass over the two
+    rules that matter: consecutive starts collapse, and a retry does not
+    reset."""
+    build_id = await _new_build(pg_client)
+    await _register_task(pg_client, build_id, "pg-1")
+
+    await pg_client.post(
+        f"{BUILDS}/{build_id}/tasks/pg-1/start", params={"claim": True}
+    )
+    with_ref = await pg_client.post(
+        f"{BUILDS}/{build_id}/tasks/pg-1/start",
+        params={"executor": "modal", "executor_ref": "fc-pg"},
+    )
+    assert with_ref.json()["attempt_count"] == 1
+    assert await _frontier_attempts(pg_client, build_id) == {"pg-1": 1}
+
+    await pg_client.post(f"{BUILDS}/{build_id}/tasks/pg-1/fail")
+    await pg_client.post(f"{BUILDS}/{build_id}/tasks/pg-1/retry")
+    second = await pg_client.post(
+        f"{BUILDS}/{build_id}/tasks/pg-1/start", params={"claim": True}
+    )
+    assert second.json()["attempt_count"] == 2
+    assert await _frontier_attempts(pg_client, build_id) == {"pg-1": 2}
+    assert await _listed_attempts(pg_client, build_id) == {"pg-1": 2}

--- a/app/stardag-api/tests/test_task_attempts.py
+++ b/app/stardag-api/tests/test_task_attempts.py
@@ -1,8 +1,10 @@
-"""Per-build execution attempt counts (``attempt_count``).
+"""Per-round execution attempt counts (``attempt_count``).
 
 The number a scheduler needs to run its own retry policy: how many times
-has execution been started for this task *in this build*. Three properties
-carry the whole feature, and each is easy to break without noticing:
+has execution been started for this task in this build's *current round*,
+a round being everything since the build's most recent ``BUILD_RESUMED``
+(or since the build began, if it never was). Four properties carry the
+whole feature, and each is easy to break without noticing:
 
 - **An attempt is not a TASK_STARTED event.** Engines emit several starts
   per execution — an acquiring start for the claim/limit slot before the
@@ -15,13 +17,21 @@ carry the whole feature, and each is easy to break without noticing:
   denormalised ``latest_*`` fields it travels with, a count that spanned
   builds would let a task that failed twice last week arrive in a fresh
   trigger with no budget left.
+- **A resume resets it.** Re-triggering an existing build id is the
+  recommended way to pick a failed reactive build back up, and it does not
+  mint a new build — so without a round window the budget would already be
+  spent the moment the user asked for another go.
 - **A retry does not reset it.** A scheduler retries a failed task
   *through* ``POST .../retry``, so a resetting counter would be cleared by
   the very act it exists to bound, and ``max_attempts`` would never bind.
 
-Postgres gets its own pass over the first and third: the derivation uses a
-window function and a null-safe inequality, which render differently on
-the two dialects.
+The last two are a pair: the distinction between them is what lets a
+scheduler tell "this round is out of attempts" (a real message to show)
+from "the user asked for another round" (a real reset).
+
+Postgres gets its own pass: the derivation uses a window function, a
+null-safe inequality and a correlated scalar subquery, which render
+differently on the two dialects.
 """
 
 import pytest
@@ -201,17 +211,18 @@ async def test_suspend_then_resume_counts_the_re_execution(client: AsyncClient):
     assert resumed.json()["attempt_count"] == 2
 
 
-# --- Retry does not reset -----------------------------------------------
+# --- Retry does not reset, resume does ----------------------------------
 
 
 @pytest.mark.asyncio
 async def test_retry_does_not_reset_the_count(client: AsyncClient):
-    """``max_attempts`` is a per-build lifetime budget.
+    """Attempts accumulate across retries within one round.
 
-    A scheduler enforcing one retries *through* this endpoint — a failed
-    task is not in the frontier's actionable set until something flips it
-    back to PENDING — so a count that reset here would be reset by every
-    enforcement of the budget it defines, and the build would loop forever.
+    A scheduler enforcing a budget retries *through* this endpoint — a
+    failed task is not in the frontier's actionable set until something
+    flips it back to PENDING — so a count that reset here would be reset by
+    every enforcement of the budget it defines, and the build would loop
+    forever. Resuming the build is the reset; see below.
     """
     build_id = await _new_build(client)
     await _register_task(client, build_id, "budget-1")
@@ -228,6 +239,147 @@ async def test_retry_does_not_reset_the_count(client: AsyncClient):
         assert retried.json()["attempt_count"] == attempt
 
     assert await _frontier_attempts(client, build_id) == {"budget-1": 3}
+
+
+@pytest.mark.asyncio
+async def test_resume_starts_a_new_round_at_zero(client: AsyncClient):
+    """The re-trigger shape, end to end.
+
+    ``build_trigger(..., build_id=<existing>, reactive=True)`` resumes the
+    build and then retries its failed tasks *in that same build* — it does
+    not mint a new one. If the count spanned rounds, the budget would be
+    spent before the user's "try this again" reached the scheduler, and the
+    only way out would be to raise ``max_attempts``.
+    """
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "round-1")
+
+    # Round one: two attempts, both failed.
+    for _ in range(2):
+        await client.post(
+            f"{BUILDS}/{build_id}/tasks/round-1/start", params={"claim": True}
+        )
+        await client.post(f"{BUILDS}/{build_id}/tasks/round-1/fail")
+        await client.post(f"{BUILDS}/{build_id}/tasks/round-1/retry")
+    assert await _frontier_attempts(client, build_id) == {"round-1": 2}
+
+    # The re-trigger: resume the build, then retry the failed tasks in it
+    # (the order _trigger_reactive uses).
+    resumed = await client.post(f"{BUILDS}/{build_id}/resume")
+    assert resumed.status_code == 200
+    retried = await client.post(f"{BUILDS}/{build_id}/tasks/round-1/retry")
+
+    # The new round has spent nothing — on both the replayed path (event
+    # responses) and the grouped SQL path (frontier / listing).
+    assert retried.json()["attempt_count"] == 0
+    assert await _frontier_attempts(client, build_id) == {"round-1": 0}
+    assert await _listed_attempts(client, build_id) == {"round-1": 0}
+
+
+@pytest.mark.asyncio
+async def test_first_attempt_after_a_resume_counts_one_not_history(
+    client: AsyncClient,
+):
+    """Resume-then-attempt is 1, not 1-plus-history — and not 0.
+
+    The zero case is the subtle one: the round window is applied *before*
+    the consecutive-start collapsing, so the last start of the previous
+    round is invisible and cannot swallow the first start of this one. Get
+    that backwards and a resumed build reports no attempts however many
+    times it tries, and the budget never binds again.
+    """
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "carry-1")
+
+    # Round one ends with the task RUNNING — the last event before the
+    # resume is a start, which is exactly what could bleed across.
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/carry-1/start", params={"claim": True}
+    )
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/carry-1/start",
+        params={"executor": "modal", "executor_ref": "fc-c"},
+    )
+    assert await _frontier_attempts(client, build_id) == {"carry-1": 1}
+
+    await client.post(f"{BUILDS}/{build_id}/resume")
+    started = await client.post(f"{BUILDS}/{build_id}/tasks/carry-1/start")
+    assert started.json()["attempt_count"] == 1
+    assert await _frontier_attempts(client, build_id) == {"carry-1": 1}
+
+
+@pytest.mark.asyncio
+async def test_build_never_resumed_counts_from_the_beginning(client: AsyncClient):
+    """No resume, no window — the count spans the whole build.
+
+    Includes the no-op resume the server performs on a build with no
+    activity beyond BUILD_STARTED: that records no BUILD_RESUMED event, so
+    a build whose first orchestrator invocation attaches at a
+    trigger-minted id is not silently given a round boundary.
+    """
+    build_id = await _new_build(client)
+    # A "resume" before any task activity: deliberately not a resume.
+    await client.post(f"{BUILDS}/{build_id}/resume")
+
+    await _register_task(client, build_id, "fresh-1")
+    for attempt in range(1, 3):
+        started = await client.post(
+            f"{BUILDS}/{build_id}/tasks/fresh-1/start", params={"claim": True}
+        )
+        assert started.json()["attempt_count"] == attempt
+        await client.post(f"{BUILDS}/{build_id}/tasks/fresh-1/fail")
+        await client.post(f"{BUILDS}/{build_id}/tasks/fresh-1/retry")
+
+    assert await _frontier_attempts(client, build_id) == {"fresh-1": 2}
+
+
+@pytest.mark.asyncio
+async def test_only_the_most_recent_resume_bounds_the_round(client: AsyncClient):
+    """Two re-triggers: the window is the latest resume, not the first."""
+    build_id = await _new_build(client)
+    await _register_task(client, build_id, "rounds-3")
+
+    async def _attempt_and_fail() -> None:
+        await client.post(
+            f"{BUILDS}/{build_id}/tasks/rounds-3/start", params={"claim": True}
+        )
+        await client.post(f"{BUILDS}/{build_id}/tasks/rounds-3/fail")
+        await client.post(f"{BUILDS}/{build_id}/tasks/rounds-3/retry")
+
+    await _attempt_and_fail()
+    await client.post(f"{BUILDS}/{build_id}/resume")
+    await _attempt_and_fail()
+    await _attempt_and_fail()
+    assert await _frontier_attempts(client, build_id) == {"rounds-3": 2}
+
+    await client.post(f"{BUILDS}/{build_id}/resume")
+    await _attempt_and_fail()
+    assert await _frontier_attempts(client, build_id) == {"rounds-3": 1}
+
+
+@pytest.mark.asyncio
+async def test_resume_windows_every_task_in_the_build(client: AsyncClient):
+    """A resume is build-level, so it opens a new round for every task at
+    once — the grouped query must not window only the task it happens to
+    sort first."""
+    build_id = await _new_build(client)
+    for task_id in ("multi-a", "multi-b"):
+        await _register_task(client, build_id, task_id)
+        await client.post(
+            f"{BUILDS}/{build_id}/tasks/{task_id}/start", params={"claim": True}
+        )
+        await client.post(f"{BUILDS}/{build_id}/tasks/{task_id}/fail")
+    assert await _listed_attempts(client, build_id) == {"multi-a": 1, "multi-b": 1}
+
+    await client.post(f"{BUILDS}/{build_id}/resume")
+    await client.post(f"{BUILDS}/{build_id}/tasks/multi-a/retry")
+    await client.post(
+        f"{BUILDS}/{build_id}/tasks/multi-a/start", params={"claim": True}
+    )
+
+    # multi-a has one attempt in the new round; multi-b has none — and
+    # neither carries anything over from the old one.
+    assert await _listed_attempts(client, build_id) == {"multi-a": 1, "multi-b": 0}
 
 
 # --- Per-build scoping --------------------------------------------------
@@ -332,11 +484,11 @@ async def test_frontier_exposes_counts_on_actionable_running_and_roots(
 
 @pytest.mark.asyncio
 async def test_attempt_counts_on_postgres(pg_client: AsyncClient):
-    """The derivation is a LAG window function plus a null-safe inequality
-    (``IS DISTINCT FROM`` on Postgres, ``IS NOT`` on SQLite), so the
-    dialect the product actually runs on gets its own pass over the two
-    rules that matter: consecutive starts collapse, and a retry does not
-    reset."""
+    """The derivation is a LAG window function, a null-safe inequality
+    (``IS DISTINCT FROM`` on Postgres, ``IS NOT`` on SQLite) and a
+    correlated scalar subquery for the round cutoff, so the dialect the
+    product actually runs on gets its own pass over all three rules:
+    consecutive starts collapse, a retry does not reset, a resume does."""
     build_id = await _new_build(pg_client)
     await _register_task(pg_client, build_id, "pg-1")
 
@@ -358,3 +510,19 @@ async def test_attempt_counts_on_postgres(pg_client: AsyncClient):
     assert second.json()["attempt_count"] == 2
     assert await _frontier_attempts(pg_client, build_id) == {"pg-1": 2}
     assert await _listed_attempts(pg_client, build_id) == {"pg-1": 2}
+
+    # ...and the re-trigger opens a new round at zero. Mirrors the real
+    # order: the round's last attempt has failed, then the build is
+    # resumed, then its failed tasks are retried.
+    await pg_client.post(f"{BUILDS}/{build_id}/tasks/pg-1/fail")
+    await pg_client.post(f"{BUILDS}/{build_id}/resume")
+    retried = await pg_client.post(f"{BUILDS}/{build_id}/tasks/pg-1/retry")
+    assert retried.json()["attempt_count"] == 0
+    assert await _frontier_attempts(pg_client, build_id) == {"pg-1": 0}
+    assert await _listed_attempts(pg_client, build_id) == {"pg-1": 0}
+
+    third = await pg_client.post(
+        f"{BUILDS}/{build_id}/tasks/pg-1/start", params={"claim": True}
+    )
+    assert third.json()["attempt_count"] == 1
+    assert await _frontier_attempts(pg_client, build_id) == {"pg-1": 1}


### PR DESCRIPTION
Server half of a task-level retry policy for reactive scheduling
([#208](https://github.com/stardag-dev/stardag/issues/208)). A follow-up
SDK PR consumes it; nothing here changes existing behaviour.

Based on `refactor/denormalise-build-status` (#221).

## Why

In reactive mode the scheduler records a failed execution and never
respawns it — *"retries are the execution backend's job"*. But a backend's
function-level retries only cover exceptions raised **inside** a container
that started. They do not cover:

- a spawn that failed before the container existed,
- an OOM kill or a preemption,
- a worker that died after writing partial output.

There is no `max_attempts` anywhere in the SDK, so under `FAIL_FAST` a
single transient failure kills the whole build. Closing that needs a
**durable** attempt count: a tick is short-lived and cannot remember how
many times it has tried.

## The field

**`attempt_count: int`** — how many times execution has been started for
this task **since its build's most recent `BUILD_RESUMED` event**, or
since the build began if it has never been resumed. `0` means "not
attempted in this round".

**Presence is guaranteed.** Every response of this API that declares the
field always populates it — it is a non-optional `int` on the schema, and
every route that returns one of these models computes it (including the
concurrency-limit eviction route, which spends an extra query purely so
there is no "was it computed here?" case). A consumer that sees the key
missing is therefore talking to a server older than this PR, and *that* is
the only reason to model it as optional client-side. Do not default a
missing key to `0`: absence means "unknown, don't enforce", and collapsing
it into `0` would make an unbounded retry loop unavoidable.

Exposed on:

| surface | model | notes |
| --- | --- | --- |
| `GET /builds/{id}/frontier` | `FrontierTaskRef` | on all of `actionable`, `running`, `roots` |
| `GET /builds/{id}/tasks` | `TaskWithStatusResponse` | for UI/CLI; this model has no other consumer, and that consumer is per-build |
| every task lifecycle event | `TaskEventResponse` | `start` / `fail` / `retry` / `complete` / … , **including the event just recorded** |

The event responses are there so a caller that has just recorded a failure,
or won a claiming start, can apply its budget without a second round-trip —
and against a count that is authoritative rather than a snapshot some
racing scheduler may have moved on from.

**Not** added to the environment-global task responses (`TaskResponse`,
`GET /tasks`), where "how many attempts" would have no build to be about.

## The double-start rule

`attempt_count` counts **attempts, not `TASK_STARTED` events**. Engines
routinely emit several starts per execution:

- **reactive** (`_act_on_frontier`): an *acquiring* start — the atomic
  claim / limit-slot acquisition, before the spawn, with no executor ref —
  and then a second start carrying the ref once the spawn returned.
- **resident** (`_concurrent`): the same claim-then-ref pair, plus the
  worker's own self-reported start when the executor reports lifecycle,
  which lands minutes later under cold start. Three starts, one execution.
- **sequential / unclaimed**: exactly one start.

Counting events would make the same task look like it had 1, 2 or 3
attempts depending on which engine and which executor ran it, and would
exhaust any retry budget on the first try.

The rule instead counts **transitions into RUNNING**: a start begins a new
attempt unless the previous *status-affecting* event was itself a start.
A run of consecutive starts collapses to the one execution it describes,
whatever the engine's reason for re-recording. This is engine-agnostic by
construction — it needs no knowledge of who emits how many starts, only
that nothing else happened to the task in between.

Status-neutral events (`TASK_REFERENCED`, `TASK_PENDING`,
`TASK_WAITING_FOR_LOCK`) are excluded from "previous", so one landing
inside an attempt's acquire→spawn window cannot split it in two. They
cannot change status, so they cannot end an attempt either.

Pinned by `tests/test_task_attempts.py`, which asserts `1` for all three
shapes above, plus the neutral-event case, plus that a start *after* a
terminal event does begin attempt 2.

## The round window: a resume resets, a retry does not

This is the part that makes the budget usable, and the two halves are
easy to conflate.

**`BUILD_RESUMED` starts a new round, and the count restarts at zero.**
`build_trigger(..., build_id=<existing>, reactive=True)` is fully
supported and is the recommended way to pick a failed reactive build back
up. It does **not** mint a new build: `_trigger_reactive` resumes *this*
one and its discovery calls `task_retry` on the failed tasks in it. If the
count spanned the build's whole history, the budget would already be spent
the moment the user asked for another go, and resuming would additionally
require raising `max_attempts` — for the one action anybody reaches for
after a failure.

`BUILD_RESUMED` is the right cut rather than a special case:

- it is exactly the durable marker of "another round was asked for";
- it needs no new event type, column or marker — the event already
  exists and is already emitted on that path;
- it keeps the count per-build, so nothing about the scoping argument
  below changes;
- the server only emits it when the build has activity beyond
  `BUILD_STARTED`, so a **first** trigger is unaffected (verified: a
  no-op resume before any task activity records nothing and creates no
  round boundary);
- repeated re-triggers do hand out fresh budgets, but that is a user
  deciding to try again — visible and user-driven, not a scheduler
  looping.

**`TASK_RETRIED` on its own does not reset.** A scheduler enforcing a
budget retries a failed task *through* that endpoint — a `FAILED` task is
not in the frontier's actionable set until something flips it back to
`PENDING` — so a counter cleared by it would be cleared by every
enforcement of the budget it defines, and `max_attempts` would never bind.

The distinction is what lets a scheduler tell **"this round is out of
attempts"** (a real message to show a user who clicked Retry) from **"the
user asked for another round"** (a real reset).

One implementation detail worth naming, because getting it backwards is
silent: the round cutoff is applied **before** the `LAG`, not after. If it
were applied afterwards, the last start of the previous round would still
be the first post-resume start's predecessor, collapse it, and a resumed
build would report zero attempts however many times it tried.

## Per-build scoping

Unlike the denormalised `latest_*` fields it travels with — environment-
global, because a completed task is completed for everyone — this is
scoped to **one build** (and now one round of it). A task that spent two
attempts in an earlier build must arrive in a fresh trigger with a full
budget, or a lifetime budget would make it permanently unschedulable in
every future build in the environment.

Because it differs from everything around it, it is stated explicitly in
the `FrontierTaskRef` field comment, in the frontier endpoint docstring,
and on the deriving function.

## Derive vs denormalise

**Derived**, and there was not much of a contest. Attempts are per-build
and per-round, and there is no per-`(build, task)` row in the schema to
hang a column on. Denormalising would mean a new table, a fold on every
start path (three of them, all racy), a backfill, and — with the round
window — a reset fanned out across every task of a build on each resume.
All to replace one grouped query over an index that already exists
(`ix_events_build_task_type`). Deriving also keeps the rule in exactly one
place, expressed declaratively, where it cannot drift from the event log.

**No migration**, no new column, no backfill.

## Query shape

One grouped statement: a `LAG` window function partitioned by task and
ordered by `(created_at, id)`, filtered to the status-affecting event
types and to the round, with a null-safe inequality so the first event in
a stream still counts. The round cutoff is a correlated scalar subquery
(`max(created_at)` of the build's `BUILD_RESUMED` events, a point lookup
on `ix_events_build_task_type` since build-level events carry
`task_id IS NULL`), so windowing costs no extra round trip.

`LAG`, `IS DISTINCT FROM` and the correlated subquery all render
differently per dialect, so there is a Postgres pass over all three rules
(verified against a throwaway 16 instance).

## Cost

**Frontier: +1 query, from 5 to 6** — measured, not estimated, and
unchanged by the round window. It is a single grouped query, never one per
task: the frontier is re-read on every linger poll (~3 s per active
build), so an N+1 there would be the worst possible place for one. The
scan is bounded to the union of task pks the response actually carries
(`actionable ∪ running ∪ roots`), so the added cost tracks the size of the
response rather than the size of the build's event history — and a
frontier with no tasks to report issues **no** extra query at all.

`GET /builds/{id}/tasks`: +1 grouped query, mirroring the `artifact_count`
aggregate beside it.

Task event responses: **+1** small indexed lookup for the round cutoff.
The tally itself still rides on the per-build replay
`get_task_status_in_build` already performs, but the cutoff cannot be
pushed into that query — the *status* fold has to see the whole stream (a
task completed before a resume is still completed), so only the tally is
windowed. That replay also gained an explicit `id` tiebreak on its
ordering so equal timestamps replay deterministically, which the attempt
rule is sensitive to.

The concurrency-limit eviction route spends one extra query so the field is
never null anywhere (see **Presence is guaranteed** above). That route is
admin recovery and runs at human frequency.

## Verification

```
468 passed, 29 skipped        # SQLite (default)
495 passed,  1 skipped, 1 failed   # with STARDAG_API_TEST_DATABASE_URL → Postgres 16
```

The one Postgres failure is
`test_claim_expiry.py::test_migration_backfills_claims_that_are_already_running`,
which is **pre-existing on the base branch** and unrelated to this PR —
confirmed by reverting `src/` to the base commit and reproducing it
identically. This PR touches neither migrations nor claim expiry.

`pre-commit` clean on every changed file, including `pyright-stardag-api`.

Purely additive: every existing field keeps its exact semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012NyR9Kc9ZP5Ko7dVndhi3Y
