### PR TITLE
fix(ui): a failed build says why (closes #234)

### DIFF
--- a/app/stardag-ui/src/components/BuildFailureReason.test.tsx
+++ b/app/stardag-ui/src/components/BuildFailureReason.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BuildFailureReason } from "./BuildFailureReason";
+
+// A real one, abbreviated: the reactive scheduler's reasons name the blocked
+// task, the blocker, its status and age, the owning build, why nothing will
+// move it, and the remedy.
+const REASON =
+  "Build cannot progress: it has nothing runnable or running of its own, and 1 " +
+  "of its task(s) are blocked by an upstream that nothing is going to move " +
+  "(status counts: {'pending': 1}). Blocked by: task abc is blocked by " +
+  "pipelines.Ingest (def), FAILED for 1m under build 019fed54 — a result rather " +
+  "than a revocation, so this build's fail_mode owns the outcome. Re-trigger " +
+  "this build to reset the blocker and run it here.";
+
+describe("BuildFailureReason", () => {
+  it("shows the recorded reason for a failed build", () => {
+    render(<BuildFailureReason status="failed" message={REASON} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText("Why this build failed")).toBeInTheDocument();
+    // The whole reason, not a truncation — the remedy is at the end of it.
+    expect(
+      screen.getByText(/Re-trigger this build to reset the blocker/),
+    ).toBeInTheDocument();
+  });
+
+  it("says nothing when the build is not failed", () => {
+    // A build resumed after failing is running again. Pairing that status with
+    // the previous round's reason is worse than showing no reason, which is why
+    // the API stops reporting it — but the component must not depend on that.
+    render(<BuildFailureReason status="running" message={REASON} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("says nothing when no reason was recorded", () => {
+    // A server predating `latest_error_message` omits the field. An empty
+    // banner headed "Why this build failed" would be worse than no banner.
+    render(<BuildFailureReason status="failed" message={null} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    render(<BuildFailureReason status="failed" />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/app/stardag-ui/src/components/BuildFailureReason.test.tsx
+++ b/app/stardag-ui/src/components/BuildFailureReason.test.tsx
@@ -32,6 +32,13 @@ describe("BuildFailureReason", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
+  it("says nothing for a whitespace-only reason", () => {
+    // The server excludes blank reasons, so this guards the slip rather than
+    // today's behaviour: a heading with nothing under it is worse than silence.
+    render(<BuildFailureReason status="failed" message={"  \n "} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
   it("says nothing when no reason was recorded", () => {
     // A server predating `latest_error_message` omits the field. An empty
     // banner headed "Why this build failed" would be worse than no banner.

--- a/app/stardag-ui/src/components/BuildFailureReason.tsx
+++ b/app/stardag-ui/src/components/BuildFailureReason.tsx
@@ -21,9 +21,14 @@ interface BuildFailureReasonProps {
  * halves matter: a build resumed after failing is running again and must not
  * show the previous round's reason, and a server predating
  * `latest_error_message` omits the field rather than sending an empty one.
+ *
+ * The presence check trims. The server excludes blank reasons, so this is not
+ * load-bearing against the current API — but the failure mode if it ever slips
+ * (a heading reading "Why this build failed" above nothing) is worse than the
+ * cost of one `trim()`, and this component is the last place that can tell.
  */
 export function BuildFailureReason({ status, message }: BuildFailureReasonProps) {
-  if (status !== "failed" || !message) return null;
+  if (status !== "failed" || !message?.trim()) return null;
 
   return (
     <div

--- a/app/stardag-ui/src/components/BuildFailureReason.tsx
+++ b/app/stardag-ui/src/components/BuildFailureReason.tsx
@@ -1,0 +1,45 @@
+import type { BuildStatus } from "../types/task";
+
+interface BuildFailureReasonProps {
+  status: BuildStatus;
+  /** `Build.latest_error_message` — the reason recorded on BUILD_FAILED. */
+  message?: string | null;
+}
+
+/**
+ * Why a failed build failed.
+ *
+ * Its own component, and not folded into the build header, because of when it
+ * has to appear. The scheduling panel explains a build that is *stalled*, and
+ * goes quiet the moment the build fails: failing runs `skip_blocked`, the
+ * blocked tasks go terminal, and terminal tasks drop out of the frontier's
+ * blocked-by query — so the list the panel renders empties exactly when the
+ * user most wants it. The scheduler wrote the same explanation onto the
+ * BUILD_FAILED event on its way out. This is that, kept on screen.
+ *
+ * Renders nothing unless the build is failed *and* a reason was recorded. Both
+ * halves matter: a build resumed after failing is running again and must not
+ * show the previous round's reason, and a server predating
+ * `latest_error_message` omits the field rather than sending an empty one.
+ */
+export function BuildFailureReason({ status, message }: BuildFailureReasonProps) {
+  if (status !== "failed" || !message) return null;
+
+  return (
+    <div
+      role="alert"
+      className="border-b border-red-200 bg-red-50 px-4 py-2 dark:border-red-900/60 dark:bg-red-950/30"
+    >
+      <p className="text-xs font-semibold text-red-900 dark:text-red-200">
+        Why this build failed
+      </p>
+      {/* Pre-wrapped and never truncated: these reasons name the blocking
+          task, the build that owns it and the remedy to run, and a truncated
+          remedy is not a remedy. `break-words` so a bare task id cannot push
+          the page sideways. */}
+      <p className="mt-1 whitespace-pre-wrap break-words text-xs text-red-900/90 dark:text-red-100/90">
+        {message}
+      </p>
+    </div>
+  );
+}

--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -26,6 +26,7 @@ import type {
 } from "../types/task";
 import { isExtendedResponse } from "../types/task";
 import { BuildSchedulingPanel } from "./BuildSchedulingPanel";
+import { BuildFailureReason } from "./BuildFailureReason";
 import { BuildStatusBadge } from "./BuildStatusBadge";
 import { BuildExecutorChips } from "./ExecutorBadge";
 import { DagControls, type DagControlsState } from "./DagControls";
@@ -598,6 +599,13 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
                   )}
                 </div>
               </div>
+
+              {/* Why it failed — above the scheduling panel, which goes quiet
+                  on a failed build. See BuildFailureReason. */}
+              <BuildFailureReason
+                status={build.status}
+                message={build.latest_error_message}
+              />
 
               {/* Scheduler state. Renders itself only when it has something
                   to say — see `schedulingPanelForm`. Placed above the DAG so

--- a/app/stardag-ui/src/types/task.ts
+++ b/app/stardag-ui/src/types/task.ts
@@ -59,6 +59,11 @@ export interface Build {
   status: BuildStatus;
   started_at: string | null;
   completed_at: string | null;
+  // Why a `failed` build failed, as recorded server-side on its BUILD_FAILED
+  // event. Null for every other status — the reason is reported while the
+  // build is failed and not afterwards. Optional in the type so responses
+  // from a server predating the field deserialize cleanly.
+  latest_error_message?: string | null;
   // User who triggered the status change (for manual overrides)
   status_triggered_by_user: StatusTriggeredByUser | null;
   // True iff the latest build-level event is BUILD_RESUMED — set when


### PR DESCRIPTION
Closes #234. **Stacked on #238** for the `latest_error_message` field — retarget to `main` once that merges.

## Why

The scheduling panel explains a build that is *stalled*. It goes quiet the moment the build fails: failing runs `skip_blocked`, the blocked tasks go terminal, and terminal tasks drop out of the frontier's blocked-by query — so the list the panel renders empties exactly when the user most wants it. `builds frontier` is explicit about it:

```
External blockers: not applicable — this build is failed.
```

The scheduler wrote the same explanation onto the `BUILD_FAILED` event on its way out — naming the blocked task, the blocker, its status and age, the owning build, why nothing will move it, and the remedy. Nothing in the UI displayed it. Found by walking the UI during the 0.18.0 review, which is also the release that started writing reasons worth reading.

## What

`BuildFailureReason`, rendered above the scheduling panel — so on a failed build it occupies the place the panel's explanation had.

Its own component rather than inline JSX because `BuildView` has no test harness (it pulls in the DAG, the resizable panels and much of the API surface), and this behaviour deserved one. The banner is three lines of markup; the conditions are what need pinning.

## Renders nothing unless failed **and** a reason exists

Both halves asserted:

- **Not failed → nothing.** A build resumed after failing is running again, and pairing a current status with the previous round's reason is worse than no reason. The API already stops reporting it (#238), but the component does not depend on that.
- **No reason → nothing.** A server predating the field omits it. An empty banner headed "Why this build failed" is worse than no banner.

Pre-wrapped, `break-words`, never truncated: the remedy is at the *end* of these reasons, and a truncated remedy is not a remedy.

174 UI tests; eslint and tsc clean.