### PR TITLE
feat(examples): declare task_modules on the Modal example apps

### DIFF
--- a/lib/stardag-examples/src/stardag_examples/modal/basic/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/basic/app.py
@@ -49,6 +49,11 @@ image = (
 # stardag_api_key_secret=... to override, or None to disable.
 app = sd_modal.StardagApp(
     "stardag_examples-basic",
+    # Declared so a reactive scheduler tick can rebuild these tasks from
+    # registry data rather than from the build task store's pickles, which
+    # need target-root write access at trigger time and are invalidated by a
+    # redeploy. Inference alone only warns; declaring is what enables it.
+    task_modules=["stardag_examples.modal.basic.task"],
     builder_settings=sd_modal.FunctionSettings(image=image),
     worker_settings={
         "default": sd_modal.FunctionSettings(image=image),

--- a/lib/stardag-examples/src/stardag_examples/modal/basic/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/basic/app.py
@@ -49,10 +49,7 @@ image = (
 # stardag_api_key_secret=... to override, or None to disable.
 app = sd_modal.StardagApp(
     "stardag_examples-basic",
-    # Declared so a reactive scheduler tick can rebuild these tasks from
-    # registry data rather than from the build task store's pickles, which
-    # need target-root write access at trigger time and are invalidated by a
-    # redeploy. Inference alone only warns; declaring is what enables it.
+    # Optional: lets reactive ticks rebuild tasks without the pickle store.
     task_modules=["stardag_examples.modal.basic.task"],
     builder_settings=sd_modal.FunctionSettings(image=image),
     worker_settings={

--- a/lib/stardag-examples/src/stardag_examples/modal/ml_pipeline/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/ml_pipeline/app.py
@@ -24,6 +24,11 @@ image = (
 
 app = sd_modal.StardagApp(
     "stardag_examples-ml_pipeline",
+    # Declared so a reactive scheduler tick can rebuild these tasks from
+    # registry data rather than from the build task store's pickles, which
+    # need target-root write access at trigger time and are invalidated by a
+    # redeploy. Inference alone only warns; declaring is what enables it.
+    task_modules=["stardag_examples.ml_pipeline.*"],
     builder_settings=sd_modal.FunctionSettings(
         image=image,
         secrets=[

--- a/lib/stardag-examples/src/stardag_examples/modal/ml_pipeline/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/ml_pipeline/app.py
@@ -24,10 +24,7 @@ image = (
 
 app = sd_modal.StardagApp(
     "stardag_examples-ml_pipeline",
-    # Declared so a reactive scheduler tick can rebuild these tasks from
-    # registry data rather than from the build task store's pickles, which
-    # need target-root write access at trigger time and are invalidated by a
-    # redeploy. Inference alone only warns; declaring is what enables it.
+    # Optional: lets reactive ticks rebuild tasks without the pickle store.
     task_modules=["stardag_examples.ml_pipeline.*"],
     builder_settings=sd_modal.FunctionSettings(
         image=image,

--- a/lib/stardag-examples/src/stardag_examples/modal/prefect/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/prefect/app.py
@@ -19,11 +19,6 @@ image = (
 # logic).
 app = sd_modal.StardagApp(
     "stardag_examples-prefect",
-    # Declared so a reactive scheduler tick can rebuild these tasks from
-    # registry data rather than from the build task store's pickles, which
-    # need target-root write access at trigger time and are invalidated by a
-    # redeploy. Inference alone only warns; declaring is what enables it.
-    task_modules=["stardag_examples.ml_pipeline.*"],
     build_function=sd_modal.PrefectBuilder(),
     builder_settings=sd_modal.FunctionSettings(
         image=image,

--- a/lib/stardag-examples/src/stardag_examples/modal/prefect/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/prefect/app.py
@@ -19,6 +19,11 @@ image = (
 # logic).
 app = sd_modal.StardagApp(
     "stardag_examples-prefect",
+    # Declared so a reactive scheduler tick can rebuild these tasks from
+    # registry data rather than from the build task store's pickles, which
+    # need target-root write access at trigger time and are invalidated by a
+    # redeploy. Inference alone only warns; declaring is what enables it.
+    task_modules=["stardag_examples.ml_pipeline.*"],
     build_function=sd_modal.PrefectBuilder(),
     builder_settings=sd_modal.FunctionSettings(
         image=image,

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/app.py
@@ -67,10 +67,7 @@ image = (
 
 app = sd_modal.StardagApp(
     "stardag_examples-walkthrough",
-    # Declared so a reactive scheduler tick can rebuild these tasks from
-    # registry data rather than from the build task store's pickles, which
-    # need target-root write access at trigger time and are invalidated by a
-    # redeploy. Inference alone only warns; declaring is what enables it.
+    # Optional: lets reactive ticks rebuild tasks without the pickle store.
     task_modules=["stardag_examples.modal.walkthrough.tasks"],
     # Registry credentials are injected into every function automatically
     # from the `stardag-api-key` Modal secret (created via

--- a/lib/stardag-examples/src/stardag_examples/modal/walkthrough/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/walkthrough/app.py
@@ -67,6 +67,11 @@ image = (
 
 app = sd_modal.StardagApp(
     "stardag_examples-walkthrough",
+    # Declared so a reactive scheduler tick can rebuild these tasks from
+    # registry data rather than from the build task store's pickles, which
+    # need target-root write access at trigger time and are invalidated by a
+    # redeploy. Inference alone only warns; declaring is what enables it.
+    task_modules=["stardag_examples.modal.walkthrough.tasks"],
     # Registry credentials are injected into every function automatically
     # from the `stardag-api-key` Modal secret (created via
     # `stardag modal stardag-api-key create`) — StardagApp's default

--- a/lib/stardag-examples/uv.lock
+++ b/lib/stardag-examples/uv.lock
@@ -3886,7 +3886,7 @@ wheels = [
 
 [[package]]
 name = "stardag"
-version = "0.11.0"
+version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -3899,9 +3899,9 @@ dependencies = [
     { name = "typer" },
     { name = "uuid6" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cf/12/42ef3c7b4c55372f3566d0def445320ef359c2e4bc90c176a87843d1e943/stardag-0.11.0.tar.gz", hash = "sha256:0d7b40513adb20db5cf8912c222577ed4276f30e928e1833376b59642d3019e3", size = 606651, upload-time = "2026-07-15T09:40:28.759Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/44/4e/6849bacaf9f622b93f50e196493912b05d953efff142e1648834232aef68/stardag-0.18.0.tar.gz", hash = "sha256:a8781e97a13adc8cee6518589b3c7cc4e7e3b472481992c715a8f8bf4741d1c9", size = 797703, upload-time = "2026-08-11T17:50:36.437Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/93/32314e867a23c161e69c6037563e276f37c4b1ecc1b2a88edc48c9b5b37b/stardag-0.11.0-py3-none-any.whl", hash = "sha256:3d868f39e9e8a8169263681476cf620428e70a7d90a22a78438e53e56c1cf54a", size = 245472, upload-time = "2026-07-15T09:40:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/65/a9/d1828c89a4e773c3fbe66c531c4994123719bdc90d905583c154c0fd0200/stardag-0.18.0-py3-none-any.whl", hash = "sha256:dedaa1eec217e50efc064dc3c9c89f7792d3d633d226fe3e48a6a40414aac9fe", size = 371096, upload-time = "2026-08-11T17:50:34.709Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Post-release follow-up: this needed `stardag` on PyPI, because `lib/stardag-examples` is checked against the **published** SDK and 0.11.0 predates the parameter. The lockfile moves 0.11.0 → 0.18.0 with it.

## Why it matters for the examples

Declaring `task_modules` is what *enables* pickle-free ticks — inference alone only warns, deliberately, so an SDK upgrade never silently changes how a build gets its task objects. Until now these examples demonstrated the fallback (ticks reading the build task store's pickles, which need target-root write access at trigger time and are invalidated by a redeploy).

The annotation is one line. An earlier revision explained the whole mechanism in four, which out-weighed the code it annotated in a file whose job is to show what a Modal app looks like.

## Three apps, not four

| App | `task_modules` |
| --- | --- |
| `basic` | `stardag_examples.modal.basic.task` |
| `walkthrough` | `stardag_examples.modal.walkthrough.tasks` |
| `ml_pipeline` | `stardag_examples.ml_pipeline.*` |
| `prefect` | **none — deliberately** |

**The prefect example is left alone.** It exists to demonstrate a custom `build_function` (`PrefectBuilder`), and `build_trigger(reactive=True)` returns early via `_trigger_reactive()`: it spawns `bootstrap`, never the `build` function. So the reactive path bypasses the builder that example is entirely about, and declaring `task_modules` there would advertise readiness for the one mode that ignores its point.

For the record, it does **not** change the deployed function set either way: `tick` and `bootstrap` are registered unconditionally in `finalize()` for every `StardagApp`, and only `tick_watchdog` is conditional (on `watchdog_period_minutes`). That app already deploys a tick function and still will.

## The module lists are not what the layout suggests

`basic` and `walkthrough` define their tasks *under* `modal/`, and `ml_pipeline` builds `stardag_examples.ml_pipeline.class_api`'s DAG. My first attempt declared `stardag_examples.basic.*` and `stardag_examples.walkthrough.*`; neither package exists, and a wrong glob degrades silently to the pickle path — exactly the failure this feature exists to make visible.

## Verified with the SDK's own check

Not by eye. `uncovered_task_classes` — the function `_preflight_task_modules` gates on — over each app's fully-walked DAG:

```
basic                  tasks=  2  uncovered=NONE
walkthrough            tasks=  4  uncovered=NONE
ml_pipeline            tasks= 20  uncovered=NONE
```

`pre-commit run pyright-stardag-examples --all-files` clean; examples suite passes (13 passed, 9 skipped) against 0.18.0.
