### PR TITLE
fix(reactive): a task in this build's plan is this build's to run

### DIFF
--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1945,15 +1945,20 @@ async def _close_plan_over_dependencies(
     missing one deadlocks. So no attempt is made to decide whether a
     recorded edge is still current.
 
-    **RUNNING upstreams are deliberately left out**, and that is the one
-    conservative choice here. A RUNNING task is the single status carrying
-    an execution claim: another build is actively running it, the claim is
-    already coordinating, and nothing deadlocks — the existing cross-build
-    wait handles it. Admitting one would place a task this build did not
-    start into its own ``running`` list, where its liveness heuristics would
-    begin probing an execution belonging to someone else. Strictly, the
-    principle says it belongs in the plan too; that is a further
-    simplification, not a deadlock fix, and it deserves its own change.
+    **RUNNING upstreams are admitted like any other.** Excluding them was
+    tempting — another build is executing it, so nothing is deadlocked
+    *right now* — but closure runs once, at registration, while RUNNING is
+    transient. The moment the task stops running the exclusion becomes a
+    permanent hole, and the likeliest way for it to stop running is an
+    operator releasing a stale claim: the documented remedy would strand
+    every build that inherited the dependency while it was running.
+
+    A task this build did not start therefore appears in its own
+    ``running``, and its liveness heuristics may act on it. That is correct:
+    the destructive action is gated on the claim's expiry, and past that
+    expiry the server no longer honours the claim and will hand the task to
+    the next claimant whoever asks. Which build started it was never what
+    made recovery safe — the claim is.
     """
     if not task_pks:
         return 0
@@ -1975,9 +1980,7 @@ async def _close_plan_over_dependencies(
                     .join(TaskDependency, TaskDependency.upstream_task_id == Task.id)
                     .where(
                         TaskDependency.downstream_task_id.in_(frontier_pks),
-                        Task.latest_status.not_in(
-                            (TaskStatus.COMPLETED, TaskStatus.RUNNING)
-                        ),
+                        Task.latest_status != TaskStatus.COMPLETED,
                         Task.id.not_in(in_plan),
                     )
                     .distinct()

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1913,6 +1913,101 @@ async def get_build_frontier(
 # --- Tasks within Builds ---
 
 
+async def _close_plan_over_dependencies(
+    db: AsyncSession,
+    *,
+    build_id: UUID,
+    task_pks: Sequence[UUID],
+) -> int:
+    """Admit incomplete upstreams of ``task_pks`` into this build's plan.
+
+    **A build's plan is every dependency of its roots that was not complete
+    at discovery time**, pruned at complete tasks — whose own upstreams are
+    assumed complete with them. That is not a new rule: it is exactly what
+    discovery does when it walks ``task.requires()``.
+
+    The gap is that discovery walks *static* edges while gating consults
+    every recorded edge, dynamic ones included. A dynamic edge is written by
+    whichever build first ran the task and then outlives it, environment
+    -global and permanent. A later build that statically discovers the same
+    task therefore inherits the dependency without inheriting the task, and
+    is gated on an upstream it never registered — which no build containing
+    it can schedule, because the only thing that would produce it is the
+    very task being gated. A permanent deadlock.
+
+    Admitting an upstream is a status-neutral TASK_REFERENCED: nothing about
+    the upstream's own state changes, it simply becomes part of this build's
+    plan, which is what makes it schedulable here.
+
+    Over-approximating is safe, under-approximating is not. If this run
+    would in fact yield different dynamic dependencies, the build completes
+    an upstream it did not need — wasted work, correct outcome — whereas
+    missing one deadlocks. So no attempt is made to decide whether a
+    recorded edge is still current.
+
+    **RUNNING upstreams are deliberately left out**, and that is the one
+    conservative choice here. A RUNNING task is the single status carrying
+    an execution claim: another build is actively running it, the claim is
+    already coordinating, and nothing deadlocks — the existing cross-build
+    wait handles it. Admitting one would place a task this build did not
+    start into its own ``running`` list, where its liveness heuristics would
+    begin probing an execution belonging to someone else. Strictly, the
+    principle says it belongs in the plan too; that is a further
+    simplification, not a deadlock fix, and it deserves its own change.
+    """
+    if not task_pks:
+        return 0
+
+    admitted = 0
+    frontier_pks = list(task_pks)
+    seen: set[UUID] = set(task_pks)
+    while frontier_pks:
+        in_plan = (
+            select(Event.task_id)
+            .where(Event.build_id == build_id, Event.task_id.is_not(None))
+            .distinct()
+            .scalar_subquery()
+        )
+        rows = (
+            (
+                await db.execute(
+                    select(Task)
+                    .join(TaskDependency, TaskDependency.upstream_task_id == Task.id)
+                    .where(
+                        TaskDependency.downstream_task_id.in_(frontier_pks),
+                        Task.latest_status.not_in(
+                            (TaskStatus.COMPLETED, TaskStatus.RUNNING)
+                        ),
+                        Task.id.not_in(in_plan),
+                    )
+                    .distinct()
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        frontier_pks = []
+        for upstream in rows:
+            if upstream.id in seen:
+                continue
+            seen.add(upstream.id)
+            db.add(
+                Event(
+                    build_id=build_id,
+                    task_id=upstream.id,
+                    event_type=EventType.TASK_REFERENCED,
+                )
+            )
+            admitted += 1
+            frontier_pks.append(upstream.id)
+        if frontier_pks:
+            # Flush so the next level's `in_plan` subquery sees these.
+            await db.flush()
+
+    return admitted
+
+
 async def _reconcile_dependency_edges(
     *,
     db: AsyncSession,
@@ -2173,6 +2268,8 @@ async def register_task(
     db.add(event)
     await db.flush()
     apply_event_to_task(db_task, event)
+
+    await _close_plan_over_dependencies(db, build_id=build_id, task_pks=[db_task.id])
 
     await db.commit()
     await db.refresh(db_task)
@@ -2530,6 +2627,12 @@ async def register_tasks_bulk(
         # round-trip needed.
         for t, ev in zip(tasks_in, events):
             apply_event_to_task(db_task_by_task_id[t.task_id], ev)
+
+    await _close_plan_over_dependencies(
+        db,
+        build_id=build_id,
+        task_pks=[t.id for t in db_task_by_task_id.values()],
+    )
 
     # One final flush + commit at the end. Earlier flushes (just the
     # task INSERT batch) populated the rows we need to FK against.

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from datetime import datetime, timedelta
-from typing import Annotated
+from typing import Annotated, Any, Sequence
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -1753,6 +1753,7 @@ async def get_build_frontier(
     # edges (ix_task_dep_downstream), bounded by LIMIT.
     blocked_by_external: list[FrontierExternalBlocker] = []
     blocked_by_external_truncated = False
+    blocker_rows: Sequence[Any] = []
     if not actionable_tasks and not running_tasks:
         blocked = aliased(Task)
         blocker = aliased(Task)
@@ -1768,6 +1769,7 @@ async def get_build_frontier(
                     blocker.latest_status_expires_at,
                     blocker.latest_status_build_id,
                     blocker.id.in_(build_task_ids),
+                    blocker.id,
                 )
                 .select_from(TaskDependency)
                 .join(blocked, TaskDependency.downstream_task_id == blocked.id)
@@ -1791,34 +1793,10 @@ async def get_build_frontier(
         blocked_by_external_truncated = (
             len(blocker_rows) > _MAX_FRONTIER_EXTERNAL_BLOCKERS
         )
-        blocked_by_external = [
-            FrontierExternalBlocker(
-                task_id=blocked_task_id,
-                blocking_task_id=blocking_task_id,
-                blocking_task_namespace=blocking_namespace,
-                blocking_task_name=blocking_name,
-                blocking_status=blocking_status,
-                blocking_status_at=blocking_status_at,
-                # The point of the whole entry: a blocker RUNNING under a
-                # build that died used to be indistinguishable from one
-                # running normally, leaving the consumer to guess from
-                # elapsed time. Past this instant it is provably gone.
-                blocking_status_expires_at=blocking_status_expires_at,
-                blocking_status_build_id=blocking_status_build_id,
-                blocking_in_build=bool(blocking_in_build),
-            )
-            for (
-                blocked_task_id,
-                blocking_task_id,
-                blocking_namespace,
-                blocking_name,
-                blocking_status,
-                blocking_status_at,
-                blocking_status_expires_at,
-                blocking_status_build_id,
-                blocking_in_build,
-            ) in blocker_rows[:_MAX_FRONTIER_EXTERNAL_BLOCKERS]
-        ]
+        # Response objects are built lower down, once attempt counts are
+        # known: an in-plan blocker carries its attempts so a scheduler can
+        # apply the same retry budget it applies to anything else.
+        blocker_rows = blocker_rows[:_MAX_FRONTIER_EXTERNAL_BLOCKERS]
 
     root_task_ids: list[str] = list(build.root_task_ids or [])
     roots: list[Task] = []
@@ -1853,9 +1831,48 @@ async def get_build_frontier(
     attempt_task_pks = {t.id for t in actionable_tasks}
     attempt_task_pks.update(t.id for t in running_tasks)
     attempt_task_pks.update(t.id for t in roots)
+    # In-plan blockers too — a scheduler may reset one, and it needs the
+    # budget to decide. Out-of-plan blockers are skipped: they have no
+    # attempts in this build by definition.
+    attempt_task_pks.update(row[9] for row in blocker_rows if row[8])
     attempt_counts = await get_attempt_counts_in_build(
         db, build_id, list(attempt_task_pks)
     )
+
+    blocked_by_external = [
+        FrontierExternalBlocker(
+            task_id=blocked_task_id,
+            blocking_task_id=blocking_task_id,
+            blocking_task_namespace=blocking_namespace,
+            blocking_task_name=blocking_name,
+            blocking_status=blocking_status,
+            blocking_status_at=blocking_status_at,
+            # The point of the whole entry: a blocker RUNNING under a build
+            # that died used to be indistinguishable from one running
+            # normally, leaving the consumer to guess from elapsed time.
+            # Past this instant it is provably gone.
+            blocking_status_expires_at=blocking_status_expires_at,
+            blocking_status_build_id=blocking_status_build_id,
+            blocking_in_build=bool(blocking_in_build),
+            # Only meaningful for a blocker in this build's plan; a task
+            # outside it has spent no attempts here.
+            blocking_attempt_count=(
+                attempt_counts.get(blocker_pk, 0) if blocking_in_build else None
+            ),
+        )
+        for (
+            blocked_task_id,
+            blocking_task_id,
+            blocking_namespace,
+            blocking_name,
+            blocking_status,
+            blocking_status_at,
+            blocking_status_expires_at,
+            blocking_status_build_id,
+            blocking_in_build,
+            blocker_pk,
+        ) in blocker_rows
+    ]
 
     def _ref(t: Task) -> FrontierTaskRef:
         return FrontierTaskRef(

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -1768,8 +1768,12 @@ async def get_build_frontier(
                     blocker.latest_status_at,
                     blocker.latest_status_expires_at,
                     blocker.latest_status_build_id,
-                    blocker.id.in_(build_task_ids),
-                    blocker.id,
+                    # Labelled, because these two are the ones read by name
+                    # before the row is destructured below — and a positional
+                    # index into a ten-column select is a silent breakage
+                    # waiting for someone to reorder it.
+                    blocker.id.in_(build_task_ids).label("blocking_in_build"),
+                    blocker.id.label("blocker_pk"),
                 )
                 .select_from(TaskDependency)
                 .join(blocked, TaskDependency.downstream_task_id == blocked.id)
@@ -1834,7 +1838,9 @@ async def get_build_frontier(
     # In-plan blockers too — a scheduler may reset one, and it needs the
     # budget to decide. Out-of-plan blockers are skipped: they have no
     # attempts in this build by definition.
-    attempt_task_pks.update(row[9] for row in blocker_rows if row[8])
+    attempt_task_pks.update(
+        row.blocker_pk for row in blocker_rows if row.blocking_in_build
+    )
     attempt_counts = await get_attempt_counts_in_build(
         db, build_id, list(attempt_task_pks)
     )

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -408,6 +408,11 @@ class FrontierExternalBlocker(BaseModel):
     # only wait for whoever owns it. True still blocks, but the blocker
     # shows up in this build's own ``actionable``/``running`` as well.
     blocking_in_build: bool
+    # Attempts spent by the blocker in *this* build's current round, when it
+    # is part of this build's task set (null otherwise — a task outside the
+    # plan has no attempts in it). Lets a scheduler apply its retry budget
+    # to an in-plan blocker without a second round-trip.
+    blocking_attempt_count: int | None = None
 
 
 class BuildFrontierResponse(BaseModel):

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -2045,6 +2045,8 @@ async def _assert_frontier_reports_cross_build_blocker(client: AsyncClient) -> N
             ],
             "blocking_status_build_id": build_a,
             "blocking_in_build": False,
+            # Out of this build's plan, so it has spent no attempts in it.
+            "blocking_attempt_count": None,
         }
     ]
     assert frontier_b["blocked_by_external"][0]["blocking_status_at"] is not None
@@ -2069,6 +2071,38 @@ async def _assert_frontier_reports_cross_build_blocker(client: AsyncClient) -> N
 
 
 @pytest.mark.asyncio
+async def test_frontier_reports_attempts_for_an_in_plan_blocker(client):
+    """A blocker inside this build's plan carries its attempt count.
+
+    A scheduler may reset such a blocker and run it — the task is in its
+    plan, so it is its to run. It needs the attempts already spent to stay
+    inside the same retry budget an ordinary task obeys; without it, a task
+    that fails every time would be reset, rerun and re-failed forever.
+    """
+    build = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{build}/tasks", json=_register_payload("up"))
+    await client.post(
+        f"/api/v1/builds/{build}/tasks",
+        json=_register_payload("down", deps=["up"]),
+    )
+    # This build spends one attempt on the shared task...
+    await client.post(f"/api/v1/builds/{build}/tasks/up/start")
+    await client.post(f"/api/v1/builds/{build}/tasks/up/fail")
+
+    # ...then another build cancels it (the fail-fast cascade shape), so the
+    # status this build is now looking at was set elsewhere.
+    other = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{other}/tasks", json=_register_payload("up"))
+    await client.post(f"/api/v1/builds/{other}/tasks/up/cancel")
+
+    frontier = (await client.get(f"/api/v1/builds/{build}/frontier")).json()
+    blockers = frontier["blocked_by_external"]
+    assert len(blockers) == 1
+    assert blockers[0]["blocking_task_id"] == "up"
+    assert blockers[0]["blocking_in_build"] is True
+    assert blockers[0]["blocking_attempt_count"] == 1
+
+
 async def test_frontier_reports_blocker_owned_by_another_build(client: AsyncClient):
     await _assert_frontier_reports_cross_build_blocker(client)
 

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -2071,18 +2071,37 @@ async def _assert_frontier_reports_cross_build_blocker(client: AsyncClient) -> N
 
 
 @pytest.mark.asyncio
-@pytest.mark.xfail(
-    reason=(
-        "Known deadlock, not yet fixed. A build's plan is not closed over "
-        "dynamic dependency edges recorded by other builds, while gating "
-        "consults all of them — so the build is gated on a task no build "
-        "containing it can schedule. The fix (admit incomplete upstreams "
-        "into the plan at registration) changes what a build's task set IS, "
-        "and with it the graph view's primary/context split, so it is "
-        "deliberately not bundled into a release."
-    ),
-    strict=True,
-)
+async def test_plan_closure_stops_at_complete_upstreams(client):
+    """Closure prunes exactly where discovery does.
+
+    A complete upstream gates nothing, and its own upstreams are assumed
+    complete with it — so the walk stops there rather than dragging a
+    build's whole historical ancestry into its plan.
+    """
+    seed = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{seed}/tasks", json=_register_payload("gp"))
+    await client.post(
+        f"/api/v1/builds/{seed}/tasks", json=_register_payload("mid", deps=["gp"])
+    )
+    await client.post(
+        f"/api/v1/builds/{seed}/tasks", json=_register_payload("leaf", deps=["mid"])
+    )
+    # "mid" is complete, so nothing above it should be inherited.
+    await client.post(f"/api/v1/builds/{seed}/tasks/mid/start")
+    await client.post(f"/api/v1/builds/{seed}/tasks/mid/complete")
+
+    other = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{other}/tasks", json=_register_payload("leaf"))
+
+    frontier = (await client.get(f"/api/v1/builds/{other}/frontier")).json()
+    in_plan = set(frontier["status_counts"])
+    # leaf (pending) is the build's; "gp" must NOT have been pulled in.
+    assert frontier["status_counts"].get("completed") is None, (
+        f"a complete upstream was admitted: {frontier}"
+    )
+    assert frontier["status_counts"] == {"pending": 1}, in_plan
+
+
 async def test_registration_pulls_in_known_upstreams(client):
     """A build's plan must be closed under the dependency relation.
 

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -1994,18 +1994,18 @@ async def test_frontier_reflects_cross_build_running(client: AsyncClient):
 
 
 async def _assert_frontier_reports_cross_build_blocker(client: AsyncClient) -> None:
-    """A build whose only remaining task is gated by an upstream that another
-    build left RUNNING has nothing actionable and nothing running — the
-    frontier must say so explicitly instead of looking terminal."""
+    """A task another build is running is *in this build's plan*, not outside it.
+
+    Registration closes the plan over every recorded dependency edge, so an
+    upstream that was not complete — running included — belongs to the build
+    that depends on it. The build therefore has a running task and is not
+    stalled, and there is no "blocked by something outside my plan" to
+    report. The claim is what coordinates: this build will be denied the
+    start until the holder finishes or its claim lapses.
+    """
     build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
     await client.post(
-        f"/api/v1/builds/{build_a}/tasks",
-        json={
-            "task_id": "ext-up",
-            "task_namespace": "pipelines.ingest",
-            "task_name": "Upstream",
-            "task_data": {},
-        },
+        f"/api/v1/builds/{build_a}/tasks", json=_register_payload("ext-up")
     )
     await client.post(
         f"/api/v1/builds/{build_a}/tasks",
@@ -2016,58 +2016,18 @@ async def _assert_frontier_reports_cross_build_blocker(client: AsyncClient) -> N
         params={"executor": "modal", "executor_ref": "fc-build-a"},
     )
 
-    # Build B references only the downstream task; the upstream (and the
-    # edge, which is environment-global) belongs to build A entirely.
     build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
     await client.post(
         f"/api/v1/builds/{build_b}/tasks", json=_register_payload("ext-down")
     )
 
     frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
-    # The shape that used to read as "this build cannot progress".
-    assert frontier_b["actionable"] == []
-    assert frontier_b["running"] == []
-    assert frontier_b["status_counts"] == {"pending": 1}
-
-    assert frontier_b["blocked_by_external_truncated"] is False
-    assert frontier_b["blocked_by_external"] == [
-        {
-            "task_id": "ext-down",
-            "blocking_task_id": "ext-up",
-            "blocking_task_namespace": "pipelines.ingest",
-            "blocking_task_name": "Upstream",
-            "blocking_status": "running",
-            "blocking_status_at": frontier_b["blocked_by_external"][0][
-                "blocking_status_at"
-            ],
-            "blocking_status_expires_at": frontier_b["blocked_by_external"][0][
-                "blocking_status_expires_at"
-            ],
-            "blocking_status_build_id": build_a,
-            "blocking_in_build": False,
-            # Out of this build's plan, so it has spent no attempts in it.
-            "blocking_attempt_count": None,
-        }
-    ]
-    assert frontier_b["blocked_by_external"][0]["blocking_status_at"] is not None
-    # The blocker holds a live claim, so build B is told when it lapses —
-    # the one liveness question B cannot answer for itself (it cannot probe
-    # build A's executor).
-    assert (
-        frontier_b["blocked_by_external"][0]["blocking_status_expires_at"] is not None
-    )
-
-    # Build A owns the blocker, so from its side nothing is external — and
-    # its own liveness signal (`running`) covers the same task.
-    frontier_a = (await client.get(f"/api/v1/builds/{build_a}/frontier")).json()
-    assert frontier_a["blocked_by_external"] == []
-    assert [t["task_id"] for t in frontier_a["running"]] == ["ext-up"]
-
-    # Once the blocker completes, the downstream is this build's to run.
-    await client.post(f"/api/v1/builds/{build_a}/tasks/ext-up/complete")
-    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    # ext-up is in B's plan and running, so B is not stalled...
+    assert [t["task_id"] for t in frontier_b["running"]] == ["ext-up"]
+    assert frontier_b["status_counts"] == {"pending": 1, "running": 1}
+    # ...and nothing is reported as blocking from outside the plan.
     assert frontier_b["blocked_by_external"] == []
-    assert [t["task_id"] for t in frontier_b["actionable"]] == ["ext-down"]
+    assert frontier_b["blocked_by_external_truncated"] is False
 
 
 @pytest.mark.asyncio
@@ -2191,49 +2151,36 @@ async def test_frontier_reports_blocker_owned_by_another_build_postgres(pg_clien
 
 
 @pytest.mark.asyncio
-async def test_frontier_external_blocker_reports_in_build_membership(
+async def test_every_reported_blocker_is_now_in_this_builds_plan(
     client: AsyncClient,
 ):
-    """`blocking_in_build` separates the two ways a stalled build is held up.
+    """`blocking_in_build` is False only for builds registered before plan
+    closure existed.
 
-    Chain top -> mid -> down, where `top` runs under another build and `mid`
-    is registered here but was last touched there (registration is
-    status-neutral, so ownership does not move). This build is stalled on
-    both: one blocker it has never heard of, one it can see but cannot
-    advance.
+    Closure admits every incomplete upstream at registration, so a build
+    cannot be gated by something outside its own plan. The field stays on
+    the model — builds registered under the old rule still have open plans,
+    and the scheduler's out-of-plan handling remains their safety net — but
+    for anything registered now it is always True, which is what makes the
+    blocker actionable rather than a dead end.
     """
     build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
-    await client.post(
-        f"/api/v1/builds/{build_a}/tasks", json=_register_payload("chain-top")
-    )
-    await client.post(
-        f"/api/v1/builds/{build_a}/tasks",
-        json=_register_payload("chain-mid", ["chain-top"]),
-    )
-    await client.post(f"/api/v1/builds/{build_a}/tasks/chain-top/start")
+    for tid, deps in (("top", None), ("mid", ["top"]), ("down", ["mid"])):
+        await client.post(
+            f"/api/v1/builds/{build_a}/tasks", json=_register_payload(tid, deps)
+        )
+    await client.post(f"/api/v1/builds/{build_a}/tasks/top/start")
+    await client.post(f"/api/v1/builds/{build_a}/tasks/top/cancel")
 
     build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
-    await client.post(
-        f"/api/v1/builds/{build_b}/tasks", json=_register_payload("chain-mid")
-    )
-    await client.post(
-        f"/api/v1/builds/{build_b}/tasks",
-        json=_register_payload("chain-down", ["chain-mid"]),
-    )
+    await client.post(f"/api/v1/builds/{build_b}/tasks", json=_register_payload("down"))
 
     frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
-    assert frontier_b["actionable"] == []
-    assert frontier_b["running"] == []
-
-    entries = {e["task_id"]: e for e in frontier_b["blocked_by_external"]}
-    # Never registered here: this build can only wait for whoever owns it.
-    assert entries["chain-mid"]["blocking_task_id"] == "chain-top"
-    assert entries["chain-mid"]["blocking_in_build"] is False
-    assert entries["chain-mid"]["blocking_status"] == "running"
-    assert entries["chain-mid"]["blocking_status_build_id"] == build_a
-    # Registered here, but held back by the above — visible, not advanceable.
-    assert entries["chain-down"]["blocking_task_id"] == "chain-mid"
-    assert entries["chain-down"]["blocking_in_build"] is True
+    blockers = frontier_b["blocked_by_external"]
+    assert blockers, frontier_b
+    assert all(e["blocking_in_build"] for e in blockers), blockers
+    # And the whole incomplete chain came with it.
+    assert frontier_b["status_counts"] == {"pending": 2, "cancelled": 1}
 
 
 @pytest.mark.asyncio
@@ -2265,10 +2212,14 @@ async def test_frontier_omits_external_blockers_while_the_build_progresses(
         f"/api/v1/builds/{build_b}/tasks", json=_register_payload("gate-free")
     )
 
-    # Something to run: not stalled, so no diagnostic even though the
-    # external blocker is present and gating `gate-down`.
+    # Something to run: not stalled, so no diagnostic. `gate-up` is in B's
+    # plan now (closure), and RUNNING tasks stay in `actionable` — that is
+    # the scheduler's probe partition, not a spawn list.
     frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
-    assert [t["task_id"] for t in frontier_b["actionable"]] == ["gate-free"]
+    assert sorted(t["task_id"] for t in frontier_b["actionable"]) == [
+        "gate-free",
+        "gate-up",
+    ]
     assert frontier_b["blocked_by_external"] == []
 
     # Running counts as progress too. (A RUNNING task stays in `actionable`
@@ -2276,15 +2227,31 @@ async def test_frontier_omits_external_blockers_while_the_build_progresses(
     # that the gate is an OR, not a check on `actionable` alone.)
     await client.post(f"/api/v1/builds/{build_b}/tasks/gate-free/start")
     frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
-    assert [t["task_id"] for t in frontier_b["running"]] == ["gate-free"]
+    assert sorted(t["task_id"] for t in frontier_b["running"]) == [
+        "gate-free",
+        "gate-up",
+    ]
     assert frontier_b["blocked_by_external"] == []
 
-    # Out of work: now the build looks stuck, and the answer appears.
+    # Out of its own work, but still not stalled: the upstream is running,
+    # in this build's plan, and this build waits on it like any other
+    # running task of its own. There is nothing to diagnose.
     await client.post(f"/api/v1/builds/{build_b}/tasks/gate-free/complete")
+    frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    assert [t["task_id"] for t in frontier_b["running"]] == ["gate-up"]
+    assert frontier_b["blocked_by_external"] == []
+
+    # Stalled only when nothing is driving the upstream. Another build
+    # cancels it (the fail-fast shape) — now it is in this build's plan in a
+    # status nothing will move, which is the one case worth reporting, and
+    # it is reported as in-plan so a scheduler can reset and run it.
+    await client.post(f"/api/v1/builds/{build_a}/tasks/gate-up/cancel")
     frontier_b = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
     assert frontier_b["actionable"] == []
     assert frontier_b["running"] == []
-    assert [e["task_id"] for e in frontier_b["blocked_by_external"]] == ["gate-down"]
+    blockers = frontier_b["blocked_by_external"]
+    assert [e["blocking_task_id"] for e in blockers] == ["gate-up"]
+    assert blockers[0]["blocking_in_build"] is True
 
 
 @pytest.mark.asyncio
@@ -2306,6 +2273,10 @@ async def test_frontier_external_blockers_are_capped_and_flagged(
             f"/api/v1/builds/{build_a}/tasks", json=_register_payload(tid, ["cap-up"])
         )
     await client.post(f"/api/v1/builds/{build_a}/tasks/cap-up/start")
+    # Cancelled, not left running: a running upstream is in the plan and
+    # keeps the build un-stalled, so the blocker list is never computed.
+    # Only a status nothing is driving produces the diagnostic.
+    await client.post(f"/api/v1/builds/{build_a}/tasks/cap-up/cancel")
 
     build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
     for tid in ("cap-down-1", "cap-down-2"):

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -2071,6 +2071,62 @@ async def _assert_frontier_reports_cross_build_blocker(client: AsyncClient) -> N
 
 
 @pytest.mark.asyncio
+@pytest.mark.xfail(
+    reason=(
+        "Known deadlock, not yet fixed. A build's plan is not closed over "
+        "dynamic dependency edges recorded by other builds, while gating "
+        "consults all of them — so the build is gated on a task no build "
+        "containing it can schedule. The fix (admit incomplete upstreams "
+        "into the plan at registration) changes what a build's task set IS, "
+        "and with it the graph view's primary/context split, so it is "
+        "deliberately not bundled into a release."
+    ),
+    strict=True,
+)
+async def test_registration_pulls_in_known_upstreams(client):
+    """A build's plan must be closed under the dependency relation.
+
+    Registration walks `task.requires()` — static edges only — while gating
+    consults *every* recorded edge, including dynamic ones a previous build
+    discovered at runtime. A task can therefore be gated by an upstream that
+    is not in its plan, which no build containing it can ever schedule:
+    a permanent deadlock, and the one shape the whole cross-build blocker
+    machinery was built to describe rather than prevent.
+
+    A dynamic edge outlives the build that recorded it, so a later build
+    that statically discovers the same task inherits the dependency and must
+    inherit the upstream with it.
+    """
+    # Build A runs "parent" and discovers "dyn-up" dynamically.
+    build_a = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks", json=_register_payload("parent")
+    )
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks",
+        json=_register_payload("dyn-up"),
+    )
+    await client.post(
+        f"/api/v1/builds/{build_a}/tasks",
+        json=_register_payload("parent", deps=["dyn-up"]),
+    )
+
+    # Build B registers only "parent" — its static requires() has no dyn-up.
+    build_b = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_b}/tasks", json=_register_payload("parent")
+    )
+
+    frontier = (await client.get(f"/api/v1/builds/{build_b}/frontier")).json()
+    # dyn-up must be in B's plan — and actionable, since nothing gates it.
+    # Without closure B reports it as an out-of-plan blocker instead, which
+    # no build containing "parent" can ever clear.
+    assert [t["task_id"] for t in frontier["actionable"]] == ["dyn-up"], (
+        f"dyn-up not schedulable by build B: {frontier}"
+    )
+    assert frontier["blocked_by_external"] == []
+
+
 async def test_frontier_reports_attempts_for_an_in_plan_blocker(client):
     """A blocker inside this build's plan carries its attempt count.
 

--- a/app/stardag-api/tests/test_claim_expiry.py
+++ b/app/stardag-api/tests/test_claim_expiry.py
@@ -424,7 +424,17 @@ async def test_frontier_surfaces_the_claim_expiry(client: AsyncClient):
 async def test_expired_cross_build_blocker_is_still_a_blocker(
     client: AsyncClient, async_session: AsyncSession
 ):
-    """The correction worth encoding as a test: proving a blocker dead does
+    """An expired claim on an upstream is this build's to recover.
+
+    It used to be reported as a blocker outside the plan, with the expiry as
+    evidence the holder was gone — evidence the build could read but not act
+    on. With the plan closed over dependency edges the upstream is simply a
+    RUNNING task *in this build*, carrying a lapsed claim, which the
+    scheduler's ordinary recovery path handles: past the expiry the server
+    hands the task to the next claimant, whoever asks.
+
+    The old wording, kept because the reasoning still holds: proving a
+    blocker dead does
     NOT unblock the build. An upstream that is not in this build's task set
     is not in its plan either, so this build still cannot run it — what the
     expiry buys is certainty in place of inference, not one less blocker."""
@@ -442,14 +452,15 @@ async def test_expired_cross_build_blocker_is_still_a_blocker(
     await client.post(f"{BUILDS}/{build_b}/tasks", json=_register("blk-down"))
 
     frontier = (await client.get(f"{BUILDS}/{build_b}/frontier")).json()
-    assert frontier["actionable"] == []
-    blockers = frontier["blocked_by_external"]
-    assert [b["blocking_task_id"] for b in blockers] == ["blk-up"]
-    # ...but build B is now *told* the holder is gone, instead of having to
-    # infer it from blocking_status_at.
-    expires_at = datetime.fromisoformat(blockers[0]["blocking_status_expires_at"])
+    # In this build's plan and running, so nothing is "blocking from
+    # outside" and the build is not stalled.
+    running = {t["task_id"]: t for t in frontier["running"]}
+    assert "blk-up" in running, frontier
+    assert frontier["blocked_by_external"] == []
+    # The expiry rides along, so the scheduler is *told* the holder is gone
+    # rather than inferring it from latest_status_at.
+    expires_at = datetime.fromisoformat(running["blk-up"]["latest_status_expires_at"])
     assert _utc(expires_at) < datetime.now(timezone.utc)
-    assert blockers[0]["blocking_in_build"] is False
 
 
 # --- Postgres ------------------------------------------------------------

--- a/app/stardag-api/tests/test_graph.py
+++ b/app/stardag-api/tests/test_graph.py
@@ -135,8 +135,12 @@ async def test_build_graph_upstream_depth_one(client: AsyncClient):
             assert node["is_primary"] is True
             assert node["traversal_depth"] == 0
         elif node["task_name"] == "UpstreamTask":
-            assert node["is_primary"] is False
-            assert node["traversal_depth"] == 1
+            # Primary now: an upstream that was not complete at discovery
+            # time is part of the build — this build cannot finish without
+            # it and is entitled to run it. Only *complete* upstreams stay
+            # context. See _close_plan_over_dependencies.
+            assert node["is_primary"] is True
+            assert node["traversal_depth"] == 0
 
 
 @pytest.mark.asyncio
@@ -149,6 +153,13 @@ async def test_build_graph_depth_limiting(client: AsyncClient):
     await register_task(client, build_id, "t-b", "TaskB", dependency_task_ids=["t-a"])
     await register_task(client, build_id, "t-c", "TaskC", dependency_task_ids=["t-b"])
     await register_task(client, build_id, "t-d", "TaskD", dependency_task_ids=["t-c"])
+    # Complete the chain. Depth limiting governs *context* nodes, and an
+    # incomplete upstream is no longer context — it belongs to the build
+    # that depends on it. Only completed upstreams (whose own upstreams are
+    # assumed complete with them) sit outside the plan.
+    for tid in ("t-a", "t-b", "t-c"):
+        await client.post(f"/api/v1/builds/{build_id}/tasks/{tid}/start")
+        await client.post(f"/api/v1/builds/{build_id}/tasks/{tid}/complete")
 
     # Build 2: only has TaskD
     build2_id = await create_build(client)
@@ -199,7 +210,11 @@ async def test_build_graph_grouping(client: AsyncClient):
     group = data["groups"][0]
     assert group["task_name"] == "LoadData"
     assert group["count"] == 5
-    assert group["depth"] == 1
+    # Depth 0, not 1: these upstreams are incomplete, so they are part of
+    # this build's own plan rather than context one level up. Grouping is
+    # what is under test here, and it applies at whatever depth the nodes
+    # land — see _close_plan_over_dependencies.
+    assert group["depth"] == 0
     assert group["status"] == "pending"  # no events = pending
     assert len(group["sample_task_ids"]) == 5  # up to 5 samples
 

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
@@ -280,40 +280,48 @@ describe("BuildSchedulingPanel", () => {
     expect(screen.queryByText("skipped")).toBeNull();
   });
 
-  it("distinguishes a blocker outside this build from one inside it", async () => {
+  // The blocking task is in this build's plan — closure guarantees it — so
+  // the copy explains what happens next from the blocker's *status*, not from
+  // which build owns it. The plan-membership chip stays as a diagnostic for
+  // builds registered before closure existed.
+  it.each([
+    ["running", /holds the execution claim/i],
+    ["cancelled", /resets it and runs it/i],
+    ["suspended", /yielded dynamic dependencies/i],
+    ["failed", /result, not a revocation/i],
+    ["skipped", /result, not a revocation/i],
+  ] as const)("explains a %s blocker by what happens next", async (status, copy) => {
     vi.mocked(fetchBuildFrontier).mockResolvedValue(
       makeFrontier({
-        blocked_by_external: [makeBlocker({ blocking_in_build: false })],
+        blocked_by_external: [
+          makeBlocker({ blocking_status: status, blocking_in_build: true }),
+        ],
       }),
     );
     const user = userEvent.setup();
-    const { unmount } = renderPanel();
-    // Visible without expanding anything: a blocker that is not part of
-    // this build at all is the case with no local remedy.
-    expect(await screen.findByText("outside this build")).toBeInTheDocument();
-    await user.click(
-      screen.getByRole("button", { name: "Explain why GrindBeans is blocking" }),
-    );
-    expect(
-      await screen.findByText(/never registered the blocking task/i),
-    ).toBeInTheDocument();
-    // The remedy is named, not a dead end: re-triggering closes the plan.
-    expect(screen.getByText(/re-triggering this build/i)).toBeInTheDocument();
-    unmount();
-
-    vi.mocked(fetchBuildFrontier).mockResolvedValue(
-      makeFrontier({ blocked_by_external: [makeBlocker({ blocking_in_build: true })] }),
-    );
     renderPanel();
+
     expect(await screen.findByText("GrindBeans")).toBeInTheDocument();
     expect(screen.queryByText("outside this build")).toBeNull();
     await user.click(
       screen.getByRole("button", { name: "Explain why GrindBeans is blocking" }),
     );
-    expect(
-      await screen.findByText(/in this build's own task set/i),
-    ).toBeInTheDocument();
+    expect(await screen.findByText(copy)).toBeInTheDocument();
+    // Deleted with the out-of-plan handling: a build cannot be gated by an
+    // upstream it never registered any more.
     expect(screen.queryByText(/never registered the blocking task/i)).toBeNull();
+  });
+
+  it("still flags a blocker outside this build's plan", async () => {
+    vi.mocked(fetchBuildFrontier).mockResolvedValue(
+      makeFrontier({
+        blocked_by_external: [makeBlocker({ blocking_in_build: false })],
+      }),
+    );
+    renderPanel();
+    // Only reachable for a build registered before plan closure; reported
+    // because it changes what a reader should expect, not what a tick does.
+    expect(await screen.findByText("outside this build")).toBeInTheDocument();
   });
 
   it("says so when the blocker list was truncated", async () => {

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
@@ -280,10 +280,10 @@ describe("BuildSchedulingPanel", () => {
     expect(screen.queryByText("skipped")).toBeNull();
   });
 
-  // The blocking task is in this build's plan — closure guarantees it — so
-  // the copy explains what happens next from the blocker's *status*, not from
-  // which build owns it. The plan-membership chip stays as a diagnostic for
-  // builds registered before closure existed.
+  // The copy explains what happens next from the blocker's *status*, not from
+  // which build owns it or whether it is in this build's plan — the chip
+  // reports that separately, and it stays reachable (closure runs once, so a
+  // dynamic edge written later is outside the plan).
   it.each([
     ["running", /holds the execution claim/i],
     ["cancelled", /resets it and runs it/i],

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.test.tsx
@@ -294,7 +294,11 @@ describe("BuildSchedulingPanel", () => {
     await user.click(
       screen.getByRole("button", { name: "Explain why GrindBeans is blocking" }),
     );
-    expect(await screen.findByText(/has never registered/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/never registered the blocking task/i),
+    ).toBeInTheDocument();
+    // The remedy is named, not a dead end: re-triggering closes the plan.
+    expect(screen.getByText(/re-triggering this build/i)).toBeInTheDocument();
     unmount();
 
     vi.mocked(fetchBuildFrontier).mockResolvedValue(
@@ -309,7 +313,7 @@ describe("BuildSchedulingPanel", () => {
     expect(
       await screen.findByText(/in this build's own task set/i),
     ).toBeInTheDocument();
-    expect(screen.queryByText(/has never registered/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/never registered the blocking task/i)).toBeNull();
   });
 
   it("says so when the blocker list was truncated", async () => {

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
@@ -113,7 +113,7 @@ function BlockerCard({
   let explanation: string;
   if (!blocker.blocking_in_build) {
     explanation =
-      "This build has never registered the blocking task, so it will never schedule it — it can only wait for whoever owns it.";
+      "This build never registered the blocking task, so it cannot schedule it. Builds registered since plan closure landed always include their incomplete upstreams, so re-triggering this build brings the task into its plan and lets it run.";
   } else if (ownedByThisBuild) {
     explanation =
       "The blocking task is in this build's own task set and this build put it into that status, but it is not actionable, so nothing here will move it on.";

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
@@ -109,17 +109,24 @@ function BlockerCard({
     ? `${blocker.blocking_task_namespace}/${blocker.blocking_task_name}`
     : blocker.blocking_task_name;
 
-  // The remedy differs by ownership, so the copy has to as well.
+  // The blocking task is in this build's plan (closure guarantees it), so
+  // what happens next is a function of its status, not of who owns it.
   let explanation: string;
-  if (!blocker.blocking_in_build) {
-    explanation =
-      "This build never registered the blocking task, so it cannot schedule it. Builds registered since plan closure landed always include their incomplete upstreams, so re-triggering this build brings the task into its plan and lets it run.";
-  } else if (ownedByThisBuild) {
+  if (ownedByThisBuild) {
     explanation =
       "The blocking task is in this build's own task set and this build put it into that status, but it is not actionable, so nothing here will move it on.";
+  } else if (blocker.blocking_status === "cancelled") {
+    explanation =
+      "Another build cancelled the blocking task. That revoked permission to run it, not the task itself, and it is in this build's plan — so this build's next tick resets it and runs it, bounded by the per-task attempt budget.";
+  } else if (blocker.blocking_status === "running") {
+    explanation =
+      "Another build holds the execution claim on the blocking task. It resolves when that build finishes the task or the claim expires — until then, running it here would be a duplicate execution.";
+  } else if (blocker.blocking_status === "suspended") {
+    explanation =
+      "The blocking task yielded dynamic dependencies and is waiting for them. The build that owns it is working through them; this build resolves as that one progresses.";
   } else {
     explanation =
-      "The blocking task is in this build's own task set — it is in the table below — but another build set its current status, so this build will not advance it.";
+      "The blocking task's status is a result, not a revocation, so a tick leaves it to this build's fail_mode rather than overriding the policy the build was triggered with. Re-trigger this build to reset it and run it here.";
   }
 
   return (

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
@@ -109,8 +109,10 @@ function BlockerCard({
     ? `${blocker.blocking_task_namespace}/${blocker.blocking_task_name}`
     : blocker.blocking_task_name;
 
-  // The blocking task is in this build's plan (closure guarantees it), so
-  // what happens next is a function of its status, not of who owns it.
+  // What happens next is a function of the blocker's status, not of who owns
+  // it or whether it is in this build's plan. Plan membership is still worth
+  // reporting — the chip below does that — but it does not change the copy:
+  // a RUNNING blocker resolves when its claim does either way.
   let explanation: string;
   if (ownedByThisBuild) {
     explanation =

--- a/docs/design/execution-claims-and-liveness.md
+++ b/docs/design/execution-claims-and-liveness.md
@@ -26,6 +26,62 @@ Four facts about stardag force the shape of everything below.
    containers that read the frontier, act, and exit. Nothing on the
    scheduling side stays alive for the duration of a task.
 
+## Builds collaborate; the claim is the only coordination
+
+Everything below rests on one principle, worth stating before the mechanics
+because most of the bugs in this area came from quietly violating it:
+
+> **A build is a request for a set of root tasks to be materialised, not an
+> owner of the tasks that materialise them.** The execution claim is the
+> only cross-build coordination primitive. Which build completes a task is
+> otherwise irrelevant.
+
+That follows from the constraints above rather than being a preference.
+Tasks are content-addressed, so the output is a property of the environment;
+within one deployed app the worker selector and resources are a pure
+function of the task, so _which_ build ran it cannot change the result. What
+must not happen is two builds executing the same task at once — and that is
+exactly, and only, what the claim prevents.
+
+Two consequences are load-bearing, and both were violated by earlier
+versions of this code:
+
+**A build's plan is closed under the dependency relation.** It contains
+every dependency of its roots that was not complete at discovery time,
+pruned at complete tasks — whose own upstreams are assumed complete with
+them. Discovery enforces this for `requires()`; registration extends it to
+every recorded edge, because dynamic dependency edges are written by
+whichever build first ran the task and then outlive it. A build gated by
+something outside its own plan can never clear it: nothing else is going to
+run it, and the only thing that would produce it is the task being gated.
+That was a permanent deadlock.
+
+**A build acts on everything in its plan, whatever build last touched it.**
+A shared task another build cancelled — the fail-fast cascade is the common
+way — holds no claim and has no live execution. Deferring to the build that
+cancelled it turned one build's fail-fast into every overlapping build's
+failure. The scheduler resets such a task and runs it, bounded by the
+per-task retry budget.
+
+What stays build-scoped is **authority to revoke**: cascade-cancel touches
+only tasks whose current status this build produced, so cancelling build B
+cannot release claims held by build C's live workers. Authority to revoke
+and permission to complete are different questions, and only the first
+belongs to a build.
+
+### What this makes unnecessary
+
+A body of machinery exists to describe a build blocked by a task outside its
+plan: blocker classification, owning-build liveness lookups, wait-or-fail
+verdicts, and remediation copy naming another build. With the plan closed,
+that state is unreachable for anything registered under the current rule —
+a gating upstream is in the plan, so the build is either running it, about
+to run it, or resetting it.
+
+The machinery is retained, not deleted, for one honest reason: builds
+registered _before_ closure existed still have open plans, and the handling
+remains their only safety net. New code should not add to it.
+
 ## The design: the claim is a status, not a lease
 
 `Task.latest_status == RUNNING` _is_ the execution claim. It is arbitrated in

--- a/docs/design/execution-claims-and-liveness.md
+++ b/docs/design/execution-claims-and-liveness.md
@@ -97,22 +97,33 @@ build was triggered with.
 ### What this makes unnecessary
 
 A body of machinery existed to describe a build blocked by a task outside its
-plan, and to tell its operator that the only remedy lived under another
-build. With the plan closed that state is unreachable for anything registered
-under the current rule — a gating upstream is in the plan, so the build is
-running it, about to run it, or resetting it — so the out-of-plan branch, its
-remediation copy and the two-remedy split in the CLI and the UI are **gone**.
-`blocking_in_build` survives on the wire as a diagnostic for builds
-registered before closure existed; nothing branches on it. What keeps a tick
-from resetting a task outside its plan is the attempt budget: the server
-reports no attempt count for one, and a missing count refuses the retry.
+plan, and to tell its operator that the only remedy lived under another build.
+That advice is gone — the out-of-plan branch, its remediation copy and the
+two-remedy split in the CLI and the UI — because the remedy it named was never
+the right one. `blocking_in_build` survives on the wire as a diagnostic;
+nothing branches on it. What keeps a tick from resetting a task outside its
+plan is the attempt budget: the server reports no attempt count for one, and a
+missing count refuses the retry.
 
-What is _not_ unnecessary, and was nearly deleted with the rest: the
-wait-or-fail verdicts and the owning-build liveness lookup. A closed plan
-still contains tasks this build must not touch — a `SUSPENDED` shared task
-being progressed by the build that suspended it is the case that matters —
-and for those the owner's status is the only liveness evidence that exists,
-because a task holding no claim carries no expiry to read.
+**What closure does _not_ buy, and it is easy to overstate.** Closure runs
+once, at registration. A dependency edge written _afterwards_ is not in the
+plan, and there is a routine way for that to happen: a concurrent build's
+worker yields dynamic dependencies, which are registered into _its_ plan, while
+this build closed its plan a minute earlier and never saw the edges. So a build
+registered under the current rule can still be gated by a task outside its
+plan. Verified live, not hypothetical: two builds sharing a task that suspends
+on dynamic children leave the second build reporting those children as
+out-of-plan blockers.
+
+Which is exactly why the wait-or-fail verdicts and the owning-build liveness
+lookup stay, and why they were nearly deleted with the rest. They are what
+makes that state benign rather than a deadlock: the children are RUNNING under
+live claims, so the build **waits**, and when they finish it proceeds. If their
+owner dies, their claims lapse, the shared parent goes `SKIPPED`, and the build
+fails naming it with a remedy addressed to itself. The same machinery covers a
+`SUSPENDED` shared task being progressed by the build that suspended it, where
+the owner's status is the only liveness evidence that exists at all, because a
+task holding no claim carries no expiry to read.
 
 ## The design: the claim is a status, not a lease
 

--- a/docs/design/execution-claims-and-liveness.md
+++ b/docs/design/execution-claims-and-liveness.md
@@ -69,18 +69,50 @@ cannot release claims held by build C's live workers. Authority to revoke
 and permission to complete are different questions, and only the first
 belongs to a build.
 
+### Revocation is not a result
+
+"Acts on everything in its plan" is not "resets everything in its plan". A
+mid-flight tick of some _other_ build resets exactly one status, and the line
+it draws is between a revocation of permission to run and a statement about
+the task:
+
+| Status      | Another build's tick, mid-flight                | At trigger / resume |
+| ----------- | ----------------------------------------------- | ------------------- |
+| `CANCELLED` | **reset and run** — a revocation, not a verdict | reset               |
+| `FAILED`    | leave — a _result_; `fail_mode` owns it         | reset               |
+| `SKIPPED`   | leave — a consequence of a failure              | reset               |
+| `SUSPENDED` | leave — the owning build is progressing it      | reset               |
+| `RUNNING`   | leave — the claim is coordinating               | **not** reset       |
+| `COMPLETED` | n/a                                             | pruned              |
+
+So `RUNNING` is the only status that blocks a trigger, and a trigger resets
+the whole retryable set — identically for a new build id and for a resume,
+since both go through the reactive bootstrap.
+
+The asymmetry between the two columns is the point: at trigger _you asked_,
+so retrying a previous failure is what you meant. Mid-flight nobody asked,
+and a tick that reset a failure would silently override the `fail_mode` the
+build was triggered with.
+
 ### What this makes unnecessary
 
-A body of machinery exists to describe a build blocked by a task outside its
-plan: blocker classification, owning-build liveness lookups, wait-or-fail
-verdicts, and remediation copy naming another build. With the plan closed,
-that state is unreachable for anything registered under the current rule —
-a gating upstream is in the plan, so the build is either running it, about
-to run it, or resetting it.
+A body of machinery existed to describe a build blocked by a task outside its
+plan, and to tell its operator that the only remedy lived under another
+build. With the plan closed that state is unreachable for anything registered
+under the current rule — a gating upstream is in the plan, so the build is
+running it, about to run it, or resetting it — so the out-of-plan branch, its
+remediation copy and the two-remedy split in the CLI and the UI are **gone**.
+`blocking_in_build` survives on the wire as a diagnostic for builds
+registered before closure existed; nothing branches on it. What keeps a tick
+from resetting a task outside its plan is the attempt budget: the server
+reports no attempt count for one, and a missing count refuses the retry.
 
-The machinery is retained, not deleted, for one honest reason: builds
-registered _before_ closure existed still have open plans, and the handling
-remains their only safety net. New code should not add to it.
+What is _not_ unnecessary, and was nearly deleted with the rest: the
+wait-or-fail verdicts and the owning-build liveness lookup. A closed plan
+still contains tasks this build must not touch — a `SUSPENDED` shared task
+being progressed by the build that suspended it is the case that matters —
+and for those the owner's status is the only liveness evidence that exists,
+because a task holding no claim carries no expiry to read.
 
 ## The design: the claim is a status, not a lease
 

--- a/docs/docs/configuration/cli.md
+++ b/docs/docs/configuration/cli.md
@@ -458,8 +458,9 @@ nothing to the counts this build can see. The command names the blocking task
 and the build that owns it.
 
 A build's plan includes every dependency that was not complete when it was
-discovered, so the blocker is this build's own task, and what happens next is
-a function of its **status** rather than of which build produced it:
+discovered, so the blocker is usually this build's own task — the **In this
+build** column says which. Either way, what happens next is a function of the
+blocker's **status** rather than of which build produced it:
 
 - `running` — another build holds the execution claim. It resolves when that
   build finishes the task or the claim expires.

--- a/docs/docs/configuration/cli.md
+++ b/docs/docs/configuration/cli.md
@@ -473,6 +473,21 @@ a function of its **status** rather than of which build produced it:
   `fail_mode` rather than overriding the policy you chose, so **re-trigger the
   build** to reset them and run them here.
 
+One case needs a hand: a blocker still `running` after its execution claim has
+expired. No build is claiming it, and a `running` task is not schedulable, so
+release the claim first — either from the blocking build's scheduling panel in
+the UI ("Release claim" on the blocker) or with:
+
+```bash
+stardag tasks cancel <owned-by-build> <blocking-task-id>
+```
+
+Use the build from the **Owned by build** column, not the stalled build. The id
+you pass becomes the task's new status owner, so cancelling it under the
+stalled build makes that build own the `cancelled` status — at which point the
+task drops out of its external-blocker list and its next tick no longer treats
+it as something to reset. The UI action fills the owning build in for you.
+
 One important caveat the output states explicitly: the registry computes the
 blocker list **only for a build with nothing actionable and nothing running**.
 An empty list therefore means "not externally blocked _or_ not stalled" — for

--- a/docs/docs/configuration/cli.md
+++ b/docs/docs/configuration/cli.md
@@ -457,12 +457,16 @@ nothing to the counts this build can see. The command names the blocking task
 (namespace and name, not just an id), its status, how long it has been in it,
 and the build that owns it — plus which of the two remedies applies:
 
-- **Not in this build's task set.** This build will never schedule it; it can
-  only wait for the owner. If the owner is gone, release the claim with
-  `stardag tasks cancel <owning-build-id> <task-id>`.
-- **In this build's task set, but another build produced its status.** It
-  resolves when that build finishes it; retrying from here would not release
-  the claim.
+- **In this build's task set, but another build produced its status.** The
+  normal case, and the only one a build registered today can reach: a build's
+  plan includes every dependency that was not complete when it was
+  discovered. If the task is running, it resolves when the holder finishes or
+  its claim expires. If it is cancelled, failed or skipped, this build resets
+  it and runs it itself — a shared task another build cancelled is still this
+  build's to run.
+- **Not in this build's task set.** Only reachable for builds registered
+  before plan closure existed. This build cannot schedule it; re-trigger the
+  build to bring the task into its plan.
 
 One important caveat the output states explicitly: the registry computes the
 blocker list **only for a build with nothing actionable and nothing running**.

--- a/docs/docs/configuration/cli.md
+++ b/docs/docs/configuration/cli.md
@@ -455,18 +455,23 @@ dependency edges are per **environment**, not per build, so an upstream that
 some other build left `RUNNING` gates this build's tasks while contributing
 nothing to the counts this build can see. The command names the blocking task
 (namespace and name, not just an id), its status, how long it has been in it,
-and the build that owns it — plus which of the two remedies applies:
+and the build that owns it.
 
-- **In this build's task set, but another build produced its status.** The
-  normal case, and the only one a build registered today can reach: a build's
-  plan includes every dependency that was not complete when it was
-  discovered. If the task is running, it resolves when the holder finishes or
-  its claim expires. If it is cancelled, failed or skipped, this build resets
-  it and runs it itself — a shared task another build cancelled is still this
-  build's to run.
-- **Not in this build's task set.** Only reachable for builds registered
-  before plan closure existed. This build cannot schedule it; re-trigger the
-  build to bring the task into its plan.
+A build's plan includes every dependency that was not complete when it was
+discovered, so the blocker is this build's own task, and what happens next is
+a function of its **status** rather than of which build produced it:
+
+- `running` — another build holds the execution claim. It resolves when that
+  build finishes the task or the claim expires.
+- `cancelled` — a revocation of permission to run, not a verdict on the task.
+  This build's next tick resets it and runs it itself, bounded by the per-task
+  attempt budget: a shared task another build's fail-fast cancelled is still
+  this build's to run.
+- `suspended` — the owning build is working through the dynamic dependencies
+  the task yielded. It resolves as that build progresses them.
+- `failed`, `skipped` — results. A tick leaves them to this build's
+  `fail_mode` rather than overriding the policy you chose, so **re-trigger the
+  build** to reset them and run them here.
 
 One important caveat the output states explicitly: the registry computes the
 blocker list **only for a build with nothing actionable and nothing running**.

--- a/lib/stardag/src/stardag/_cli/builds.py
+++ b/lib/stardag/src/stardag/_cli/builds.py
@@ -526,6 +526,14 @@ def _render_external_blockers(frontier: BuildFrontier) -> None:
         "— a tick leaves them to this build's fail_mode, so re-trigger the "
         "build to reset them and run them here."
     )
+    console.print(
+        "\n[dim]A blocker stuck [bold]running[/bold] after its claim has "
+        "expired is the one case needing a hand: release the claim with "
+        "'stardag tasks cancel <owned-by-build> <blocking-task-id>', using the "
+        "build in the 'Owned by build' column — not this build, since the id "
+        "you pass becomes the task's new status owner and this build's next "
+        "tick would then stop seeing the task as recoverable.[/dim]"
+    )
 
 
 @app.command("ticks")

--- a/lib/stardag/src/stardag/_cli/builds.py
+++ b/lib/stardag/src/stardag/_cli/builds.py
@@ -513,24 +513,19 @@ def _render_external_blockers(frontier: BuildFrontier) -> None:
             "truncated list still proves the build is waiting, not stuck."
         )
 
-    # The two cases need different remedies, so say which applies.
-    out_of_build = [b for b in frontier.blocked_by_external if not b.blocking_in_build]
-    in_build = [b for b in frontier.blocked_by_external if b.blocking_in_build]
-    if out_of_build:
-        console.print(
-            f"\n[bold]{len(out_of_build)} blocker(s) are not in this build's task "
-            "set[/bold] — this build will never schedule them and can only wait "
-            "for the build that owns them. Check that owner with "
-            "'stardag builds show <owning-build-id>'; if it is gone, release the "
-            "claim with 'stardag tasks cancel <owning-build-id> <task-id>'."
-        )
-    if in_build:
-        console.print(
-            f"\n[bold]{len(in_build)} blocker(s) are in this build's task set[/bold] "
-            "but another build produced their current status. They will resolve "
-            "when that build finishes them; a retry from here would not release "
-            "the claim."
-        )
+    # What happens next is a function of the blocker's status, not of which
+    # build produced it — so say it once, by status.
+    console.print(
+        "\n[bold]What happens next depends on the status[/bold] — "
+        "[bold]running[/bold] means another build holds the execution claim; "
+        "it resolves when that build finishes or the claim expires. "
+        "[bold]cancelled[/bold] is a revocation, not a result: this build's "
+        "next tick resets it and runs it itself. [bold]suspended[/bold] "
+        "resolves as the owning build works through the dynamic dependencies "
+        "it yielded. [bold]failed[/bold] and [bold]skipped[/bold] are results "
+        "— a tick leaves them to this build's fail_mode, so re-trigger the "
+        "build to reset them and run them here."
+    )
 
 
 @app.command("ticks")

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -740,6 +740,10 @@ class TickSummary:
     external_blockers: int = 0
     external_blockers_waited: int = 0
     external_blockers_fatal: int = 0
+    # Blockers in this build's own task set that it reset so it could run
+    # them itself (the collaboration path: a shared task another build
+    # cancelled is still this build's to run).
+    in_build_blockers_reset: int = 0
 
 
 # Outcomes worth persisting. ``not_reactive`` is excluded by definition:
@@ -1832,9 +1836,14 @@ class _ExternalBlockers(typing.NamedTuple):
     queued: list[_BlockerVerdict]
     # Out-of-build and nothing is going to run it. Fail.
     fatal: list[_BlockerVerdict]
-    # In this build's own task set: already accounted for by actionable /
-    # running / status_counts, so it must not influence the wait-or-fail
-    # decision. Kept only to enrich the message.
+    # In this build's own task set, in a status a retry moves, with budget
+    # left: this build's to run. Reset and schedule, don't fail — see
+    # ``_classify_external_blockers``.
+    recoverable: list[_BlockerVerdict]
+    # In this build's own task set but not recoverable (a status no retry
+    # moves, or the attempt budget is spent): already accounted for by
+    # actionable / running / status_counts, so it must not influence the
+    # wait-or-fail decision. Kept only to enrich the message.
     in_build: list[_BlockerVerdict]
 
     @property
@@ -1872,6 +1881,7 @@ async def _classify_external_blockers(
     now: datetime,
     *,
     registry: RegistryABC,
+    config: TickConfig,
 ) -> _ExternalBlockers:
     """Split the frontier's external blockers into wait / fail / ignore.
 
@@ -1936,6 +1946,7 @@ async def _classify_external_blockers(
     executing: list[_BlockerVerdict] = []
     queued: list[_BlockerVerdict] = []
     fatal: list[_BlockerVerdict] = []
+    recoverable: list[_BlockerVerdict] = []
     in_build: list[_BlockerVerdict] = []
 
     # Owning-build statuses resolved during THIS classification only. A wide
@@ -1971,7 +1982,27 @@ async def _classify_external_blockers(
 
     for blocker in frontier.blocked_by_external:
         if blocker.blocking_in_build:
-            in_build.append(_BlockerVerdict(blocker, "in this build's own task set"))
+            # A task in this build's own plan is this build's to run,
+            # whatever build last touched it. Builds collaborate: the claim
+            # is the only cross-build coordination primitive, and this
+            # blocker holds none — a retryable status carries no claim.
+            #
+            # The shape that motivates it is fail-fast. Another build starts
+            # a shared task, hits an unrelated failure and cascade-cancels
+            # what it started — correctly, since it owns those claims. That
+            # releases the claim, which is the point, but leaves the task
+            # CANCELLED, which is not schedulable. Without this, one build's
+            # fail-fast became every overlapping build's failure.
+            if blocker.blocking_status in _RETRYABLE_STATUSES and _retry_allowed(
+                blocker.blocking_attempt_count, config.max_attempts
+            ):
+                recoverable.append(
+                    _BlockerVerdict(blocker, "in this build's own task set, resettable")
+                )
+            else:
+                in_build.append(
+                    _BlockerVerdict(blocker, "in this build's own task set")
+                )
             continue
 
         if blocker.blocking_status in _RUNNING_STATUSES:
@@ -2042,7 +2073,11 @@ async def _classify_external_blockers(
             )
 
     return _ExternalBlockers(
-        executing=executing, queued=queued, fatal=fatal, in_build=in_build
+        executing=executing,
+        queued=queued,
+        fatal=fatal,
+        recoverable=recoverable,
+        in_build=in_build,
     )
 
 
@@ -2212,7 +2247,32 @@ async def _handle_terminal(
         # failure.
         now = datetime.now(timezone.utc)
         truncated = frontier.blocked_by_external_truncated
-        blockers = await _classify_external_blockers(frontier, now, registry=registry)
+        blockers = await _classify_external_blockers(
+            frontier, now, registry=registry, config=config
+        )
+
+        # Recoverable in-plan blockers first: this build can reset them and
+        # run them itself, so there is nothing to wait for and nothing to
+        # fail on. Done before the wait/fail decision because it *removes*
+        # the reason for both — the next tick finds them actionable.
+        if blockers.recoverable:
+            reset_ids = [v.blocker.blocking_task_id for v in blockers.recoverable]
+            for task_id in reset_ids:
+                try:
+                    await registry.task_retry_by_id_aio(build_id, task_id)
+                except Exception as e:
+                    # Best-effort: another tick may have reset it already, or
+                    # completed it outright. Either way the next frontier read
+                    # tells the truth, and failing the build over a lost race
+                    # is the outcome this whole path exists to avoid.
+                    logger.warning(f"Could not reset in-build blocker {task_id}: {e}")
+            summary.in_build_blockers_reset += len(reset_ids)
+            logger.info(
+                f"Build {build_id}: reset {len(reset_ids)} blocker(s) in this "
+                f"build's own task set so this build can run them: "
+                f"{', '.join(reset_ids[:_MAX_REPORTED_BLOCKERS])}"
+            )
+            return None
         waiting = blockers.waiting
         summary.external_blockers += len(frontier.blocked_by_external)
         summary.external_blockers_waited += len(waiting)

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -398,10 +398,17 @@ class DiscoveryResult:
 # expresses. RUNNING is deliberately absent: it holds a live execution
 # claim, and releasing that claim is cancellation, not retry.
 #
-# Only the re-trigger path passes retry_failed=True. Workers registering
-# dynamically yielded deps call discover_and_register_aio with the default
-# (False), so a worker can never reset its own parent's SUSPENDED status
-# out from under itself.
+# Every trigger passes retry_failed=True — a new build id and a resume
+# alike, because both go through ``run_reactive_bootstrap`` now that
+# discovery runs inside Modal. Workers registering dynamically yielded deps
+# call discover_and_register_aio with the default (False), so a worker can
+# never reset its own parent's SUSPENDED status out from under itself.
+#
+# So RUNNING is the only status that blocks a trigger, while a *mid-flight*
+# tick resets only CANCELLED (see ``_classify_external_blockers``). The
+# asymmetry is intended: at trigger *you asked*, so retrying a previous
+# failure is what you meant. Mid-flight nobody asked, and ``fail_mode`` owns
+# what happens to a failure.
 _RETRYABLE_STATUSES = ("failed", "cancelled", "skipped", "suspended")
 
 
@@ -732,17 +739,19 @@ class TickSummary:
     # three times).
     #
     # ``external_blockers`` is every entry the frontier reported while the
-    # build looked stalled, including in-build ones; ``waited`` and
-    # ``fatal`` split only the out-of-build entries, so the three do not
-    # add up. A tick with waited > 0 and fatal == 0 is the healthy
-    # "waiting on another build" state; fatal > 0 always accompanies a
-    # failed build.
+    # build looked stalled; ``waited`` and ``fatal`` cover only the entries
+    # that drove the wait-or-fail decision, so the three do not add up —
+    # a blocker whose status is a result influences neither (see
+    # ``_ExternalBlockers.inert``). A tick with waited > 0 and fatal == 0 is
+    # the healthy "waiting on another build" state; fatal > 0 always
+    # accompanies a failed build.
     external_blockers: int = 0
     external_blockers_waited: int = 0
     external_blockers_fatal: int = 0
-    # Blockers in this build's own task set that it reset so it could run
-    # them itself (the collaboration path: a shared task another build
-    # cancelled is still this build's to run).
+    # Blockers this build reset so it could run them itself (the
+    # collaboration path: a shared task another build cancelled is still this
+    # build's to run). Only ever a task in this build's plan — the attempt
+    # budget the reset is bounded by does not exist for anything else.
     in_build_blockers_reset: int = 0
 
 
@@ -1827,24 +1836,24 @@ class _BlockerVerdict(typing.NamedTuple):
 class _ExternalBlockers(typing.NamedTuple):
     """Partition of a frontier's ``blocked_by_external`` (see below)."""
 
-    # Out-of-build, RUNNING, claim not lapsed: someone else is executing
-    # it, and their completion frees this build. Wait.
+    # RUNNING with a claim that has not lapsed: someone is executing it, and
+    # their completion frees this build. Wait.
     executing: list[_BlockerVerdict]
-    # Out-of-build, not running (so holding no claim, so carrying no
-    # expiry), but owned by a build that is still live — that build is
-    # going to schedule it. Wait.
+    # Not running (so holding no claim, so carrying no expiry) and in a
+    # status its owning build is still driving — that build is going to move
+    # it. Wait.
     queued: list[_BlockerVerdict]
-    # Out-of-build and nothing is going to run it. Fail.
+    # Nothing is going to move it and this build cannot reset it. Fail.
     fatal: list[_BlockerVerdict]
-    # In this build's own task set, in a status a retry moves, with budget
-    # left: this build's to run. Reset and schedule, don't fail — see
+    # CANCELLED with attempt budget left: a revocation, not a verdict, so
+    # this build's to run. Reset and schedule, don't fail — see
     # ``_classify_external_blockers``.
     recoverable: list[_BlockerVerdict]
-    # In this build's own task set but not recoverable (a status no retry
-    # moves, or the attempt budget is spent): already accounted for by
-    # actionable / running / status_counts, so it must not influence the
-    # wait-or-fail decision. Kept only to enrich the message.
-    in_build: list[_BlockerVerdict]
+    # A *result* (FAILED/SKIPPED), or a CANCELLED whose budget is spent: the
+    # outcome belongs to ``fail_mode``, which already sees it in
+    # ``status_counts``, so it must not influence the wait-or-fail decision.
+    # Kept only to enrich the message.
+    inert: list[_BlockerVerdict]
 
     @property
     def waiting(self) -> list[_BlockerVerdict]:
@@ -1876,6 +1885,15 @@ def _blocker_status_age_seconds(
     return (now - status_at).total_seconds()
 
 
+# Blocker statuses whose fate belongs to the build that owns them. Neither
+# holds an execution claim, so the server clears the expiry with the claim
+# and the owner's status is the only liveness evidence that exists: PENDING
+# means that build has not scheduled it yet, SUSPENDED means that build is
+# working through its dynamic dependencies. Both are transient while the
+# owner lives — and both are a permanent wedge once it dies.
+_OWNER_DRIVEN_STATUSES = ("pending", "suspended")
+
+
 async def _classify_external_blockers(
     frontier: BuildFrontier,
     now: datetime,
@@ -1883,21 +1901,39 @@ async def _classify_external_blockers(
     registry: RegistryABC,
     config: TickConfig,
 ) -> _ExternalBlockers:
-    """Split the frontier's external blockers into wait / fail / ignore.
+    """Split the frontier's external blockers into reset / wait / fail / ignore.
 
     The frontier reports these only when the build has nothing actionable
     and nothing running — precisely the state the stuck-build check reads as
-    "this build is dead". The split decides whether it actually is, on two
-    questions: is the blocker in this build's own task set, and is anyone
-    going to move it?
+    "this build is dead". Each entry is an upstream of one of this build's
+    tasks whose current status *another* build produced. The split decides,
+    per blocker, whether anyone — this build included — is going to move it.
 
-    ``blocking_in_build`` → **ignored**: already visible in ``actionable`` /
-    ``running`` / ``status_counts``, so letting it drive this decision would
-    double-count it (a blocker genuinely stuck *in* this build still fails
-    the build, exactly as before).
+    **Plan membership is not one of the questions.** A build's plan is closed
+    under the dependency relation, so a gating upstream is this build's own
+    task; see ``docs/design/execution-claims-and-liveness.md``. What decides
+    is the blocker's *status*, because the status is what says whether it is
+    a revocation, a result, or work in flight.
 
-    Out-of-build, the second question is answered from different evidence in
-    the two halves of the table.
+    **CANCELLED — reset it and run it.** A cancel releases the execution
+    claim (that is the whole point of the fail-fast cascade) and leaves the
+    task in a status nothing schedules. It revokes *permission to run*; it is
+    not a verdict on the task, and permission is not build-scoped — a task in
+    this build's plan is this build's to run, whatever build last touched it.
+    Without this, one build's fail-fast became every overlapping build's
+    failure. Bounded by the same per-task attempt budget an ordinary retry
+    obeys, so a task that fails on every attempt cannot loop here. A blocker
+    outside the plan excludes itself without a plan check: the server reports
+    no attempt count for one, and a missing count refuses the retry (see
+    :func:`_retry_allowed`).
+
+    **FAILED / SKIPPED — leave them.** A failure is a *result*, and results
+    belong to ``fail_mode``: FAIL_FAST has already failed the build on the
+    same count, and CONTINUE means "finish what you can, then fail". A tick
+    that reset them would override the policy the user chose, and would do it
+    on nobody's request. They go to ``inert`` — named in the failure message,
+    influencing nothing. A re-trigger, where the user *did* ask, resets the
+    whole retryable set (see ``_RETRYABLE_STATUSES``).
 
     **RUNNING — read the claim's expiry.** A RUNNING task holds an execution
     claim, and the claim's expiry is the one piece of liveness evidence a
@@ -1916,14 +1952,16 @@ async def _classify_external_blockers(
       self-closing (new starts all carry an expiry) and the escape hatch is
       a task cancel, which the log line names.
 
-    **Everything else — ask the owning build.** A PENDING/SUSPENDED/terminal
-    task holds no claim, so the server clears the expiry with it and there
-    is nothing to read. The wedge is real (a task abandoned SUSPENDED blocks
-    every downstream build), so this half still decides, the only way it can:
+    **PENDING / SUSPENDED — ask the owning build** (``_OWNER_DRIVEN_STATUSES``).
+    Neither holds a claim, so the server clears the expiry with it and there
+    is nothing to read. The wedge is real — a task abandoned SUSPENDED blocks
+    every downstream build — so this half still decides, the only way it can:
 
-    - owning build still live → **wait**; it is going to schedule it.
-      Without this a PENDING dynamic dependency of a healthy concurrent
-      build would fail this build.
+    - owning build still live → **wait**; it is going to move it. Without
+      this a SUSPENDED shared task would fail every *other* build that
+      depends on it while the owner is legitimately mid-flight through its
+      dynamic dependencies, and a PENDING dynamic dependency of a healthy
+      concurrent build would do the same.
     - owning build terminal → **fail**; nothing will move it.
     - ``blocking_status_build_id is None`` → **fail** without a lookup: no
       status-moving event was ever recorded against it, so there is nobody
@@ -1933,21 +1971,25 @@ async def _classify_external_blockers(
       of life, and a silent indefinite hang is the failure mode #208 exists
       to kill.
 
-    So the owning-build lookup survives, for non-RUNNING blockers **only** —
+    So the owning-build lookup earns its place, for these statuses **only** —
     not out of caution but because it is the only evidence that exists for a
-    status carrying no claim. What a live owner does not buy is a deadline:
-    a build gone silent without transitioning is reaped server-side, not
+    status carrying no claim. What a live owner does not buy is a deadline: a
+    build gone silent without transitioning is reaped server-side, not
     guessed at here from a task's age.
 
-    None of this changes the outcome for a dead blocker outside this build's
-    task set: this build can never run it, so the build still fails. What
-    the expiry buys is certainty about *why*, and a message that says so.
+    **Why waiting on a SUSPENDED blocker is bounded**, and not the open-ended
+    hang it looks like: SUSPENDED persists only while the owner progresses the
+    dynamic dependencies it yielded, or while the owner is itself stuck on a
+    RUNNING task — and a RUNNING task carries a claim with an expiry. Once
+    that lapses the owner recovers or fails it, ``skip_blocked`` moves the
+    suspended parent to SKIPPED, the owner goes terminal, and this build stops
+    waiting. The wait ends on the same bound everything else here uses.
     """
     executing: list[_BlockerVerdict] = []
     queued: list[_BlockerVerdict] = []
     fatal: list[_BlockerVerdict] = []
     recoverable: list[_BlockerVerdict] = []
-    in_build: list[_BlockerVerdict] = []
+    inert: list[_BlockerVerdict] = []
 
     # Owning-build statuses resolved during THIS classification only. A wide
     # DAG stalled behind one build yields one blocker entry per blocked edge,
@@ -1981,27 +2023,23 @@ async def _classify_external_blockers(
         return owner_statuses[owner_id]
 
     for blocker in frontier.blocked_by_external:
-        if blocker.blocking_in_build:
-            # A task in this build's own plan is this build's to run,
-            # whatever build last touched it. Builds collaborate: the claim
-            # is the only cross-build coordination primitive, and this
-            # blocker holds none — a retryable status carries no claim.
-            #
-            # The shape that motivates it is fail-fast. Another build starts
-            # a shared task, hits an unrelated failure and cascade-cancels
-            # what it started — correctly, since it owns those claims. That
-            # releases the claim, which is the point, but leaves the task
-            # CANCELLED, which is not schedulable. Without this, one build's
-            # fail-fast became every overlapping build's failure.
-            if blocker.blocking_status in _RETRYABLE_STATUSES and _retry_allowed(
-                blocker.blocking_attempt_count, config.max_attempts
-            ):
+        if blocker.blocking_status == "cancelled":
+            # A revocation, not a verdict: the cancel released the claim, and
+            # a task in this build's plan is this build's to run whatever
+            # build last touched it. Budget-bounded, and the budget also
+            # excludes an out-of-plan blocker, which has no attempt count.
+            if _retry_allowed(blocker.blocking_attempt_count, config.max_attempts):
                 recoverable.append(
-                    _BlockerVerdict(blocker, "in this build's own task set, resettable")
+                    _BlockerVerdict(blocker, "cancelled, so this build's to reset")
                 )
             else:
-                in_build.append(
-                    _BlockerVerdict(blocker, "in this build's own task set")
+                inert.append(
+                    _BlockerVerdict(
+                        blocker,
+                        "cancelled, but not resettable from here (its attempt "
+                        "budget in this build is spent, or this build has no "
+                        "attempts on it to count)",
+                    )
                 )
             continue
 
@@ -2016,8 +2054,8 @@ async def _classify_external_blockers(
                     _BlockerVerdict(
                         blocker,
                         f"its execution claim lapsed at {expires_at}, so the "
-                        "claim is abandoned and re-claimable — but not by "
-                        "this build",
+                        "claim is abandoned and re-claimable — but a RUNNING "
+                        "task is not schedulable until someone releases it",
                     )
                 )
             elif expires_at is None:
@@ -2039,9 +2077,25 @@ async def _classify_external_blockers(
                 )
             continue
 
-        # Not running: no claim is held, so there is no expiry to read. It
-        # moves only if the build owning its status is still going to
-        # schedule it.
+        if blocker.blocking_status not in _OWNER_DRIVEN_STATUSES:
+            # A result — FAILED or SKIPPED — or a status no build drives at
+            # all (an UNREGISTERED phantom, or one a future server adds).
+            # Nothing is going to move it, but the decision is not this
+            # path's to take: it is in this build's plan, so it is in
+            # ``status_counts``, and ``fail_mode`` owns what happens to a
+            # failure. Recorded for the message only.
+            inert.append(
+                _BlockerVerdict(
+                    blocker,
+                    "a result rather than a revocation, so this build's "
+                    "fail_mode owns the outcome — re-trigger to reset it",
+                )
+            )
+            continue
+
+        # PENDING or SUSPENDED: no claim is held, so there is no expiry to
+        # read. It moves only if the build owning its status is still going to
+        # move it.
         owner_id = blocker.blocking_status_build_id
         if owner_id is None:
             fatal.append(
@@ -2077,7 +2131,7 @@ async def _classify_external_blockers(
         queued=queued,
         fatal=fatal,
         recoverable=recoverable,
-        in_build=in_build,
+        inert=inert,
     )
 
 
@@ -2127,56 +2181,28 @@ def _describe_blockers(
     return described
 
 
-def _blocker_remediation(verdicts: Sequence[_BlockerVerdict]) -> str:
+def _blocker_remedy(verdicts: Sequence[_BlockerVerdict]) -> str:
     """How to get out of it — the part the error used to lack.
 
-    Both documented endpoints are addressed to a *build*, so a blocker
-    whose owning build was never recorded has no build id to substitute
-    into them. Telling that reader to "retry it under the build that owns
-    it" is not a remedy, it is the shape of one — and this function exists
-    precisely for the reader who is stuck.
+    One remedy, because there is one: the blocker is in this build's plan
+    (closure guarantees it), so re-triggering resets it and runs it here. The
+    exception is a RUNNING blocker, which holds a claim no reset can take.
     """
-    unowned = [
-        verdict
-        for verdict in verdicts
-        if verdict.blocker.blocking_status_build_id is None
-    ]
-    owned = [
-        verdict
-        for verdict in verdicts
-        if verdict.blocker.blocking_status_build_id is not None
-    ]
-
-    parts: list[str] = []
-    if owned:
-        remedy = (
-            "Retry the blocking task under the build that owns it "
-            "(POST /api/v1/builds/{build_id}/tasks/{task_id}/retry) to reset "
-            "it to pending — this now works from suspended as well as from "
-            "failed/cancelled/skipped — then re-trigger this build"
+    remedy = (
+        "Re-trigger this build to reset the blocker and run it here — a "
+        "trigger resets failed/cancelled/skipped/suspended tasks in the plan, "
+        "which a mid-flight tick deliberately does not"
+    )
+    if any(
+        verdict.blocker.blocking_status in _RUNNING_STATUSES for verdict in verdicts
+    ):
+        remedy += (
+            ". A blocker stuck RUNNING holds an execution claim no reset can "
+            "take — and while a lapsed claim is re-claimable, no build is "
+            "claiming it: cancel the task (POST /api/v1/builds/{build_id}"
+            "/tasks/{task_id}/cancel) to release the claim first"
         )
-        if any(
-            verdict.blocker.blocking_status in _RUNNING_STATUSES for verdict in owned
-        ):
-            remedy += (
-                ". A blocker stuck RUNNING holds an execution claim no retry "
-                "can take — and while a lapsed claim is re-claimable, no "
-                "build is claiming it: cancel it (POST /api/v1/builds/"
-                "{build_id}/tasks/{task_id}/cancel) to release the claim "
-                "first"
-            )
-        parts.append(remedy + ".")
-    if unowned:
-        parts.append(
-            "No build is recorded as having set the status of "
-            f"{'some of these blockers' if owned else 'this blocker'}, so "
-            "there is no build id to address a retry or cancel to. Find the "
-            "task in the registry UI (or `stardag tasks list`), which names "
-            "the build that owns each claim; if nothing owns it, the status "
-            "predates claim recording and the task has to be re-run under a "
-            "new build."
-        )
-    return " ".join(parts)
+    return remedy + "."
 
 
 async def _handle_terminal(
@@ -2251,8 +2277,8 @@ async def _handle_terminal(
             frontier, now, registry=registry, config=config
         )
 
-        # Recoverable in-plan blockers first: this build can reset them and
-        # run them itself, so there is nothing to wait for and nothing to
+        # Recoverable (cancelled) blockers first: this build can reset them
+        # and run them itself, so there is nothing to wait for and nothing to
         # fail on. Done before the wait/fail decision because it *removes*
         # the reason for both — the next tick finds them actionable.
         if blockers.recoverable:
@@ -2268,8 +2294,8 @@ async def _handle_terminal(
                     logger.warning(f"Could not reset in-build blocker {task_id}: {e}")
             summary.in_build_blockers_reset += len(reset_ids)
             logger.info(
-                f"Build {build_id}: reset {len(reset_ids)} blocker(s) in this "
-                f"build's own task set so this build can run them: "
+                f"Build {build_id}: reset {len(reset_ids)} cancelled blocker(s) "
+                f"in this build's own plan so this build can run them: "
                 f"{', '.join(reset_ids[:_MAX_REPORTED_BLOCKERS])}"
             )
             return None
@@ -2332,34 +2358,33 @@ async def _handle_terminal(
         if blockers.fatal:
             # Precise, actionable failure: which task, its name, its status,
             # how long it has been in it, which build owns it, why that owner
-            # is not going to move it — plus how to release it. The status
+            # is not going to move it — plus how to get it moving. The status
             # counts alone (the whole of the old message) point nowhere near
-            # the cause when the cause is not in this build's task set at all.
+            # the cause when the cause is an upstream in a status no tick of
+            # this build will touch.
             reason = (
                 f"Build cannot progress: it has nothing runnable or running "
                 f"of its own, and {len(blockers.fatal)} of its task(s) are "
-                "blocked by an upstream owned by another build that will not "
-                f"move it (status counts: {counts}). Knowing the blocker is "
-                "dead does not unblock this build — the blocker is not in "
-                "this build's task set, so this build can never run it; it "
-                "has to be released under the build that owns it. Blocked "
-                f"by: {_describe_blockers(blockers.fatal, now, truncated)}"
-                f". {_blocker_remediation(blockers.fatal)}"
+                "blocked by an upstream that nothing is going to move "
+                f"(status counts: {counts}). Blocked by: "
+                f"{_describe_blockers(blockers.fatal, now, truncated)}"
+                f". {_blocker_remedy(blockers.fatal)}"
             )
         else:
-            # No out-of-build blocker: genuinely stuck (failed deps in
-            # CONTINUE mode, a lost task pickle, or a blocker inside this
-            # build that will never run). Fail rather than idle forever —
-            # naming any in-build blockers, which are otherwise invisible in
-            # the status counts.
+            # Nothing to wait for and nothing fatal: genuinely stuck (failed
+            # deps in CONTINUE mode, a lost task pickle, a blocker whose
+            # status is a result this tick will not override). Fail rather
+            # than idle forever — naming the inert blockers, whose role in it
+            # the status counts do not reveal.
             reason = (
                 "No runnable or running tasks left but roots are not "
                 f"complete (status counts: {counts})"
             )
-            if blockers.in_build:
-                reason += ". Blocked within this build by: " + _describe_blockers(
-                    blockers.in_build, now, truncated
+            if blockers.inert:
+                reason += ". Blocked by: " + _describe_blockers(
+                    blockers.inert, now, truncated
                 )
+                reason += f" {_blocker_remedy(blockers.inert)}"
         logger.error(f"Failing build {build_id}: {reason}")
         await registry.build_fail_aio(build_id, reason)
         return "failed"

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -1909,11 +1909,16 @@ async def _classify_external_blockers(
     tasks whose current status *another* build produced. The split decides,
     per blocker, whether anyone — this build included — is going to move it.
 
-    **Plan membership is not one of the questions.** A build's plan is closed
-    under the dependency relation, so a gating upstream is this build's own
-    task; see ``docs/design/execution-claims-and-liveness.md``. What decides
-    is the blocker's *status*, because the status is what says whether it is
-    a revocation, a result, or work in flight.
+    **Plan membership is not one of the questions.** What decides is the
+    blocker's *status*, because the status is what says whether it is a
+    revocation, a result, or work in flight. A build's plan is closed under the
+    dependency relation, so a gating upstream is *usually* this build's own
+    task — but closure runs once, at registration, and an edge written after
+    that is not in the plan. A concurrent build's worker yielding dynamic
+    dependencies does exactly that, routinely. Such a blocker is still decided
+    here, on the same evidence as any other, and the attempt budget is what
+    stops the CANCELLED branch acting on one (see below). See
+    ``docs/design/execution-claims-and-liveness.md``.
 
     **CANCELLED — reset it and run it.** A cancel releases the execution
     claim (that is the whole point of the fail-fast cascade) and leaves the
@@ -2184,9 +2189,11 @@ def _describe_blockers(
 def _blocker_remedy(verdicts: Sequence[_BlockerVerdict]) -> str:
     """How to get out of it — the part the error used to lack.
 
-    One remedy, because there is one: the blocker is in this build's plan
-    (closure guarantees it), so re-triggering resets it and runs it here. The
-    exception is a RUNNING blocker, which holds a claim no reset can take.
+    One remedy, because one covers it: re-triggering this build re-runs
+    discovery, which closes the plan again over whatever edges exist *now* and
+    resets the retryable set — so it reaches a blocker that was outside the
+    plan as well as one inside it. The exception is a RUNNING blocker, which
+    holds a claim no reset can take.
 
     Spelled in the **surfaces a user actually has** — the UI and the CLI — not
     as the REST routes underneath them. This text lands in a build's

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -2188,20 +2188,31 @@ def _blocker_remedy(verdicts: Sequence[_BlockerVerdict]) -> str:
     (closure guarantees it), so re-triggering resets it and runs it here. The
     exception is a RUNNING blocker, which holds a claim no reset can take.
 
-    The cancel that releases such a claim is spelled with the **owning**
-    build's id, which the blocker description above it supplies. Any build in
-    the environment is accepted there — the route does not require the task to
-    be in it — but the id chosen becomes the task's
-    ``latest_status_build_id``, and cancelling under the stuck build makes
-    that build the owner of the CANCELLED status. The frontier then stops
-    reporting the task as an external blocker at all, so the very reset this
-    message is steering towards never happens and the build has to be
-    re-triggered anyway. Under the owner, the next tick resets it and runs it.
+    Spelled in the **surfaces a user actually has** — the UI and the CLI — not
+    as the REST routes underneath them. This text lands in a build's
+    ``error_message``, read by someone whose build just died; a bare
+    ``POST /api/v1/...`` leaves them to find a base URL, mint a token and
+    assemble a body before they can act on it.
+
+    The UI is named first because it cannot get the build id wrong: the
+    scheduling panel addresses a claim action to the blocker's
+    ``blocking_status_build_id``. That matters more than it looks. Any build in
+    the environment is accepted by the route — it does not require the task to
+    be in it — but the id given becomes the task's ``latest_status_build_id``,
+    so cancelling under the *stuck* build makes that build the owner of the
+    CANCELLED status. The frontier then stops reporting the task as an external
+    blocker at all, so the very reset this message is steering towards never
+    happens and the build has to be re-triggered anyway. Under the owner, the
+    next tick resets it and runs it — which is why the CLI form spells the
+    argument ``<owning-build-id>`` and says which build that is.
     """
     remedy = (
         "Re-trigger this build to reset the blocker and run it here — a "
         "trigger resets failed/cancelled/skipped/suspended tasks in the plan, "
-        "which a mid-flight tick deliberately does not"
+        "which a mid-flight tick deliberately does not. Trigger it with this "
+        "same build id: build_trigger(..., build_id=<this build>, "
+        "reactive=True). A task-level Retry (in the UI, or 'stardag tasks "
+        "retry') is not the same thing and will not do it"
     )
     if any(
         verdict.blocker.blocking_status in _RUNNING_STATUSES for verdict in verdicts
@@ -2209,11 +2220,14 @@ def _blocker_remedy(verdicts: Sequence[_BlockerVerdict]) -> str:
         remedy += (
             ". A blocker stuck RUNNING holds an execution claim no reset can "
             "take — and while a lapsed claim is re-claimable, no build is "
-            "claiming it: cancel the task first, addressed to the build that "
-            "owns it (named above), i.e. POST /api/v1/builds/<owning-build-id>"
-            "/tasks/<blocking-task-id>/cancel — addressing it to this build "
-            "instead would make this build the owner of the cancelled status, "
-            "which stops the next tick from picking the task up"
+            "claiming it, so release it first: in the UI, open the blocking "
+            "build's scheduling panel and use the blocker's 'Release claim' "
+            "action, which addresses it to the owning build for you; from the "
+            "CLI, 'stardag tasks cancel <owning-build-id> "
+            "<blocking-task-id>'. It has to be the build that owns the blocker "
+            "(named above), not this one — cancelling it under this build "
+            "would make this build the owner of the cancelled status, which "
+            "stops the next tick from picking the task up"
         )
     return remedy + "."
 

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -2088,7 +2088,7 @@ async def _classify_external_blockers(
                 _BlockerVerdict(
                     blocker,
                     "a result rather than a revocation, so this build's "
-                    "fail_mode owns the outcome — re-trigger to reset it",
+                    "fail_mode owns the outcome",
                 )
             )
             continue
@@ -2384,7 +2384,7 @@ async def _handle_terminal(
                 reason += ". Blocked by: " + _describe_blockers(
                     blockers.inert, now, truncated
                 )
-                reason += f" {_blocker_remedy(blockers.inert)}"
+                reason += f". {_blocker_remedy(blockers.inert)}"
         logger.error(f"Failing build {build_id}: {reason}")
         await registry.build_fail_aio(build_id, reason)
         return "failed"

--- a/lib/stardag/src/stardag/build/_reactive.py
+++ b/lib/stardag/src/stardag/build/_reactive.py
@@ -2187,6 +2187,16 @@ def _blocker_remedy(verdicts: Sequence[_BlockerVerdict]) -> str:
     One remedy, because there is one: the blocker is in this build's plan
     (closure guarantees it), so re-triggering resets it and runs it here. The
     exception is a RUNNING blocker, which holds a claim no reset can take.
+
+    The cancel that releases such a claim is spelled with the **owning**
+    build's id, which the blocker description above it supplies. Any build in
+    the environment is accepted there — the route does not require the task to
+    be in it — but the id chosen becomes the task's
+    ``latest_status_build_id``, and cancelling under the stuck build makes
+    that build the owner of the CANCELLED status. The frontier then stops
+    reporting the task as an external blocker at all, so the very reset this
+    message is steering towards never happens and the build has to be
+    re-triggered anyway. Under the owner, the next tick resets it and runs it.
     """
     remedy = (
         "Re-trigger this build to reset the blocker and run it here — a "
@@ -2199,8 +2209,11 @@ def _blocker_remedy(verdicts: Sequence[_BlockerVerdict]) -> str:
         remedy += (
             ". A blocker stuck RUNNING holds an execution claim no reset can "
             "take — and while a lapsed claim is re-claimable, no build is "
-            "claiming it: cancel the task (POST /api/v1/builds/{build_id}"
-            "/tasks/{task_id}/cancel) to release the claim first"
+            "claiming it: cancel the task first, addressed to the build that "
+            "owns it (named above), i.e. POST /api/v1/builds/<owning-build-id>"
+            "/tasks/<blocking-task-id>/cancel — addressing it to this build "
+            "instead would make this build the owner of the cancelled status, "
+            "which stops the next tick from picking the task up"
         )
     return remedy + "."
 
@@ -2282,7 +2295,18 @@ async def _handle_terminal(
         # fail on. Done before the wait/fail decision because it *removes*
         # the reason for both — the next tick finds them actionable.
         if blockers.recoverable:
-            reset_ids = [v.blocker.blocking_task_id for v in blockers.recoverable]
+            # Deduplicated, because the frontier reports one entry per
+            # (blocked, blocker) *edge*: a shared upstream appears once for
+            # every task of this build that depends on it, which is the normal
+            # shape for the fan-out this path exists to unblock. Without the
+            # dedupe a diamond retries the same task N times — the second call
+            # hitting a row that is already PENDING, so it fails and logs — and
+            # ``in_build_blockers_reset`` counts edges rather than tasks.
+            # ``dict.fromkeys`` rather than a set: registration order is what
+            # makes the log line's truncated list stable.
+            reset_ids = list(
+                dict.fromkeys(v.blocker.blocking_task_id for v in blockers.recoverable)
+            )
             for task_id in reset_ids:
                 try:
                     await registry.task_retry_by_id_aio(build_id, task_id)

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -121,13 +121,16 @@ class FrontierExternalBlocker(StardagBaseModel):
     # "never lapses". Always None for a non-RUNNING blocker: it holds no
     # claim, so "will anyone move it?" must be asked of its owning build.
     blocking_status_expires_at: datetime | None = None
-    # Whether the blocker is also part of *this* build's task set. True is
-    # the normal case, and the only one reachable for a build registered
-    # under plan closure: a build's plan holds every dependency that was not
-    # complete at discovery, so the blocker is this build's own task and
-    # shows up in its ``actionable``/``running`` too. False survives for
-    # builds registered before closure existed — this build cannot schedule
-    # it, and re-triggering is what brings it into the plan.
+    # Whether the blocker is also part of *this* build's task set. True is the
+    # normal case: a build's plan holds every dependency that was not complete
+    # at discovery, so the blocker is this build's own task and shows up in its
+    # ``actionable``/``running`` too.
+    #
+    # False is still reachable, and not only for builds registered before
+    # closure existed. Closure runs once, at registration, so a dependency edge
+    # written afterwards is not in the plan — which is what happens whenever a
+    # concurrent build's worker yields dynamic dependencies into its own plan.
+    # Re-triggering re-runs discovery and brings them in.
     #
     # Reported for diagnostics, not branched on: the scheduler decides from
     # the blocker's *status* (see

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -126,6 +126,13 @@ class FrontierExternalBlocker(StardagBaseModel):
     # only wait for whoever owns it. True still blocks, but the blocker also
     # shows up in this build's own ``actionable``/``running``.
     blocking_in_build: bool
+    # Attempts this blocker has already spent **in this build's round**,
+    # when the blocker is in this build's plan (None otherwise, and on
+    # servers predating the field). A tick that resets an in-plan blocker
+    # needs this to stay inside the same budget an ordinary retry obeys —
+    # otherwise a task that fails every time is reset, rerun and re-failed
+    # forever.
+    blocking_attempt_count: int | None = None
 
 
 class BuildFrontier(StardagBaseModel):

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -121,10 +121,13 @@ class FrontierExternalBlocker(StardagBaseModel):
     # "never lapses". Always None for a non-RUNNING blocker: it holds no
     # claim, so "will anyone move it?" must be asked of its owning build.
     blocking_status_expires_at: datetime | None = None
-    # Whether the blocker is also part of *this* build's task set. False is
-    # the pathological case: this build will never schedule it, so it can
-    # only wait for whoever owns it. True still blocks, but the blocker also
-    # shows up in this build's own ``actionable``/``running``.
+    # Whether the blocker is also part of *this* build's task set. True is
+    # the normal case, and the only one reachable for a build registered
+    # under plan closure: a build's plan holds every dependency that was not
+    # complete at discovery, so the blocker is this build's own task and
+    # shows up in its ``actionable``/``running`` too. False survives for
+    # builds registered before closure existed — this build cannot schedule
+    # it, and re-triggering is what brings it into the plan.
     blocking_in_build: bool
     # Attempts this blocker has already spent **in this build's round**,
     # when the blocker is in this build's plan (None otherwise, and on

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -128,6 +128,12 @@ class FrontierExternalBlocker(StardagBaseModel):
     # shows up in its ``actionable``/``running`` too. False survives for
     # builds registered before closure existed — this build cannot schedule
     # it, and re-triggering is what brings it into the plan.
+    #
+    # Reported for diagnostics, not branched on: the scheduler decides from
+    # the blocker's *status* (see
+    # ``stardag.build._reactive._classify_external_blockers``), and the
+    # attempt count below is what keeps it from resetting a task outside the
+    # plan.
     blocking_in_build: bool
     # Attempts this blocker has already spent **in this build's round**,
     # when the blocker is in this build's plan (None otherwise, and on

--- a/lib/stardag/tests/test__cli/test_builds.py
+++ b/lib/stardag/tests/test__cli/test_builds.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta, timezone
 from unittest import mock
 from uuid import uuid4
 
+import pytest
 from typer.testing import CliRunner
 
 from stardag._cli.builds import app
@@ -285,29 +286,25 @@ class TestFrontier:
         assert "5h" in result.output  # how long it has been held up
         assert OTHER_BUILD_ID in result.output
 
-    def test_out_of_build_blocker_gets_its_own_remedy(self):
+    @pytest.mark.parametrize("in_build", [True, False])
+    def test_guidance_is_by_status_not_by_plan_membership(self, in_build: bool):
+        """Plan closure makes the blocker this build's own task, so what
+        happens next follows from its status. The two-remedy split — one
+        addressed to this build, one to the build that owns the task — is
+        gone, and the same guidance is printed either way."""
         registry = _mock_registry(
             build_get_frontier=_frontier(
-                blocked_by_external=[_blocker(blocking_in_build=False)]
+                blocked_by_external=[_blocker(blocking_in_build=in_build)]
             )
         )
         with _patch_resolve(registry):
             result = runner.invoke(app, ["frontier", BUILD_ID])
         assert result.exit_code == 0, result.output
-        assert "not in this build's task set" in result.output
-        assert "stardag tasks cancel" in result.output
-
-    def test_in_build_blocker_gets_a_different_remedy(self):
-        registry = _mock_registry(
-            build_get_frontier=_frontier(
-                blocked_by_external=[_blocker(blocking_in_build=True)]
-            )
-        )
-        with _patch_resolve(registry):
-            result = runner.invoke(app, ["frontier", BUILD_ID])
-        assert result.exit_code == 0, result.output
-        assert "in this build's task set" in result.output
-        assert "a retry from here would not release" in result.output
+        output = " ".join(result.output.split())  # rich wraps the paragraph
+        assert "What happens next depends on the status" in output
+        assert "another build holds the execution claim" in output
+        assert "re-trigger the build" in output
+        assert "not in this build's task set" not in output
 
     def test_truncation_is_surfaced(self):
         registry = _mock_registry(

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -2144,15 +2144,18 @@ class TestExternalBlockers:
         assert str(registry.status_build_id[self.BLOCKER_ID]) in message  # its owner
         assert "execution claim lapsed" in message
         # A reset cannot take a claim, lapsed or not, so the remedy is a
-        # cancel — and it is the only extra clause the remedy carries. It has
-        # to name whose build id goes in the URL: any build in the environment
-        # is accepted there, but addressing it to *this* build makes this build
-        # the owner of the cancelled status, at which point the task stops
-        # being an external blocker and the reset it would have got never
-        # happens.
-        assert "cancel the task first" in message
-        assert "the build that owns it (named above)" in message
-        assert "<owning-build-id>" in message
+        # release — and it is the only extra clause the remedy carries.
+        assert "release it first" in message
+        # Named in surfaces the reader has, not as a REST route they would have
+        # to find a base URL and a token for.
+        assert "'Release claim' action" in message
+        assert "stardag tasks cancel <owning-build-id> <blocking-task-id>" in message
+        assert "/api/v1" not in message
+        # And it has to say *whose* build id: any build in the environment is
+        # accepted, but addressing it to *this* build makes this build the owner
+        # of the cancelled status, at which point the task stops being an
+        # external blocker and the reset it would have got never happens.
+        assert "the build that owns the blocker (named above), not this one" in message
 
     async def test_running_blocker_without_an_expiry_waits(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
@@ -2240,7 +2243,7 @@ class TestExternalBlockers:
         # One remedy, since the blocker is in this build's plan: re-trigger.
         # Only a RUNNING blocker needs the cancel-first hint.
         assert "Re-trigger this build" in message
-        assert "cancel the task first" not in message
+        assert "release it first" not in message
 
     @pytest.mark.parametrize("owner_build_status", ["running", "pending"])
     async def test_non_running_blocker_of_a_live_build_waits(

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -135,6 +135,7 @@ class FakeReactiveRegistry(NoOpRegistry):
         # this build's tasks (dependency edges are global too) while
         # contributing to neither ``actionable`` nor ``status_counts``.
         self.not_in_build: set[str] = set()
+        self.blocker_attempts: dict[str, int] = {}
         # task_id -> the build whose event produced the current status. An
         # ABSENT key means "this build's own doing" (the common case), which
         # is what makes a task NOT an external blocker; an explicit None is a
@@ -230,6 +231,7 @@ class FakeReactiveRegistry(NoOpRegistry):
         status_at: "datetime | None" = None,
         expires_at: "datetime | None" = None,
         in_build: bool = False,
+        attempt_count: int = 0,
     ) -> None:
         """Register an upstream whose current status this build did not set.
 
@@ -252,6 +254,7 @@ class FakeReactiveRegistry(NoOpRegistry):
             self.expires_at[task_id] = expires_at
         if not in_build:
             self.not_in_build.add(task_id)
+        self.blocker_attempts[task_id] = attempt_count
         for downstream in blocks:
             self.upstreams.setdefault(downstream, set()).add(task_id)
 
@@ -380,6 +383,15 @@ class FakeReactiveRegistry(NoOpRegistry):
         self.calls.append(("complete", tid))
         self._count_event(tid, is_start=False)
         self.statuses[tid] = "completed"
+
+    async def task_retry_by_id_aio(self, build_id, task_id):
+        """Id-based retry — what a tick uses for a blocker it cannot
+        reconstruct (it has the id off the frontier, not the object)."""
+        self.calls.append(("retry", task_id))
+        self._count_event(task_id, is_start=False)
+        if self.statuses.get(task_id) in _RETRYABLE_STATUSES:
+            self.statuses[task_id] = "pending"
+            self.refs.pop(task_id, None)
 
     async def task_retry_aio(self, build_id, task):
         tid = str(task.id)
@@ -582,6 +594,13 @@ class FakeReactiveRegistry(NoOpRegistry):
                             ),
                             blocking_status_build_id=owner_id,
                             blocking_in_build=up not in self.not_in_build,
+                            # Mirrors the server: attempts are per build, so
+                            # only a blocker in this build's plan has any.
+                            blocking_attempt_count=(
+                                self.blocker_attempts.get(up, 0)
+                                if up not in self.not_in_build
+                                else None
+                            ),
                         )
                     )
         return BuildFrontier(
@@ -2010,6 +2029,7 @@ class TestExternalBlockers:
         blocker_age_seconds: float | None = 60.0,
         blocker_expires_in_seconds: float | None = None,
         in_build: bool = False,
+        blocker_attempts: int = 0,
         owner_build_id: "UUID | None" = None,
         owner_build_status: "str | None" = "running",
         owner_build_known: bool = True,
@@ -2033,6 +2053,7 @@ class TestExternalBlockers:
                 + timedelta(seconds=blocker_expires_in_seconds)
             ),
             in_build=in_build,
+            attempt_count=blocker_attempts,
             owner_build_id=owner_build_id,
             owner_build_status=owner_build_status,
             owner_build_known=owner_build_known,
@@ -2387,15 +2408,86 @@ class TestExternalBlockers:
         assert summary.external_blockers_waited == 2
         assert registry.build_get_calls == [owner]
 
-    async def test_in_build_blocker_does_not_cause_a_wait(
+    async def test_cancelled_in_build_blocker_is_retried_not_failed(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
     ):
-        """A blocker inside this build's own task set is already modelled by
-        actionable/running/status_counts, so it must not buy the build a
-        wait — but it does get named, since the status counts alone never
-        said which task was holding things up."""
+        """Builds collaborate: a task in *this build's own plan* is this
+        build's to run, whatever build last touched it.
+
+        The motivating shape is fail-fast. Build A starts a shared task,
+        hits an unrelated failure, and cascade-cancels the tasks it started
+        — correctly, since it owns those claims. The cancel releases the
+        claim, which is the whole point. But the task is left CANCELLED,
+        which is not schedulable, so build B — which shares the dependency
+        and has failed at nothing — used to die on it too. One build's
+        fail-fast became every overlapping build's failure.
+
+        Nothing owns the task now: no claim, no live execution. It is in B's
+        plan, so B resets it and runs it.
+        """
         _, registry, locks, executor, store = self._blocked_build(
             blocker_status="cancelled", in_build=True
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                fail_mode=FailMode.CONTINUE,
+            ),
+        )
+
+        # Reset, not failed: the next tick finds it actionable.
+        assert summary.terminal_status is None
+        assert ("retry", self.BLOCKER_ID) in registry.calls
+        assert registry.statuses[self.BLOCKER_ID] == "pending"
+        assert registry.build_error_message is None
+
+    async def test_in_build_retry_respects_the_attempt_budget(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """Retrying an in-plan blocker must not become an infinite loop.
+
+        A task that genuinely fails every time would otherwise be reset,
+        rerun and re-failed forever. The budget that already bounds ordinary
+        retries bounds this one too, and the build fails once it is spent —
+        which is the honest outcome, since nothing will move the task.
+        """
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="failed", in_build=True, blocker_attempts=5
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                fail_mode=FailMode.CONTINUE,
+                max_attempts=2,
+            ),
+        )
+
+        assert summary.terminal_status == "failed"
+        assert ("retry", self.BLOCKER_ID) not in registry.calls
+        message = registry.build_error_message or ""
+        assert "Blocked within this build by" in message
+
+    async def test_in_build_blocker_that_cannot_be_retried_still_fails(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """Not every in-plan blocker is recoverable. One in a status no
+        retry moves is named and the build fails, rather than idling."""
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="unregistered", in_build=True
         )
 
         summary = await run_tick_aio(

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -2143,8 +2143,8 @@ class TestExternalBlockers:
         assert self.BLOCKER_ID in message
         assert str(registry.status_build_id[self.BLOCKER_ID]) in message  # its owner
         assert "execution claim lapsed" in message
-        # Certainty about the cause is not the power to fix it from here.
-        assert "does not unblock this build" in message
+        # A reset cannot take a claim, lapsed or not, so the remedy is a
+        # cancel — and it is the only extra clause the remedy carries.
         assert "release the claim" in message
 
     async def test_running_blocker_without_an_expiry_waits(
@@ -2200,18 +2200,16 @@ class TestExternalBlockers:
         assert summary.outcome == "lingered_out"
         assert registry.build_get_calls == []
 
-    @pytest.mark.parametrize(
-        "blocker_status", ["pending", "suspended", "failed", "cancelled", "skipped"]
-    )
-    async def test_non_running_external_blocker_fails_immediately(
+    @pytest.mark.parametrize("blocker_status", ["pending", "suspended"])
+    async def test_owner_driven_blocker_of_a_terminal_build_fails_immediately(
         self,
         blocker_status: str,
         default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
     ):
-        """Nobody is executing the blocker, the build that owns it has gone
-        terminal, and this build will never schedule it (it is not in this
-        build's task set) — so waiting would be waiting forever. Fail now,
-        naming the task and the build that owns it."""
+        """PENDING and SUSPENDED say "the owning build is going to move this".
+        Once that build has gone terminal, nobody is, and waiting would be
+        waiting forever. Fail now, naming the task, the build that owns it and
+        the one remedy there is."""
         _, registry, locks, executor, store = self._blocked_build(
             blocker_status=blocker_status, owner_build_status="completed"
         )
@@ -2232,9 +2230,9 @@ class TestExternalBlockers:
         assert "pipelines.Ingest" in message
         assert blocker_status.upper() in message
         assert f"under build {registry.status_build_id[self.BLOCKER_ID]}" in message
-        # Actionable: retry now covers suspended too (#208 A2), and only a
-        # RUNNING blocker needs the cancel-first hint.
-        assert "/retry" in message
+        # One remedy, since the blocker is in this build's plan: re-trigger.
+        # Only a RUNNING blocker needs the cancel-first hint.
+        assert "Re-trigger this build" in message
         assert "release the claim" not in message
 
     @pytest.mark.parametrize("owner_build_status", ["running", "pending"])
@@ -2322,12 +2320,9 @@ class TestExternalBlockers:
         assert registry.build_get_calls == []  # nothing to look up
         message = registry.build_error_message or ""
         assert "no build owns its status" in message
-        # Both documented remedies are addressed to a build, so quoting
-        # them here would hand the reader a URL with no id to put in it.
-        # Say what can actually be done instead.
-        assert "/retry" not in message
-        assert "no build id to address a retry or cancel to" in message
-        assert "stardag tasks list" in message
+        # The remedy needs no owning build id to be actionable: the blocker is
+        # in *this* build's plan, so re-triggering *this* build resets it.
+        assert "Re-trigger this build" in message
 
     async def test_failed_owner_lookup_fails_without_propagating(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
@@ -2451,7 +2446,7 @@ class TestExternalBlockers:
     async def test_in_build_retry_respects_the_attempt_budget(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
     ):
-        """Retrying an in-plan blocker must not become an infinite loop.
+        """Resetting an in-plan blocker must not become an infinite loop.
 
         A task that genuinely fails every time would otherwise be reset,
         rerun and re-failed forever. The budget that already bounds ordinary
@@ -2459,7 +2454,7 @@ class TestExternalBlockers:
         which is the honest outcome, since nothing will move the task.
         """
         _, registry, locks, executor, store = self._blocked_build(
-            blocker_status="failed", in_build=True, blocker_attempts=5
+            blocker_status="cancelled", in_build=True, blocker_attempts=5
         )
 
         summary = await run_tick_aio(
@@ -2479,7 +2474,171 @@ class TestExternalBlockers:
         assert summary.terminal_status == "failed"
         assert ("retry", self.BLOCKER_ID) not in registry.calls
         message = registry.build_error_message or ""
-        assert "Blocked within this build by" in message
+        assert "Blocked by" in message
+        assert "attempt budget in this build is spent" in message
+
+    @pytest.mark.parametrize("blocker_status", ["failed", "skipped"])
+    async def test_a_result_in_this_builds_plan_is_left_to_fail_mode(
+        self,
+        blocker_status: str,
+        default_in_memory_fs_target: typing.Type[InMemoryFileTarget],
+    ):
+        """S1, and the line the collaboration rule stops at: a task in this
+        build's plan is this build's to *run*, but only a CANCELLED status is
+        a revocation of permission to run. FAILED and SKIPPED are results.
+
+        Build A ran the shared task and it failed. Nothing about that failure
+        belongs to B: resetting it would rerun a task that just told the
+        environment it does not work, on nobody's request, and would override
+        the ``fail_mode`` B was triggered with. B fails instead, naming the
+        blocker — and a re-trigger, where the user *does* ask, resets it.
+
+        Budget deliberately intact (attempts 0 of 2): the point is the status,
+        not an exhausted retry allowance.
+        """
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status=blocker_status, in_build=True, blocker_attempts=0
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                # CONTINUE, or FAIL_FAST would fail the build on the status
+                # count before terminal detection ever looks at a blocker.
+                fail_mode=FailMode.CONTINUE,
+                max_attempts=2,
+            ),
+        )
+
+        assert summary.terminal_status == "failed"
+        assert ("retry", self.BLOCKER_ID) not in registry.calls
+        assert registry.statuses[self.BLOCKER_ID] == blocker_status
+        # A result influences neither half of the wait-or-fail decision: the
+        # build's own terminal logic owns the outcome.
+        assert summary.external_blockers == 1
+        assert summary.external_blockers_waited == 0
+        assert summary.external_blockers_fatal == 0
+        assert summary.in_build_blockers_reset == 0
+        message = registry.build_error_message or ""
+        assert "pipelines.Ingest" in message
+        assert "a result rather than a revocation" in message
+        assert "Re-trigger this build" in message
+
+    def _suspended_shared_task(
+        self, *, owner_build_status: str, child_claim_lapsed: bool
+    ):
+        """S2's shape: a shared task suspended on a dynamic child of its own.
+
+        The child is registered into the *owning* build's plan only, which is
+        what happens when this build registered before the owner's worker
+        yielded. It also keeps the suspended parent out of ``actionable``: a
+        suspended task with every upstream complete is simply schedulable, and
+        that is not the state S2 is about.
+        """
+        _, registry, locks, executor, store = self._blocked_build(
+            blocker_status="suspended",
+            in_build=True,
+            owner_build_id=(owner := uuid4()),
+            owner_build_status=owner_build_status,
+        )
+        registry.add_blocking_task(
+            "dynamic-child",
+            blocks={self.BLOCKER_ID},
+            status="running",
+            owner_build_id=owner,
+            # Same owner, so the same status — the fake keeps one entry per
+            # build and the default would overwrite the parent's.
+            owner_build_status=owner_build_status,
+            expires_at=datetime.now(timezone.utc)
+            + timedelta(minutes=-1 if child_claim_lapsed else 60),
+            namespace="pipelines",
+            name="Child",
+        )
+        return registry, locks, executor, store
+
+    async def test_suspended_blocker_in_this_builds_plan_is_waited_on(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """S2: build A is mid-flight through the shared task's dynamic deps.
+
+        A ran the shared task, its worker registered dynamic dependencies,
+        yielded, and returned — leaving the task SUSPENDED with the children
+        in A's plan. The task is in B's plan too, but resetting it would rerun
+        all of its pre-yield work for nothing while A is legitimately making
+        progress, and would race A's own scheduling of the children.
+
+        So B waits. Bounded, not open-ended: SUSPENDED persists only while A
+        progresses the children, and A stalling on one of them stalls on a
+        RUNNING task whose claim expires.
+        """
+        registry, locks, executor, store = self._suspended_shared_task(
+            owner_build_status="running", child_claim_lapsed=False
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                fail_mode=FailMode.CONTINUE,
+            ),
+        )
+
+        assert summary.terminal_status is None
+        assert registry.build_status == "running"
+        assert ("retry", self.BLOCKER_ID) not in registry.calls
+        assert registry.statuses[self.BLOCKER_ID] == "suspended"
+        assert summary.in_build_blockers_reset == 0
+        # Both edges are waited on: the suspended parent (its owner is live)
+        # and the running child (its claim is live).
+        assert summary.external_blockers_waited == 2
+        assert summary.external_blockers_fatal == 0
+
+    async def test_suspended_blocker_of_a_dead_owner_fails(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """The other end of S2's bound, and why the wait is not a hang.
+
+        The owning build died while its dynamic child was running, so the
+        child's claim lapses and the suspended parent has nobody left to
+        progress it. Both are fatal on their own evidence — the claim for the
+        child, the owner's status for the parent — and the build fails naming
+        them instead of waiting forever. A re-trigger resets the whole chain.
+        """
+        registry, locks, executor, store = self._suspended_shared_task(
+            owner_build_status="failed", child_claim_lapsed=True
+        )
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                fail_mode=FailMode.CONTINUE,
+            ),
+        )
+
+        assert summary.terminal_status == "failed"
+        assert ("retry", self.BLOCKER_ID) not in registry.calls
+        assert summary.external_blockers_fatal == 2
+        assert summary.external_blockers_waited == 0
+        message = registry.build_error_message or ""
+        assert "its owning build is failed" in message  # the suspended parent
+        assert "execution claim lapsed" in message  # its dynamic child
 
     async def test_in_build_blocker_that_cannot_be_retried_still_fails(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
@@ -2509,7 +2668,7 @@ class TestExternalBlockers:
         assert summary.external_blockers_fatal == 0
         message = registry.build_error_message or ""
         assert "No runnable or running tasks left" in message
-        assert "Blocked within this build by" in message
+        assert "Blocked by" in message
         assert "pipelines.Ingest" in message
 
     async def test_a_fatal_blocker_wins_over_a_waitable_one(

--- a/lib/stardag/tests/test_build/test_reactive.py
+++ b/lib/stardag/tests/test_build/test_reactive.py
@@ -2144,8 +2144,15 @@ class TestExternalBlockers:
         assert str(registry.status_build_id[self.BLOCKER_ID]) in message  # its owner
         assert "execution claim lapsed" in message
         # A reset cannot take a claim, lapsed or not, so the remedy is a
-        # cancel — and it is the only extra clause the remedy carries.
-        assert "release the claim" in message
+        # cancel — and it is the only extra clause the remedy carries. It has
+        # to name whose build id goes in the URL: any build in the environment
+        # is accepted there, but addressing it to *this* build makes this build
+        # the owner of the cancelled status, at which point the task stops
+        # being an external blocker and the reset it would have got never
+        # happens.
+        assert "cancel the task first" in message
+        assert "the build that owns it (named above)" in message
+        assert "<owning-build-id>" in message
 
     async def test_running_blocker_without_an_expiry_waits(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
@@ -2233,7 +2240,7 @@ class TestExternalBlockers:
         # One remedy, since the blocker is in this build's plan: re-trigger.
         # Only a RUNNING blocker needs the cancel-first hint.
         assert "Re-trigger this build" in message
-        assert "release the claim" not in message
+        assert "cancel the task first" not in message
 
     @pytest.mark.parametrize("owner_build_status", ["running", "pending"])
     async def test_non_running_blocker_of_a_live_build_waits(
@@ -2442,6 +2449,50 @@ class TestExternalBlockers:
         assert ("retry", self.BLOCKER_ID) in registry.calls
         assert registry.statuses[self.BLOCKER_ID] == "pending"
         assert registry.build_error_message is None
+
+    async def test_a_shared_cancelled_blocker_is_reset_once_per_task(
+        self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]
+    ):
+        """The frontier reports one entry per (blocked, blocker) *edge*.
+
+        A cancelled upstream shared by several of this build's tasks therefore
+        arrives once per dependent — the normal shape for the fan-out this path
+        exists to unblock, and a diamond is enough to produce it. Resetting per
+        entry would call retry N times on one task: the calls after the first
+        hit a row that is already PENDING, so they fail and log, and
+        ``in_build_blockers_reset`` would count edges rather than tasks.
+        """
+        root, registry, locks, executor, store = self._blocked_build(
+            blocker_status="cancelled", in_build=True
+        )
+        # A second task of this build gated by the *same* blocker.
+        sibling = SyncOnlyTask(name="shared-blocker-sibling")
+        store.save_task(sibling)
+        registry.add_task(str(sibling.id), status="pending")
+        registry.upstreams.setdefault(str(sibling.id), set()).add(self.BLOCKER_ID)
+
+        summary = await run_tick_aio(
+            uuid4(),
+            registry=registry,
+            task_executor=executor,
+            lock_manager=locks,
+            task_store=store,
+            config=TickConfig(
+                linger_seconds=0.2,
+                poll_interval_seconds=0.01,
+                fail_mode=FailMode.CONTINUE,
+            ),
+        )
+
+        assert summary.terminal_status is None
+        # Two edges reported, one task reset.
+        assert summary.external_blockers == 0  # short-circuited by the reset
+        retries = [
+            call for call in registry.calls if call == ("retry", self.BLOCKER_ID)
+        ]
+        assert len(retries) == 1, registry.calls
+        assert summary.in_build_blockers_reset == 1
+        assert registry.statuses[self.BLOCKER_ID] == "pending"
 
     async def test_in_build_retry_respects_the_attempt_budget(
         self, default_in_memory_fs_target: typing.Type[InMemoryFileTarget]


### PR DESCRIPTION
Three defects with one root: **a build deferring to build identity where the
execution claim should be the only cross-build coordination.**

> A build is a **request for a set of root tasks to be materialised**, not an
> owner of the tasks that materialise them. The execution claim is the only
> cross-build coordination primitive. Which build completes a task is
> otherwise irrelevant.

That follows from the design rather than being a preference: tasks are
content-addressed, and within one deployed app the worker selector and
resources are a pure function of the task, so _which_ build ran a task cannot
change its result.

---

## 1. A build could be gated by a task no build could schedule

A build's plan is every dependency of its roots not complete at discovery
time, pruned at complete tasks. Discovery enforces that for `requires()` —
**static** edges. Gating consults every recorded edge, and _dynamic_ edges are
written by whichever build first ran the task and then outlive it,
environment-global and permanent.

So a later build that statically discovers the same task inherits the
dependency without inheriting the task, and is gated on an upstream it never
registered — which nothing can schedule, because the only thing that would
produce it is the very task being gated. Permanent deadlock, and the shape the
cross-build blocker machinery was built to _describe_ rather than prevent.

**Fix.** Registration admits incomplete upstreams into the plan, transitively,
stopping at complete tasks. Admission is a status-neutral `TASK_REFERENCED`:
the upstream's own state is untouched, it simply becomes part of this build's
plan, which is what makes it schedulable here.

Over-approximating is safe, under-approximating is not: a stale edge costs one
unnecessary upstream — wasted work, correct outcome — while a missing one
deadlocks.

`RUNNING` upstreams are admitted **too**. Excluding them was wrong, not merely
conservative: closure runs once, at registration, and RUNNING is transient, so
the moment the task stops running the exclusion becomes a permanent hole in
the plan — and the likeliest way for it to stop running is an operator
releasing a stale claim, i.e. the documented remedy stranding every build that
inherited the dependency. The objection was that a task this build did not
start lands in its own `running`, where its liveness heuristics may act on it;
that is correct behaviour, because the destructive action is gated on the
claim's expiry, and past the expiry the server hands the task to whoever asks
next. Which build started it was never what made recovery safe — the claim is.

### Intended visible consequence

An incomplete upstream now belongs to the build that depends on it, so the
graph view reports it as **primary** rather than context, and `upstream_depth`
reveals only _complete_ upstreams. Three graph tests say so now;
`depth_limiting` completes its chain, since depth limiting governs context
nodes and an incomplete upstream is no longer one.

## 2. One build's fail-fast became every overlapping build's failure

Build A starts a shared task, hits an unrelated failure, and cascade-cancels
what it started — correctly: it owns those claims, and releasing them is the
point. But the task is left `CANCELLED`, which is not schedulable. Build B,
which shares the dependency and has failed at nothing, found it in its **own
plan**, could not run it, and died on it too.

Nothing owned that task any more: no claim, no live execution, and the build
that last touched it was gone.

**Fix.** A tick meeting a `CANCELLED` blocker resets it and schedules it next
pass instead of failing. Bounded by the existing per-task attempt budget, so a
task that fails every time is retried until the budget is spent and then fails
the build honestly.

Needs `FrontierExternalBlocker.blocking_attempt_count` — attempts spent in
_this_ build's round, for in-plan blockers only. Additive; a server without it
reports `None`, which refuses the retry and preserves today's behaviour.

## 3. …but a failure is not a cancellation

The first cut of #2 reset the whole retryable set. That is right for exactly
one status, and the line it draws is between a revocation of permission to run
and a statement about the task:

| Status      | Another build's tick, mid-flight                | At trigger / resume |
| ----------- | ----------------------------------------------- | ------------------- |
| `CANCELLED` | **reset and run** — a revocation, not a verdict | reset               |
| `FAILED`    | leave — a _result_; `fail_mode` owns it         | reset               |
| `SKIPPED`   | leave — a consequence of a failure              | reset               |
| `SUSPENDED` | leave — the owning build is progressing it      | reset               |
| `RUNNING`   | leave — the claim is coordinating               | **not** reset       |
| `COMPLETED` | n/a                                             | pruned              |

Resetting a `FAILED` blocker reruns a task that just reported it does not
work, on nobody's request, and overrides the `fail_mode` the build was
triggered with. Resetting a `SUSPENDED` one redoes all of the task's pre-yield
work while the owning build is legitimately mid-flight through the dynamic
dependencies it yielded, and races that build's own scheduling of them.

The asymmetry with the right-hand column is the point: at trigger _you asked_,
so retrying a previous failure is what you meant.

This was a **latent** gap, not active misbehaviour — the test fake never
reported a dep added via `add_task` as a blocker at all, so nothing
constructed a cross-build `failed` blocker with budget remaining. The new
tests construct it, and fail without the narrowing.

### What that lets us delete

With plan membership no longer deciding anything, the `blocking_in_build ==
False` branch goes and the partition is driven by status alone. Also gone: the
remediation copy addressed to another build, the out-of-plan clause in the
fatal message, the UI's "never registered the blocking task" branch, and the
two-remedy split in the CLI and its docs. None of it was ever released.

There is one remedy now, and it is local: **re-trigger this build**, which
resets the whole retryable set because the blocker is in its plan. An
out-of-plan blocker excludes itself from the reset without a plan check — the
server reports no attempt count for one, and a missing count refuses the
retry.

What **survives**, and was nearly deleted with the rest: the claim-expiry read
for `RUNNING` blockers, the owning-build liveness lookup, the
executing/queued/fatal partition and the wait-or-fail decision. A closed plan
still contains tasks this build must not touch — a `SUSPENDED` shared task
being progressed by the build that suspended it is the case that matters — and
for those the owner's status is the only liveness evidence that exists,
because a task holding no claim carries no expiry to read. That wait is
bounded: `SUSPENDED` persists only while the owner progresses the children,
and an owner stuck on one is stuck on a `RUNNING` task whose claim expires.

`blocking_in_build` stays on the wire, and the UI keeps its chip, as a
diagnostic for builds registered before closure existed. Nothing branches on
it.

Cascade-cancel's ownership check is unchanged. That is authority to _revoke_,
which must stay build-scoped: cancelling build B must not release claims held
by build C's live workers.

---

## Tests

- a cancelled in-plan blocker is reset and scheduled, not failed
- a `failed` / `skipped` in-plan blocker is **not** reset — budget deliberately
  intact, so the status is what decides
- a `suspended` in-plan blocker is waited on, not reset, while its owner lives
- …and fails, naming the blocker, once that owner is terminal and the child's
  claim has lapsed
- the reset respects the attempt budget
- an in-plan blocker in a status nothing moves still fails, and is named
- the frontier reports attempts for an in-plan blocker, `None` outside it
- a build inherits an upstream reachable only by another build's dynamic edge
- closure stops at complete upstreams (no historical ancestry dragged in)
- CLI and UI copy is chosen by status, and the plan-membership split is gone

Verified that the cancelled-reset, the dynamic-edge inheritance and all three
narrowing tests fail without their fixes.

**562** API tests against real PostgreSQL, **1272** SDK, **171** UI.

Live-verified on a Modal + Neon deployment: two builds sharing a task, where
B inherited the running shared task without registering it, A fail-fast
cancelled it, and B's tick reset it and carried on. Before this, B failed.
