### PR TITLE
Release v0.18.0 — builds collaborate, and triggering got fast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,11 +127,14 @@ build_id=<existing>, reactive=True)` is the recommended way to pick a
   keeps its exact semantics.
 
   `blocking_in_build` is reported for diagnostics and is not the field a
-  scheduler should branch on — plan closure (below) makes `false` unreachable
-  for anything registered under the current rule, and what happens next
-  follows from the blocker's status. `blocking_attempt_count` is `null` for a
-  blocker outside the plan, which is also what keeps a scheduler from
-  resetting one: it has no budget to spend there.
+  scheduler should branch on: what happens next follows from the blocker's
+  status. Plan closure (below) makes `true` the normal case, but `false` stays
+  reachable — closure runs once, at registration, so an edge written afterwards
+  is outside the plan, which is what happens whenever a concurrent build's
+  worker yields dynamic dependencies into its own plan.
+  `blocking_attempt_count` is `null` for a blocker outside the plan, which is
+  also what keeps a scheduler from resetting one: it has no budget to spend
+  there.
 
 - **Registration closes a build's plan over every recorded dependency edge**
   ([#208](https://github.com/stardag-dev/stardag/issues/208)). A build's plan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.18.0] — 2026-08-09
+
 ### Registry API
 
 - **The API now knows which SDK is calling it, and can say so when that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,17 @@ build_id=<existing>, reactive=True)` is the recommended way to pick a
   or a migration. Retention is bounded per build (newest 50 by default,
   `STARDAG_API_MAX_TICK_SUMMARIES_PER_BUILD`), pruned on insert.
   Additive: nothing writes to these endpoints yet.
