### PR TITLE
fix(ui): stop telling a build it needs intervention after its work is done

### DIFF
--- a/app/stardag-ui/src/components/BuildFailureReason.test.tsx
+++ b/app/stardag-ui/src/components/BuildFailureReason.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { BuildFailureReason } from "./BuildFailureReason";
 
@@ -46,5 +47,34 @@ describe("BuildFailureReason", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     render(<BuildFailureReason status="failed" />);
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("collapses to a dated record once the roots have completed anyway", async () => {
+    // The reason is history at this point, not a call to action — the build's
+    // work got done elsewhere. It must stay reachable, though: it is the only
+    // account of why this build stopped, and the message embeds the status
+    // counts *as they were*, which is exactly what makes an unlabelled one
+    // misleading.
+    const user = userEvent.setup();
+    render(
+      <BuildFailureReason
+        status="failed"
+        message={REASON}
+        failedAt="2026-08-06T20:24:37Z"
+        superseded
+      />,
+    );
+
+    // Not shouting: no alert role, and the reason is not on screen yet.
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Re-trigger this build to reset the blocker/)).toBeNull();
+
+    // But it is one click away, and dated so it reads as a past event.
+    const toggle = screen.getByRole("button", { name: /Why it was recorded as failed/ });
+    expect(toggle).toHaveTextContent(/2026/);
+    await user.click(toggle);
+    expect(
+      await screen.findByText(/Re-trigger this build to reset the blocker/),
+    ).toBeInTheDocument();
   });
 });

