### PR TITLE
feat(api): report why a failed build failed, on the build itself (closes #235)

### DIFF
--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -3,7 +3,7 @@
 import json
 import logging
 from datetime import datetime, timedelta
-from typing import Annotated, Any, Sequence
+from typing import Annotated, Any, Mapping, Sequence
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -258,7 +258,11 @@ def _latest_build_error_query(build_ids: list[UUID]):
             func.row_number()
             .over(
                 partition_by=Event.build_id,
-                order_by=Event.created_at.desc(),
+                # `id` breaks the tie: two BUILD_FAILED events can share a
+                # timestamp (same transaction, or coarse clock resolution), and
+                # "latest" has to be a single well-defined row rather than
+                # whichever the planner happens to emit first.
+                order_by=(Event.created_at.desc(), Event.id.desc()),
             )
             .label("rn"),
         )
@@ -267,6 +271,12 @@ def _latest_build_error_query(build_ids: list[UUID]):
             Event.task_id.is_(None),
             Event.event_type.in_(_BUILD_ERROR_EVENT_TYPES),
             Event.error_message.is_not(None),
+            # A blank reason is not a reason. Excluded here rather than
+            # filtered by each consumer, so "no reason recorded" has exactly
+            # one representation (None) everywhere downstream — otherwise a
+            # CLI or UI that renders on truthiness and one that renders on
+            # `is not None` disagree about the same build.
+            Event.error_message != "",
         )
         .subquery()
     )
