### PR TITLE
docs: the registry ships four migrations, not three

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -79,9 +79,8 @@ of a confusing 404 or 422.
 **Upgrade your registry first.** This SDK uses endpoints and fields added in
 the same release (claim expiry, the frontier's blocker reporting, tick
 summaries, bulk cancel, attempt counts). Against an older registry those
-calls fail. The registry ships three migrations, one of which backfills
-build status and one of which backfills claim expiry — see
-[CHANGELOG.md](CHANGELOG.md).
+calls fail. The registry ships four migrations, two of which backfill data —
+build status, and claim expiry — see [CHANGELOG.md](CHANGELOG.md).
 
 One thing to check before upgrading a registry with long-running work: the
 claim-expiry backfill stamps existing RUNNING tasks with


### PR DESCRIPTION
The v0.18.0 release notes say the registry ships **three** migrations. It ships **four** between `v0.17.0` and `v0.18.0`:

| Migration | Backfills? |
| --- | --- |
| `add_build_tick_summaries` | no |
| `add_tasks_environment_id_latest_status_` (index) | no |
| `add_tasks_latest_status_expires_at_` | **yes** — claim expiry |
| `denormalised_build_status_columns_with_` | **yes** — build status |

So "two of which backfill" was already correct, and the two it names are the right two — the operational guidance holds. Only the count was wrong, and the count is what an operator reconciles against `alembic history` before upgrading.

Caught while dry-running the release-notes → GitHub Release rewrite, after the tag was already pushed. I published the release body as-is rather than hand-editing it, so that the body and the repo file could not silently disagree; once this merges I'll re-run the script to refresh the published body from the corrected source.