--- a/app/stardag-ui/src/components/BuildFailureReason.test.tsx
+++ b/app/stardag-ui/src/components/BuildFailureReason.test.tsx
@@ -70,7 +70,9 @@ describe("BuildFailureReason", () => {
     expect(screen.queryByText(/Re-trigger this build to reset the blocker/)).toBeNull();
 
     // But it is one click away, and dated so it reads as a past event.
-    const toggle = screen.getByRole("button", { name: /Why it was recorded as failed/ });
+    const toggle = screen.getByRole("button", {
+      name: /Why it was recorded as failed/,
+    });
     expect(toggle).toHaveTextContent(/2026/);
     await user.click(toggle);
     expect(

--- a/app/stardag-ui/src/components/BuildFailureReason.tsx
+++ b/app/stardag-ui/src/components/BuildFailureReason.tsx
@@ -1,9 +1,19 @@
+import { useState } from "react";
 import type { BuildStatus } from "../types/task";
+import { formatAbsoluteTime } from "../utils/time";
 
 interface BuildFailureReasonProps {
   status: BuildStatus;
   /** `Build.latest_error_message` — the reason recorded on BUILD_FAILED. */
   message?: string | null;
+  /** When the build reached its terminal state (`Build.completed_at`). */
+  failedAt?: string | null;
+  /**
+   * True when every root this build asked for has since completed (see
+   * `rootsSatisfied`). The reason is then a historical record rather than a
+   * live problem, so it collapses instead of shouting.
+   */
+  superseded?: boolean;
 }
 
 /**
@@ -20,15 +30,67 @@ interface BuildFailureReasonProps {
  * Renders nothing unless the build is failed *and* a reason was recorded. Both
  * halves matter: a build resumed after failing is running again and must not
  * show the previous round's reason, and a server predating
- * `latest_error_message` omits the field rather than sending an empty one.
+ * `latest_error_message` omits the field rather than sending an empty one. The
+ * presence check trims — a heading over nothing is worse than silence.
  *
- * The presence check trims. The server excludes blank reasons, so this is not
- * load-bearing against the current API — but the failure mode if it ever slips
- * (a heading reading "Why this build failed" above nothing) is worse than the
- * cost of one `trim()`, and this component is the last place that can tell.
+ * **Two registers.** Live, it is a red banner: something needs attention. Once
+ * the roots have completed anyway (`superseded`), the same text is a *record* —
+ * why this build stopped, then — so it collapses behind a disclosure and is
+ * dated. It is not dropped: the reason is the only account of why the build
+ * stopped, and "did we ever understand what happened here?" is a question worth
+ * being able to answer months later. But it must not read as a current claim,
+ * least of all because the message embeds the status counts *as they were*,
+ * which is precisely what makes a stale one misleading.
  */
-export function BuildFailureReason({ status, message }: BuildFailureReasonProps) {
+export function BuildFailureReason({
+  status,
+  message,
+  failedAt,
+  superseded = false,
+}: BuildFailureReasonProps) {
+  const [open, setOpen] = useState(false);
   if (status !== "failed" || !message?.trim()) return null;
+
+  const when = failedAt ? formatAbsoluteTime(failedAt) : null;
+
+  // Pre-wrapped and never truncated: these reasons name the blocking task, the
+  // build that owns it and the remedy to run, and a truncated remedy is not a
+  // remedy. `break-words` so a bare task id cannot push the page sideways.
+  const body = (
+    <p className="mt-1 whitespace-pre-wrap break-words text-xs text-gray-700 dark:text-gray-300">
+      {message}
+    </p>
+  );
+
+  if (superseded) {
+    return (
+      <div className="border-b border-gray-200 bg-gray-50 px-4 py-1.5 dark:border-gray-700 dark:bg-gray-800/50">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="flex items-center gap-1.5 rounded text-xs text-gray-600 hover:text-gray-900 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:text-gray-400 dark:hover:text-gray-100"
+        >
+          <svg
+            className={`h-3 w-3 transition-transform ${open ? "rotate-90" : ""}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+          <span>Why it was recorded as failed{when ? ` on ${when}` : ""}</span>
+        </button>
+        {open && body}
+      </div>
+    );
+  }
 
   return (
     <div
@@ -38,10 +100,6 @@ export function BuildFailureReason({ status, message }: BuildFailureReasonProps)
       <p className="text-xs font-semibold text-red-900 dark:text-red-200">
         Why this build failed
       </p>
-      {/* Pre-wrapped and never truncated: these reasons name the blocking
-          task, the build that owns it and the remedy to run, and a truncated
-          remedy is not a remedy. `break-words` so a bare task id cannot push
-          the page sideways. */}
       <p className="mt-1 whitespace-pre-wrap break-words text-xs text-red-900/90 dark:text-red-100/90">
         {message}
       </p>

--- a/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
+++ b/app/stardag-ui/src/components/BuildSchedulingPanel.tsx
@@ -491,6 +491,39 @@ export function BuildSchedulingPanel({
     />
   );
 
+  if (form === "satisfied") {
+    // Every root is complete, so there is nothing to diagnose and nothing to
+    // intervene in — however the build's own status reads. Green rather than
+    // amber, and deliberately short: the interesting question ("why does the
+    // status still say failed?") is answered by the failure reason above this
+    // panel, not by repeating it here.
+    const completedElsewhere = buildStatus !== "completed";
+    return (
+      <div className="border-b border-green-200 bg-green-50 px-4 py-1.5 dark:border-green-900/60 dark:bg-green-950/30">
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+          <span aria-hidden="true" className="text-green-700 dark:text-green-400">
+            ✓
+          </span>
+          <h3 className="text-xs font-semibold text-green-900 dark:text-green-200">
+            Everything this build asked for is complete
+          </h3>
+          <span className="text-xs text-green-900/80 dark:text-green-100/80">
+            {buildStatus === "running"
+              ? "— its roots finished, so a scheduler tick will complete it"
+              : `— its roots finished after the build was recorded as ${buildStatus}, ` +
+                "so nothing is outstanding. Re-trigger it to reconcile the record."}
+          </span>
+        </div>
+        {completedElsewhere && (
+          <p className="mt-1 text-xs text-green-900/70 dark:text-green-100/70">
+            Tasks are shared across builds, so another build may have finished them.
+            Which build ran a task does not change its result.
+          </p>
+        )}
+      </div>
+    );
+  }
+
   if (form === "collapsed") {
     // A progressing reactive build: one line, never an empty box. It must
     // not imply anything about blockers — the server does not look for

--- a/app/stardag-ui/src/components/BuildView.tsx
+++ b/app/stardag-ui/src/components/BuildView.tsx
@@ -26,6 +26,7 @@ import type {
 } from "../types/task";
 import { isExtendedResponse } from "../types/task";
 import { BuildSchedulingPanel } from "./BuildSchedulingPanel";
+import { rootsSatisfiedFrom } from "../utils/claims";
 import { BuildFailureReason } from "./BuildFailureReason";
 import { BuildStatusBadge } from "./BuildStatusBadge";
 import { BuildExecutorChips } from "./ExecutorBadge";
@@ -351,6 +352,17 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
   // placeholder names alongside real tasks.
   const realTasks = useMemo(() => allTasks.filter((t) => !t.is_phantom), [allTasks]);
 
+  // Whether every root has since completed — see `rootsSatisfiedFrom`. Computed
+  // from the task list this view already fetched rather than from the frontier,
+  // which only the scheduling panel holds; both call the same rule so the two
+  // cannot disagree about the same build.
+  const rootsSuperseded = useMemo(() => {
+    const statusById = new Map(
+      allTasks.map((t) => [t.task_id, t.latest_status ?? t.status]),
+    );
+    return rootsSatisfiedFrom(build?.root_task_ids ?? [], (id) => statusById.get(id));
+  }, [allTasks, build?.root_task_ids]);
+
   // Client-side filtering
   const filteredTasks = realTasks.filter((task) => {
     if (
@@ -605,6 +617,8 @@ export function BuildView({ buildId, onBack, onNavigateToBuild }: BuildViewProps
               <BuildFailureReason
                 status={build.status}
                 message={build.latest_error_message}
+                failedAt={build.completed_at}
+                superseded={rootsSuperseded}
               />
 
               {/* Scheduler state. Renders itself only when it has something

--- a/app/stardag-ui/src/utils/claims.test.ts
+++ b/app/stardag-ui/src/utils/claims.test.ts
@@ -105,6 +105,14 @@ describe("schedulingPanelForm", () => {
     ).toBe("stalled");
   });
 
+  it("leaves a cancelled build alone", () => {
+    // Stopped on purpose. Announcing that its roots finished anyway is noise,
+    // and the form tells the reader to re-trigger to reconcile the record —
+    // which contradicts the intent of cancelling. Before the satisfied form
+    // existed a cancelled build got the quiet strip; it still does.
+    expect(schedulingPanelForm(supersededProd, "cancelled")).toBe("collapsed");
+  });
+
   it("leaves a completed build alone", () => {
     // Already done; the panel has nothing to add, and a green "work is done"
     // banner on a completed build is noise.

--- a/app/stardag-ui/src/utils/claims.test.ts
+++ b/app/stardag-ui/src/utils/claims.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import type { BuildFrontier, FrontierTaskRef } from "../types/task";
+import { rootsSatisfied, rootsSatisfiedFrom, schedulingPanelForm } from "./claims";
+
+function ref(
+  taskId: string,
+  status: FrontierTaskRef["latest_status"],
+): FrontierTaskRef {
+  return { task_id: taskId, latest_status: status };
+}
+
+function frontier(overrides: Partial<BuildFrontier> = {}): BuildFrontier {
+  return {
+    build_id: "b-1",
+    build_status: "running",
+    needs_tick: false,
+    root_task_ids: ["root-1"],
+    roots: [ref("root-1", "completed")],
+    status_counts: { completed: 3 },
+    actionable: [],
+    running: [],
+    blocked_by_external: [],
+    blocked_by_external_truncated: false,
+    reactive_app_name: "some-app",
+    ...overrides,
+  };
+}
+
+describe("rootsSatisfied", () => {
+  it("is true when every root is complete", () => {
+    expect(rootsSatisfied(frontier())).toBe(true);
+  });
+
+  it("is false for a build with no roots", () => {
+    // Not a corner case: `POST /builds` defaults `root_task_ids` to `[]`, so
+    // every build is briefly rootless between being minted and having its roots
+    // registered. `every()` over an empty list is vacuously true, so without an
+    // explicit guard a build mid-creation — or an abandoned one that never got
+    // roots — would report its request satisfied and be told so.
+    expect(rootsSatisfied(frontier({ root_task_ids: [], roots: [] }))).toBe(false);
+    expect(rootsSatisfiedFrom([], () => "completed")).toBe(false);
+  });
+
+  it("is false when a root cannot be resolved", () => {
+    // The server reports `roots` by looking the ids up, so a shorter list means
+    // a root is missing rather than complete. Unknown is not complete.
+    expect(rootsSatisfied(frontier({ root_task_ids: ["root-1", "root-2"] }))).toBe(
+      false,
+    );
+    expect(rootsSatisfiedFrom(["root-1"], () => undefined)).toBe(false);
+  });
+
+  it("is false when any root is still incomplete", () => {
+    expect(
+      rootsSatisfied(
+        frontier({
+          root_task_ids: ["root-1", "root-2"],
+          roots: [ref("root-1", "completed"), ref("root-2", "suspended")],
+        }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("schedulingPanelForm", () => {
+  // The build that started the whole effort: it failed waiting on a shared task,
+  // another build completed that task later, and the panel went on insisting
+  // "nothing is going to happen without intervention" over finished work.
+  const supersededProd = frontier({
+    build_status: "failed",
+    status_counts: { completed: 3 },
+    root_task_ids: ["d61cba54"],
+    roots: [ref("d61cba54", "completed")],
+    reactive_app_name: "mmt-train-dev-3261",
+  });
+
+  it("does not call a failed build stalled once its roots have completed", () => {
+    expect(schedulingPanelForm(supersededProd, "failed")).toBe("satisfied");
+  });
+
+  it("does not call a running build stalled once its roots have completed", () => {
+    // Same shape, reachable because a cross-build completion does not wake the
+    // waiting build: only its own worker notifies it, so without a watchdog it
+    // sits RUNNING with its work done.
+    expect(
+      schedulingPanelForm({ ...supersededProd, build_status: "running" }, "running"),
+    ).toBe("satisfied");
+  });
+
+  it("still flags a genuinely stuck build that has no roots", () => {
+    // An abandoned build whose only task was cancelled, with no roots recorded.
+    // Nothing will advance it, so "needs intervention" is the correct message —
+    // and the roots guard is what keeps it.
+    expect(
+      schedulingPanelForm(
+        frontier({
+          build_status: "running",
+          root_task_ids: [],
+          roots: [],
+          status_counts: { cancelled: 1 },
+          reactive_app_name: null,
+        }),
+        "running",
+      ),
+    ).toBe("stalled");
+  });
+
+  it("leaves a completed build alone", () => {
+    // Already done; the panel has nothing to add, and a green "work is done"
+    // banner on a completed build is noise.
+    expect(schedulingPanelForm(supersededProd, "completed")).toBe("collapsed");
+  });
+
+  it("still flags a failed build whose roots are not complete", () => {
+    expect(
+      schedulingPanelForm(
+        frontier({
+          build_status: "failed",
+          roots: [ref("root-1", "suspended")],
+          status_counts: { completed: 2, suspended: 1 },
+        }),
+        "failed",
+      ),
+    ).toBe("stalled");
+  });
+});

--- a/app/stardag-ui/src/utils/claims.ts
+++ b/app/stardag-ui/src/utils/claims.ts
@@ -43,7 +43,60 @@ export function availableClaimActions(status: TaskStatus): ClaimAction[] {
 /** A task whose global status is one of these is holding an execution claim. */
 export const CLAIM_HOLDING_STATUSES: TaskStatus[] = ["running", "suspended"];
 
-export type SchedulingPanelForm = "hidden" | "collapsed" | "stalled";
+export type SchedulingPanelForm = "hidden" | "collapsed" | "stalled" | "satisfied";
+
+/**
+ * Whether every root this build asked for is now complete.
+ *
+ * A build is a *request for a set of root tasks to be materialised*. If the
+ * roots are complete then so is everything they needed, and the request has
+ * been satisfied — whatever the build's own status says, and whichever build
+ * actually ran the tasks. Tasks are content-addressed and shared, so a build
+ * can fail waiting on a task that another build completes an hour later. Its
+ * status stays `failed` (an honest record of what its own driver decided) while
+ * this becomes true.
+ *
+ * **Three clauses, and each excludes a real state:**
+ *
+ * - `roots.length > 0` — a build with no roots has nothing to satisfy, and
+ *   `every()` over an empty list is vacuously true. This is not a corner case:
+ *   `POST /builds` defaults `root_task_ids` to `[]`, so *every* build passes
+ *   through rootless between being minted and having its roots registered,
+ *   which is exactly what `build_trigger` does. Without this clause a build
+ *   mid-creation would report its request satisfied.
+ * - `roots.length === root_task_ids.length` — the server reports `roots` by
+ *   looking the ids up, so a shorter list means some root is not resolvable
+ *   (deleted, or in another environment). Unknown is not complete. Mirrors the
+ *   SDK's own `roots_known` in `_handle_terminal`.
+ * - `every(completed)` — the actual question.
+ */
+export function rootsSatisfied(frontier: BuildFrontier): boolean {
+  const statusById = new Map(frontier.roots.map((r) => [r.task_id, r.latest_status]));
+  return (
+    frontier.roots.length === frontier.root_task_ids.length &&
+    rootsSatisfiedFrom(frontier.root_task_ids, (id) => statusById.get(id))
+  );
+}
+
+/**
+ * The same rule against any source of task statuses.
+ *
+ * Exists so the two places that need it cannot drift: the scheduling panel asks
+ * it of a `BuildFrontier`, while the build view asks it of the task list it has
+ * already fetched — and a build being told "your work is done" by one component
+ * and "you need intervention" by the other would be worse than either message
+ * alone.
+ *
+ * An unresolvable root answers `undefined`, which is not `"completed"`, so
+ * unknown counts as not satisfied without a special case.
+ */
+export function rootsSatisfiedFrom(
+  rootTaskIds: string[],
+  statusOf: (taskId: string) => TaskStatus | undefined,
+): boolean {
+  if (rootTaskIds.length === 0) return false;
+  return rootTaskIds.every((id) => statusOf(id) === "completed");
+}
 
 /**
  * When — and how loudly — the build scheduling panel has something to say.
@@ -68,6 +121,14 @@ export type SchedulingPanelForm = "hidden" | "collapsed" | "stalled";
  *   it failed*. An ordinary DAG failure (a task raised) explains itself
  *   in the task table and does not need a scheduler post-mortem.
  *
+ * `"satisfied"` short-circuits all of that. A build whose roots are complete
+ * is not stalled and never needs intervention, whatever its status — so it must
+ * not be told it does. This is the shape that motivated the form: a build fails
+ * waiting on a shared task, another build completes the task, and the panel goes
+ * on insisting "nothing is going to happen without intervention" over work that
+ * is finished. It applies to `running` too, and there the copy differs: nothing
+ * is wrong, the build simply has not been ticked since the roots landed.
+ *
  * `"collapsed"` is a single quiet line for a reactive build the rule does
  * not flag: the live counts, plus access to the tick trail, which exists
  * nowhere else in the UI. `"hidden"` is everything else — a healthy
@@ -81,6 +142,14 @@ export function schedulingPanelForm(
   const totalTasks = Object.values(frontier.status_counts).reduce((a, b) => a + b, 0);
   const stalledShape =
     totalTasks > 0 && frontier.actionable.length === 0 && frontier.running.length === 0;
+
+  // Before any stalled reasoning: if the request is satisfied there is nothing
+  // to diagnose. Checked ahead of `stalledShape` on purpose — a satisfied build
+  // has no actionable and no running tasks by definition, so it always *looks*
+  // stalled.
+  if (rootsSatisfied(frontier) && buildStatus !== "completed") {
+    return "satisfied";
+  }
 
   let stalled = false;
   if (stalledShape) {

--- a/app/stardag-ui/src/utils/claims.ts
+++ b/app/stardag-ui/src/utils/claims.ts
@@ -58,8 +58,9 @@ export type SchedulingPanelForm = "hidden" | "collapsed" | "stalled" | "satisfie
  *
  * **Three clauses, and each excludes a real state:**
  *
- * - `roots.length > 0` — a build with no roots has nothing to satisfy, and
- *   `every()` over an empty list is vacuously true. This is not a corner case:
+ * - a non-empty root list — enforced in `rootsSatisfiedFrom` below, since that
+ *   is where `every()` is called and where the vacuous-truth trap lives. A build
+ *   with no roots has nothing to satisfy. This is not a corner case:
  *   `POST /builds` defaults `root_task_ids` to `[]`, so *every* build passes
  *   through rootless between being minted and having its roots registered,
  *   which is exactly what `build_trigger` does. Without this clause a build
@@ -147,7 +148,17 @@ export function schedulingPanelForm(
   // to diagnose. Checked ahead of `stalledShape` on purpose — a satisfied build
   // has no actionable and no running tasks by definition, so it always *looks*
   // stalled.
-  if (rootsSatisfied(frontier) && buildStatus !== "completed") {
+  //
+  // `completed` and `cancelled` are excluded, and for the same reason the
+  // stalled rule below excludes them: neither is a build anyone needs told
+  // anything. `completed` already says it. `cancelled` was stopped on purpose —
+  // announcing that its roots finished anyway is noise, and the form's advice to
+  // re-trigger and reconcile the record actively contradicts the user's
+  // intent. Both simply fall through to the quiet strip, which is what they got
+  // before this form existed.
+  const deliberatelyTerminal =
+    buildStatus === "completed" || buildStatus === "cancelled";
+  if (!deliberatelyTerminal && rootsSatisfied(frontier)) {
     return "satisfied";
   }
 


### PR DESCRIPTION
## The bug

A build fails waiting on a shared task. Another build completes that task later. The first build's status stays `failed`, and the scheduling panel keeps saying:

> Nothing runnable, and no wake-up pending — needs intervention
> Nothing in this build is actionable and nothing is running… Nothing is going to happen without intervention.

…while every task in it is `completed`. The failure banner alongside it reports `status counts: {'completed': 2, 'suspended': 1}` — true when it failed, false now.

This is the build that started the 0.17 → 0.18 effort, and it still read wrong after the release.

## Not a status bug

Build status derives **only** from build-level events — it is an assertion by whoever drove the build, and therefore historical. Task status is a property of the environment: content-addressed, shared, always current. Divergence is structural, and it is the same property that lets builds collaborate. Retro-completing a failed build would rewrite an event-sourced history to make a screen read better. So this fixes what the UI *says*.

## `rootsSatisfied` + a `"satisfied"` form

A build is a request for its roots to be materialised. If the roots are complete then so is everything they needed, whichever build ran it — there is nothing to intervene in.

Checked **before** any stalled reasoning, because a satisfied build has nothing actionable and nothing running by definition, so it always *looks* stalled.

**Status-agnostic**, and that matters: a RUNNING build reaches the same state. A cross-build completion does not wake the waiting build — `notify` is called by a worker for its *own* build, with no fan-out — so without a watchdog configured it sits RUNNING with its work done. Its copy differs (a tick will complete it) but the diagnosis is the same.

## The guard that a real build caught

Three clauses, each excluding a state that occurs:

| Clause | Excludes |
| --- | --- |
| `rootTaskIds.length > 0` | a build with no roots — `every()` over `[]` is vacuously true |
| `roots.length === root_task_ids.length` | an unresolvable root; unknown is not complete |
| `every(completed)` | the actual question |

The first is the interesting one. `BuildCreate.root_task_ids` **defaults to `[]`**, so every build is briefly rootless between being minted and having its roots registered — which is exactly what `build_trigger` does. Without the guard, a build mid-creation (or an abandoned one that never got roots) would be told its request was satisfied.

I found this by checking the predicate against a real abandoned build rather than by reasoning about it, and it is now pinned by two tests. The SDK's own `roots_known` carries the same `> 0` for the same reason.

## The reason is demoted, not dropped

Once superseded, the failure reason collapses behind a **dated** disclosure. Still one click away — it is the only account of why the build stopped, and that is worth being able to answer months later — but no longer presented as current, which matters most because the message embeds the status counts *as they were*.

## One rule, two callers

`rootsSatisfiedFrom` is called by the panel (from the frontier) and by the build view (from the task list it already fetched), so the two components cannot tell the same build different things.

## Tests

185 UI tests (17 files). Verified the tests fail without the fix: the two behavioural ones without the short-circuit, and two guard ones without the empty-roots check. Fixtures are the two real builds — the production one that motivated this, and the abandoned no-roots one that caught the guard.

Follow-up for the builds *list* (showing this at a glance, and stopping `cleanup` from cancelling builds whose work is done) is filed separately.