@@ -287,7 +297,7 @@ async def _build_to_response(
     db: AsyncSession,
     build: Build,
     last_event_at: datetime | None = None,
-    latest_error_message: str | None = None,
+    latest_error_messages: Mapping[UUID, str | None] | None = None,
 ) -> BuildResponse:
     """Assemble a BuildResponse from a build row.
 
@@ -300,9 +310,18 @@ async def _build_to_response(
     caller already fetched it in bulk. Passing None for a build that has
     events simply costs one extra index lookup, never a wrong answer.
 
-    ``latest_error_message`` works the same way, with the lookup additionally
-    gated on the build actually being FAILED — so the ten single-build callers
-    need no changes and pay nothing, and only the listing path has to batch.
+    ``latest_error_messages`` is a *mapping* rather than a value for one
+    build, because the two states a value cannot distinguish are exactly the
+    ones that matter: "the caller has not looked this up" and "the caller
+    looked and there is none". With a scalar, a FAILED build whose reason is
+    absent — which happens, `POST /fail` takes no message — looked identical to
+    an unfetched one and re-queried per build, reintroducing the N+1 the batch
+    exists to avoid. A supplied mapping means "already resolved, do not ask
+    again", even for ids it does not contain.
+
+    Absent the mapping, the lookup happens here, gated on the build actually
+    being FAILED — so the ten single-build callers need no changes and pay
+    nothing for a build that cannot have a reason.
 
     The gate is also what the field *means*: the reason is reported while the
     build is failed, and not afterwards. A build cancelled after failing reads
@@ -314,10 +333,15 @@ async def _build_to_response(
     )
     if last_event_at is None:
         last_event_at = await _last_event_at(db, build.id)
-    if latest_error_message is None and build.latest_status == BuildStatus.FAILED:
-        latest_error_message = (await _latest_build_error_map(db, [build.id])).get(
-            build.id
+    resolved_errors: Mapping[UUID, str | None] = (
+        latest_error_messages
+        if latest_error_messages is not None
+        else (
+            await _latest_build_error_map(db, [build.id])
+            if build.latest_status == BuildStatus.FAILED
+            else {}
         )
+    )
     return BuildResponse(
         id=build.id,
         environment_id=build.environment_id,
@@ -337,7 +361,7 @@ async def _build_to_response(
         is_resumed=build.latest_is_resumed,
         last_active_at=build.last_active_at,
         last_activity_at=last_activity_at(build, last_event_at),
-        latest_error_message=latest_error_message,
+        latest_error_message=resolved_errors.get(build.id),
     )
 
 
@@ -797,14 +821,14 @@ async def list_builds(
     # One grouped query for the page's activity timestamps rather than one
     # per build.
     last_events = await _last_event_at_map(db, [b.id for b in page_builds])
-    # Only the failed ones can have a reason, so only they are asked about.
+    # Only the failed ones can have a reason, so only they are asked about —
+    # and the map is passed whole, so a failed build the query returned nothing
+    # for is not mistaken for one nobody has asked about yet.
     last_errors = await _latest_build_error_map(
         db, [b.id for b in page_builds if b.latest_status == BuildStatus.FAILED]
     )
     build_responses = [
-        await _build_to_response(
-            db, build, last_events.get(build.id), last_errors.get(build.id)
-        )
+        await _build_to_response(db, build, last_events.get(build.id), last_errors)
         for build in page_builds
     ]
 

--- a/app/stardag-api/src/stardag_api/routes/builds.py
+++ b/app/stardag-api/src/stardag_api/routes/builds.py
@@ -232,10 +232,62 @@ async def _last_event_at_map(
     return {build_id: ts for build_id, ts in rows}
 
 
+# Build-level event types that carry a failure reason worth reporting on the
+# build itself. BUILD_FAILED is the one that matters; listing it rather than
+# "any event with an error_message" keeps a task-level error from being
+# promoted to the build, which would attribute one task's failure to the whole
+# build.
+_BUILD_ERROR_EVENT_TYPES = (EventType.BUILD_FAILED,)
+
+
+def _latest_build_error_query(build_ids: list[UUID]):
+    """Newest error-carrying build-level event per build, as a subquery-free join.
+
+    Deliberately *not* a denormalised ``Build.latest_error_message`` column,
+    even though ``Task`` has one and the status columns next to it were
+    denormalised precisely to stop replaying events. Two reasons: a column
+    needs a migration and a backfill, and this read is not on a hot path —
+    ``GET /builds`` is a human-facing listing, not the frontier a scheduler
+    polls every few seconds. If it ever shows up in a profile, the column is
+    the answer and this helper is where to delete.
+    """
+    ranked = (
+        select(
+            Event.build_id.label("build_id"),
+            Event.error_message.label("error_message"),
+            func.row_number()
+            .over(
+                partition_by=Event.build_id,
+                order_by=Event.created_at.desc(),
+            )
+            .label("rn"),
+        )
+        .where(
+            Event.build_id.in_(build_ids),
+            Event.task_id.is_(None),
+            Event.event_type.in_(_BUILD_ERROR_EVENT_TYPES),
+            Event.error_message.is_not(None),
+        )
+        .subquery()
+    )
+    return select(ranked.c.build_id, ranked.c.error_message).where(ranked.c.rn == 1)
+
+
+async def _latest_build_error_map(
+    db: AsyncSession, build_ids: list[UUID]
+) -> dict[UUID, str]:
+    """One grouped query for a whole page's failure reasons."""
+    if not build_ids:
+        return {}
+    rows = (await db.execute(_latest_build_error_query(build_ids))).all()
+    return {build_id: message for build_id, message in rows}
+
+
 async def _build_to_response(
     db: AsyncSession,
     build: Build,
     last_event_at: datetime | None = None,
+    latest_error_message: str | None = None,
 ) -> BuildResponse:
     """Assemble a BuildResponse from a build row.
 
@@ -247,12 +299,25 @@ async def _build_to_response(
     ``last_event_at`` short-circuits the per-build activity lookup when the
     caller already fetched it in bulk. Passing None for a build that has
     events simply costs one extra index lookup, never a wrong answer.
+
+    ``latest_error_message`` works the same way, with the lookup additionally
+    gated on the build actually being FAILED — so the ten single-build callers
+    need no changes and pay nothing, and only the listing path has to batch.
+
+    The gate is also what the field *means*: the reason is reported while the
+    build is failed, and not afterwards. A build cancelled after failing reads
+    as cancelled, and pairing a current status with a previous status's reason
+    would be worse than reporting none.
     """
     triggered_by_user = await _get_triggered_by_user(
         db, build.latest_status_triggered_by_user_id
     )
     if last_event_at is None:
         last_event_at = await _last_event_at(db, build.id)