+- **A failed build now reports _why_, on the build itself.**
+  `BuildResponse.latest_error_message` carries the reason recorded on the
+  build's newest `BUILD_FAILED` event, so "why did this fail" no longer costs a
+  `GET /builds/{id}/events` per build — which is why no listing ever showed it.
+  Reported while the build is `failed` and not afterwards: a build resumed after
+  failing is running again, and a current status paired with a previous round's
+  reason misleads worse than no reason. A blank reason is normalised to `null`,
+  so "none recorded" has one representation. Derived from the event rather than
+  denormalised onto the row (unlike `Task.latest_error_message`), batched into
+  one grouped query per page on the listing path.
+
 - **`GET /builds/{id}/frontier` now reports why a build is waiting on work
   it does not own** ([#208](https://github.com/stardag-dev/stardag/issues/208)).
   Dependency gating is environment-global (task rows and edges are shared
@@ -341,6 +352,14 @@ build_id=<existing>, reactive=True)` is the recommended way to pick a
   `POST /builds/bulk-cancel` will act on, including the per-build reasons
   anything was skipped — because a preview that disagrees with the action
   is worse than no preview.
+
+- **A failed build says why it failed.** The scheduling panel explains a build
+  while it is _stalled_, and goes quiet the moment it fails — failing skips the
+  blocked tasks, and terminal tasks leave the frontier's blocker list. The
+  reason the scheduler recorded on its way out (which task, its status and age,
+  the owning build, why nothing will move it, and the remedy) is now shown on
+  the failed build, in the place the panel's explanation occupied. Untruncated,
+  because the remedy is at the end of it.
 
 - **A build that is not progressing now says why.** When nothing is
   actionable and nothing is running, the build view names each blocking
@@ -594,6 +613,12 @@ liveness)` plus a staleness bound on how long the blocker had sat in its
   new (optional, default `None`) hook an executor implements to expose its
   wall-clock limit. `StartClaimResult.latest_status_at` is replaced by
   `latest_status_expires_at`.
+
+- **`stardag builds show` prints a failed build's reason.**
+  `BuildSummary.latest_error_message` models the new server field, and the
+  command renders it as **Failure reason** — the most useful row on a failed
+  build, since the reactive scheduler's reasons name the blocking task, the
+  build that owns it and what to run. Absent on servers predating the field.
 
 - **New `stardag builds` and `stardag tasks` CLI groups.** There was no way
   to list builds, inspect a build's scheduling frontier, cancel a build or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,10 +119,54 @@ build_id=<existing>, reactive=True)` is the recommended way to pick a
   could gate a build's tasks while contributing nothing it could see — a
   scheduler then read "nothing actionable, nothing running" as "cannot
   progress" and failed the build. The new `blocked_by_external` list pairs
-  each such blocked task with its blocker (identity, status, the owning
-  build id and status timestamp, and whether the blocker is in this build's
-  task set), capped with an explicit `blocked_by_external_truncated` flag.
-  Purely additive: every existing field keeps its exact semantics.
+  each such blocked task with its blocker (identity, status, status
+  timestamp, the owning build id, the claim's expiry where the blocker holds
+  one, the attempts the blocker has spent in this build's round, and whether
+  the blocker is in this build's task set), capped with an explicit
+  `blocked_by_external_truncated` flag. Purely additive: every existing field
+  keeps its exact semantics.
+
+  `blocking_in_build` is reported for diagnostics and is not the field a
+  scheduler should branch on — plan closure (below) makes `false` unreachable
+  for anything registered under the current rule, and what happens next
+  follows from the blocker's status. `blocking_attempt_count` is `null` for a
+  blocker outside the plan, which is also what keeps a scheduler from
+  resetting one: it has no budget to spend there.
+
+- **Registration closes a build's plan over every recorded dependency edge**
+  ([#208](https://github.com/stardag-dev/stardag/issues/208)). A build's plan
+  is every dependency of its roots that was not complete at discovery time,
+  pruned at complete tasks. Discovery enforces that by walking
+  `requires()` — **static** edges. But gating consults every recorded edge,
+  and _dynamic_ edges are written by whichever build first ran the task and
+  then outlive it: environment-global and permanent. So a later build that
+  statically discovers the same task inherited the dependency without
+  inheriting the task, and was gated on an upstream **no build containing it
+  could schedule** — the only thing that would produce it being the very task
+  being gated. Permanent deadlock.
+
+  Both registration endpoints now admit incomplete upstreams into the plan,
+  transitively, stopping at complete tasks. Admission is a status-neutral
+  `TASK_REFERENCED`: the upstream's own state is untouched, it simply becomes
+  part of this build's plan, which is what makes it schedulable here.
+  Over-approximating is safe and under-approximating is not — a stale edge
+  costs one unnecessary upstream, a missing one deadlocks — so no attempt is
+  made to judge whether a recorded edge is current.
+
+  RUNNING upstreams are admitted too. Closure runs **once**, at registration,
+  while RUNNING is transient: excluding them would leave a permanent hole in
+  the plan the moment the task stopped running, and the likeliest way for it
+  to stop is an operator releasing a stale claim — the documented remedy
+  stranding every build that inherited the dependency. Safety comes from the
+  claim, not from which build started the task.
+
+  **Visible consequence, and it is the intended one:** an incomplete upstream
+  now belongs to the build that depends on it, so `GET /builds/{id}/graph`
+  reports it as a **primary** node rather than as greyed-out context, and
+  `upstream_depth` reveals only _complete_ upstreams. It also joins the
+  build's own `actionable`/`running` and its status counts. Nothing to change
+  on your side, but the counts and the graph will look different.
+
 - **Frontier task refs now actually carry `latest_status_at`.** The field
   was declared and documented as the input to scheduler staleness bounds
   but never populated, so it always serialised as `null` and those guards
@@ -297,10 +341,13 @@ build_id=<existing>, reactive=True)` is the recommended way to pick a
 
 - **A build that is not progressing now says why.** When nothing is
   actionable and nothing is running, the build view names each blocking
-  upstream, its status, how long it has been held, and which build owns it
-  — including blockers that are not part of the build at all, which are
-  otherwise invisible from it. Each carries the remedy (release the claim,
-  or reset the task to pending) addressed to the owning build. Behind a
+  upstream, its status, how long it has been held, and which build owns it.
+  Each carries what happens next, which follows from the blocker's
+  **status**: `running` resolves when the claim finishes or expires;
+  `cancelled` is a revocation, so this build's next tick resets it and runs
+  it; `suspended` resolves as the owning build works through the dynamic
+  dependencies it yielded; `failed` and `skipped` are results left to this
+  build's `fail_mode`, so re-triggering is the way to reset them. Behind a
   disclosure: the scheduler's own tick trail, with runs of identical ticks
   collapsed ("lease held ×20") and counters that stayed at zero dropped, so
   a stalled build's repetition reads as a diagnosis instead of a log.
@@ -508,14 +555,14 @@ liveness)` plus a staleness bound on how long the blocker had sat in its
   is waited on; one whose claim has **lapsed** fails the build, with the
   message saying the claim is provably abandoned rather than presumed so.
 
-  What this does **not** change: proving a blocker dead still does not let
-  your build run it — a blocker outside your build's task set has to be
-  released under the build that owns it, so the build still fails, just with
-  certainty about why. And the collapse applies to RUNNING blockers only: a
-  SUSPENDED or PENDING blocker holds no claim and therefore carries no
-  expiry, so "will anyone move it?" is still asked of its owning build (an
-  abandoned-SUSPENDED upstream remains a real wedge, recovered by retrying
-  it under its owner).
+  What this does **not** change: proving a blocker dead does not make it
+  schedulable. A RUNNING task is not runnable whoever holds the lapsed claim,
+  so the build still fails — just with certainty about why, and pointing at
+  the cancel that releases it. And the collapse applies to RUNNING blockers
+  only: a SUSPENDED or PENDING blocker holds no claim and therefore carries
+  no expiry, so "will anyone move it?" is still asked of its owning build (an
+  abandoned-SUSPENDED upstream remains a real wedge, recovered by
+  re-triggering the build that is waiting on it).
 
 - **Every start records a claim TTL derived from the executor's own
   timeout.** For Modal that is the worker function's `timeout` from its
@@ -527,9 +574,8 @@ liveness)` plus a staleness bound on how long the blocker had sat in its
   Setting an explicit `timeout` on long-running Modal workers is therefore
   worth doing.
 
-- **Removed: `TickConfig.stale_external_blocker_seconds`,
-  `TickConfig.stale_running_no_ref_seconds` and
-  `ClaimConfig.stale_running_no_ref_seconds`.** All three configured a local
+- **Removed: `TickConfig.stale_running_no_ref_seconds` and
+  `ClaimConfig.stale_running_no_ref_seconds`.** Both configured a local
   guess at how long "too long" is, which the claim's own expiry now answers.
   A task RUNNING without an executor ref (a scheduler that died between the
   claiming start and the spawn) is failed when its claim lapses instead of
@@ -569,10 +615,12 @@ liveness)` plus a staleness bound on how long the blocker had sat in its
   partitions it renders the build's **external blockers** — tasks of this
   build held back by an upstream whose current status _another_ build
   produced — naming the blocking task's namespace/name (not just an id), its
-  status, how long it has been in it, the owning build, and which of the two
-  remedies applies (a blocker outside this build's task set can only be
-  waited on or released; one inside it resolves when its owner finishes it).
-  It also states honestly that the registry computes that list only for a
+  status, how long it has been in it, the owning build, and what happens next,
+  which follows from the status rather than from which build produced it
+  (`running` waits on the claim, `cancelled` is reset by the next tick,
+  `suspended` waits on the owning build, `failed`/`skipped` need a
+  re-trigger). It also states honestly that the registry computes that list
+  only for a
   build with nothing actionable and nothing running, so an empty list never
   reads as "no blockers" for a build that is merely progressing.
 
@@ -692,9 +740,10 @@ liveness)` plus a staleness bound on how long the blocker had sat in its
   sees, which are scoped to this build. That shape read as "nothing
   runnable, nothing running, so this build is dead", and the build was
   failed within seconds of triggering with an error naming only status
-  counts. Common whenever DAGs overlap, and especially when the blocker is
-  a dynamic dependency registered under an earlier build, so it is not in
-  the new build's task set at all.
+  counts. Common whenever DAGs overlap, and worst when the blocker was a
+  dynamic dependency registered under an earlier build — which plan closure
+  (see the Registry API section) now pulls into the new build's plan instead
+  of leaving it gating a build that could never schedule it.
 
   A tick now reads the frontier's blocking upstreams and asks, for each,
   whether anyone is going to move it. A blocker **another build is
@@ -706,24 +755,38 @@ liveness)` plus a staleness bound on how long the blocker had sat in its
   status, or that status could not be resolved — fails the build
   immediately, naming the task, its namespace/name, its status, how long it
   has been in it, the build that owns it, why that owner will not move it,
-  and how to release it. A blocker inside this build's own task set is
-  unchanged: it is already visible in the counts, and still fails the build
-  when it can never run.
+  and the one remedy there is: **re-trigger this build**, which resets the
+  blocker (it is in this build's plan) and runs it here.
 
-  Both waits are bounded by the new
-  `TickConfig.stale_external_blocker_seconds` (default 6 hours), measured on
-  how long the blocker has sat in its status rather than on the tick, which
-  is too short-lived to bound anything: past the bound the blocker is
-  presumed abandoned and the build fails with the full explanation instead
-  of hanging silently. `None` waits indefinitely. `TickSummary` gains
-  `external_blockers`, `external_blockers_waited` and
-  `external_blockers_fatal`, and `BuildInfo` gains `status` (the build's
-  derived status, `None` when a server or custom registry does not report
-  it). Owner liveness is resolved only when a build actually looks stalled,
-  and once per owning build per pass, so a healthy build issues no extra
-  requests however often it polls. Requires a stardag-api version matching
-  this SDK; against an older server the blocker list is always empty and
-  terminal detection behaves exactly as before.
+  **Which of those questions gets asked is decided by the blocker's status,
+  not by which build owns it.** A build's plan is closed under the dependency
+  relation, so a gating upstream is this build's own task; deferring to
+  whichever build last touched it is what turned one build's fail-fast into
+  every overlapping build's failure. A `CANCELLED` blocker is a revocation of
+  permission to run, not a verdict on the task, and permission is not
+  build-scoped — the tick **resets it and runs it**, bounded by
+  `max_attempts`. `FAILED` and `SKIPPED` are _results_: `fail_mode` owns them
+  (FAIL_FAST has already failed the build on the same count; CONTINUE means
+  "finish what you can, then fail"), so a tick names them in the failure and
+  changes nothing. A `SUSPENDED` blocker is waited on while its owning build
+  lives, because resetting it would redo all of the task's pre-yield work
+  while that build is legitimately progressing the children it yielded. At
+  **trigger** time the whole retryable set is reset, `RUNNING` excepted — the
+  asymmetry is deliberate: at trigger you asked, mid-flight nobody did.
+
+  Waits are bounded by evidence rather than by a timer. For a RUNNING blocker
+  it is the claim's expiry; for a SUSPENDED or PENDING one — which holds no
+  claim, so has no expiry to read — it is the owning build going terminal,
+  and a build gone silent without transitioning is reaped server-side.
+  `TickSummary` gains `external_blockers`, `external_blockers_waited`,
+  `external_blockers_fatal` and `in_build_blockers_reset`, and `BuildInfo`
+  gains `status` (the build's derived status, `None` when a server or custom
+  registry does not report it). Owner liveness is resolved only when a build
+  actually looks stalled, only for the blockers whose status needs it, and
+  once per owning build per pass, so a healthy build issues no extra requests
+  however often it polls. Requires a stardag-api version matching this SDK;
+  against an older server the blocker list is always empty and terminal
+  detection behaves exactly as before.
 
 - **Fixed: re-triggering a reactive build now recovers tasks left
   `SUSPENDED`.** A task that suspended for dynamic dependencies and was
@@ -738,15 +801,16 @@ liveness)` plus a staleness bound on how long the blocker had sat in its
   remains deliberately non-retryable: it holds a live execution claim, and
   releasing that claim is cancellation, not retry.
 
-- **`TickConfig.stale_running_no_ref_seconds` takes effect for the first
-  time**, now that the frontier actually populates
-  `FrontierTaskRef.latest_status_at`. The field was declared and documented
-  as the input to that bound but never sent by the server — it silently
-  serialised as `null` on every ref, leaving the guard dead. Against a
-  matching server, a task stuck RUNNING without an executor ref for longer
-  than the bound (default 30 minutes) is now failed as intended. Raise the
-  bound if you run long ref-less tasks — e.g. a resident build sharing
-  tasks with a concurrently ticking reactive one.
+- **Fixed: a task stuck RUNNING with no executor ref is now actually
+  recovered.** A scheduler that died between the claiming start and the spawn
+  leaves a task RUNNING that no worker will ever report on.
+  `stale_running_no_ref_seconds` was supposed to bound that, but it was
+  measured against `FrontierTaskRef.latest_status_at`, which the server
+  declared and never populated — so it serialised as `null` on every ref and
+  the guard was dead code for its whole life. The frontier now populates the
+  field, and the bound it feeds has been replaced outright by the claim's
+  expiry (see the removal above), which is evidence rather than a guess and
+  needs no tuning for long ref-less tasks.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
-## [0.18.0] — 2026-08-09
+## [0.18.0] — 2026-08-11
 
 ### Registry API
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
-## v0.18.0 — Stuck builds explain themselves, and triggering got fast
+## v0.18.0 — Builds collaborate, and triggering got fast
 
 Reactive scheduling worked until something went wrong. Then a build sat at
 RUNNING forever with no way to ask why, and the usual answer — a task in
@@ -32,11 +32,30 @@ orchestrator that died wedged its tasks permanently. Claims now carry an
 expiry, granted at start and derived from the executor's own timeout, and
 both the claim check and the concurrency-limit count honour it.
 
-**A build that cannot progress says so.** The frontier reports the upstreams
-blocking it, their status, how long they have been held and which build owns
-them — including blockers that are not part of the build at all. A reactive
-build now **waits** for a live cross-build blocker instead of failing with
-"No runnable or running tasks left".
+**Builds collaborate instead of owning tasks.** A build is a request for a
+set of root tasks to be materialised, not an owner of the tasks that
+materialise them. The execution claim is the only thing coordinating across
+builds; which build completes a task is otherwise irrelevant.
+
+Two things follow, and both were previously wrong:
+
+_A build's plan holds every dependency that was not complete when it was
+discovered._ Discovery walks `requires()`, but dependency edges also come
+from tasks that yielded them dynamically in some earlier build, and those
+edges outlive it. A build could therefore be gated by an upstream it never
+registered — which nothing could ever run, since the only thing that would
+produce it was the task being gated. Registration now closes the plan over
+every recorded edge, pruning at complete tasks.
+
+_A shared task another build cancelled is still this build's to run._ When a
+fail-fast build cancels the tasks it started, it correctly releases those
+claims — but the tasks were left `CANCELLED`, which is not schedulable, so
+every other build sharing the dependency died with it. One build's fail-fast
+is now just that: one build's. Any build with the task in its plan resets it
+and runs it, bounded by the per-task retry budget.
+
+**A build that still cannot progress says why.** The frontier names the
+tasks holding it up, their status and how long they have been in it.
 
 **Operational surface.** New `stardag builds` and `stardag tasks` CLI groups:
 list builds by status/idleness/app, list the tasks holding claims, and clean
@@ -97,6 +116,14 @@ app = StardagApp(
     ...
 )
 ```
+
+**A build's task set now includes upstreams it did not register.** Because
+the plan is closed over every recorded dependency edge, a task another build
+is running — or one it cancelled — appears in your build's own
+`actionable`/`running` and in its DAG view as a primary node rather than as
+greyed-out context. `upstream_depth` in the graph view therefore reveals
+only _complete_ upstreams; incomplete ones are already in the build. Nothing
+to change on your side, but the counts and the view will look different.
 
 **The watchdog sweep is scoped to the app that owns each build.** It used to
 page every RUNNING build and filter client-side, which meant an environment

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,121 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.18.0 — Stuck builds explain themselves, and triggering got fast
+
+Reactive scheduling worked until something went wrong. Then a build sat at
+RUNNING forever with no way to ask why, and the usual answer — a task in
+_another_ build holding an execution claim nobody would ever release — was
+invisible from anywhere in the product.
+
+This release closes that loop, and makes triggering roughly ten times
+faster on the way.
+
+**Triggering discovers the DAG inside Modal.** A reactive trigger now
+spawns a `bootstrap` function that walks the DAG, registers it, persists the
+task objects and only then arms the build and spawns the first tick.
+Discovery means one target existence check per task; from your laptop
+against a `modalvol://` root each is a rate-limited Volume API call, while
+inside Modal the volume is a mounted filesystem. A 127-task trigger went
+from 64s — most of it rate-limit backoff — to 6.6s. It also means a
+reactive trigger needs **registry credentials only**, with no target-root
+access at all.
+
+**Execution claims expire.** `Task.latest_status == RUNNING` _is_ the claim,
+and it recorded no liveness evidence a third party could evaluate — so an
+orchestrator that died wedged its tasks permanently. Claims now carry an
+expiry, granted at start and derived from the executor's own timeout, and
+both the claim check and the concurrency-limit count honour it.
+
+**A build that cannot progress says so.** The frontier reports the upstreams
+blocking it, their status, how long they have been held and which build owns
+them — including blockers that are not part of the build at all. A reactive
+build now **waits** for a live cross-build blocker instead of failing with
+"No runnable or running tasks left".
+
+**Operational surface.** New `stardag builds` and `stardag tasks` CLI groups:
+list builds by status/idleness/app, list the tasks holding claims, and clean
+up abandoned builds in bulk with a dry run that is the same query the reaper
+acts on. Scheduler ticks record what they decided, per build.
+
+**Reactive scheduling is more concurrent.** Ticks fan out with bounded
+concurrency instead of spawning serially, discovery runs concurrently, and
+the per-pass spawn cap is derived from the tick container's own timeout.
+Tasks get a retry policy for failures the backend cannot retry itself.
+
+**The SDK identifies itself.** Every request carries
+`X-Stardag-SDK-Version`, and a registry that requires a newer SDK answers
+`426` with a message naming both versions and the upgrade command, instead
+of a confusing 404 or 422.
+
+---
+
+### Upgrade order
+
+**Upgrade your registry first.** This SDK uses endpoints and fields added in
+the same release (claim expiry, the frontier's blocker reporting, tick
+summaries, bulk cancel, attempt counts). Against an older registry those
+calls fail. The registry ships three migrations, one of which backfills
+build status and one of which backfills claim expiry — see
+[CHANGELOG.md](CHANGELOG.md).
+
+One thing to check before upgrading a registry with long-running work: the
+claim-expiry backfill stamps existing RUNNING tasks with
+`latest_status_at + <default TTL>` (7 days). A task that has been RUNNING
+longer than that gets an expiry already in the past, so the next tick treats
+its claim as lapsed and may recover it. That is the intended healing for a
+genuinely wedged task; run this first if you want to know what it will touch:
+
+```sql
+SELECT count(*) FROM tasks
+WHERE latest_status = 'running'
+  AND latest_status_at < now() - interval '7 days';
+```
+
+### Migration guide
+
+**Reactive triggers now need registry credentials in your Modal
+environment**, because discovery runs there rather than on the triggering
+machine. `StardagApp` injects them from the `stardag-api-key` secret by
+default. To keep discovery local — for a target root only your machine can
+reach, say — pass `reactive_discovery="local"`.
+
+**Declaring `task_modules` is now what enables pickle-free ticks.**
+Inference still happens, but it is observation-only: an SDK upgrade never
+starts eliding pickles on its own. Nothing breaks if you do not declare —
+ticks keep reading the build task store exactly as before. To opt in:
+
+```python
+app = StardagApp(
+    "my-app",
+    task_modules=["my_pkg.tasks.*", "my_pkg.pipelines.*"],
+    ...
+)
+```
+
+**The watchdog sweep is scoped to the app that owns each build.** It used to
+page every RUNNING build and filter client-side, which meant an environment
+with more stale builds than the sweep's page budget could starve the
+watchdog of the builds it exists to find. The cost is that an app deployed
+**without** `watchdog_period_minutes` no longer gets incidental coverage
+from another app's watchdog. Set it on every app you want swept.
+
+**`stardag builds list --older-than` implies `--status running`.** Idleness
+only means anything for a build that has not finished; a completed build has
+no activity by definition and always will, so including terminal builds
+filled a staleness listing with history sorted oldest-first. Pairing
+`--older-than` with any other status is rejected.
+
+**Custom `RegistryABC` implementations may need updating.** The
+compatibility shims for registry backends that predate recent keyword
+arguments have been removed, and `build_list_running` is now expressed in
+terms of `build_list` with server-side filtering. If you have your own
+`RegistryABC` subclass, check `build_list_running`'s signature. If you use
+the shipped `APIRegistry` — which is almost certainly the case — nothing
+changes.
+
+---
+
 ## v0.17.0 — stardag ships its type information (PEP 561)
 
 The published distribution now includes a


### PR DESCRIPTION
Release notes and changelog for **v0.18.0**, dated **2026-08-11** — the day it
ships, not the day it was drafted.

There is no version file to bump: `hatch.version.source = "vcs"`, so the version
comes from the git tag. Merge this to `main`, then tag the resulting `main`
commit — see [Tagging](#tagging) below.

## What it covers

The 20-PR reactive-scheduling stack (**#209–#228**): reactive discovery moving
into Modal, execution-claim expiry, cross-build blocker reporting and remedies,
the `stardag builds` / `stardag tasks` CLI groups, the Builds view and claim
triage in the UI, tick-summary persistence, fan-out and retry policy, and the
SDK version contract.

Plus four PRs merged after this branch was first cut, all in the changelog:

| PR       | What                                                                                                                  |
| -------- | --------------------------------------------------------------------------------------------------------------------- |
| **#233** | Builds collaborate: a build's plan is closed under the dependency relation, and a `CANCELLED` shared task is this build's to reset and run — while `FAILED`/`SKIPPED` stay `fail_mode`'s to decide and `SUSPENDED` is waited on. Deletes the out-of-plan blocker handling the closure made unnecessary. |
| **#237** | Task Explorer's detail panel refreshes after a claim action, instead of asserting a claim is held seconds after it was released. `onTaskCancelled` is now required, which surfaced a third affected call site. |
| **#238** | A failed build reports *why* on `BuildResponse.latest_error_message`, in `BuildSummary`, and as a **Failure reason** row in `stardag builds show`. |
| **#239** | The UI shows that reason on a failed build — where the scheduling panel's explanation used to be, since the panel goes quiet the moment a build fails. |

#237–#239 came out of walking the UI on a live Modal+Neon deployment; #234–#236
are the issues they close.

## Verification

`main` at the tip being tagged:

- **567** API tests against real PostgreSQL
- **1016** SDK tests (excluding `tests/test_integration/test_modal`, which needs
  live Modal credentials)
- **175** UI tests
- a single Alembic head (`e87efdab31ca`) — and **no new migration** since the
  original cut: #238 derives a build's failure reason from its events rather
  than denormalising a column, specifically to avoid a fifth migration days
  before a release

Beyond the suites, this tree ran on a live Modal + Neon stack: migrations
applied over pre-existing data, reactive builds completed end to end, and the
two scenarios #233 turns on were verified by event log — a shared task that
**fails** under another build is left alone, and one that **suspends** under a
live build is waited on, each confirmed by the absence of a `TASK_RETRIED`
attributed to the waiting build.

The same tree is now **deployed to the hosted registry**, which is the required
order — see below.

## Order of operations

**The registry must be upgraded before this SDK is released**, and it has been.
The SDK calls endpoints and reads fields added in the same release; against an
older registry those calls fail. The reverse is safe — the registry serves older
SDKs unchanged, and the SDK version floor ships dormant (`minimum_version` unset,
so no request is ever rejected for its version).

Compatibility of that registry upgrade for **older** SDK clients was checked
field by field before deploying: no routes removed, no response fields removed,
every added request field optional, the three new 422s all guarding new
parameters, no new enum values, and migrations additive. The one genuine
behavioural change is the point of the release — claims now expire, so a task
running past its TTL (7 days by default) can have its claim taken.

## Tagging

Not on this branch. Merge to `main` first, then tag the merge commit that lands
there:

```bash
git checkout main && git pull origin main
git tag v0.18.0
git push origin v0.18.0
```

CI then builds the sdist and wheel, publishes to TestPyPI and PyPI, and creates
the GitHub Release. Its body is rewritten from `RELEASE_NOTES.md` afterwards —
GitHub Releases render GFM-with-`<br>`, so this file's hard wrapping has to be
unwrapped first.
