### PR TITLE
fix(ui): re-read the task after a claim action (closes #236)

### DIFF
--- a/app/stardag-ui/src/components/ClaimTriage.tsx
+++ b/app/stardag-ui/src/components/ClaimTriage.tsx
@@ -62,6 +62,14 @@ interface ClaimTriageProps {
   selectedTaskId: string | null;
   onSelectTask: (task: Task) => void;
   onNavigateToBuild?: (buildId: string) => void;
+  /**
+   * Bumped by the parent when something outside this list changed a task —
+   * a claim action taken in the detail panel, say. This list reloads itself
+   * after its own bulk release, but it cannot see writes it did not make,
+   * and a released claim still listed as held is an invitation to release
+   * it again.
+   */
+  reloadToken?: number;
 }
 
 /**
@@ -81,6 +89,7 @@ export function ClaimTriage({
   selectedTaskId,
   onSelectTask,
   onNavigateToBuild,
+  reloadToken = 0,
 }: ClaimTriageProps) {
   const { activeWorkspaceRole } = useEnvironment();
   const isAdmin = activeWorkspaceRole === "owner" || activeWorkspaceRole === "admin";
@@ -142,7 +151,7 @@ export function ClaimTriage({
     // `statuses` is covered by the derived `statusKey`; listing the array
     // itself would refetch on every render.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [environmentId, page, statusKey, ageSeconds, reloadNonce]);
+  }, [environmentId, page, statusKey, ageSeconds, reloadNonce, reloadToken]);
 
   // Reset to page 1 when the filters change under the user.
   useEffect(() => {

--- a/app/stardag-ui/src/components/ConcurrencyLimits.tsx
+++ b/app/stardag-ui/src/components/ConcurrencyLimits.tsx
@@ -399,7 +399,18 @@ export function ConcurrencyLimits() {
       {/* Holder task detail panel */}
       {selectedTask && (
         <div className="w-96 flex-shrink-0 border-l border-gray-200 dark:border-gray-700">
-          <TaskDetail task={selectedTask} onClose={() => setSelectedTask(null)} />
+          <TaskDetail
+            task={selectedTask}
+            onClose={() => setSelectedTask(null)}
+            // Releasing a holder's claim frees the slot it occupies, so both
+            // the holder list and the limit's own counts are stale the moment
+            // the panel's write lands.
+            onTaskCancelled={() => {
+              if (expandedKey) void loadHolders(expandedKey);
+              void loadLimits();
+              setSelectedTask(null);
+            }}
+          />
         </div>
       )}
     </div>