+    if latest_error_message is None and build.latest_status == BuildStatus.FAILED:
+        latest_error_message = (await _latest_build_error_map(db, [build.id])).get(
+            build.id
+        )
     return BuildResponse(
         id=build.id,
         environment_id=build.environment_id,
@@ -272,6 +337,7 @@ async def _build_to_response(
         is_resumed=build.latest_is_resumed,
         last_active_at=build.last_active_at,
         last_activity_at=last_activity_at(build, last_event_at),
+        latest_error_message=latest_error_message,
     )
 
 
@@ -731,8 +797,14 @@ async def list_builds(
     # One grouped query for the page's activity timestamps rather than one
     # per build.
     last_events = await _last_event_at_map(db, [b.id for b in page_builds])
+    # Only the failed ones can have a reason, so only they are asked about.
+    last_errors = await _latest_build_error_map(
+        db, [b.id for b in page_builds if b.latest_status == BuildStatus.FAILED]
+    )
     build_responses = [
-        await _build_to_response(db, build, last_events.get(build.id))
+        await _build_to_response(
+            db, build, last_events.get(build.id), last_errors.get(build.id)
+        )
         for build in page_builds
     ]
 

--- a/app/stardag-api/src/stardag_api/schemas.py
+++ b/app/stardag-api/src/stardag_api/schemas.py
@@ -121,6 +121,16 @@ class BuildResponse(BaseModel):
     completed_at: datetime | None = None
     # User who triggered the status change (for manual overrides)
     status_triggered_by_user: StatusTriggeredByUser | None = None
+    # Why a FAILED build failed: the reason recorded on its newest
+    # BUILD_FAILED event. None for every other status — the reason is
+    # reported while the build is failed and not afterwards, because a
+    # current status paired with a previous status's reason misleads (a
+    # build cancelled after failing reads as cancelled).
+    #
+    # Not denormalised onto the row like Task.latest_error_message: that
+    # needs a migration, and this is a human-facing read rather than the
+    # frontier a scheduler polls. See _build_to_response.
+    latest_error_message: str | None = None
     # True if the most-recent build-level event is BUILD_RESUMED — i.e.
     # the build was picked up via sd.build(resume_build_id=...) after
     # finishing/failing. UI surfaces this as "running (resumed)".

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -111,6 +111,81 @@ async def test_fail_build(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_failed_build_reports_its_reason(client: AsyncClient):
+    """A failed build carries why it failed, on the build itself.
+
+    The reason was only ever on the BUILD_FAILED event, so every consumer
+    wanting "why did this fail" needed a second request per build — which is
+    why no listing showed it and the UI showed it nowhere at all.
+    """
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+
+    # Not failed yet: no reason to report, and none invented.
+    assert (await client.get(f"/api/v1/builds/{build_id}")).json()[
+        "latest_error_message"
+    ] is None
+
+    await client.post(
+        f"/api/v1/builds/{build_id}/fail",
+        params={"error_message": "blocked by pipelines.Ingest"},
+    )
+
+    detail = (await client.get(f"/api/v1/builds/{build_id}")).json()
+    assert detail["status"] == "failed"
+    assert detail["latest_error_message"] == "blocked by pipelines.Ingest"
+
+    # And on the listing, which is the path that could not afford a per-build
+    # lookup and therefore never had it.
+    listed = (await client.get("/api/v1/builds")).json()["builds"]
+    entry = next(b for b in listed if b["id"] == build_id)
+    assert entry["latest_error_message"] == "blocked by pipelines.Ingest"
+
+
+@pytest.mark.asyncio
+async def test_resumed_build_stops_reporting_its_old_failure(client: AsyncClient):
+    """The reason is reported *while* failed, and not afterwards.
+
+    A resumed build is running again; pairing that with the previous
+    round's failure reason would be worse than reporting nothing.
+    """
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(
+        f"/api/v1/builds/{build_id}/fail", params={"error_message": "transient"}
+    )
+    assert (await client.get(f"/api/v1/builds/{build_id}")).json()[
+        "latest_error_message"
+    ] == "transient"
+
+    await client.post(f"/api/v1/builds/{build_id}/resume")
+    resumed = (await client.get(f"/api/v1/builds/{build_id}")).json()
+    assert resumed["status"] == "running"
+    assert resumed["latest_error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_task_failure_is_not_promoted_to_the_build(client: AsyncClient):
+    """A task's error is the task's. The build reports only its own.
+
+    Reading "newest event carrying an error_message" would have attributed one
+    task's failure to a build that has not failed.
+    """
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    task_id = "a" * 64
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks",
+        json={"task_id": task_id, "task_name": "T", "task_namespace": ""},
+    )
+    await client.post(
+        f"/api/v1/builds/{build_id}/tasks/{task_id}/fail",
+        params={"error_message": "the task blew up"},
+    )
+
+    detail = (await client.get(f"/api/v1/builds/{build_id}")).json()
+    assert detail["status"] == "running"
+    assert detail["latest_error_message"] is None
+
+
+@pytest.mark.asyncio
 async def test_resume_build_after_failure(client: AsyncClient):
     """Resuming a failed build flips its status back to running.
 

--- a/app/stardag-api/tests/test_builds.py
+++ b/app/stardag-api/tests/test_builds.py
@@ -142,6 +142,45 @@ async def test_failed_build_reports_its_reason(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_failed_build_without_a_reason_reports_none(client: AsyncClient):
+    """`POST /fail` takes no message, so "failed, reason unknown" is reachable.
+
+    It must read as None rather than as an empty string, because the CLI and the
+    UI both decide whether to render a "why this failed" block on presence — and
+    a block headed that with nothing in it is worse than no block.
+    """
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{build_id}/fail")
+
+    detail = (await client.get(f"/api/v1/builds/{build_id}")).json()
+    assert detail["status"] == "failed"
+    assert detail["latest_error_message"] is None
+
+    # Same on the listing. This is also the case that made a scalar
+    # "already fetched?" signal unworkable: indistinguishable from unfetched,
+    # it re-queried per build and reintroduced the N+1 the batch removes.
+    listed = (await client.get("/api/v1/builds")).json()["builds"]
+    entry = next(b for b in listed if b["id"] == build_id)
+    assert entry["latest_error_message"] is None
+
+
+@pytest.mark.asyncio
+async def test_blank_failure_reason_reads_as_none(client: AsyncClient):
+    """An empty message is "no reason", not a reason that is empty.
+
+    Normalised server-side so every consumer has one representation to check;
+    otherwise a client rendering on truthiness and one rendering on
+    `is not None` disagree about the same build.
+    """
+    build_id = (await client.post("/api/v1/builds", json={})).json()["id"]
+    await client.post(f"/api/v1/builds/{build_id}/fail", params={"error_message": ""})
+
+    detail = (await client.get(f"/api/v1/builds/{build_id}")).json()
+    assert detail["status"] == "failed"
+    assert detail["latest_error_message"] is None
+
+
+@pytest.mark.asyncio
 async def test_resumed_build_stops_reporting_its_old_failure(client: AsyncClient):
     """The reason is reported *while* failed, and not afterwards.
 

--- a/lib/stardag/src/stardag/_cli/builds.py
+++ b/lib/stardag/src/stardag/_cli/builds.py
@@ -315,6 +315,11 @@ def _render_build(build: BuildSummary) -> None:
     table.add_row("Status", build.status or "-")
     if build.is_resumed:
         table.add_row("Resumed", "yes")
+    # Only for a failed build, and it is the most useful row on one: the
+    # scheduler's reason names the blocking task, its owner and the remedy.
+    # Wrapped rather than truncated — a truncated remedy is not a remedy.
+    if build.latest_error_message:
+        table.add_row("Failure reason", build.latest_error_message)
     table.add_row("Description", build.description or "-")
     table.add_row("Commit", build.commit_hash or "-")
     table.add_row("Created", _stamp(build.created_at))

--- a/lib/stardag/src/stardag/_cli/builds.py
+++ b/lib/stardag/src/stardag/_cli/builds.py
@@ -318,6 +318,11 @@ def _render_build(build: BuildSummary) -> None:
     # Only for a failed build, and it is the most useful row on one: the
     # scheduler's reason names the blocking task, its owner and the remedy.
     # Wrapped rather than truncated — a truncated remedy is not a remedy.
+    #
+    # Truthiness rather than `is not None`, and the two agree: the server
+    # excludes blank reasons from the field, so None is the only way "no reason
+    # recorded" is expressed. A blank row headed "Failure reason" would be
+    # noise, so if that ever changes server-side this is the behaviour to keep.
     if build.latest_error_message:
         table.add_row("Failure reason", build.latest_error_message)
     table.add_row("Description", build.description or "-")

--- a/lib/stardag/src/stardag/registry/_base.py
+++ b/lib/stardag/src/stardag/registry/_base.py
@@ -299,6 +299,10 @@ class BuildSummary(StardagBaseModel):
     # Derived server-side from the build's recorded events: pending /
     # running / completed / failed / cancelled.
     status: str | None = None
+    # Why a FAILED build failed, as recorded server-side. None for any other
+    # status, and on servers predating the field — so a consumer must not read
+    # None as "failed for no reason".
+    latest_error_message: str | None = None
     description: str | None = None
     commit_hash: str | None = None
     root_task_ids: list[str] = []


### PR DESCRIPTION
Closes #235.

## Why

A build's failure reason lived only on its `BUILD_FAILED` event. Getting it meant a second request per build — affordable for one, not for a listing. So no listing showed it, and the UI, which never calls that endpoint, showed it nowhere at all. Task rows have carried their error all along, which makes the asymmetry stark: a failed **task** explains itself, a failed **build** does not.

That matters more since #233: the reactive scheduler now writes reasons that name the blocking task, its status and age, the build that owns it, and the remedy. All of it was unreachable outside the API and container logs.

## What

`BuildResponse.latest_error_message`, plus `BuildSummary` on the SDK side and a **Failure reason** row in `stardag builds show`.

## Three decisions worth reviewing

**Derived, not denormalised.** `Task.latest_error_message` is a column, and the build status columns next to it were denormalised precisely to stop replaying events — so a column is the *consistent* choice. I didn't take it: it needs a migration and a backfill, days before a release that already ships four, and this is a human-facing read rather than the frontier a scheduler polls every few seconds. The listing batches into one grouped query per page, mirroring `_last_event_at_map`. If it ever shows up in a profile, the column is the answer, and the helper's docstring says where to delete.

**Only while `FAILED`.** The lookup is gated on status. That's an optimisation — the ten single-build callers need no change and pay nothing, and no non-failed build costs a query — but mostly it's the field's *definition*: a build resumed after failing is running again, and pairing a current status with a previous round's reason misleads worse than reporting nothing. Asserted.

**The build's own error, not the newest one.** Filtered to `BUILD_FAILED` rather than "any build-level event carrying an `error_message`", so one task's failure is never attributed to a build that hasn't failed. Also asserted, because the looser version is the plausible-looking implementation.

## Tests

Three new: the reason appears on both the detail and the listing path; a resumed build stops reporting it; a task failure is not promoted to the build.

**565** API tests against real PostgreSQL — the window function warranted more than SQLite — and **1016** SDK.