--- a/app/stardag-ui/src/components/TaskDetail.test.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.test.tsx
@@ -318,6 +318,7 @@ describe("TaskDetail claim holder", () => {
         task={makeTask()}
         buildId={VIEWED_BUILD}
         onClose={() => {}}
+        onTaskCancelled={() => {}}
         onStatusBuildClick={onStatusBuildClick}
       />,
     );
@@ -364,12 +365,14 @@ describe("TaskDetail claim holder", () => {
 
   it("offers a reset as well for a suspended task, and retries under the holder", async () => {
     vi.mocked(retryTask).mockResolvedValue(undefined);
+    const onTaskCancelled = vi.fn();
     const user = userEvent.setup();
     render(
       <TaskDetail
         task={makeTask({ status: "suspended", latest_status: "suspended" })}
         buildId={VIEWED_BUILD}
         onClose={() => {}}
+        onTaskCancelled={onTaskCancelled}
       />,
     );
 
@@ -380,11 +383,23 @@ describe("TaskDetail claim holder", () => {
     await waitFor(() =>
       expect(retryTask).toHaveBeenCalledWith(HOLDER_BUILD, "tid-grind-beans", "env-1"),
     );
+    // The reset path has to ask for a re-read too. This panel renders the
+    // status — and the claim notice with it — from its `task` prop, so a parent
+    // that is not told keeps showing "holding an execution claim" for a task
+    // that was just reset to pending.
+    expect(onTaskCancelled).toHaveBeenCalled();
   });
 
   it("hides the remedies from non-admin members but keeps the diagnosis", async () => {
     mockWorkspaceRole = "member";
-    render(<TaskDetail task={makeTask()} buildId={VIEWED_BUILD} onClose={() => {}} />);
+    render(
+      <TaskDetail
+        task={makeTask()}
+        buildId={VIEWED_BUILD}
+        onClose={() => {}}
+        onTaskCancelled={() => {}}
+      />,
+    );
 
     expect(
       await screen.findByText("Execution claim held by another build"),
@@ -403,6 +418,7 @@ describe("TaskDetail claim holder", () => {
         task={makeTask({ status: "completed", latest_status: "completed" })}
         buildId={VIEWED_BUILD}
         onClose={() => {}}
+        onTaskCancelled={() => {}}
       />,
     );
     expect(await screen.findByText("GrindBeans")).toBeInTheDocument();
@@ -411,7 +427,9 @@ describe("TaskDetail claim holder", () => {
 
   it("reports the holder without cross-build wording when no build is in view", async () => {
     // The task explorer renders this panel with no build context.
-    render(<TaskDetail task={makeTask()} onClose={() => {}} />);
+    render(
+      <TaskDetail task={makeTask()} onClose={() => {}} onTaskCancelled={() => {}} />,
+    );
     expect(await screen.findByText("Holding an execution claim")).toBeInTheDocument();
     expect(screen.queryByText(/not the build you are viewing/)).not.toBeInTheDocument();
   });

--- a/app/stardag-ui/src/components/TaskDetail.tsx
+++ b/app/stardag-ui/src/components/TaskDetail.tsx
@@ -300,7 +300,19 @@ interface TaskDetailProps {
   task: Task;
   buildId?: string;
   onClose: () => void;
-  onTaskCancelled?: () => void;
+  /**
+   * Called after this panel's own write changed the task — a claim action or
+   * the cancel button.
+   *
+   * **Required on purpose.** This panel renders the task's status, and the
+   * "holding an execution claim" notice with it, from the `task` prop — a
+   * snapshot its parent handed it. It has no way to re-read that itself, so a
+   * parent that omits the callback leaves the panel asserting a claim is held
+   * seconds after the user released it: an instruction to act, still on screen
+   * after acting. That is exactly what happened while this was optional, so it
+   * is now a type error to forget rather than a defect to notice.
+   */
+  onTaskCancelled: () => void;
   onStatusBuildClick?: (buildId: string) => void;
 }
 
@@ -422,7 +434,7 @@ export function TaskDetail({
     if (!confirmed) return;
 
     if (await runTaskAction("release", buildId)) {
-      onTaskCancelled?.();
+      onTaskCancelled();
     }
   };
 
@@ -435,7 +447,7 @@ export function TaskDetail({
           : `Reset to pending under build ${holderBuildId.slice(0, 8)}.`,
       );
       setClaimAction(null);
-      onTaskCancelled?.();
+      onTaskCancelled();
     }
   }, [claimAction, holderBuildId, runTaskAction, onTaskCancelled]);
 

--- a/app/stardag-ui/src/components/TaskExplorer.tsx
+++ b/app/stardag-ui/src/components/TaskExplorer.tsx
@@ -172,14 +172,23 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
     if (!selectedTask) return;
     // Merged rather than replaced: `fetchTask` returns a `Task`, while the
     // selection is a `TaskSearchResult` carrying search-only extras (artifact
-    // columns) that a plain assignment would drop. Guarded on the id so a slow
-    // response cannot land on a different row the user has since selected, and
-    // swallowed on failure — the list refetch is what guarantees the view
-    // converges, and one failed row re-read must not clear a live selection.
-    void fetchTask(selectedTask.task_id, selectedTask.environment_id)
+    // columns) that a plain assignment would drop. Failure is swallowed — the
+    // list refetch is what guarantees the view converges, and one failed row
+    // re-read must not clear a live selection.
+    //
+    // Guarded on (environment, task), not the task alone. `task_id` is a
+    // content hash and rows are unique per `(environment_id, task_id)`, so the
+    // *same* id legitimately exists in two environments: switch environment
+    // while this is in flight, select the same task there, and an id-only
+    // guard would merge the previous environment's row into it.
+    const requestedTaskId = selectedTask.task_id;
+    const requestedEnvironmentId = selectedTask.environment_id;
+    void fetchTask(requestedTaskId, requestedEnvironmentId)
       .then((fresh) =>
         setSelectedTask((latest) =>
-          latest && latest.task_id === fresh.task_id
+          latest &&
+          latest.task_id === requestedTaskId &&
+          latest.environment_id === requestedEnvironmentId
             ? ({ ...latest, ...fresh } as TaskSearchResult)
             : latest,
         ),

--- a/app/stardag-ui/src/components/TaskExplorer.tsx
+++ b/app/stardag-ui/src/components/TaskExplorer.tsx
@@ -160,6 +160,32 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
 
   // Selected task for detail view
   const [selectedTask, setSelectedTask] = useState<TaskSearchResult | null>(null);
+  // Bumped whenever a write from the detail panel changed a task. Both list
+  // modes take it as a refetch trigger, and the selected task is re-read with
+  // it: `TaskDetail` renders "Holding an execution claim" off the object this
+  // component handed it, so without the re-read a released claim keeps being
+  // reported as held — an instruction to act, still on screen after acting.
+  const [taskChangeNonce, setTaskChangeNonce] = useState(0);
+
+  const handleTaskChanged = useCallback(() => {
+    setTaskChangeNonce((n) => n + 1);
+    if (!selectedTask) return;
+    // Merged rather than replaced: `fetchTask` returns a `Task`, while the
+    // selection is a `TaskSearchResult` carrying search-only extras (artifact
+    // columns) that a plain assignment would drop. Guarded on the id so a slow
+    // response cannot land on a different row the user has since selected, and
+    // swallowed on failure — the list refetch is what guarantees the view
+    // converges, and one failed row re-read must not clear a live selection.
+    void fetchTask(selectedTask.task_id, selectedTask.environment_id)
+      .then((fresh) =>
+        setSelectedTask((latest) =>
+          latest && latest.task_id === fresh.task_id
+            ? ({ ...latest, ...fresh } as TaskSearchResult)
+            : latest,
+        ),
+      )
+      .catch(() => undefined);
+  }, [selectedTask]);
 
   // Update breadcrumb navigation
   useEffect(() => {
@@ -452,6 +478,7 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
     sortBy,
     sortDir,
     visibleArtifactNames,
+    taskChangeNonce,
   ]);
 
   useEffect(() => {
@@ -886,6 +913,7 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
                   selectedTaskId={selectedTask?.task_id ?? null}
                   onSelectTask={(task) => setSelectedTask(task as TaskSearchResult)}
                   onNavigateToBuild={onNavigateToBuild}
+                  reloadToken={taskChangeNonce}
                 />
               ) : (
                 <>
@@ -1056,6 +1084,7 @@ export function TaskExplorer({ onNavigateToBuild }: TaskExplorerProps) {
                   <TaskDetail
                     task={selectedTask as Task}
                     onClose={() => setSelectedTask(null)}
+                    onTaskCancelled={handleTaskChanged}
                   />
                 </div>
               </Panel>


### PR DESCRIPTION
Closes #236.

## The bug

`TaskDetail` renders the task's status — and the **"holding an execution claim"** notice with it — from its `task` **prop**, a snapshot its parent handed it when the row was selected. It calls `onTaskCancelled` after its own writes so the parent can re-read.

`BuildView` wires that callback. `TaskExplorer` did not:

```tsx
<TaskDetail task={selectedTask as Task} onClose={() => setSelectedTask(null)} />
```

So releasing or resetting a claim from **Task Explorer → Claims** succeeded, showed its inline confirmation, and left the panel still asserting the claim was held until the page was reloaded.

That is worse than cosmetic: the notice it fails to clear is an instruction to act. Having just released a claim you are shown a panel saying the task still holds one — inviting a second release against a task that no longer holds anything, which is precisely what the disabled checkboxes elsewhere in that view were added to prevent.

## The fix

`TaskExplorer` passes a handler that re-reads the selected task and refetches whichever list is showing (`ClaimTriage` gains a `reloadToken`; the search path joins the existing nonce).

The selected task is **merged, not replaced** — `fetchTask` returns a `Task` while the selection is a `TaskSearchResult` carrying search-only artifact columns that assignment would drop. The re-read is id-guarded, so a slow response cannot land on a row the user has since selected, and its failure is swallowed: the list refetch is what guarantees convergence, and one failed row read must not clear a live selection.

## `onTaskCancelled` is now required

This is the part that stops it recurring. The panel cannot re-read on its own, so a parent that omits the callback is *always* wrong — better a type error than a defect someone notices in a UI review.

Making it required immediately found a **third call site**: `ConcurrencyLimits` renders the same panel with the same bug, and there releasing a holder's claim frees a concurrency slot, so both the holder list and the limit's counts go stale. Fixed here too.

## Tests

The release path already asserted the callback fires. The reset path — the one this was reported through — did not; it does now. The missing *wiring* is covered by `tsc` rather than by a render test, which is both stronger and cheaper than mounting `TaskExplorer` with its full dependency surface.

171 UI tests pass; eslint and tsc clean.