### PR TITLE
refactor(modal): split the 3.6k-line _app.py into cohesive modules

### DIFF
--- a/lib/stardag/src/stardag/integration/modal/__init__.py
+++ b/lib/stardag/src/stardag/integration/modal/__init__.py
@@ -1,22 +1,81 @@
+"""Stardag on Modal — deploy an app, then run builds on it.
+
+:class:`StardagApp` wraps a ``modal.App`` and registers the functions a
+stardag deployment consists of: ``build`` (a resident orchestrator),
+``worker_*`` (one per configured worker), and — for reactive scheduling —
+``bootstrap``, ``tick`` and an optional ``tick_watchdog``.
+
+Example usage:
+
+    import modal
+    from stardag.integration.modal import StardagApp, FunctionSettings
+
+    # Define your image (user has full control)
+    image = (
+        modal.Image.debian_slim()
+        .pip_install("pandas", "numpy", "stardag")
+        .add_local_python_source("my_code")  # Local sources last for caching
+    )
+
+    # Create the app (functions are NOT created yet)
+    stardag_app = StardagApp(
+        "my-app",
+        builder_settings=FunctionSettings(image=image),
+        worker_settings={"default": FunctionSettings(image=image)},
+    )
+
+    # Deploy with: stardag modal deploy my_app.py --profile prod
+    # The --profile flag injects environment variables as a Modal secret
+
+    # To run tasks remotely (after deployment):
+    from my_tasks import my_task
+    stardag_app.build_spawn(my_task)  # Looks up deployed function by name
+
+Everything below is private; import from this package rather than from the
+modules directly. Roughly in the order a build passes through them:
+
+- :mod:`._profile`, :mod:`._volumes`, :mod:`._settings` — deploy-time
+  inputs: profile env vars, target-root volumes, the ``FunctionSettings``
+  declaration and the merge applied to it.
+- :mod:`._protocols`, :mod:`._selector` — the contracts of the two
+  callables an app deploys, and worker routing.
+- :mod:`._app` — ``StardagApp`` itself: registering those functions
+  (``finalize``) and triggering builds on them.
+- :mod:`._builder` — the resident ``build`` function (``Builder``).
+- :mod:`._executor` — the orchestrator side (``ModalTaskExecutor``):
+  spawning tasks onto workers, re-attaching, cancelling.
+- :mod:`._runner` — the worker side (``Runner``): running one task and
+  self-reporting its lifecycle.
+- :mod:`._bootstrap`, :mod:`._tick` — reactive scheduling: arming a build,
+  then driving it one frontier pass at a time.
+- :mod:`._metadata` — the Modal coordinates behind the UI's dashboard deep
+  links, and the env-var channel that carries them to workers.
+- :mod:`._target`, :mod:`._config` — ``modalvol://`` targets and image
+  helpers.
+"""
+
 from stardag.integration.modal._app import (
-    Builder,
-    BuildFailedError,
-    BuildFunction,
     BuildTriggerResult,
     FinalizeResult,
-    FunctionSettings,
-    PrefectBuilder,
-    ReactiveDiscovery,
-    RunFunction,
-    Runner,
     StardagApp,
+)
+from stardag.integration.modal._bootstrap import ReactiveDiscovery
+from stardag.integration.modal._builder import (
+    BuildFailedError,
+    Builder,
+    PrefectBuilder,
+)
+from stardag.integration.modal._config import get_package_deps, with_stardag_on_image
+from stardag.integration.modal._executor import ModalTaskExecutor
+from stardag.integration.modal._profile import get_profile_env_vars, get_profile_secret
+from stardag.integration.modal._protocols import BuildFunction, RunFunction
+from stardag.integration.modal._runner import Runner
+from stardag.integration.modal._selector import (
     WorkerSelection,
     WorkerSelector,
     WorkerSelectorByName,
-    get_profile_env_vars,
-    get_profile_secret,
 )
-from stardag.integration.modal._config import get_package_deps, with_stardag_on_image
+from stardag.integration.modal._settings import FunctionSettings
 from stardag.integration.modal._target import (
     MODAL_VOLUME_URI_PREFIX,
     VOLUME_MOUNT_PATH_PREFIX,
@@ -34,6 +93,7 @@ __all__ = [
     "RunFunction",
     "StardagApp",
     "Builder",
+    "ModalTaskExecutor",
     "PrefectBuilder",
     "Runner",
     "FinalizeResult",

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -789,7 +789,7 @@ class StardagApp:
                     # pre-flight compare the DAG against what the ticks
                     # will actually import rather than against the
                     # caller's local app definition.
-                    task_modules=task_module_patterns,
+                    task_module_patterns=task_module_patterns,
                     elide_pickles=elide_pickles,
                     require_pickle_free=require_pickle_free,
                 )
@@ -1166,7 +1166,7 @@ class StardagApp:
                         registry=registry,
                         app_name=self.name,
                         tick_kwargs=tick_kwargs,
-                        task_modules=self.task_modules,
+                        task_module_patterns=self.task_modules,
                         elide_pickles=(
                             self._task_modules_declared or self.require_pickle_free
                         ),

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -1,261 +1,81 @@
-"""Stardag Modal integration - App and executor for running tasks on Modal.
+"""The StardagApp that owns a Modal deployment.
 
-This module provides:
-- StardagApp: A wrapper around modal.App that manages builder and worker functions
-- ModalTaskExecutor: A task executor that sends tasks to Modal for remote execution
-- Helper functions for profile-based environment configuration
+:class:`StardagApp` wraps a ``modal.App``, registers the functions a stardag
+deployment consists of (:meth:`StardagApp.finalize`), and is the entry point
+for running builds on it (``build_spawn`` / ``build_remote`` /
+``build_trigger``).
 
-Example usage:
-
-    import modal
-    from stardag.integration.modal import StardagApp, FunctionSettings
-
-    # Define your image (user has full control)
-    image = (
-        modal.Image.debian_slim()
-        .pip_install("pandas", "numpy", "stardag")
-        .add_local_python_source("my_code")  # Local sources last for caching
-    )
-
-    # Create the app (functions are NOT created yet)
-    stardag_app = StardagApp(
-        "my-app",
-        builder_settings=FunctionSettings(image=image),
-        worker_settings={"default": FunctionSettings(image=image)},
-    )
-
-    # Deploy with: stardag modal deploy my_app.py --profile prod
-    # The --profile flag injects environment variables as a Modal secret
-
-    # To run tasks remotely (after deployment):
-    from my_tasks import my_task
-    stardag_app.build_spawn(my_task)  # Looks up deployed function by name
+The bodies of the registered functions mostly live in sibling modules — the
+wrappers here are thin closures over what ``finalize`` resolved at deploy
+time, because a deployed container never sees the ``StardagApp`` object. See
+this package's ``__init__`` for a map of those modules.
 """
 
 from __future__ import annotations
 
-import asyncio
 import inspect
 import json
 import logging
-import os
-import pathlib
-import traceback as tb_module
 import typing
 from uuid import UUID
 
 import modal
 
-from stardag import BaseTask, TaskStruct, build, flatten_task_struct
-from stardag._core.base_task import _has_custom_run, _has_custom_run_aio
-from stardag.exceptions import StardagError
-from stardag.build import (
-    BuildExitStatus,
-    BuildTaskStore,
-    FailMode,
-    DetachedExecutionStatus,
-    DetachedHandle,
-    TaskExecutionError,
-    TaskExecutorABC,
-    TickConfig,
-    discover_and_register_aio,
-    get_current_build_id,
-    run_tick_aio,
-)
-from stardag.build._base import GlobalLockConfig
-from stardag.build._base import BuildSummary
-from stardag.build._reactive import claim_ttl_seconds
+from stardag import BaseTask
+from stardag.build import BuildSummary
 from stardag.build._task_modules import (
-    PickleElisionPlan,
     TaskModulesError,
-    declared_task_module_patterns,
     expand_task_module_patterns,
-    format_uncovered_message,
-    import_task_modules,
-    plan_pickle_elision,
     set_declared_task_module_patterns,
-    uncovered_task_classes,
     validate_task_module_patterns,
 )
-from stardag.config import clear_config_cache, config_provider, load_config
-from stardag.integration.modal._target import (
-    MODAL_VOLUME_URI_PREFIX,
-    get_default_volume_mount_path,
-    get_volume_name_and_path,
+from stardag.exceptions import StardagError
+from stardag.integration.modal._bootstrap import (
+    ReactiveDiscovery,
+    _advise_uncovered_root_task_modules,
+    _fail_build_best_effort,
+    run_reactive_bootstrap,
 )
-from stardag.registry._base import (
-    NoOpRegistry,
-    get_git_commit_hash,
-    registry_provider,
+from stardag.integration.modal._builder import _default_build
+from stardag.integration.modal._logging import _setup_logging
+from stardag.integration.modal._metadata import (
+    MODAL_EXECUTOR_NAME,
+    STARDAG_MODAL_WORKSPACE_ENV,
+    _get_modal_environment,
+    _get_modal_workspace,
 )
-from stardag.registry._lock import RegistryGlobalConcurrencyLockManager
+from stardag.integration.modal._protocols import (
+    BuildFunction,
+    RunFunction,
+    _callable_accepts_env_overrides,
+    _RunFunctionWithEnv,
+)
+from stardag.integration.modal._runner import _default_run
+from stardag.integration.modal._selector import (
+    WorkerSelector,
+    _default_worker_selector,
+)
+from stardag.integration.modal._settings import (
+    FunctionSettings,
+    _prepare_function_settings,
+)
+from stardag.integration.modal._target import get_default_volume_mount_path
+from stardag.integration.modal._tick import (
+    LimitKeySelector,
+    _run_tick,
+    _run_watchdog_sweep,
+    _tick_function_timeout_seconds,
+    _TickDeployment,
+    _validate_tick_kwargs,
+)
+from stardag.integration.modal._volumes import (
+    TargetRootsVolumes,
+    get_target_roots_volumes,
+)
+from stardag.registry._base import NoOpRegistry, registry_provider
 from stardag.utils.env import temp_env_vars
 
-try:
-    from stardag.integration.prefect import (
-        build_flow as prefect_build_flow,
-    )
-    from stardag.integration.prefect import (
-        create_markdown,
-        upload_task_on_complete_artifacts,
-    )
-except ImportError:
-    prefect_build_flow = None
-    create_markdown = None
-    upload_task_on_complete_artifacts = None
-
 logger = logging.getLogger(__name__)
-
-
-# --- Configuration helpers ---
-
-
-def get_profile_env_vars(profile: str | None = None) -> dict[str, str]:
-    """Get environment variables from a stardag profile for Modal deployment.
-
-    These environment variables configure the stardag SDK inside Modal containers
-    to connect to the correct registry, workspace, and environment.
-
-    Args:
-        profile: Profile name to use. If None, uses the active profile
-            (from STARDAG_PROFILE env var or default profile in config).
-
-    Returns:
-        Dict of environment variables to inject into Modal functions:
-        - STARDAG_API_URL: API endpoint
-        - STARDAG_WORKSPACE_ID: Workspace UUID
-        - STARDAG_ENVIRONMENT_ID: Environment UUID
-        - STARDAG_TARGET_ROOTS: JSON dict of target roots (pydantic-settings parses this)
-        - COMMIT_HASH: Current git commit (for traceability)
-
-    Example:
-        >>> env_vars = get_profile_env_vars("production")
-        >>> print(env_vars)
-        {
-            'STARDAG_API_URL': 'https://api.stardag.com',
-            'STARDAG_WORKSPACE_ID': '...',
-            'STARDAG_ENVIRONMENT_ID': '...',
-            'STARDAG_TARGET_ROOTS': '{"default": "s3://bucket/prefix"}',
-            'COMMIT_HASH': 'abc123...'
-        }
-    """
-    # Load config for specific profile if provided
-    if profile:
-        # Temporarily set STARDAG_PROFILE to load that profile's config
-        old_profile = os.environ.get("STARDAG_PROFILE")
-        os.environ["STARDAG_PROFILE"] = profile
-        try:
-            clear_config_cache()
-            config = load_config()
-        finally:
-            if old_profile is not None:
-                os.environ["STARDAG_PROFILE"] = old_profile
-            else:
-                os.environ.pop("STARDAG_PROFILE", None)
-            clear_config_cache()
-    else:
-        config = config_provider.get()
-
-    env_vars: dict[str, str] = {}
-
-    reg = config.registry
-    if reg:
-        env_vars["STARDAG_API_URL"] = reg.url
-        if reg.workspace_id:
-            env_vars["STARDAG_WORKSPACE_ID"] = reg.workspace_id
-        if reg.environment_id:
-            env_vars["STARDAG_ENVIRONMENT_ID"] = reg.environment_id
-
-    # Add target roots as JSON (pydantic-settings parses JSON for nested fields)
-    if config.target.roots:
-        env_vars["STARDAG_TARGET_ROOTS"] = json.dumps(config.target.roots)
-
-    # Add git commit for traceability
-    commit_hash = get_git_commit_hash()
-    if commit_hash:
-        env_vars["COMMIT_HASH"] = commit_hash
-
-    return env_vars
-
-
-def get_profile_secret(profile: str | None = None) -> modal.Secret:
-    """Create a Modal secret from a stardag profile's environment variables.
-
-    This is the recommended way to inject profile configuration into Modal
-    functions at runtime, rather than baking them into the image.
-
-    Args:
-        profile: Profile name to use. If None, uses the active profile.
-
-    Returns:
-        A modal.Secret that can be passed to FunctionSettings.secrets.
-
-    Example:
-        >>> secret = get_profile_secret("production")
-        >>> stardag_app = StardagApp(
-        ...     "my-app",
-        ...     builder_settings=FunctionSettings(
-        ...         image=my_image,
-        ...         secrets=[secret],  # Injected at runtime
-        ...     ),
-        ...     ...
-        ... )
-    """
-    env_vars = get_profile_env_vars(profile)
-    return modal.Secret.from_dict(typing.cast(dict[str, str | None], env_vars))
-
-
-class TargetRootsVolumes(typing.NamedTuple):
-    """Result of get_target_roots_volumes().
-
-    Attributes:
-        by_root_key: Dict of target root key to Modal Volume instance.
-        by_volume_name: Dict of volume name to Modal Volume instance (deduped).
-    """
-
-    by_root_key: dict[str, modal.Volume]
-    by_volume_name: dict[str, modal.Volume]
-
-
-def get_target_roots_volumes(
-    target_roots: dict[str, str] | None = None,
-    create_if_missing: bool = True,
-) -> TargetRootsVolumes:
-    """Get Modal volumes for configured target roots.
-
-    Scans target roots for ``modalvol://`` URIs and returns the corresponding
-    Modal Volume objects, both keyed by target root name and deduped by
-    volume name.
-
-    Args:
-        target_roots: Dict of target root key to URI or None (default from config).
-        create_if_missing: Whether to create the Modal volume if it doesn't exist.
-            When True, volumes are eagerly hydrated to trigger creation.
-            When False, volumes are lazy references (hydrated by Modal at deploy time).
-
-    Returns:
-        TargetRootsVolumes with volumes keyed by root key and by volume name.
-    """
-    if target_roots is None:
-        config = config_provider.get()
-        target_roots = config.target.roots
-
-    by_root_key: dict[str, modal.Volume] = {}
-    by_volume_name: dict[str, modal.Volume] = {}
-    for key, uri in target_roots.items():
-        if not uri.startswith(MODAL_VOLUME_URI_PREFIX):
-            continue
-        volume_name, _ = get_volume_name_and_path(uri)
-        if volume_name not in by_volume_name:
-            vol = modal.Volume.from_name(
-                volume_name, create_if_missing=create_if_missing
-            )
-            if create_if_missing:
-                vol.hydrate()
-            by_volume_name[volume_name] = vol
-        by_root_key[key] = by_volume_name[volume_name]
-
-    return TargetRootsVolumes(by_root_key=by_root_key, by_volume_name=by_volume_name)
 
 
 class FinalizeResult(typing.NamedTuple):
@@ -277,221 +97,6 @@ class FinalizeResult(typing.NamedTuple):
     volume_mounts: dict[str, str] = {}
     auto_volumes: dict[str, modal.Volume] = {}
     task_modules: list[str] = []
-
-
-# --- Function settings ---
-
-
-def _dedupe_secrets(secrets: list[modal.Secret]) -> list[modal.Secret]:
-    """De-duplicate Modal secrets by name, preserving order.
-
-    Named secrets (``Secret.from_name``) dedupe by name so a secret
-    propagated from the builder to a worker that also declares it is applied
-    once. Secrets without a usable name (e.g. ``Secret.from_dict``) fall back
-    to object identity.
-    """
-    seen: set[str | int] = set()
-    result: list[modal.Secret] = []
-    for secret in secrets:
-        key: str | int = getattr(secret, "name", None) or id(secret)
-        if key in seen:
-            continue
-        seen.add(key)
-        result.append(secret)
-    return result
-
-
-def _run_watchdog_sweep(
-    registry: typing.Any,
-    tick: typing.Callable[..., typing.Any],
-    sweep_limit: int = 100,
-    tick_timeout_seconds: float | None = None,
-    reactive_app_name: str | None = None,
-) -> None:
-    """One watchdog pass: tick every running build this app owns.
-
-    ``reactive_app_name`` scopes the listing to this app's own reactive
-    builds. Without it, ``sweep_limit`` is spent on whatever RUNNING builds
-    happen to be most recently active in the environment — including builds
-    no tick of this app can advance (resident builds, and builds whose
-    orchestrator died without emitting a terminal event, which stay RUNNING
-    forever). Once those exceed the limit the safety net stops reaching
-    genuine reactive builds entirely, and silently.
-
-    The trade-off is losing the incidental cross-app coverage a sweep used to
-    provide. That was accidental and competed for the same limit; an app's own
-    watchdog is the supported mechanism, and ``build_trigger`` already warns
-    when a reactive build is triggered on an app without one.
-
-    ``linger_seconds=0`` (one frontier pass per build) is essential: the
-    sweep runs ticks sequentially in one function call — persisted linger
-    settings (default 120 s) would blow through the function timeout after
-    a couple of builds and starve the rest of the safety-net tick.
-
-    The same "one container, many builds" property applies to the per-pass
-    spawn cap, which is derived from how long the container may live: every
-    build in the sweep would otherwise size its fan-out as though it had
-    the whole container to itself, and the first wide build would spend the
-    entire timeout while the rest of the sweep never ran. Each build is
-    therefore handed its **share** of the budget. Truncating here is
-    cheap and self-correcting — the watchdog is a safety net, builds are
-    normally driven by their own ticks, and a truncated pass re-acts on a
-    fresh frontier immediately.
-    """
-    if type(registry) is NoOpRegistry:
-        logger.warning("Tick watchdog: no registry configured; nothing to do.")
-        return
-    # Scoping is server-side now that `build_list_running` is expressed in
-    # terms of `build_list`, so every RegistryABC gets it and the signature
-    # shim this used to need went with it. `scoped` still exists because
-    # the truncation remedy below differs by it.
-    scoped = reactive_app_name is not None
-    running_builds = registry.build_list_running(
-        limit=sweep_limit, reactive_app_name=reactive_app_name
-    )
-    scope = (
-        f"reactive builds owned by {reactive_app_name!r}"
-        if scoped
-        else "running builds"
-    )
-    if len(running_builds) >= sweep_limit:
-        # The remedy follows `scoped`, not whether a name was *asked* for:
-        # a scoping request the registry cannot honour still yields a
-        # listing capped by RUNNING builds of every kind, and "run fewer
-        # reactive builds per app" would then be advice about the wrong
-        # population.
-        remedy = (
-            "Cancel or clean up builds that are RUNNING but abandoned, or "
-            "reduce the number of concurrent reactive builds for this app."
-            if scoped
-            else "This listing was not scoped to a reactive app, so the cap "
-            "was consumed by RUNNING builds of every kind — most likely "
-            "abandoned ones. Clean those up (`stardag builds cleanup`); an "
-            "upgraded registry would also scope this listing."
-        )
-        logger.warning(
-            f"Tick watchdog: {sweep_limit}+ {scope}; only the {sweep_limit} "
-            "most recently active are swept, so a less-recently-active build "
-            f"may not be ticked this period. {remedy}"
-        )
-    sweep_kwargs: dict[str, typing.Any] = {"linger_seconds": 0}
-    if tick_timeout_seconds is not None and running_builds:
-        sweep_kwargs["tick_timeout_seconds"] = tick_timeout_seconds / len(
-            running_builds
-        )
-    for running_build_id in running_builds:
-        try:
-            tick(str(running_build_id), tick_kwargs=dict(sweep_kwargs))
-        except Exception:
-            logger.exception(f"Watchdog tick failed for build {running_build_id}")
-
-
-_TICK_KWARGS_ALLOWED = (
-    "linger_seconds",
-    "poll_interval_seconds",
-    "fail_mode",
-    # Fan-out throttles. Both default to something derived (see TickConfig
-    # and stardag.build._reactive._spawn_cap) and both are here because the
-    # thing the derivation cannot see — how the *tick* function is sized
-    # relative to its workers, and how much concurrency the registry
-    # deployment behind it will take — is per-deployment, and a build
-    # triggered against that deployment is where it can be said.
-    "max_concurrent_actions",
-    "max_spawns_per_tick",
-    # Per-build attempt budget. Belongs here more than most: the budget is
-    # per build by definition, and a build that has exhausted it is
-    # unblocked by re-triggering *with a raised* max_attempts — which only
-    # works if a re-trigger can say it.
-    "max_attempts",
-)
-
-
-def _tick_function_timeout_seconds(
-    tick_settings: "FunctionSettings | None",
-    builder_settings: "FunctionSettings | None",
-) -> float | None:
-    """The Modal ``timeout`` the deployed ``tick`` function will carry.
-
-    Resolved from **whichever settings actually register the function** —
-    ``tick_settings`` when given, otherwise ``builder_settings``, which is
-    the same fallback ``finalize`` applies. Reading ``tick_settings`` alone
-    would silently yield "unknown" for every app that does not configure
-    the tick separately (the common case), and a spawn cap derived from a
-    timeout the function was not registered with is precisely the mistake
-    this plumbing exists to remove.
-
-    ``None`` when neither declares one: Modal's own default is not a
-    promise this SDK should encode, and the cap has further rungs to fall
-    back to (see ``stardag.build._reactive._spawn_cap``).
-    """
-    # An empty `tick_settings` falls back deliberately — it declares
-    # nothing, and `finalize` resolves it the same way.
-    settings = tick_settings if tick_settings else builder_settings
-    # `is not None`, not truthiness: `timeout=0` is a value someone
-    # configured, and reporting it as "not declared" would hand the spawn
-    # cap a different rung to fall back to than the one the function was
-    # actually registered with.
-    timeout = (settings or {}).get("timeout")
-    return float(timeout) if timeout is not None else None
-
-
-def _build_tick_config(
-    stored_tick_kwargs: dict[str, typing.Any] | None,
-    tick_kwargs: dict[str, typing.Any] | None,
-    limit_key_selector: "typing.Callable[[BaseTask], typing.Sequence[str]] | None",
-    tick_timeout_seconds: float | None = None,
-) -> TickConfig:
-    """Assemble a TickConfig for one tick invocation.
-
-    Precedence: explicit ``tick_kwargs`` (manual/ops invocations) over the
-    build's stored ``reactive_tick_kwargs`` (set at trigger time in the
-    registry — shared by all ticks) over TickConfig defaults. The
-    concurrency-limit key selector is deployed-app configuration (callables
-    can't ride in the JSON tick config).
-
-    ``tick_timeout_seconds`` is the deployed ``tick`` function's own Modal
-    ``timeout`` — how long this container may live, which is what the
-    per-pass spawn cap is derived from. It is applied as a *default* rather
-    than an override so a caller that runs several ticks in one container
-    can pass its own share of the budget (the watchdog sweep does), and it
-    is deliberately absent from ``_TICK_KWARGS_ALLOWED``: persisting it in
-    a build's stored tick config would freeze a deploy-time fact into
-    per-build state and go stale on the next redeploy.
-    """
-    config_kwargs: dict[str, typing.Any] = {
-        **(stored_tick_kwargs or {}),
-        **(tick_kwargs or {}),
-    }
-    if "fail_mode" in config_kwargs:
-        config_kwargs["fail_mode"] = FailMode(config_kwargs["fail_mode"])
-    config_kwargs.setdefault("tick_timeout_seconds", tick_timeout_seconds)
-    return TickConfig(limit_key_selector=limit_key_selector, **config_kwargs)
-
-
-def _validate_tick_kwargs(
-    tick_kwargs: dict[str, typing.Any] | None,
-) -> dict[str, typing.Any] | None:
-    """Validate + JSON-normalize reactive tick_kwargs.
-
-    They are persisted in the build's ``reactive_tick_kwargs`` in the
-    registry (JSON) so all ticks of the build share them — hence only
-    JSON-scalar TickConfig fields are allowed here. ``fail_mode`` may be
-    passed as a FailMode and is stored as its string value.
-    """
-    if not tick_kwargs:
-        return tick_kwargs
-    unknown = set(tick_kwargs) - set(_TICK_KWARGS_ALLOWED)
-    if unknown:
-        raise TypeError(
-            f"Unsupported tick_kwargs {sorted(unknown)}; allowed (JSON-"
-            f"persistable TickConfig fields): {list(_TICK_KWARGS_ALLOWED)}. "
-            "Callables like a concurrency-limit key selector belong in the "
-            "deployed app configuration, not per-trigger kwargs."
-        )
-    normalized = dict(tick_kwargs)
-    if "fail_mode" in normalized:
-        normalized["fail_mode"] = str(FailMode(normalized["fail_mode"]))
-    return normalized
 
 
 class BuildTriggerResult(typing.NamedTuple):
@@ -523,1810 +128,6 @@ class BuildTriggerResult(typing.NamedTuple):
 
     build_id: UUID
     function_call: typing.Any
-
-
-class FunctionSettings(typing.TypedDict, total=False):
-    """Settings for Modal function configuration.
-
-    These settings are passed to modal.App.function() when creating
-    builder and worker functions.
-
-    Attributes:
-        image: Required. The Modal image to use for the function.
-        gpu: GPU configuration (e.g., "A10G", "T4", or list for fallback).
-        cpu: CPU cores (float or (min, max) tuple).
-        memory: Memory in MB (int or (min, max) tuple).
-        timeout: Function timeout in seconds.
-        volumes: Dict of mount path to Volume or CloudBucketMount.
-        secrets: List of Modal secrets to inject.
-        concurrency_limit: Max number of concurrent containers.
-        allow_concurrent_inputs: Max concurrent inputs per container.
-        container_idle_timeout: Seconds before idle container shuts down.
-        keep_warm: Number of containers to keep warm.
-        ephemeral_disk: Ephemeral disk size in MB.
-        retries: Number of retries on failure.
-    """
-
-    image: typing.Required[modal.Image]
-    gpu: str | list[str]
-    cpu: float | tuple[float, float]
-    memory: int | tuple[int, int]
-    timeout: int
-    volumes: dict[
-        typing.Union[str, pathlib.PurePosixPath],
-        typing.Union[modal.Volume, modal.CloudBucketMount],
-    ]
-    secrets: list[modal.Secret]
-    concurrency_limit: int
-    allow_concurrent_inputs: int
-    container_idle_timeout: int
-    keep_warm: int
-    ephemeral_disk: int
-    retries: int
-
-
-# --- Worker selector ---
-
-
-WorkerSelection = typing.Union[str, tuple[str, dict[str, str]]]
-"""Return type of a :data:`WorkerSelector`.
-
-Either a worker name (``str``), or a ``(worker_name, env_overrides)`` tuple
-where ``env_overrides`` is a dict of environment variables to set temporarily
-around the task's ``run`` call inside the worker container (e.g. to tune
-task-specific execution knobs such as worker/thread counts or batch sizes).
-See :meth:`Runner.__call__`.
-"""
-
-WorkerSelector = typing.Callable[[BaseTask], WorkerSelection]
-"""Type for functions that select which worker to use for a task.
-
-A selector returns either a worker name, or a ``(worker_name, env_overrides)``
-tuple (see :data:`WorkerSelection`).
-"""
-
-
-def _normalize_worker_selection(
-    selection: WorkerSelection,
-) -> tuple[str, dict[str, str] | None]:
-    """Split a :data:`WorkerSelection` into ``(worker_name, env_overrides)``.
-
-    Accepts either a bare worker name or a ``(worker_name, env_overrides)``
-    tuple and always returns the two-tuple form (``env_overrides`` is ``None``
-    when the selector returned a bare name).
-    """
-    if isinstance(selection, tuple):
-        worker_name, env_overrides = selection
-        return worker_name, env_overrides
-    return selection, None
-
-
-def _default_worker_selector(task: BaseTask) -> WorkerSelection:
-    """Default worker selector - always returns 'default'."""
-    return "default"
-
-
-def _callable_accepts_env_overrides(fn: typing.Callable[..., typing.Any]) -> bool:
-    """Whether ``fn`` accepts an ``env_overrides`` argument.
-
-    Used to stay backward-compatible with custom ``RunFunction`` implementations
-    written against the older ``(task)``-only signature (before the optional
-    ``env_overrides`` parameter was added).
-    """
-    try:
-        signature = inspect.signature(fn)
-    except (TypeError, ValueError):
-        return False
-    for param in signature.parameters.values():
-        if param.kind is inspect.Parameter.VAR_KEYWORD:
-            return True
-        if param.name == "env_overrides":
-            return True
-    return False
-
-
-# --- Task executor ---
-
-
-def _is_transient_modal_error(exception: BaseException) -> bool:
-    """Best-effort classification of transport-level (retryable) errors.
-
-    Anything raised by ``FunctionCall.get`` that reflects the CALL's outcome
-    (``modal.exception.RemoteError``, user exceptions re-raised from the
-    function, expired results) is terminal; connection/socket/gRPC-transport
-    failures are not — they say nothing about the call.
-    """
-    if isinstance(exception, (OSError, ConnectionError)):
-        return True
-    module = type(exception).__module__ or ""
-    if module.startswith("grpclib") or module.startswith("h2"):
-        return True
-    return type(exception).__name__ in ("ClientClosed", "StreamTerminatedError")
-
-
-MODAL_EXECUTOR_NAME = "modal"
-"""Executor name recorded with detached executions (see DetachedHandle)."""
-
-STARDAG_BUILD_ID_ENV = "STARDAG_BUILD_ID"
-"""Env var through which the build id reaches Modal workers.
-
-Injected into ``env_overrides`` by :class:`ModalTaskExecutor` (so it is also
-set as a process env var around the task's run) and read by
-:class:`Runner` to report the task's lifecycle events from inside the
-worker. Riding on ``env_overrides`` keeps the worker function signature
-unchanged — older deployed workers simply apply it as a harmless env var.
-"""
-
-STARDAG_MODAL_APP_NAME_ENV = "STARDAG_MODAL_APP_NAME"
-"""Env var carrying the Modal app name to workers (reactive scheduling).
-
-Lets a worker wake the scheduler by spawning the app's ``tick`` function
-when it finishes a task. Transported like ``STARDAG_BUILD_ID``.
-"""
-
-STARDAG_REACTIVE_ENV = "STARDAG_REACTIVE"
-"""Env var flagging reactive scheduling to workers ("1" when reactive).
-
-In reactive mode the worker additionally registers dynamically yielded
-deps (with task-store persistence) and wakes the scheduler after terminal
-events — there is no resident orchestrator to do either.
-"""
-
-STARDAG_CLAIM_TTL_SECONDS_ENV = "STARDAG_CLAIM_TTL_SECONDS"
-"""Env var carrying the claim TTL the orchestrator derived for this task.
-
-The worker's own TASK_STARTED is a start like any other, so without this
-it would re-stamp the claim with the registry's generic default and undo
-the orchestrator's derivation (see
-``stardag.build._reactive.claim_ttl_seconds``). Forwarding it also *improves*
-the bound: the worker's start is recorded when execution actually begins, so
-the expiry is re-based off the real start rather than off the pre-spawn
-claim, which absorbed however long the call sat queued.
-"""
-
-STARDAG_MODAL_WORKSPACE_ENV = "STARDAG_MODAL_WORKSPACE"
-"""Env var carrying the resolved Modal workspace name to workers.
-
-Part of the executor-metadata channel: the orchestrator resolves the
-workspace once (token lookup or explicit override) and forwards it so the
-worker's self-reported TASK_STARTED carries the same metadata dict.
-Transported like ``STARDAG_BUILD_ID``.
-"""
-
-STARDAG_MODAL_ENVIRONMENT_ENV = "STARDAG_MODAL_ENVIRONMENT"
-"""Env var carrying the Modal environment name to workers (see
-``STARDAG_MODAL_WORKSPACE``)."""
-
-STARDAG_MODAL_FUNCTION_NAME_ENV = "STARDAG_MODAL_FUNCTION_NAME"
-"""Env var carrying the Modal function name (``worker_<name>``) to workers
-(see ``STARDAG_MODAL_WORKSPACE``)."""
-
-STARDAG_MODAL_APP_ID_ENV = "STARDAG_MODAL_APP_ID"
-"""Env var carrying the resolved Modal app id (``ap-…``) to workers.
-
-Part of the executor-metadata channel: the orchestrator resolves the app
-id once (best-effort ``modal.App.lookup``) and forwards it so the worker's
-self-reported start carries it too. Lets the UI build stable, stop/
-redeploy-proof dashboard deep links (the app-id URL form outlives a given
-deployed app version). Transported like ``STARDAG_BUILD_ID``."""
-
-STARDAG_MODAL_FUNCTION_ID_ENV = "STARDAG_MODAL_FUNCTION_ID"
-"""Env var carrying the Modal function id (``fu-…``) to workers (see
-``STARDAG_MODAL_APP_ID``)."""
-
-
-# Cache for the token-derived Modal workspace name. Resolved at most once
-# per process (including failed lookups — metadata is best-effort and a
-# broken token shouldn't re-pay the lookup timeout on every task).
-_MODAL_WORKSPACE_UNRESOLVED = object()
-_modal_workspace_cache: typing.Any = _MODAL_WORKSPACE_UNRESOLVED
-# Serialises cold-start lookups so a burst of concurrent starts performs
-# one network lookup instead of N parallel ones. Safe to share across
-# sequential event loops: it is never held across loop boundaries.
-_modal_workspace_lock = asyncio.Lock()
-
-
-async def _get_modal_workspace_aio() -> str | None:
-    """Best-effort Modal workspace name for the configured token (cached)."""
-    global _modal_workspace_cache
-    if _modal_workspace_cache is not _MODAL_WORKSPACE_UNRESOLVED:
-        return typing.cast("str | None", _modal_workspace_cache)
-    async with _modal_workspace_lock:
-        if _modal_workspace_cache is _MODAL_WORKSPACE_UNRESOLVED:
-            # Prefer the workspace baked into the container env at deploy
-            # time. The token lookup below only works where a Modal token is
-            # configured — the local triggering/deploy process — NOT inside a
-            # Modal container (worker/tick/build), which is exactly where
-            # task-level executor metadata is produced. finalize() resolves
-            # the workspace locally and injects it as STARDAG_MODAL_WORKSPACE
-            # so containers read it here instead of failing the token lookup.
-            env_workspace = os.environ.get(STARDAG_MODAL_WORKSPACE_ENV)
-            if env_workspace:
-                _modal_workspace_cache = env_workspace
-            else:
-                try:
-                    _modal_workspace_cache = await _lookup_modal_workspace_aio()
-                except Exception as e:
-                    # Cache the failure too: metadata is best-effort and a
-                    # broken token / unreachable Modal API must neither raise
-                    # into a task start nor re-pay the lookup on every start.
-                    _modal_workspace_cache = None
-                    logger.debug(
-                        f"Modal workspace lookup failed (metadata omitted): {e}"
-                    )
-    return typing.cast("str | None", _modal_workspace_cache)
-
-
-async def _lookup_modal_workspace_aio() -> str | None:
-    from modal.config import _lookup_workspace
-    from modal.config import config as modal_config
-
-    server_url = modal_config.get("server_url")
-    token_id = modal_config.get("token_id")
-    token_secret = modal_config.get("token_secret")
-    if not (server_url and token_id and token_secret):
-        return None
-    response = await _lookup_workspace(server_url, token_id, token_secret)
-    # `workspace_name` is the org/display name and is empty for personal
-    # workspaces; `username` is the account slug used in dashboard URLs
-    # (what `modal token info` prints as "Workspace"). Prefer the explicit
-    # workspace name when present, else fall back to the username — else the
-    # (common) personal-workspace case resolves to nothing.
-    return response.workspace_name or response.username or None
-
-
-def _get_modal_workspace() -> str | None:
-    """Sync wrapper for :func:`_get_modal_workspace_aio` (cached).
-
-    Returns None (without caching a failure) when called from inside a
-    running event loop where ``asyncio.run`` is unavailable.
-    """
-    global _modal_workspace_cache
-    if _modal_workspace_cache is not _MODAL_WORKSPACE_UNRESOLVED:
-        return typing.cast("str | None", _modal_workspace_cache)
-    # The deploy-baked env works regardless of an event loop (no lookup).
-    env_workspace = os.environ.get(STARDAG_MODAL_WORKSPACE_ENV)
-    if env_workspace:
-        _modal_workspace_cache = env_workspace
-        return env_workspace
-    try:
-        asyncio.get_running_loop()
-    except RuntimeError:
-        return asyncio.run(_get_modal_workspace_aio())
-    return None
-
-
-def _get_modal_environment() -> str | None:
-    """The active Modal environment name from Modal config, if any."""
-    from modal.config import config as modal_config
-
-    return modal_config.get("environment") or None
-
-
-# Upper bound (seconds) on the best-effort Modal id lookups performed on the
-# critical path before ``spawn``. Matches the 3 s deadline Modal's own
-# ``_lookup_workspace`` gRPC call uses: a *hung* (not merely refused) Modal
-# API must not stall the first task start beyond this cap. On timeout the id
-# is treated as an ordinary best-effort failure (key omitted, debug-logged).
-_MODAL_ID_LOOKUP_TIMEOUT_SECONDS = 3.0
-
-
-async def _get_modal_app_id_aio(
-    app_name: str, environment_name: str | None
-) -> str | None:
-    """Best-effort Modal app id (``ap-…``) for the deployed app.
-
-    Unlike the token workspace lookup, ``modal.App.lookup`` resolves both
-    locally and *inside a Modal container* (worker/tick/build) — which is
-    where task-level executor metadata is produced — so it needs no
-    deploy-baked env fallback. Never raises: on any failure (including the
-    bounded-timeout expiry) the id is omitted from the executor metadata and
-    the failure logged at debug. Bounded by ``_MODAL_ID_LOOKUP_TIMEOUT_SECONDS``
-    so a hung Modal API cannot stall a task start. Resolution is cached by the
-    once-resolved base executor metadata dict.
-
-    Caveat: with ``environment_name=None`` the lookup resolves against the
-    *config-default* Modal environment. If the app is deployed to one
-    environment but local config defaults to another that happens to hold a
-    same-named app, the id (like the ``environment`` metadata key in that same
-    scenario) will be that of the wrong app. Pass the resolved environment to
-    avoid this.
-    """
-    try:
-        app = await asyncio.wait_for(
-            modal.App.lookup.aio(app_name, environment_name=environment_name),
-            timeout=_MODAL_ID_LOOKUP_TIMEOUT_SECONDS,
-        )
-        return app.app_id
-    except Exception as e:
-        logger.debug(f"Modal app id lookup failed (metadata omitted): {e}")
-        return None
-
-
-async def _get_modal_function_id_aio(function: modal.Function) -> str | None:
-    """Best-effort Modal function id (``fu-…``) for a worker function.
-
-    Hydrates the (lazy) ``modal.Function`` handle if needed and reads
-    ``object_id``. ``hydrate`` is a no-op when already hydrated. Never
-    raises: on failure (including the bounded-timeout expiry) the id is
-    omitted and the failure logged at debug. Bounded by
-    ``_MODAL_ID_LOOKUP_TIMEOUT_SECONDS`` so a hung Modal API cannot stall a
-    task start.
-    """
-    try:
-        await asyncio.wait_for(
-            function.hydrate.aio(), timeout=_MODAL_ID_LOOKUP_TIMEOUT_SECONDS
-        )
-        return function.object_id
-    except Exception as e:
-        logger.debug(f"Modal function id resolution failed (metadata omitted): {e}")
-        return None
-
-
-class ModalTaskExecutor(TaskExecutorABC):
-    """Task executor that sends tasks to Modal for remote execution.
-
-    This executor submits tasks to Modal worker functions. Use with
-    RoutedTaskExecutor to route some tasks to Modal and others locally.
-
-    By default tasks are executed *detached* (``worker.spawn`` + a tracked
-    ``FunctionCall``): the worker invocation survives this process, its
-    function call id is recorded in the registry, and a resumed build
-    re-attaches to still-running workers instead of re-executing them.
-    Pass ``detached=False`` for the legacy blocking ``worker.remote`` mode.
-
-    Example:
-        from stardag.build import HybridConcurrentTaskExecutor, RoutedTaskExecutor
-
-        modal_executor = ModalTaskExecutor(
-            modal_app_name="my-app",
-            worker_selector=lambda task: "gpu" if needs_gpu(task) else "default",
-        )
-        local_executor = HybridConcurrentTaskExecutor()
-
-        routed = RoutedTaskExecutor(
-            executors={"modal": modal_executor, "local": local_executor},
-            router=lambda task: "modal" if run_on_modal(task) else "local",
-        )
-        build([task], task_executor=routed)
-    """
-
-    def __init__(
-        self,
-        *,
-        modal_app_name: str,
-        worker_selector: WorkerSelector,
-        detached: bool = True,
-        worker_reports_lifecycle: bool = True,
-        reactive: bool = False,
-        modal_workspace: str | None = None,
-        worker_timeouts: dict[str, int] | None = None,
-    ):
-        """Initialize Modal executor.
-
-        Args:
-            modal_app_name: Name of the Modal app with worker functions.
-            worker_selector: Function that selects which Modal worker to use per task.
-            detached: Execute tasks as detached spawned function calls
-                (restart-safe, re-attachable, explicitly cancellable).
-                False restores the legacy blocking ``remote`` calls.
-            worker_reports_lifecycle: Whether the deployed workers report the
-                task lifecycle (started/completed/suspended/failed events +
-                artifacts) themselves via the default :class:`Runner`. When
-                True the build engine skips its own completed/suspended/
-                resumed reporting for Modal-routed tasks. Set False when
-                driving an app deployed with an older stardag version whose
-                workers don't self-report, or when using a custom
-                ``run_function`` without lifecycle reporting.
-            modal_workspace: Explicit Modal workspace name for the executor
-                metadata recorded with task starts (UI deep links). Default:
-                resolved once from the configured Modal token, best-effort.
-            worker_timeouts: Per-worker Modal function ``timeout`` (seconds),
-                as declared in the app's ``worker_settings``. Only the
-                deploy process can see those settings, so they are passed in
-                rather than looked up. Used to derive the execution-claim
-                TTL recorded with every start (see
-                :meth:`execution_timeout_seconds`); an absent worker simply
-                yields no timeout and the registry's default applies.
-        """
-        self.modal_app_name = modal_app_name
-        self.worker_selector = worker_selector
-        self.detached = detached
-        self.worker_timeouts = dict(worker_timeouts or {})
-        self.worker_reports_lifecycle = worker_reports_lifecycle
-        # Reactive scheduling: forward the app name + reactive flag so
-        # workers register their dynamic deps and wake the scheduler tick.
-        self.reactive = reactive
-        self.modal_workspace = modal_workspace
-        # Executor metadata shared by every start this executor records
-        # (per-task starts add the worker function name). Resolved lazily
-        # at the first invocation, best-effort — metadata must never fail
-        # or delay a task start beyond the one cached lookup.
-        self._base_executor_metadata: dict[str, typing.Any] | None = None
-        # Cache of worker name -> modal.Function. ``modal.Function.from_name``
-        # returns a lazy handle (no network call until invoked), but it is
-        # invoked on every ``submit`` so we memoize it per worker name to avoid
-        # recreating the handle for every task.
-        self._worker_functions: dict[str, modal.Function] = {}
-        # Cache of worker name -> resolved function id (``fu-…``), best-effort.
-        # A ``None`` value is a *resolved* negative (a failed/timed-out
-        # hydration) and is kept so a persistently failing lookup is not
-        # re-paid on every task start — membership, not truthiness, marks
-        # "resolved". Mirrors the once-resolved memoization of the base
-        # metadata dict (which likewise caches a missing app id).
-        self._worker_function_ids: dict[str, str | None] = {}
-        # One-time (per executor) skew-visibility log; see reports_lifecycle.
-        self._reports_lifecycle_logged = False
-        # In-flight detached executions by task UUID, for explicit cancel().
-        # Asyncio cancellation of ``FunctionCall.get`` does NOT stop the
-        # remote call (unlike ``remote.aio``), so FAIL_FAST relies on this.
-        self._in_flight: dict[UUID, modal.FunctionCall] = {}
-
-    def _get_worker_function(self, worker_name: str) -> modal.Function:
-        """Return the (memoized) ``modal.Function`` handle for a worker."""
-        worker_function = self._worker_functions.get(worker_name)
-        if worker_function is None:
-            worker_function = modal.Function.from_name(
-                app_name=self.modal_app_name,
-                name=f"worker_{worker_name}",
-            )
-            self._worker_functions[worker_name] = worker_function
-        return worker_function
-
-    async def _get_base_executor_metadata(self) -> dict[str, typing.Any] | None:
-        """Resolve the executor metadata shared by all starts (cached).
-
-        Best-effort: resolution failures are logged at debug level and
-        yield the identity-only dict — never an exception.
-        """
-        if self._base_executor_metadata is None:
-            metadata: dict[str, typing.Any] = {
-                "kind": MODAL_EXECUTOR_NAME,
-                "app_name": self.modal_app_name,
-            }
-            environment: str | None = None
-            try:
-                workspace = self.modal_workspace or await _get_modal_workspace_aio()
-                if workspace:
-                    metadata["workspace"] = workspace
-                environment = _get_modal_environment()
-                if environment:
-                    metadata["environment"] = environment
-            except Exception:
-                logger.debug(
-                    "Failed to resolve Modal workspace/environment for "
-                    "executor metadata",
-                    exc_info=True,
-                )
-            # App id (``ap-…``): app-wide, so it lives in the base metadata
-            # alongside workspace/environment. Resolved once and cached here
-            # (the base metadata is memoized per executor). Best-effort —
-            # _get_modal_app_id_aio never raises.
-            app_id = await _get_modal_app_id_aio(self.modal_app_name, environment)
-            if app_id:
-                metadata["app_id"] = app_id
-            self._base_executor_metadata = metadata
-        return self._base_executor_metadata
-
-    async def _metadata_for_worker(
-        self, worker_name: str
-    ) -> dict[str, typing.Any] | None:
-        """Base executor metadata + the worker's function name/id (best-effort)."""
-        try:
-            base_metadata = await self._get_base_executor_metadata()
-            if base_metadata is None:
-                return None
-            metadata = {**base_metadata, "function_name": f"worker_{worker_name}"}
-            # Function id (``fu-…``): per-worker, so it lives here alongside
-            # the function name. Best-effort — hydrate the worker handle and
-            # read object_id; _get_modal_function_id_aio never raises. Cached
-            # per worker name (success *and* failure): a resolved ``None`` is
-            # kept so a broken/hung hydration is not re-attempted on every
-            # start (membership marks "resolved", not truthiness).
-            if worker_name not in self._worker_function_ids:
-                self._worker_function_ids[
-                    worker_name
-                ] = await _get_modal_function_id_aio(
-                    self._get_worker_function(worker_name)
-                )
-            function_id = self._worker_function_ids[worker_name]
-            if function_id:
-                metadata["function_id"] = function_id
-            return metadata
-        except Exception:
-            logger.debug("Failed to resolve Modal executor metadata", exc_info=True)
-            return None
-
-    async def get_executor_metadata(
-        self, task: BaseTask
-    ) -> dict[str, typing.Any] | None:
-        """Executor metadata for ``task`` without spawning anything.
-
-        Runs the worker selector (idempotent) to resolve the function
-        name — lets slot-acquiring TASK_STARTED events recorded before
-        the spawn carry the same metadata as the post-spawn start.
-        """
-        try:
-            worker_name, _ = _normalize_worker_selection(self.worker_selector(task))
-        except Exception:
-            logger.debug(
-                "Worker selection failed while resolving executor metadata",
-                exc_info=True,
-            )
-            return None
-        return await self._metadata_for_worker(worker_name)
-
-    def execution_timeout_seconds(self, task: BaseTask) -> float | None:
-        """The Modal ``timeout`` of the worker function this task routes to.
-
-        Modal kills a function call at its ``timeout``, so this is a hard
-        upper bound on how long an execution of ``task`` can be alive — the
-        one fact that makes an execution claim's expiry defensible rather
-        than a guess.
-
-        Returns None when the deployed settings were not passed in (see
-        ``worker_timeouts``), when the selected worker declares no timeout,
-        or when worker selection fails: none of those is a reason to fail a
-        start, and the registry's own default covers them.
-        """
-        if not self.worker_timeouts:
-            return None
-        try:
-            worker_name, _ = _normalize_worker_selection(self.worker_selector(task))
-        except Exception:
-            logger.debug(
-                "Worker selection failed while resolving the execution timeout",
-                exc_info=True,
-            )
-            return None
-        timeout = self.worker_timeouts.get(worker_name)
-        return float(timeout) if timeout is not None else None
-
-    async def _prepare_invocation(
-        self, task: BaseTask
-    ) -> tuple[modal.Function, dict[str, str] | None, dict[str, typing.Any] | None]:
-        """Resolve the worker function, env overrides, and executor metadata.
-
-        When ``worker_reports_lifecycle`` and an enclosing build is active,
-        the build id is injected as the ``STARDAG_BUILD_ID`` env override so
-        the worker-side :class:`Runner` can report lifecycle events. The
-        resolved executor metadata rides along the same channel
-        (``STARDAG_MODAL_*``) so worker self-reported starts carry it too —
-        as does the derived claim TTL, so the worker's own start does not
-        re-stamp the claim with the registry's generic default.
-        """
-        worker_name, env_overrides = _normalize_worker_selection(
-            self.worker_selector(task)
-        )
-        worker_function = self._get_worker_function(worker_name)
-        executor_metadata = await self._metadata_for_worker(worker_name)
-        if self.worker_reports_lifecycle:
-            build_id = get_current_build_id()
-            if build_id is not None:
-                env_overrides = {
-                    **(env_overrides or {}),
-                    STARDAG_BUILD_ID_ENV: str(build_id),
-                    STARDAG_MODAL_APP_NAME_ENV: self.modal_app_name,
-                }
-                ttl_seconds = claim_ttl_seconds(task, self)
-                if ttl_seconds is not None:
-                    env_overrides[STARDAG_CLAIM_TTL_SECONDS_ENV] = str(ttl_seconds)
-                if executor_metadata is not None:
-                    for env_name, key in (
-                        (STARDAG_MODAL_WORKSPACE_ENV, "workspace"),
-                        (STARDAG_MODAL_ENVIRONMENT_ENV, "environment"),
-                        (STARDAG_MODAL_FUNCTION_NAME_ENV, "function_name"),
-                        (STARDAG_MODAL_APP_ID_ENV, "app_id"),
-                        (STARDAG_MODAL_FUNCTION_ID_ENV, "function_id"),
-                    ):
-                        value = executor_metadata.get(key)
-                        if value:
-                            env_overrides[env_name] = value
-                if self.reactive:
-                    env_overrides[STARDAG_REACTIVE_ENV] = "1"
-        return worker_function, env_overrides, executor_metadata
-
-    def reports_lifecycle(self, task: BaseTask) -> bool:
-        """Workers self-report lifecycle when enabled and a build is active."""
-        active = self.worker_reports_lifecycle and get_current_build_id() is not None
-        if active and not self._reports_lifecycle_logged:
-            # Make the version-skew failure mode visible: nothing verifies
-            # the deployed workers actually self-report. If the app was
-            # deployed with an older stardag (or uses a custom run function
-            # without lifecycle reporting), tasks will execute fine but sit
-            # RUNNING in the registry with artifacts lost.
-            self._reports_lifecycle_logged = True
-            logger.info(
-                "Engine-side lifecycle reporting is suppressed for "
-                f"Modal-routed tasks (app {self.modal_app_name!r}): workers "
-                "are assumed to self-report started/completed/suspended/"
-                "failed events. If the deployed app predates worker "
-                "self-reporting or uses a custom run function, pass "
-                "ModalTaskExecutor(worker_reports_lifecycle=False) — "
-                "otherwise tasks will appear stuck RUNNING in the registry."
-            )
-        return active
-
-    async def submit(self, task: BaseTask) -> None | TaskStruct | TaskExecutionError:
-        """Execute task on Modal (blocking remote call)."""
-        try:
-            worker_function, env_overrides, _ = await self._prepare_invocation(task)
-            res = await worker_function.remote.aio(task, env_overrides=env_overrides)
-            return res
-        except Exception as e:
-            return TaskExecutionError(
-                exception=e,
-                traceback="".join(tb_module.format_exception(e)),
-            )
-
-    # --- Detached execution (spawn + re-attach + cancel) ---
-
-    def supports_detached(self, task: BaseTask) -> bool:
-        """Detached mode is per-executor (constructor flag), not per-task."""
-        return self.detached
-
-    def _make_handle(
-        self,
-        task: BaseTask,
-        function_call: modal.FunctionCall,
-        executor_metadata: dict[str, typing.Any] | None = None,
-    ) -> DetachedHandle:
-        """Wrap a FunctionCall in a DetachedHandle tracking in-flight state."""
-        self._in_flight[task.id] = function_call
-
-        async def wait() -> None | TaskStruct | TaskExecutionError:
-            try:
-                return await function_call.get.aio()
-            except asyncio.CancelledError:
-                # The build engine cancels the awaiting future on FAIL_FAST /
-                # user cancellation. Unlike ``remote.aio``, cancelling
-                # ``get()`` does NOT stop the detached remote call — cancel
-                # it explicitly here. This must live in wait() (not only in
-                # the executor cancel() hook): the finally below pops the
-                # in-flight entry, and the asyncio cancellation typically
-                # lands before the hook runs, so the hook would find nothing.
-                # Shielded: this coroutine is already being cancelled.
-                try:
-                    await asyncio.shield(function_call.cancel.aio())
-                except Exception as cancel_err:
-                    logger.warning(
-                        f"Failed to cancel Modal function call "
-                        f"{function_call.object_id} for task {task.id} "
-                        f"during cancellation: {cancel_err}"
-                    )
-                raise
-            except Exception as e:
-                return TaskExecutionError(
-                    exception=e,
-                    traceback="".join(tb_module.format_exception(e)),
-                )
-            finally:
-                self._in_flight.pop(task.id, None)
-
-        return DetachedHandle(
-            executor=MODAL_EXECUTOR_NAME,
-            ref=function_call.object_id,
-            wait=wait,
-            executor_metadata=executor_metadata,
-        )
-
-    async def submit_detached(self, task: BaseTask) -> DetachedHandle:
-        """Spawn the task on its worker function; return a re-attachable handle."""
-        (
-            worker_function,
-            env_overrides,
-            executor_metadata,
-        ) = await self._prepare_invocation(task)
-        function_call = await worker_function.spawn.aio(
-            task, env_overrides=env_overrides
-        )
-        return self._make_handle(task, function_call, executor_metadata)
-
-    async def reattach(
-        self, task: BaseTask, executor: str, ref: str
-    ) -> DetachedHandle | None:
-        """Re-attach to a spawned function call by id, if it is still live.
-
-        Returns None (→ normal re-execution) when the ref belongs to a
-        different backend, the call failed/was cancelled, or the result has
-        expired. A call that already finished successfully yields a handle
-        resolving immediately to its result.
-
-        Known ambiguity (accepted): Modal's ``get(timeout=0)`` poll timeout
-        raises the *builtin* ``TimeoutError`` (modal 1.5), and a task body
-        that itself raised ``TimeoutError`` re-raises the same type — such
-        a failed call classifies as still-running here. Not narrowable:
-        ``modal.exception.TimeoutError`` is not what the poll raises, and
-        ``FunctionCall.get_call_graph()`` does not reliably surface input
-        status (verified live: stays PENDING after success/cancel). The
-        re-attach path self-corrects: awaiting the returned handle's
-        ``wait()`` re-raises the failure and the task is recorded failed.
-        """
-        if executor != MODAL_EXECUTOR_NAME or not self.detached:
-            return None
-        try:
-            function_call = modal.FunctionCall.from_id(ref)
-        except Exception:
-            return None
-        try:
-            result = await function_call.get.aio(timeout=0)
-        except TimeoutError:
-            # Still running (or queued) — the interesting case. Base
-            # metadata only: the worker function behind a bare ref isn't
-            # known here.
-            return self._make_handle(
-                task, function_call, await self._get_base_executor_metadata()
-            )
-        except Exception:
-            # Failed, cancelled, expired result, or unknown id — re-execute.
-            return None
-
-        async def resolved() -> None | TaskStruct | TaskExecutionError:
-            return result
-
-        return DetachedHandle(executor=MODAL_EXECUTOR_NAME, ref=ref, wait=resolved)
-
-    async def detached_status(
-        self, task: BaseTask, executor: str, ref: str
-    ) -> DetachedExecutionStatus:
-        """Non-blocking probe of a spawned function call's state.
-
-        Note: an expired result (>~7 days) and an unknown id also classify
-        as FAILED — callers (scheduler ticks) check target existence first,
-        so a successfully-finished-long-ago execution is already resolved
-        as complete before this is consulted.
-
-        Known ambiguity (accepted, see also ``reattach``): the poll timeout
-        is the builtin ``TimeoutError``, indistinguishable from a task body
-        that raised ``TimeoutError`` — such a failed execution classifies
-        as RUNNING here. In practice the worker's own TASK_FAILED report
-        resolves the task first; only a registry-less worker raising
-        builtin TimeoutError hits the ambiguity.
-        """
-        if executor != MODAL_EXECUTOR_NAME or not self.detached:
-            return DetachedExecutionStatus.UNKNOWN
-        try:
-            function_call = modal.FunctionCall.from_id(ref)
-            await function_call.get.aio(timeout=0)
-        except TimeoutError:
-            return DetachedExecutionStatus.RUNNING
-        except Exception as e:
-            # Transient transport/infrastructure errors must NOT classify as
-            # FAILED: callers (claim loser-resolution, tick healing) treat
-            # FAILED as proof of death — a network blip mistaken for a dead
-            # winner would let a racer record a live execution as failed and
-            # spawn the duplicate the claim exists to prevent. UNKNOWN is
-            # the safe degradation (leave/wait and re-probe later).
-            if _is_transient_modal_error(e):
-                logger.warning(
-                    f"Transient error probing Modal call {ref!r}; treating "
-                    f"as unknown: {e}"
-                )
-                return DetachedExecutionStatus.UNKNOWN
-            return DetachedExecutionStatus.FAILED
-        return DetachedExecutionStatus.SUCCEEDED
-
-    async def cancel_detached(self, task: BaseTask, executor: str, ref: str) -> None:
-        """Cancel a spawned function call by its recorded id."""
-        if executor != MODAL_EXECUTOR_NAME:
-            return
-        try:
-            await modal.FunctionCall.from_id(ref).cancel.aio()
-        except Exception as e:
-            logger.warning(
-                f"Failed to cancel Modal function call {ref!r} for task {task.id}: {e}"
-            )
-
-    async def cancel(self, task: BaseTask) -> None:
-        """Cancel the tracked in-flight function call for ``task``, if any."""
-        function_call = self._in_flight.pop(task.id, None)
-        if function_call is None:
-            return
-        try:
-            await function_call.cancel.aio()
-        except Exception as e:
-            logger.warning(
-                f"Failed to cancel Modal function call "
-                f"{function_call.object_id} for task {task.id}: {e}"
-            )
-
-    async def setup(self) -> None:
-        """No setup needed for Modal executor."""
-        pass
-
-    async def teardown(self) -> None:
-        """No teardown needed for Modal executor."""
-        pass
-
-
-# --- Build and run function protocols ---
-
-
-class BuildFailedError(Exception):
-    """Raised when a build completes with failures or pending tasks."""
-
-    pass
-
-
-class BuildFunction(typing.Protocol):
-    """Protocol for the function registered as the Modal "build" function.
-
-    This function is called remotely on Modal to orchestrate a DAG build.
-    It receives one or more root tasks, a worker selector, the Modal app
-    name, and an optional ``build_kwargs`` dict, then coordinates task
-    execution across Modal worker functions.
-
-    Args (of ``__call__``):
-        tasks: A single root ``BaseTask`` or a sequence of root tasks.
-        worker_selector: Function picking a worker name per task.
-        app_name: Name of the Modal app hosting the worker functions.
-        build_kwargs: Optional dict of extra kwargs forwarded to the
-            underlying build engine (the default ``Builder`` splats them
-            into :func:`stardag.build`). ``None`` means "no extra kwargs".
-
-    The default implementation (``Builder``) creates a ``ModalTaskExecutor``
-    and calls ``stardag.build()``. Custom implementations can subclass
-    ``Builder`` to override ``setup()``/``teardown()``/``build()``, or
-    implement this protocol directly for full control.
-
-    Any module-level code in the module where a custom build function is
-    defined will execute inside the Modal container before the function is
-    called — use this for container-level setup (imports, config, etc.).
-    """
-
-    def __call__(
-        self,
-        tasks: typing.Sequence[BaseTask] | BaseTask,
-        worker_selector: WorkerSelector,
-        app_name: str,
-        build_kwargs: dict[str, typing.Any] | None = None,
-    ) -> BuildSummary | None: ...
-
-
-class RunFunction(typing.Protocol):
-    """Protocol for the function registered as Modal "worker_*" functions.
-
-    This function is called remotely on Modal to execute a single task.
-    It receives a task instance and returns either ``None`` (task completed)
-    or the ``TaskStruct`` yielded at the first incomplete dynamic-deps yield
-    (which may include deps that are already complete — the caller is
-    expected to filter if that matters). This enables idempotent
-    re-execution: the build system schedules the yielded deps, then
-    re-invokes the task. On re-execution the generator advances past
-    previously-yielded batches whose deps are now complete.
-
-    The default implementation (``Runner``) handles sync, async, and dynamic
-    deps tasks. Custom implementations can subclass ``Runner`` to override
-    ``setup()``/``teardown()``/``run()``, or implement this protocol directly.
-
-    Any module-level code in the module where a custom run function is
-    defined will execute inside the Modal container before the function is
-    called — use this for container-level setup (imports, config, etc.).
-
-    Args (of ``__call__``):
-        task: The task instance to execute.
-
-    Implementations *may* additionally accept an optional
-    ``env_overrides: dict[str, str] | None`` keyword argument (the framework
-    always forwards it by keyword). When the ``worker_selector`` returns
-    ``(worker_name, env_overrides)`` (see :data:`WorkerSelection`), the
-    framework forwards those overrides to run functions that accept the
-    parameter; for run functions written against the older ``(task)``-only
-    signature the framework instead applies the overrides to the process
-    environment around the call. The default :class:`Runner` accepts
-    ``env_overrides`` and applies them around its ``run`` call.
-    """
-
-    def __call__(self, task: BaseTask) -> None | TaskStruct: ...
-
-
-class _RunFunctionWithEnv(typing.Protocol):
-    """Internal protocol for run functions that accept ``env_overrides``.
-
-    Used to type the call site that forwards selector-provided environment
-    overrides (see :class:`StardagApp.finalize`'s ``_modal_run`` wrapper).
-    """
-
-    def __call__(
-        self, task: BaseTask, *, env_overrides: dict[str, str] | None = None
-    ) -> None | TaskStruct: ...
-
-
-# --- Default build/run implementations, with overridable methods ---
-
-
-class Builder(BuildFunction):
-    """Default builder implementation with overridable setup/teardown.
-
-    Override ``setup()``/``teardown()``/``build()`` to customize behavior.
-    Pass an instance to ``StardagApp(build_function=MyBuilder())``.
-
-    Example:
-
-    .. code-block:: python
-
-        class MyBuilder(Builder):
-            def setup(self, tasks):
-                super().setup(tasks)
-                configure_my_environment()
-
-        stardag_app = StardagApp(
-            "my-app",
-            build_function=MyBuilder(),
-            ...
-        )
-    """
-
-    def __init__(self, *, detached: bool = True):
-        """Initialize the builder.
-
-        Args:
-            detached: Execute tasks as detached spawned Modal function calls
-                (restart-safe, re-attachable on resume, explicitly
-                cancellable). False restores the legacy blocking
-                ``remote`` calls. Passed to :class:`ModalTaskExecutor`.
-        """
-        self.detached = detached
-
-    def setup(self, tasks: typing.Sequence[BaseTask] | BaseTask) -> None:
-        """Optional setup logic before the build starts."""
-        _setup_logging()
-
-    def teardown(
-        self,
-        tasks: typing.Sequence[BaseTask] | BaseTask,
-        summary_or_exception: BuildSummary | None | Exception,
-    ) -> None:
-        """Optional teardown logic after the build finishes."""
-        if isinstance(summary_or_exception, BuildSummary):
-            summary = summary_or_exception
-            logger.info(f"Build summary:\n{repr(summary)}")
-            if summary.status != BuildExitStatus.SUCCESS:
-                raise BuildFailedError(
-                    f"Build finished with status {summary.status.value}: "
-                    f"{summary.task_count.failed} failed, "
-                    f"{summary.task_count.pending} pending"
-                )
-        elif summary_or_exception is None:
-            logger.info("Build completed without a BuildSummary.")
-        else:
-            logger.error(f"Build exception:\n{repr(summary_or_exception)}")
-
-    def __call__(
-        self,
-        tasks: typing.Sequence[BaseTask] | BaseTask,
-        worker_selector: WorkerSelector,
-        app_name: str,
-        build_kwargs: dict[str, typing.Any] | None = None,
-    ) -> BuildSummary | None:
-        """Core build logic to orchestrate the DAG build."""
-        modal_executor = ModalTaskExecutor(
-            modal_app_name=app_name,
-            worker_selector=worker_selector,
-            detached=getattr(self, "detached", True),
-        )
-        summary_or_exception: BuildSummary | None | Exception = BuildFailedError(
-            "Unknown error during build"
-        )  # Placeholder for type checking, this should never be raised
-
-        try:
-            self.setup(tasks)
-            summary = self.build(tasks, modal_executor, build_kwargs=build_kwargs)
-            summary_or_exception = summary
-            return summary
-        except Exception as exception:
-            summary_or_exception = exception
-            raise
-        finally:
-            self.teardown(tasks, summary_or_exception)
-
-    def build(
-        self,
-        tasks: typing.Sequence[BaseTask] | BaseTask,
-        task_executor: ModalTaskExecutor,
-        build_kwargs: dict[str, typing.Any] | None = None,
-    ) -> BuildSummary | None:
-        """Default build logic using stardag.build() with the ModalTaskExecutor.
-
-        ``build_kwargs`` are forwarded to :func:`stardag.build` (e.g. ``fail_mode``,
-        ``register_all``, ``global_lock_config``). Conflicting keys (``tasks``,
-        ``task_executor``) are reserved and rejected.
-        """
-        kwargs = dict(build_kwargs or {})
-        for reserved in ("tasks", "task_executor"):
-            if reserved in kwargs:
-                raise TypeError(
-                    f"build_kwargs must not contain reserved key '{reserved}'"
-                )
-        return build(tasks, task_executor=task_executor, **kwargs)
-
-
-class _WorkerLifecycleReporter:
-    """Reports a task's lifecycle events from inside a Modal worker.
-
-    Created by :class:`Runner` when a build id was forwarded (see
-    ``STARDAG_BUILD_ID_ENV``) and the container has a configured registry.
-    Reporting from the worker makes the events independent of the
-    orchestrator's lifetime: completion/failure land even if the build
-    function died mid-await, and each (re-)invocation's TASK_STARTED
-    carries its own function call id for re-attach.
-
-    All reporting is best-effort: a registry hiccup must never fail a task
-    whose actual work succeeded — failures are logged loudly and the
-    engine-side self-heal (target-existence check on the next build) covers
-    a lost completion event.
-    """
-
-    def __init__(
-        self,
-        registry: typing.Any,
-        build_id: UUID,
-        task: BaseTask,
-        *,
-        reactive: bool = False,
-        app_name: str | None = None,
-        executor_metadata: dict[str, typing.Any] | None = None,
-        claim_ttl_seconds: int | None = None,
-    ):
-        self.registry = registry
-        self.build_id = build_id
-        self.task = task
-        self.reactive = reactive
-        self.app_name = app_name
-        self.executor_metadata = executor_metadata
-        self.claim_ttl_seconds = claim_ttl_seconds
-
-    @classmethod
-    def create(
-        cls, task: BaseTask, env_overrides: dict[str, str] | None
-    ) -> "_WorkerLifecycleReporter | None":
-        def _get(key: str) -> str | None:
-            return (env_overrides or {}).get(key) or os.environ.get(key)
-
-        raw_build_id = _get(STARDAG_BUILD_ID_ENV)
-        if not raw_build_id:
-            return None
-        try:
-            build_id = UUID(raw_build_id)
-        except ValueError:
-            logger.warning(f"Invalid {STARDAG_BUILD_ID_ENV}: {raw_build_id!r}")
-            return None
-        registry = registry_provider.get()
-        # Exact-type check: only the literal do-nothing default suppresses
-        # reporting — NoOpRegistry *subclasses* may implement real behavior.
-        if type(registry) is NoOpRegistry:
-            return None
-        app_name = _get(STARDAG_MODAL_APP_NAME_ENV)
-        # Executor metadata forwarded by the orchestrator's executor (same
-        # dict it records on its own starts). Values missing on older
-        # orchestrators are simply omitted.
-        executor_metadata: dict[str, typing.Any] = {"kind": MODAL_EXECUTOR_NAME}
-        if app_name:
-            executor_metadata["app_name"] = app_name
-        for key, env_name in (
-            ("workspace", STARDAG_MODAL_WORKSPACE_ENV),
-            ("environment", STARDAG_MODAL_ENVIRONMENT_ENV),
-            ("function_name", STARDAG_MODAL_FUNCTION_NAME_ENV),
-            ("app_id", STARDAG_MODAL_APP_ID_ENV),
-            ("function_id", STARDAG_MODAL_FUNCTION_ID_ENV),
-        ):
-            value = _get(env_name)
-            if value:
-                executor_metadata[key] = value
-        # The orchestrator's derived claim TTL, if it sent one. Malformed
-        # values are ignored rather than raised on: this is a bound on an
-        # expiry, and no worker should fail to report its own start over it.
-        raw_ttl = _get(STARDAG_CLAIM_TTL_SECONDS_ENV)
-        try:
-            ttl_seconds = int(raw_ttl) if raw_ttl else None
-        except ValueError:
-            logger.warning(f"Invalid {STARDAG_CLAIM_TTL_SECONDS_ENV}: {raw_ttl!r}")
-            ttl_seconds = None
-        # A syntactically valid but out-of-range value is the same problem
-        # as a malformed one, and worse in effect: the server rejects it
-        # (422) on `task_start`, so the worker loses its whole lifecycle
-        # report over a bound on an expiry. Drop it and let the server pick
-        # its default.
-        if ttl_seconds is not None and ttl_seconds <= 0:
-            logger.warning(
-                f"Ignoring {STARDAG_CLAIM_TTL_SECONDS_ENV}={raw_ttl!r}: a claim "
-                "TTL must be positive. The server's default applies instead."
-            )
-            ttl_seconds = None
-        return cls(
-            registry,
-            build_id,
-            task,
-            reactive=_get(STARDAG_REACTIVE_ENV) == "1",
-            app_name=app_name,
-            executor_metadata=executor_metadata,
-            claim_ttl_seconds=ttl_seconds,
-        )
-
-    def _guard(self, fn: typing.Callable[[], None], what: str) -> None:
-        try:
-            fn()
-        except Exception:
-            logger.exception(
-                f"Worker lifecycle report ({what}) failed for task {self.task.id}"
-            )
-
-    def started(self) -> None:
-        def _do() -> None:
-            ref: str | None = None
-            try:
-                ref = modal.current_function_call_id()
-            except Exception:
-                pass
-            self.registry.task_start(
-                self.build_id,
-                self.task,
-                executor=MODAL_EXECUTOR_NAME,
-                executor_ref=ref,
-                executor_metadata=self.executor_metadata,
-                claim_ttl_seconds=self.claim_ttl_seconds,
-            )
-
-        self._guard(_do, "start")
-
-    def completed(self) -> None:
-        self._guard(
-            lambda: self.registry.task_complete(self.build_id, self.task),
-            "complete",
-        )
-
-        def _artifacts() -> None:
-            artifacts = self.task.artifacts()
-            if artifacts:
-                self.registry.task_upload_artifacts(self.build_id, self.task, artifacts)
-
-        self._guard(_artifacts, "artifacts")
-        self._wake_scheduler()
-
-    def suspended(self, task_struct: TaskStruct | None = None) -> None:
-        if self.reactive and task_struct is not None:
-            # No resident orchestrator to pick up the yielded deps: register
-            # them (with their requires() subtrees), persist their pickles
-            # for the scheduler, and record the dynamic edges — BEFORE the
-            # suspend event, so the frontier is consistent when a tick runs.
-            self._guard(
-                lambda: self._register_dynamic_deps(task_struct), "dynamic-deps"
-            )
-        self._guard(
-            lambda: self.registry.task_suspend(self.build_id, self.task),
-            "suspend",
-        )
-        self._wake_scheduler()
-
-    def failed(self, exception: Exception) -> None:
-        self._guard(
-            lambda: self.registry.task_fail(
-                self.build_id, self.task, error_message=str(exception)
-            ),
-            "fail",
-        )
-        self._wake_scheduler()
-
-    def _register_dynamic_deps(self, task_struct: TaskStruct) -> None:
-        result = asyncio.run(
-            discover_and_register_aio(self.registry, self.build_id, task_struct)
-        )
-        store = BuildTaskStore(self.build_id)
-        # The trigger's pre-flight structurally cannot see dynamically
-        # yielded deps — they don't exist until their parent runs — so the
-        # coverage check is re-run here, on the app's patterns as published
-        # by the deployed worker wrapper. Once per class per process: this
-        # runs on every suspending worker invocation.
-        #
-        # The same elision applies (see StardagApp._persist_discovered_tasks):
-        # without it the pickle-free property would hold only until a task
-        # yielded its first dynamic dependency, and a build with dynamic
-        # deps would still need target-root write access.
-        patterns = declared_task_module_patterns()
-        if patterns:
-            uncovered = uncovered_task_classes(
-                result.incomplete.values(), patterns, only_unwarned=True
-            )
-            if uncovered:
-                logger.warning(
-                    format_uncovered_message(
-                        uncovered,
-                        patterns,
-                        remedy=(
-                            "These were registered as dynamic dependencies, "
-                            "so the trigger's pre-flight could not see them."
-                        ),
-                    )
-                )
-            plan = plan_pickle_elision(result.incomplete.values(), patterns)
-            store.save_tasks(task for task, _ in plan.pickled)
-            logger.info(
-                f"Build {self.build_id} dynamic deps of task "
-                f"{self.task.id}: {plan.summary()}"
-            )
-        else:
-            store.save_tasks(result.incomplete.values())
-        deps = flatten_task_struct(task_struct)
-        self.registry.task_add_dependencies(
-            self.build_id, self.task, deps, is_dynamic=True
-        )
-
-    def _wake_scheduler(self) -> None:
-        """Reactive wake-up: flag the build dirty, then spawn a tick.
-
-        Order matters: the flag is set *before* the spawn, so if the tick
-        finds the scheduler lease held, the holder's linger re-check is
-        guaranteed to observe the wake-up.
-        """
-        if not self.reactive:
-            return
-        self._guard(lambda: self.registry.build_notify(self.build_id), "notify")
-        app_name = self.app_name
-        if app_name is None:
-            logger.warning(
-                "Reactive build without an app name — cannot spawn a "
-                "scheduler tick (relying on the watchdog)."
-            )
-            return
-
-        def _spawn_tick() -> None:
-            modal.Function.from_name(app_name=app_name, name="tick").spawn(
-                build_id=str(self.build_id)
-            )
-
-        self._guard(_spawn_tick, "tick-spawn")
-
-
-class Runner(RunFunction):
-    """Default runner implementation with overridable setup/teardown.
-
-    Override ``setup()``/``teardown()``/``run()`` to customize behavior.
-    Pass an instance to ``StardagApp(run_function=MyRunner())``.
-
-    Example:
-
-    .. code-block:: python
-
-        class MyRunner(Runner):
-            def setup(self, task):
-                super().setup(task)
-                torch.cuda.set_device(0)
-
-        stardag_app = StardagApp(
-            "my-app",
-            run_function=MyRunner(),
-            ...
-        )
-    """
-
-    def __init__(self, *, report_lifecycle: bool = True):
-        """Initialize the runner.
-
-        Args:
-            report_lifecycle: Report the task's lifecycle events
-                (started/completed/suspended/failed + artifacts) to the
-                registry from inside the worker, when a build id was
-                forwarded by the executor and the container has registry
-                credentials. See :class:`_WorkerLifecycleReporter`.
-        """
-        self.report_lifecycle = report_lifecycle
-
-    def setup(self, task: BaseTask) -> None:
-        """Optional setup logic before the task runs."""
-        _setup_logging()
-
-    def teardown(self, task: BaseTask, exception: Exception | None) -> None:
-        """Optional teardown logic after the task runs."""
-        if exception:
-            logger.error(f"Task {repr(task)} raised an exception: {repr(exception)}")
-
-    def __call__(
-        self, task: BaseTask, *, env_overrides: dict[str, str] | None = None
-    ) -> None | TaskStruct:
-        """Core logic to execute a single task.
-
-        Returns ``None`` when the task completed, or a ``TaskStruct`` of
-        dynamic dependencies that were not yet complete (idempotent
-        re-execution pattern — see ``run``).
-
-        Args:
-            task: The task instance to execute.
-            env_overrides: Optional environment variable overrides (selected by
-                the ``worker_selector`` — see :data:`WorkerSelection`). When
-                provided, they are set temporarily around the ``run`` call and
-                the previous environment is restored afterwards.
-        """
-        # getattr: tolerate subclasses overriding __init__ without super()
-        result: None | TaskStruct = None
-        exception: Exception | None = None
-        try:
-            self.setup(task)
-            # All lifecycle reporting happens inside the env-overrides
-            # context, so overrides carrying environment-sensitive config
-            # apply to reporting exactly as they do to run(). (Caveat:
-            # stardag's config/registry providers cache on first access —
-            # registry connection settings should come from the container's
-            # process environment, i.e. deployment secrets, not overrides.)
-            with temp_env_vars(env_overrides or {}):
-                # getattr: tolerate subclasses overriding __init__ w/o super()
-                reporter: _WorkerLifecycleReporter | None = None
-                if getattr(self, "report_lifecycle", True):
-                    try:
-                        reporter = _WorkerLifecycleReporter.create(task, env_overrides)
-                    except Exception:
-                        # Best-effort contract covers creation too: a broken
-                        # registry config must not fail a task before it runs.
-                        logger.exception(
-                            "Worker lifecycle reporter creation failed; "
-                            "running without lifecycle reporting."
-                        )
-                if reporter is not None:
-                    reporter.started()
-                try:
-                    result = self.run(task)
-                except Exception as e:
-                    if reporter is not None:
-                        reporter.failed(e)
-                    raise
-                if reporter is not None:
-                    if result is None:
-                        reporter.completed()
-                    else:
-                        reporter.suspended(result)
-        except Exception as e:
-            exception = e
-            raise
-        finally:
-            self.teardown(task, exception)
-        return result
-
-    def run(self, task: BaseTask) -> None | TaskStruct:
-        """Default run logic — handles sync, async, and dynamic deps tasks.
-
-        Dispatch policy:
-
-        - **Async-only** (``run_aio`` defined, ``run`` not overridden):
-          async generator ``run_aio`` is driven via ``_drive_async_generator``;
-          otherwise ``asyncio.run(task.run_aio())``.
-        - **Sync-only and dual** (``run`` defined, with or without ``run_aio``):
-          ``task.run()`` is called. If it returns a sync generator it is
-          driven via ``_drive_sync_generator``. Dual tasks intentionally
-          prefer the sync path here because the Modal worker invocation is
-          itself synchronous — if you need async execution for a dual task,
-          implement it in ``run()`` (e.g. via ``asyncio.run`` internally).
-
-        Generators cannot be serialized across the Modal boundary, so we
-        mirror ``_run_task_in_process``: drive forward while yielded batches
-        are fully complete, and at the first yield with any incomplete dep
-        return the entire yielded ``TaskStruct``. The ``ModalTaskExecutor``
-        builds those deps (filtering for incomplete ones) and re-invokes this
-        function — on re-execution the generator advances past the
-        now-complete batch.
-        """
-        has_run_aio = _has_custom_run_aio(task)
-        has_run = _has_custom_run(task)
-
-        if has_run_aio and not has_run:
-            # Async-only task
-            if inspect.isasyncgenfunction(type(task).run_aio):
-                return asyncio.run(_drive_async_generator(task))
-            asyncio.run(task.run_aio())
-            return None
-
-        # Sync (or dual) task — run and drive generator if returned.
-        # Dual tasks deliberately take the sync path; see method docstring.
-        return _drive_sync_generator(task.run())
-
-
-def _drive_sync_generator(
-    result: None | typing.Generator[TaskStruct, None, None] | TaskStruct,
-) -> None | TaskStruct:
-    """Drive a sync generator result for idempotent re-execution.
-
-    Advances the generator past yield batches whose deps are all complete.
-    Stops at the first yield with any incomplete dep and returns that yield's
-    full ``TaskStruct`` (which may also include already-complete deps — the
-    caller is expected to filter for incomplete ones when scheduling). If
-    the generator completes, returns ``None``.
-
-    If ``result`` is ``None`` (no dynamic deps) returns ``None``. If
-    ``result`` is already a ``TaskStruct`` (unusual but possible when a
-    user's ``run()`` returns deps directly) it is returned as-is.
-    """
-    if result is None:
-        return None
-    if not hasattr(result, "__next__"):
-        # Already a TaskStruct (unusual, but handle it)
-        return typing.cast(TaskStruct, result)
-
-    gen = typing.cast(typing.Generator[TaskStruct, None, None], result)
-    try:
-        while True:
-            yielded = next(gen)
-            deps = flatten_task_struct(yielded)
-            incomplete = [dep for dep in deps if not dep.complete()]
-            if incomplete:
-                return tuple(deps)
-    except StopIteration:
-        return None
-
-
-async def _drive_async_generator(task: BaseTask) -> None | TaskStruct:
-    """Drive an async generator ``run_aio`` for idempotent re-execution.
-
-    Same contract as ``_drive_sync_generator``: advances past fully-complete
-    yield batches and returns the first batch that contains any incomplete
-    dep as a ``TaskStruct`` (may include already-complete deps). Returns
-    ``None`` when the generator finishes.
-    """
-    agen = typing.cast(
-        typing.AsyncGenerator[TaskStruct, None],
-        task.run_aio(),  # type: ignore[assignment]
-    )
-    try:
-        async for yielded in agen:
-            deps = flatten_task_struct(yielded)
-            incomplete = [dep for dep in deps if not dep.complete()]
-            if incomplete:
-                return tuple(deps)
-    except StopAsyncIteration:
-        pass
-    return None
-
-
-_default_build = Builder()
-_default_run = Runner()
-
-
-class PrefectBuilder(Builder):
-    """Builder that uses Prefect for build orchestration.
-
-    Requires the ``stardag.integration.prefect`` package to be installed.
-    """
-
-    def __init__(
-        self,
-        on_complete_callback: typing.Callable[[BaseTask], typing.Awaitable[None]]
-        | None = None,
-        before_run_callback: typing.Callable[[BaseTask], typing.Awaitable[None]]
-        | None = None,
-    ):
-        # Prefect's build flow drives the executor via submit() only, so
-        # detached mode has no effect there — keep the legacy behavior.
-        super().__init__(detached=False)
-        self.on_complete_callback = on_complete_callback
-        self.before_run_callback = before_run_callback
-
-    def build(
-        self,
-        tasks: typing.Sequence[BaseTask] | BaseTask,
-        task_executor: ModalTaskExecutor,
-        build_kwargs: dict[str, typing.Any] | None = None,
-    ) -> BuildSummary | None:
-        if prefect_build_flow is None:
-            raise ImportError("Prefect is not installed")
-
-        import asyncio
-
-        _flow = prefect_build_flow  # local for pyright narrowing
-
-        # TODO: support multiple root tasks in PrefectBuilder
-        if isinstance(tasks, BaseTask):
-            task = tasks
-        else:
-            if len(tasks) != 1:
-                raise ValueError(
-                    f"PrefectBuilder currently supports only a single root task, "
-                    f"got {len(tasks)}"
-                )
-            task = tasks[0]
-
-        flow_kwargs = dict(build_kwargs or {})
-        # ``task`` is reserved because the flow is invoked as
-        # ``_flow(...)(task, ...)`` below — letting the user pass another
-        # ``task`` via build_kwargs would surface as a confusing
-        # "got multiple values for argument 'task'" TypeError.
-        for reserved in (
-            "task",
-            "task_executor",
-            "before_run_callback",
-            "on_complete_callback",
-        ):
-            if reserved in flow_kwargs:
-                raise TypeError(
-                    f"build_kwargs must not contain reserved key '{reserved}'"
-                )
-
-        async def _run():
-            await _flow.with_options(
-                name=f"stardag-build-{task.get_namespace()}:{task.get_name()}"
-            )(
-                task,
-                task_executor=task_executor,
-                before_run_callback=(self.before_run_callback or create_markdown),
-                on_complete_callback=(
-                    self.on_complete_callback or upload_task_on_complete_artifacts
-                ),
-                **flow_kwargs,
-            )
-
-        asyncio.run(_run())
-        # Prefect manages its own flow result; no BuildSummary available.
-        return None
-
-
-def _setup_logging():
-    """Setup logging for the modal app."""
-    logging.basicConfig(level=logging.INFO)
-
-
-# --- Reactive bootstrap (normally runs INSIDE Modal; see
-# StardagApp._trigger_reactive and run_reactive_bootstrap) ---
-
-
-def _preflight_task_modules(
-    tasks: typing.Iterable[BaseTask], task_modules: typing.Sequence[str]
-) -> None:
-    """Warn about discovered task classes ``task_modules`` doesn't cover.
-
-    **The authoritative coverage check.** It runs wherever discovery runs
-    — normally the bootstrap container — on the set discovery just walked:
-    those are exactly the tasks a tick may have to rehydrate, and reusing
-    discovery's (pruned) walk avoids a second traversal of the DAG. It is
-    never skipped, and it is what gates ``require_pickle_free`` (via the
-    persistence step, which additionally knows about round-trip failures,
-    not just coverage).
-
-    **Severity is a warning, not an error** (unless
-    ``require_pickle_free``). An uncovered class is not broken: it falls
-    back to the pickle path, which is exactly how every reactive build
-    worked before ``task_modules`` existed. Failing would therefore break
-    working setups the moment they upgrade, which is precisely what "this
-    feature is additive" forbids.
-
-    In the default (bootstrap) placement ``task_modules`` is the list
-    **baked into the deployment at ``finalize()``** — not the caller's
-    local app definition. That closes the stale-deploy blind spot this
-    check used to carry: it compares the DAG against the module list the
-    ticks will actually import, so "you changed ``task_modules`` but
-    didn't redeploy" is visible rather than silently agreeable.
-
-    Skipped entirely when the app opted out of ``task_modules`` — an app
-    that never declared any would otherwise warn about every class in
-    every DAG, on every trigger.
-    """
-    if not task_modules:
-        return
-    uncovered = uncovered_task_classes(tasks, task_modules)
-    if not uncovered:
-        return
-    logger.warning(
-        format_uncovered_message(
-            uncovered,
-            task_modules,
-            remedy=(
-                "Until then these tasks stay dependent on their "
-                "build-task-store pickles, which need target-root "
-                "write access and are invalidated by a redeploy."
-            ),
-        )
-    )
-
-
-def _advise_uncovered_root_task_modules(
-    root_tasks: typing.Sequence[BaseTask], task_modules: typing.Sequence[str]
-) -> None:
-    """Advisory, roots-only coverage note emitted at the trigger.
-
-    Purely additive early feedback, and deliberately **not** a check in
-    its own right: :func:`_preflight_task_modules` is the authoritative
-    one and always runs over the full discovered set wherever discovery
-    runs. This looks at the **root tasks only** — a fixed, tiny set the
-    trigger already holds — so it costs no ``requires()`` traversal, no
-    target I/O and no measurable time, and it is by construction a
-    *subset* of what the real check sees. Two checks that can disagree
-    would be worse than one; a subset can only ever be quieter.
-
-    Why it earns its place anyway: the dominant ``task_modules``
-    misconfiguration is "I never declared my package", and in that case
-    the roots are uncovered too. Saying so in the operator's terminal, at
-    the moment they trigger, beats saying it a container start later in a
-    log they have to go and find.
-    """
-    if not task_modules or not root_tasks:
-        return
-    uncovered = uncovered_task_classes(root_tasks, task_modules)
-    if not uncovered:
-        return
-    logger.warning(
-        format_uncovered_message(
-            uncovered,
-            task_modules,
-            remedy=(
-                "This is an early, ROOT-TASKS-ONLY note from the trigger; "
-                "the full check runs over the whole discovered DAG where "
-                "discovery runs and may name more classes."
-            ),
-        )
-    )
-
-
-def _persist_discovered_tasks(
-    build_id: UUID,
-    tasks: typing.Iterable[BaseTask],
-    *,
-    task_modules: typing.Sequence[str],
-    elide_pickles: bool,
-    require_pickle_free: bool,
-) -> None:
-    """Write the build task store, skipping pickles that aren't needed.
-
-    Unless the app *opted in* (``elide_pickles``), this is byte-for-byte
-    the old behaviour: pickle everything. With opt-in, each task gets a
-    dry run of what a tick will do — reconstruct it from exactly the
-    payload registration stored — and only the ones that fail keep a
-    pickle. A build whose classes are all covered writes nothing to the
-    target root at all.
-
-    Runs **inside the bootstrap container**, which is a large part of why
-    the move is worth doing: for a ``modalvol://`` target root the store
-    is a mounted filesystem here and a rate-limited volume API from a
-    laptop. The same writes that used to be N remote calls from the
-    trigger are now N local ones.
-
-    ``elide_pickles`` is the app's opt-in — ``task_modules`` passed
-    explicitly (or ``require_pickle_free``), NOT merely inferred —
-    resolved at ``finalize()`` and baked in alongside the module list.
-    Inference must stay observation-only: it happens for every app,
-    including apps written before the feature existed, and an SDK upgrade
-    must never start dropping pickles on its own.
-    """
-    store = BuildTaskStore(build_id)
-    if not task_modules or not elide_pickles:
-        store.save_tasks(tasks)
-        return
-    plan: PickleElisionPlan = plan_pickle_elision(tasks, task_modules)
-    if require_pickle_free:
-        error = plan.require_pickle_free_error()
-        if error is not None:
-            raise TaskModulesError(error)
-    store.save_tasks(task for task, _ in plan.pickled)
-    logger.info(f"Build {build_id} task store: {plan.summary()}")
-
-
-def _fail_build_best_effort(
-    registry: typing.Any, build_id: UUID, exception: BaseException
-) -> None:
-    """Record a terminal BUILD_FAILED for ``build_id``, never raising.
-
-    The caller is already propagating ``exception``; this exists only so
-    the propagation doesn't leave a build sitting RUNNING forever with
-    nothing driving it. A failure to record the failure is logged and
-    swallowed — masking the real cause with a registry error would be a
-    strictly worse outcome.
-    """
-    try:
-        registry.build_fail(
-            build_id,
-            error_message=f"{type(exception).__name__}: {exception}",
-        )
-    except Exception:
-        logger.exception(
-            f"Could not record BUILD_FAILED for build {build_id} after "
-            f"{type(exception).__name__}; the build may be left RUNNING "
-            "with nothing driving it (re-trigger it, or cancel it from "
-            "the UI)."
-        )
-
-
-ReactiveDiscovery = typing.Literal["modal", "local"]
-"""Where a reactive trigger discovers the DAG (see ``StardagApp``).
-
-``"modal"`` (the default) spawns the deployed ``bootstrap`` function;
-``"local"`` runs the identical bootstrap in the triggering process.
-"""
-
-
-class ReactiveBootstrapResult(typing.NamedTuple):
-    """Result of :func:`run_reactive_bootstrap`.
-
-    Attributes:
-        summary: JSON-able account of what the bootstrap did. This is what
-            the deployed ``bootstrap`` function returns to Modal.
-        tick_call: The ``FunctionCall`` handle of the first scheduler tick
-            the bootstrap spawned. Only useful in-process (it does not
-            survive a Modal return value), so the deployed function drops
-            it and the local-discovery trigger path keeps it.
-    """
-
-    summary: dict[str, typing.Any]
-    tick_call: typing.Any
-
-
-def run_reactive_bootstrap(
-    build_id: UUID,
-    task_list: list[BaseTask],
-    *,
-    registry: typing.Any,
-    app_name: str,
-    tick_kwargs: dict[str, typing.Any] | None,
-    task_modules: typing.Sequence[str],
-    elide_pickles: bool,
-    require_pickle_free: bool,
-) -> ReactiveBootstrapResult:
-    """Discover the DAG, persist it, arm the build, spawn the first tick.
-
-    Everything a reactive build needs before it can be scheduled, except
-    minting the build and registering its roots — those cost no target
-    I/O and must happen at the trigger, before anything is spawned.
-
-    Normally this runs **inside Modal**, as the body of the deployed
-    ``bootstrap`` function, because discovery is target-root I/O:
-    ``complete_aio()`` is one target existence check per task, and for a
-    ``modalvol://`` root that is a rate-limited Volume *API* call from
-    outside Modal versus a ``stat`` on a mounted filesystem inside it.
-    The task-store writes below move with it for the same reason. The
-    same code also runs at the trigger when an app opts out with
-    ``StardagApp(reactive_discovery="local")``.
-
-    **The ordering guarantee — do not "tidy" this.** The reactive marker
-    (``build_set_reactive_meta``, which is what makes ``reactive_app_name``
-    non-None) is written **last**, after discovery *and* persistence have
-    completed, and a tick no-ops on any build whose ``reactive_app_name``
-    is None. That ordering is the whole reason no tick can ever observe a
-    partially-registered DAG. It is load-bearing, not stylistic:
-    registration is chunked post-order, so the roots land *last*, and
-    mid-registration a build presents as "nothing actionable, roots not
-    complete" — exactly the shape terminal detection fails a build on.
-    Moving the marker earlier (or spawning a tick before it) reopens
-    precisely that window.
-
-    Raises on any failure without touching the build's status: recording
-    the terminal BUILD_FAILED belongs to the caller, which is the one
-    that knows whether *it* put the build into RUNNING (see
-    :meth:`StardagApp._trigger_reactive`). The first tick's spawn is part
-    of the work rather than an afterthought: an un-spawned tick is not a
-    partial success, it is a build nothing will ever move (a watchdog
-    would eventually adopt it; an app without one would simply stall).
-    """
-    discovery = asyncio.run(
-        discover_and_register_aio(
-            registry, build_id, tuple(task_list), retry_failed=True
-        )
-    )
-    # --- task-module coverage pre-flight (see _preflight_task_modules) ---
-    _preflight_task_modules(discovery.incomplete.values(), task_modules)
-    # --- task persistence, with conditional pickle elision ---
-    _persist_discovered_tasks(
-        build_id,
-        discovery.incomplete.values(),
-        task_modules=task_modules,
-        elide_pickles=elide_pickles,
-        require_pickle_free=require_pickle_free,
-    )
-    # The reactive marker/owner/config, written LAST — see the ordering
-    # guarantee in this function's docstring. This is an upsert: because
-    # the registry is mutable — unlike a possibly immutable target root —
-    # a re-trigger MAY update tick_kwargs. tick_kwargs is passed through
-    # as-is: None (a bare re-trigger) preserves the stored config
-    # server-side rather than wiping it.
-    registry.build_set_reactive_meta(
-        build_id, app_name=app_name, tick_kwargs=tick_kwargs
-    )
-    tick_function = modal.Function.from_name(app_name=app_name, name="tick")
-    tick_call = tick_function.spawn(build_id=str(build_id))
-    summary = {
-        "build_id": str(build_id),
-        "roots": len(task_list),
-        "incomplete": len(discovery.incomplete),
-        "previously_completed": len(discovery.previously_completed),
-        "retried": len(discovery.retried),
-    }
-    logger.info(f"Reactive bootstrap for build {build_id}: {summary}")
-    return ReactiveBootstrapResult(summary=summary, tick_call=tick_call)
-
-
-# --- Stardag App ---
 
 
 def _infer_task_module_patterns(_depth: int = 2) -> tuple[str, ...]:
@@ -2437,8 +238,7 @@ class StardagApp:
         bootstrap_settings: FunctionSettings | None = None,
         reactive_discovery: ReactiveDiscovery = "modal",
         watchdog_period_minutes: int | None = None,
-        limit_key_selector: typing.Callable[[BaseTask], typing.Sequence[str]]
-        | None = None,
+        limit_key_selector: LimitKeySelector | None = None,
         task_modules: typing.Sequence[str] | None = None,
         require_pickle_free: bool = False,
         modal_workspace: str | None = None,
@@ -2700,31 +500,119 @@ class StardagApp:
         assert self.modal_app.name is not None
         return self.modal_app.name
 
+    # --- finalize (deploy) ---
+
     @staticmethod
-    def _prepare_function_settings(
-        settings: FunctionSettings,
-        *,
-        extra_secrets: list[modal.Secret],
-        auto_volumes: dict[str, modal.Volume],
-    ) -> dict[str, typing.Any]:
-        """Merge extra secrets and auto-volumes into function settings.
+    def _auto_mounted_volumes(
+        target_roots_volumes: TargetRootsVolumes,
+    ) -> tuple[dict[str, str], dict[str, modal.Volume]]:
+        """Auto-mount mapping for the target roots' Modal volumes.
 
-        Auto-mounted volumes are merged with user volumes, where user-specified
-        volumes at the same mount path take precedence over auto-mounted ones.
-        Secrets are de-duplicated by name (a named secret propagated from the
-        builder plus one the function already declares should apply once).
+        Returns ``(volume_mounts, auto_volumes)``: ``mount_path ->
+        volume_name`` for the env var that tells targets to use local I/O,
+        and ``mount_path -> Volume`` for the Modal function settings.
         """
-        result: dict[str, typing.Any] = dict(settings)
+        volume_mounts: dict[str, str] = {}
+        auto_volumes: dict[str, modal.Volume] = {}
+        for vol_name, vol in target_roots_volumes.by_volume_name.items():
+            mount_path = str(get_default_volume_mount_path(vol_name))
+            volume_mounts[mount_path] = vol_name
+            auto_volumes[mount_path] = vol
+        return volume_mounts, auto_volumes
 
-        # Merge secrets: existing + extra, de-duplicated by name.
-        existing_secrets: list[modal.Secret] = list(result.get("secrets") or [])
-        result["secrets"] = _dedupe_secrets(existing_secrets + extra_secrets)
+    def _validate_api_key_secret(self) -> None:
+        """Fail deploy with a clear error if the named API-key secret is absent.
 
-        # Merge volumes: auto-mounted (lower priority) + user (higher priority)
-        user_volumes = dict(result.get("volumes") or {})
-        result["volumes"] = {**auto_volumes, **user_volumes}
+        Best-effort: only a definitive not-found errors out; no Modal
+        context / auth just skips the check so offline finalize and unit
+        tests aren't broken.
+        """
+        assert self.stardag_api_key_secret is not None
+        try:
+            self.stardag_api_key_secret.hydrate()
+        except modal.exception.NotFoundError as e:
+            name = self._api_key_secret_name
+            secret_name_flag = (
+                "" if name == "stardag-api-key" else f" --secret-name {name}"
+            )
+            raise StardagError(
+                f"StardagApp.stardag_api_key_secret refers to a Modal "
+                f"secret named {name!r} that does not exist in the "
+                f"current Modal environment. Run "
+                f"`stardag modal stardag-api-key create"
+                f"{secret_name_flag}` to mint a Stardag API key and "
+                f"sync it into a Modal secret of that name, so the "
+                f"deployed functions can authenticate to the "
+                f"registry. If you supply the API key another way, or "
+                f"set it per function, pass stardag_api_key_secret="
+                f"None."
+            ) from e
+        except Exception as e:  # noqa: BLE001 - best-effort validation
+            logger.debug(
+                f"Could not validate stardag_api_key_secret "
+                f"{self._api_key_secret_name!r} (no Modal context?); "
+                f"proceeding: {e}"
+            )
 
-        return result
+    def _resolve_extra_secrets(
+        self,
+        extra_secrets: list[modal.Secret] | None,
+        volume_mounts: dict[str, str],
+    ) -> list[modal.Secret]:
+        """The secrets injected into *every* function this app registers.
+
+        Order matters and is preserved: the caller's own secrets first,
+        then the deploy-resolved ones. Later secrets win on conflicting
+        env vars in Modal, and the earliest occurrence wins the name-based
+        de-duplication in ``_prepare_function_settings``.
+        """
+        extra_secrets = list(extra_secrets or [])
+
+        # Inject volume mount config as env var so ModalMountedVolumeFileTarget
+        # is used
+        if volume_mounts:
+            extra_secrets.append(
+                modal.Secret.from_dict(
+                    {"STARDAG_MODAL_VOLUME_MOUNTS": json.dumps(volume_mounts)}
+                )
+            )
+        # Bake the Modal workspace into every function's env. It's needed for
+        # the UI's Modal dashboard deep links (executor metadata), but the
+        # only way to resolve it — the Modal token — exists in this deploy
+        # process, NOT in the deployed containers. Resolve it here (or use
+        # the explicit override) and propagate it so containers don't have to
+        # (and can't) look it up. Best-effort: if it can't be resolved, deep
+        # links degrade gracefully (the UI shows env only).
+        deploy_workspace = self.modal_workspace or _get_modal_workspace()
+        if deploy_workspace:
+            extra_secrets.append(
+                modal.Secret.from_dict({STARDAG_MODAL_WORKSPACE_ENV: deploy_workspace})
+            )
+        # The registry API-key secret is injected into every function (build,
+        # workers, tick, watchdog) — all of them talk to the registry. It's
+        # the ONLY secret propagated across functions; per-function
+        # `secrets` stay function-local.
+        if self.stardag_api_key_secret is not None:
+            if self._api_key_secret_name is not None:
+                self._validate_api_key_secret()
+            extra_secrets.append(self.stardag_api_key_secret)
+        return extra_secrets
+
+    def _worker_timeouts(self) -> dict[str, int]:
+        """Per-worker Modal ``timeout``, as declared in ``worker_settings``.
+
+        Captured at finalize() because this is the only place they exist:
+        a tick runs in a deployed container with no access to the app
+        object, and the claim TTL it records for a task is derived from the
+        timeout of the worker that task routes to. Workers without an
+        explicit timeout are simply absent (Modal's own default is not a
+        promise this SDK should encode).
+        """
+        return {
+            worker_name: timeout
+            for worker_name, settings in self._worker_settings.items()
+            if (timeout := settings.get("timeout")) is not None
+        }
 
     def finalize(
         self,
@@ -2764,73 +652,9 @@ class StardagApp:
         target_roots_volumes = get_target_roots_volumes(
             create_if_missing=create_volumes_if_missing
         )
+        volume_mounts, auto_volumes = self._auto_mounted_volumes(target_roots_volumes)
+        extra_secrets = self._resolve_extra_secrets(extra_secrets, volume_mounts)
 
-        # Compute auto-mount mapping from discovered volumes
-        # volume_mounts: mount_path -> volume_name (for env var)
-        # auto_volumes: mount_path -> Volume (for Modal function)
-        volume_mounts: dict[str, str] = {}
-        auto_volumes: dict[str, modal.Volume] = {}
-        for vol_name, vol in target_roots_volumes.by_volume_name.items():
-            mount_path = str(get_default_volume_mount_path(vol_name))
-            volume_mounts[mount_path] = vol_name
-            auto_volumes[mount_path] = vol
-
-        extra_secrets = list(extra_secrets or [])
-
-        # Inject volume mount config as env var so ModalMountedVolumeFileTarget is used
-        if volume_mounts:
-            extra_secrets.append(
-                modal.Secret.from_dict(
-                    {"STARDAG_MODAL_VOLUME_MOUNTS": json.dumps(volume_mounts)}
-                )
-            )
-        # Bake the Modal workspace into every function's env. It's needed for
-        # the UI's Modal dashboard deep links (executor metadata), but the
-        # only way to resolve it — the Modal token — exists in this deploy
-        # process, NOT in the deployed containers. Resolve it here (or use
-        # the explicit override) and propagate it so containers don't have to
-        # (and can't) look it up. Best-effort: if it can't be resolved, deep
-        # links degrade gracefully (the UI shows env only).
-        deploy_workspace = self.modal_workspace or _get_modal_workspace()
-        if deploy_workspace:
-            extra_secrets.append(
-                modal.Secret.from_dict({STARDAG_MODAL_WORKSPACE_ENV: deploy_workspace})
-            )
-        # The registry API-key secret is injected into every function (build,
-        # workers, tick, watchdog) — all of them talk to the registry. It's
-        # the ONLY secret propagated across functions; per-function
-        # `secrets` stay function-local. Validate a by-name secret's
-        # existence with a clear error (best-effort: only a definitive
-        # not-found errors out; no Modal context / auth just skips the check
-        # so offline finalize and unit tests aren't broken).
-        if self.stardag_api_key_secret is not None:
-            if self._api_key_secret_name is not None:
-                try:
-                    self.stardag_api_key_secret.hydrate()
-                except modal.exception.NotFoundError as e:
-                    name = self._api_key_secret_name
-                    secret_name_flag = (
-                        "" if name == "stardag-api-key" else f" --secret-name {name}"
-                    )
-                    raise StardagError(
-                        f"StardagApp.stardag_api_key_secret refers to a Modal "
-                        f"secret named {name!r} that does not exist in the "
-                        f"current Modal environment. Run "
-                        f"`stardag modal stardag-api-key create"
-                        f"{secret_name_flag}` to mint a Stardag API key and "
-                        f"sync it into a Modal secret of that name, so the "
-                        f"deployed functions can authenticate to the "
-                        f"registry. If you supply the API key another way, or "
-                        f"set it per function, pass stardag_api_key_secret="
-                        f"None."
-                    ) from e
-                except Exception as e:  # noqa: BLE001 - best-effort validation
-                    logger.debug(
-                        f"Could not validate stardag_api_key_secret "
-                        f"{self._api_key_secret_name!r} (no Modal context?); "
-                        f"proceeding: {e}"
-                    )
-            extra_secrets.append(self.stardag_api_key_secret)
         # Expand the declared task-module patterns to a concrete, sorted
         # module list ONCE, here, and bake it into the deployed functions
         # below. Deploy-time expansion (rather than in-container) keeps the
@@ -2842,6 +666,18 @@ class StardagApp:
         # submodule imports): the CLI does the optional local import check.
         task_module_patterns = self.task_modules
         task_modules = expand_task_module_patterns(task_module_patterns)
+
+        def register(name: str, settings: FunctionSettings, **extra: typing.Any):
+            """Register one function on the Modal app under ``name``."""
+            prepared = _prepare_function_settings(
+                settings,
+                extra_secrets=extra_secrets,
+                auto_volumes=auto_volumes,
+            )
+            return self.modal_app.function(
+                **{**prepared, "name": name, "serialized": True, **extra}
+            )
+
         # Wrap callables in real functions for Modal compatibility.
         # Modal's is_async() only accepts inspect.isfunction()-compatible objects,
         # not callable class instances. The wrappers delegate to the actual callable
@@ -2881,213 +717,46 @@ class StardagApp:
             with temp_env_vars(env_overrides or {}):
                 return run_fn(task)
 
-        # Create builder function
-        builder_settings = self._prepare_function_settings(
-            self._builder_settings,
-            extra_secrets=extra_secrets,
-            auto_volumes=auto_volumes,
-        )
-        self.modal_app.function(
-            **{
-                **builder_settings,
-                "name": "build",
-                "serialized": True,
-            }
-        )(_modal_build)
-
+        register("build", self._builder_settings)(_modal_build)
         function_names = ["build"]
 
-        # Create worker functions
         for worker_name, settings in self._worker_settings.items():
-            worker_settings = self._prepare_function_settings(
-                settings,
-                extra_secrets=extra_secrets,
-                auto_volumes=auto_volumes,
-            )
-
             func_name = f"worker_{worker_name}"
-            self.modal_app.function(
-                **{
-                    **worker_settings,
-                    "name": func_name,
-                    "serialized": True,
-                }
-            )(_modal_run)
+            register(func_name, settings)(_modal_run)
             function_names.append(func_name)
 
         # Reactive scheduler tick (see stardag.build.run_tick_aio). Spawned
         # by build_trigger(reactive=True), by workers finishing tasks, and
         # by the optional watchdog below. Idempotent and single-flighted —
         # safe to invoke at any time; no-ops on non-reactive builds.
+        #
+        # Everything the deployed tick needs from deploy time is bundled
+        # here and closed over; the body lives in _tick._run_tick.
         app_name = self.name
-        default_worker_selector = self.worker_selector
-        limit_key_selector = self.limit_key_selector
-        modal_workspace = self.modal_workspace
-        # Per-worker Modal timeouts, captured here because this is the only
-        # place they exist: the tick runs in a deployed container with no
-        # access to the app object, and the claim TTL it records for a task
-        # is derived from the timeout of the worker that task routes to.
-        # Workers without an explicit timeout are simply absent (Modal's own
-        # default is not a promise this SDK should encode).
-        worker_timeouts = {
-            worker_name: timeout
-            for worker_name, settings in self._worker_settings.items()
-            if (timeout := settings.get("timeout")) is not None
-        }
-        # The timeout of the ``tick`` function itself — i.e. how long a tick
-        # container may live. Captured here for the same reason as
-        # ``worker_timeouts``: the deployed tick has no access to the app
-        # object, and this is the number its per-pass spawn cap is derived
-        # from (see stardag.build._reactive._spawn_cap).
-        tick_timeout_seconds = _tick_function_timeout_seconds(
-            self._tick_settings, self._builder_settings
+        tick_deployment = _TickDeployment(
+            app_name=app_name,
+            worker_selector=self.worker_selector,
+            limit_key_selector=self.limit_key_selector,
+            modal_workspace=self.modal_workspace,
+            worker_timeouts=self._worker_timeouts(),
+            tick_timeout_seconds=_tick_function_timeout_seconds(
+                self._tick_settings, self._builder_settings
+            ),
+            task_modules=tuple(task_modules),
+            task_module_patterns=task_module_patterns,
         )
 
         def _modal_tick(
             build_id: str,
             tick_kwargs: dict[str, typing.Any] | None = None,
         ) -> dict[str, typing.Any]:
-            _setup_logging()
-            import dataclasses
-            from uuid import UUID as _UUID
-
-            from stardag.build import BuildTaskStore as _BuildTaskStore
-            from stardag.exceptions import NotFoundError as _NotFoundError
-            from stardag.exceptions import (
-                is_missing_route_error as _is_missing_route_error,
-            )
-
-            build_uuid = _UUID(build_id)
-            task_store = _BuildTaskStore(build_uuid)
-            registry = registry_provider.get()
-            # The reactive marker/owner/config live in the registry (not on
-            # the target root): read them with the lighter GET /builds/{id}
-            # for this pre-lease gate — the full frontier is only fetched
-            # once the tick actually processes it (run_tick_aio). Reactive
-            # scheduling against a server predating the build_get shape 404s
-            # only on a genuine missing route; a resource-level 404 (build
-            # deleted) must propagate as a real not-found.
-            try:
-                build_info = registry.build_get(build_uuid)
-            except _NotFoundError as e:
-                if not _is_missing_route_error(e):
-                    raise
-                raise RuntimeError(
-                    "The registry server does not support reactive "
-                    "scheduling (build endpoint too old). Upgrade "
-                    "stardag-api to a version matching this SDK."
-                ) from e
-            reactive_app_name = build_info.reactive_app_name
-            if reactive_app_name is None:
-                # Not a reactively-scheduled build (e.g. a resident-
-                # orchestrator build swept by the watchdog): never schedule
-                # on top of it, and don't even acquire the scheduler lease.
-                logger.info(
-                    f"Tick for build {build_id}: not reactively scheduled "
-                    "(no reactive_app_name); skipping."
-                )
-                return {"outcome": "not_reactive"}
-            # App ownership: with multiple StardagApps in one environment,
-            # every app's watchdog sweeps ALL running reactive builds — but
-            # only the app recorded at trigger time may drive a build.
-            # A foreign app's tick would schedule with ITS commit (its
-            # workers, its selectors) and unpickle the owning app's task
-            # store (pickle skew across commits), so it must not run the
-            # tick loop itself. Instead it FORWARDS: best-effort spawn of
-            # the owner's tick, so wake-ups that land on the wrong app
-            # (e.g. a still-running worker of the previous owner after a
-            # takeover) are not dropped, and every app's watchdog sweep
-            # doubles as cross-app coverage. The owner-side single-flight
-            # lease collapses duplicate forwards. Explicit takeover =
-            # re-trigger from the new app (updates reactive_app_name and
-            # re-persists the task objects under the new code).
-            owner_app = reactive_app_name
-            if owner_app != app_name:
-                forwarded = False
-                try:
-                    modal.Function.from_name(app_name=owner_app, name="tick").spawn(
-                        build_id=build_id
-                    )
-                    forwarded = True
-                except Exception as e:
-                    # Owner app deleted/renamed: the build is orphaned —
-                    # surfaced in logs; remedy is a re-trigger from a live
-                    # app (see the how-to's app-ownership section).
-                    logger.info(
-                        f"Tick for build {build_id}: could not forward to "
-                        f"owner app {owner_app!r} (deleted?): {e}"
-                    )
-                logger.info(
-                    f"Tick for build {build_id}: owned by app "
-                    f"{owner_app!r}, not {app_name!r}; "
-                    f"{'forwarded to owner' if forwarded else 'skipping'}."
-                )
-                return {
-                    "outcome": "foreign_app",
-                    "owner_app": owner_app,
-                    "forwarded": forwarded,
-                }
-            # Per-build tick configuration persisted at trigger time in the
-            # registry — every tick (worker wake-ups and watchdog sweeps
-            # spawn with only the build id) runs with the same settings.
-            # Explicit tick_kwargs (tests/manual invocations) win over
-            # persisted ones; the limit key selector is deployed-app config.
-            config = _build_tick_config(
-                build_info.reactive_tick_kwargs,
-                tick_kwargs,
-                limit_key_selector,
-                tick_timeout_seconds=tick_timeout_seconds,
-            )
-
-            # Register the app's task classes in THIS container before the
-            # tick reconstructs anything: rehydrating a task from registry
-            # data is a dict lookup in the polymorphic registry, which is
-            # populated only as a side effect of importing the defining
-            # modules (unlike pickle, which self-imports). The list was
-            # expanded and frozen at deploy time; the import is cached per
-            # module list, so a container serving many ticks pays it once.
-            # Failures warn rather than abort — and are retained, so a
-            # later "could not rehydrate" error can name them.
-            if task_modules:
-                set_declared_task_module_patterns(task_module_patterns)
-                import_task_modules(task_modules)
-
-            executor = ModalTaskExecutor(
-                modal_app_name=app_name,
-                worker_selector=default_worker_selector,
-                reactive=True,
-                modal_workspace=modal_workspace,
-                worker_timeouts=worker_timeouts,
-            )
-            lock_manager = RegistryGlobalConcurrencyLockManager(
-                # No waiting on the scheduler lease: a held lease means
-                # another tick is active and will observe the wake-up flag.
-                config=GlobalLockConfig(lock_wait_timeout_seconds=None),
-            )
-            summary = asyncio.run(
-                run_tick_aio(
-                    build_uuid,
-                    registry=registry,
-                    task_executor=executor,
-                    lock_manager=lock_manager,
-                    task_store=task_store,
-                    config=config,
-                )
-            )
-            logger.info(f"Tick for build {build_id}: {summary}")
-            return dataclasses.asdict(summary)
+            return _run_tick(build_id, tick_kwargs, deployment=tick_deployment)
 
         # tick/watchdog default to builder_settings when tick_settings is
         # not given; the api-key secret is in extra_secrets so they get
         # registry credentials regardless of which settings apply.
-        tick_settings = self._prepare_function_settings(
-            self._tick_settings or self._builder_settings,
-            extra_secrets=extra_secrets,
-            auto_volumes=auto_volumes,
-        )
-        self.modal_app.function(
-            **{**tick_settings, "name": "tick", "serialized": True}
-        )(_modal_tick)
+        tick_settings = self._tick_settings or self._builder_settings
+        register("tick", tick_settings)(_modal_tick)
         function_names.append("tick")
 
         # Reactive bootstrap (see run_reactive_bootstrap). Spawned by
@@ -3134,14 +803,9 @@ class StardagApp:
             # back to the caller as the Modal return value.
             return result.summary
 
-        bootstrap_settings = self._prepare_function_settings(
-            self._bootstrap_settings or self._builder_settings,
-            extra_secrets=extra_secrets,
-            auto_volumes=auto_volumes,
+        register("bootstrap", self._bootstrap_settings or self._builder_settings)(
+            _modal_bootstrap
         )
-        self.modal_app.function(
-            **{**bootstrap_settings, "name": "bootstrap", "serialized": True}
-        )(_modal_bootstrap)
         function_names.append("bootstrap")
 
         if self.watchdog_period_minutes is not None:
@@ -3157,17 +821,14 @@ class StardagApp:
                 _run_watchdog_sweep(
                     registry_provider.get(),
                     _modal_tick,
-                    tick_timeout_seconds=tick_timeout_seconds,
+                    tick_timeout_seconds=tick_deployment.tick_timeout_seconds,
                     reactive_app_name=app_name,
                 )
 
-            self.modal_app.function(
-                **{
-                    **tick_settings,
-                    "name": "tick_watchdog",
-                    "serialized": True,
-                    "schedule": modal.Period(minutes=self.watchdog_period_minutes),
-                }
+            register(
+                "tick_watchdog",
+                tick_settings,
+                schedule=modal.Period(minutes=self.watchdog_period_minutes),
             )(_modal_tick_watchdog)
             function_names.append("tick_watchdog")
 
@@ -3180,6 +841,8 @@ class StardagApp:
             auto_volumes=auto_volumes,
             task_modules=task_modules,
         )
+
+    # --- Running builds on the deployed app ---
 
     def build_spawn(
         self,
@@ -3574,33 +1237,3 @@ class StardagApp:
         This is a passthrough to modal.App.local_entrypoint().
         """
         return self.modal_app.local_entrypoint(*args, **kwargs)
-
-
-class WorkerSelectorByName:
-    """Worker selector that routes tasks based on task name.
-
-    Example:
-        selector = WorkerSelectorByName(
-            name_to_worker={"heavy_task": "gpu", "io_task": "high_memory"},
-            default_worker="default",
-        )
-        stardag_app = StardagApp(..., worker_selector=selector)
-    """
-
-    def __init__(self, name_to_worker: dict[str, str], default_worker: str):
-        """Initialize the selector.
-
-        Args:
-            name_to_worker: Dict mapping task names to worker names.
-            default_worker: Worker name to use for tasks not in the mapping.
-        """
-        self.name_to_worker = name_to_worker
-        self.default_worker = default_worker
-
-    def __call__(self, task: BaseTask) -> str:
-        return self.name_to_worker.get(task.get_name(), self.default_worker)
-
-    def __repr__(self):
-        return (
-            f"{self.__class__.__name__}({self.name_to_worker}, {self.default_worker})"
-        )

--- a/lib/stardag/src/stardag/integration/modal/_bootstrap.py
+++ b/lib/stardag/src/stardag/integration/modal/_bootstrap.py
@@ -1,0 +1,296 @@
+"""Reactive bootstrap: everything a reactive build needs before it can tick.
+
+:func:`run_reactive_bootstrap` discovers the DAG, checks task-module coverage,
+persists the task store, arms the build and spawns the first tick. It normally
+runs **inside Modal**, as the body of the deployed ``bootstrap`` function
+(discovery is target-root I/O, which is far cheaper next to a mounted volume
+than from a laptop), and runs in the triggering process instead when an app
+opts out with ``StardagApp(reactive_discovery="local")``.
+
+Also here: the coverage checks and the pickle-elision decision the bootstrap
+applies, and :func:`_fail_build_best_effort`, the "never leave an orphan
+RUNNING build" helper its callers share.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import typing
+from uuid import UUID
+
+import modal
+
+from stardag import BaseTask
+from stardag.build import BuildTaskStore, discover_and_register_aio
+from stardag.build._task_modules import (
+    PickleElisionPlan,
+    TaskModulesError,
+    format_uncovered_message,
+    plan_pickle_elision,
+    uncovered_task_classes,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _preflight_task_modules(
+    tasks: typing.Iterable[BaseTask], task_modules: typing.Sequence[str]
+) -> None:
+    """Warn about discovered task classes ``task_modules`` doesn't cover.
+
+    **The authoritative coverage check.** It runs wherever discovery runs
+    — normally the bootstrap container — on the set discovery just walked:
+    those are exactly the tasks a tick may have to rehydrate, and reusing
+    discovery's (pruned) walk avoids a second traversal of the DAG. It is
+    never skipped, and it is what gates ``require_pickle_free`` (via the
+    persistence step, which additionally knows about round-trip failures,
+    not just coverage).
+
+    **Severity is a warning, not an error** (unless
+    ``require_pickle_free``). An uncovered class is not broken: it falls
+    back to the pickle path, which is exactly how every reactive build
+    worked before ``task_modules`` existed. Failing would therefore break
+    working setups the moment they upgrade, which is precisely what "this
+    feature is additive" forbids.
+
+    In the default (bootstrap) placement ``task_modules`` is the list
+    **baked into the deployment at ``finalize()``** — not the caller's
+    local app definition. That closes the stale-deploy blind spot this
+    check used to carry: it compares the DAG against the module list the
+    ticks will actually import, so "you changed ``task_modules`` but
+    didn't redeploy" is visible rather than silently agreeable.
+
+    Skipped entirely when the app opted out of ``task_modules`` — an app
+    that never declared any would otherwise warn about every class in
+    every DAG, on every trigger.
+    """
+    if not task_modules:
+        return
+    uncovered = uncovered_task_classes(tasks, task_modules)
+    if not uncovered:
+        return
+    logger.warning(
+        format_uncovered_message(
+            uncovered,
+            task_modules,
+            remedy=(
+                "Until then these tasks stay dependent on their "
+                "build-task-store pickles, which need target-root "
+                "write access and are invalidated by a redeploy."
+            ),
+        )
+    )
+
+
+def _advise_uncovered_root_task_modules(
+    root_tasks: typing.Sequence[BaseTask], task_modules: typing.Sequence[str]
+) -> None:
+    """Advisory, roots-only coverage note emitted at the trigger.
+
+    Purely additive early feedback, and deliberately **not** a check in
+    its own right: :func:`_preflight_task_modules` is the authoritative
+    one and always runs over the full discovered set wherever discovery
+    runs. This looks at the **root tasks only** — a fixed, tiny set the
+    trigger already holds — so it costs no ``requires()`` traversal, no
+    target I/O and no measurable time, and it is by construction a
+    *subset* of what the real check sees. Two checks that can disagree
+    would be worse than one; a subset can only ever be quieter.
+
+    Why it earns its place anyway: the dominant ``task_modules``
+    misconfiguration is "I never declared my package", and in that case
+    the roots are uncovered too. Saying so in the operator's terminal, at
+    the moment they trigger, beats saying it a container start later in a
+    log they have to go and find.
+    """
+    if not task_modules or not root_tasks:
+        return
+    uncovered = uncovered_task_classes(root_tasks, task_modules)
+    if not uncovered:
+        return
+    logger.warning(
+        format_uncovered_message(
+            uncovered,
+            task_modules,
+            remedy=(
+                "This is an early, ROOT-TASKS-ONLY note from the trigger; "
+                "the full check runs over the whole discovered DAG where "
+                "discovery runs and may name more classes."
+            ),
+        )
+    )
+
+
+def _persist_discovered_tasks(
+    build_id: UUID,
+    tasks: typing.Iterable[BaseTask],
+    *,
+    task_modules: typing.Sequence[str],
+    elide_pickles: bool,
+    require_pickle_free: bool,
+) -> None:
+    """Write the build task store, skipping pickles that aren't needed.
+
+    Unless the app *opted in* (``elide_pickles``), this is byte-for-byte
+    the old behaviour: pickle everything. With opt-in, each task gets a
+    dry run of what a tick will do — reconstruct it from exactly the
+    payload registration stored — and only the ones that fail keep a
+    pickle. A build whose classes are all covered writes nothing to the
+    target root at all.
+
+    Runs **inside the bootstrap container**, which is a large part of why
+    the move is worth doing: for a ``modalvol://`` target root the store
+    is a mounted filesystem here and a rate-limited volume API from a
+    laptop. The same writes that used to be N remote calls from the
+    trigger are now N local ones.
+
+    ``elide_pickles`` is the app's opt-in — ``task_modules`` passed
+    explicitly (or ``require_pickle_free``), NOT merely inferred —
+    resolved at ``finalize()`` and baked in alongside the module list.
+    Inference must stay observation-only: it happens for every app,
+    including apps written before the feature existed, and an SDK upgrade
+    must never start dropping pickles on its own.
+    """
+    store = BuildTaskStore(build_id)
+    if not task_modules or not elide_pickles:
+        store.save_tasks(tasks)
+        return
+    plan: PickleElisionPlan = plan_pickle_elision(tasks, task_modules)
+    if require_pickle_free:
+        error = plan.require_pickle_free_error()
+        if error is not None:
+            raise TaskModulesError(error)
+    store.save_tasks(task for task, _ in plan.pickled)
+    logger.info(f"Build {build_id} task store: {plan.summary()}")
+
+
+def _fail_build_best_effort(
+    registry: typing.Any, build_id: UUID, exception: BaseException
+) -> None:
+    """Record a terminal BUILD_FAILED for ``build_id``, never raising.
+
+    The caller is already propagating ``exception``; this exists only so
+    the propagation doesn't leave a build sitting RUNNING forever with
+    nothing driving it. A failure to record the failure is logged and
+    swallowed — masking the real cause with a registry error would be a
+    strictly worse outcome.
+    """
+    try:
+        registry.build_fail(
+            build_id,
+            error_message=f"{type(exception).__name__}: {exception}",
+        )
+    except Exception:
+        logger.exception(
+            f"Could not record BUILD_FAILED for build {build_id} after "
+            f"{type(exception).__name__}; the build may be left RUNNING "
+            "with nothing driving it (re-trigger it, or cancel it from "
+            "the UI)."
+        )
+
+
+ReactiveDiscovery = typing.Literal["modal", "local"]
+"""Where a reactive trigger discovers the DAG (see ``StardagApp``).
+
+``"modal"`` (the default) spawns the deployed ``bootstrap`` function;
+``"local"`` runs the identical bootstrap in the triggering process.
+"""
+
+
+class ReactiveBootstrapResult(typing.NamedTuple):
+    """Result of :func:`run_reactive_bootstrap`.
+
+    Attributes:
+        summary: JSON-able account of what the bootstrap did. This is what
+            the deployed ``bootstrap`` function returns to Modal.
+        tick_call: The ``FunctionCall`` handle of the first scheduler tick
+            the bootstrap spawned. Only useful in-process (it does not
+            survive a Modal return value), so the deployed function drops
+            it and the local-discovery trigger path keeps it.
+    """
+
+    summary: dict[str, typing.Any]
+    tick_call: typing.Any
+
+
+def run_reactive_bootstrap(
+    build_id: UUID,
+    task_list: list[BaseTask],
+    *,
+    registry: typing.Any,
+    app_name: str,
+    tick_kwargs: dict[str, typing.Any] | None,
+    task_modules: typing.Sequence[str],
+    elide_pickles: bool,
+    require_pickle_free: bool,
+) -> ReactiveBootstrapResult:
+    """Discover the DAG, persist it, arm the build, spawn the first tick.
+
+    Everything a reactive build needs before it can be scheduled, except
+    minting the build and registering its roots — those cost no target
+    I/O and must happen at the trigger, before anything is spawned.
+
+    Normally this runs **inside Modal**, as the body of the deployed
+    ``bootstrap`` function, because discovery is target-root I/O:
+    ``complete_aio()`` is one target existence check per task, and for a
+    ``modalvol://`` root that is a rate-limited Volume *API* call from
+    outside Modal versus a ``stat`` on a mounted filesystem inside it.
+    The task-store writes below move with it for the same reason. The
+    same code also runs at the trigger when an app opts out with
+    ``StardagApp(reactive_discovery="local")``.
+
+    **The ordering guarantee — do not "tidy" this.** The reactive marker
+    (``build_set_reactive_meta``, which is what makes ``reactive_app_name``
+    non-None) is written **last**, after discovery *and* persistence have
+    completed, and a tick no-ops on any build whose ``reactive_app_name``
+    is None. That ordering is the whole reason no tick can ever observe a
+    partially-registered DAG. It is load-bearing, not stylistic:
+    registration is chunked post-order, so the roots land *last*, and
+    mid-registration a build presents as "nothing actionable, roots not
+    complete" — exactly the shape terminal detection fails a build on.
+    Moving the marker earlier (or spawning a tick before it) reopens
+    precisely that window.
+
+    Raises on any failure without touching the build's status: recording
+    the terminal BUILD_FAILED belongs to the caller, which is the one
+    that knows whether *it* put the build into RUNNING (see
+    :meth:`StardagApp._trigger_reactive`). The first tick's spawn is part
+    of the work rather than an afterthought: an un-spawned tick is not a
+    partial success, it is a build nothing will ever move (a watchdog
+    would eventually adopt it; an app without one would simply stall).
+    """
+    discovery = asyncio.run(
+        discover_and_register_aio(
+            registry, build_id, tuple(task_list), retry_failed=True
+        )
+    )
+    # --- task-module coverage pre-flight (see _preflight_task_modules) ---
+    _preflight_task_modules(discovery.incomplete.values(), task_modules)
+    # --- task persistence, with conditional pickle elision ---
+    _persist_discovered_tasks(
+        build_id,
+        discovery.incomplete.values(),
+        task_modules=task_modules,
+        elide_pickles=elide_pickles,
+        require_pickle_free=require_pickle_free,
+    )
+    # The reactive marker/owner/config, written LAST — see the ordering
+    # guarantee in this function's docstring. This is an upsert: because
+    # the registry is mutable — unlike a possibly immutable target root —
+    # a re-trigger MAY update tick_kwargs. tick_kwargs is passed through
+    # as-is: None (a bare re-trigger) preserves the stored config
+    # server-side rather than wiping it.
+    registry.build_set_reactive_meta(
+        build_id, app_name=app_name, tick_kwargs=tick_kwargs
+    )
+    tick_function = modal.Function.from_name(app_name=app_name, name="tick")
+    tick_call = tick_function.spawn(build_id=str(build_id))
+    summary = {
+        "build_id": str(build_id),
+        "roots": len(task_list),
+        "incomplete": len(discovery.incomplete),
+        "previously_completed": len(discovery.previously_completed),
+        "retried": len(discovery.retried),
+    }
+    logger.info(f"Reactive bootstrap for build {build_id}: {summary}")
+    return ReactiveBootstrapResult(summary=summary, tick_call=tick_call)

--- a/lib/stardag/src/stardag/integration/modal/_bootstrap.py
+++ b/lib/stardag/src/stardag/integration/modal/_bootstrap.py
@@ -35,9 +35,15 @@ logger = logging.getLogger(__name__)
 
 
 def _preflight_task_modules(
-    tasks: typing.Iterable[BaseTask], task_modules: typing.Sequence[str]
+    tasks: typing.Iterable[BaseTask], task_module_patterns: typing.Sequence[str]
 ) -> None:
-    """Warn about discovered task classes ``task_modules`` doesn't cover.
+    """Warn about discovered task classes the declared patterns don't cover.
+
+    Takes the app's declared ``task_modules`` **patterns**, not the module
+    list they expand to: coverage is a question about patterns, and
+    :func:`uncovered_task_classes` matches classes against them. (The
+    expansion is a separate deploy-time artifact — it is what a tick
+    imports; see :class:`stardag.integration.modal._tick._TickDeployment`.)
 
     **The authoritative coverage check.** It runs wherever discovery runs
     — normally the bootstrap container — on the set discovery just walked:
@@ -54,26 +60,26 @@ def _preflight_task_modules(
     working setups the moment they upgrade, which is precisely what "this
     feature is additive" forbids.
 
-    In the default (bootstrap) placement ``task_modules`` is the list
-    **baked into the deployment at ``finalize()``** — not the caller's
-    local app definition. That closes the stale-deploy blind spot this
-    check used to carry: it compares the DAG against the module list the
-    ticks will actually import, so "you changed ``task_modules`` but
-    didn't redeploy" is visible rather than silently agreeable.
+    In the default (bootstrap) placement these are the patterns **baked
+    into the deployment at ``finalize()``** — not the caller's local app
+    definition. That closes the stale-deploy blind spot this check used to
+    carry: it compares the DAG against the patterns the deployed ticks
+    were built from, so "you changed ``task_modules`` but didn't redeploy"
+    is visible rather than silently agreeable.
 
     Skipped entirely when the app opted out of ``task_modules`` — an app
     that never declared any would otherwise warn about every class in
     every DAG, on every trigger.
     """
-    if not task_modules:
+    if not task_module_patterns:
         return
-    uncovered = uncovered_task_classes(tasks, task_modules)
+    uncovered = uncovered_task_classes(tasks, task_module_patterns)
     if not uncovered:
         return
     logger.warning(
         format_uncovered_message(
             uncovered,
-            task_modules,
+            task_module_patterns,
             remedy=(
                 "Until then these tasks stay dependent on their "
                 "build-task-store pickles, which need target-root "
@@ -84,9 +90,12 @@ def _preflight_task_modules(
 
 
 def _advise_uncovered_root_task_modules(
-    root_tasks: typing.Sequence[BaseTask], task_modules: typing.Sequence[str]
+    root_tasks: typing.Sequence[BaseTask], task_module_patterns: typing.Sequence[str]
 ) -> None:
     """Advisory, roots-only coverage note emitted at the trigger.
+
+    Takes the declared ``task_modules`` **patterns**, like
+    :func:`_preflight_task_modules`.
 
     Purely additive early feedback, and deliberately **not** a check in
     its own right: :func:`_preflight_task_modules` is the authoritative
@@ -103,15 +112,15 @@ def _advise_uncovered_root_task_modules(
     the moment they trigger, beats saying it a container start later in a
     log they have to go and find.
     """
-    if not task_modules or not root_tasks:
+    if not task_module_patterns or not root_tasks:
         return
-    uncovered = uncovered_task_classes(root_tasks, task_modules)
+    uncovered = uncovered_task_classes(root_tasks, task_module_patterns)
     if not uncovered:
         return
     logger.warning(
         format_uncovered_message(
             uncovered,
-            task_modules,
+            task_module_patterns,
             remedy=(
                 "This is an early, ROOT-TASKS-ONLY note from the trigger; "
                 "the full check runs over the whole discovered DAG where "
@@ -125,11 +134,15 @@ def _persist_discovered_tasks(
     build_id: UUID,
     tasks: typing.Iterable[BaseTask],
     *,
-    task_modules: typing.Sequence[str],
+    task_module_patterns: typing.Sequence[str],
     elide_pickles: bool,
     require_pickle_free: bool,
 ) -> None:
     """Write the build task store, skipping pickles that aren't needed.
+
+    Takes the declared ``task_modules`` **patterns** —
+    :func:`plan_pickle_elision` matches task classes against them, exactly
+    as the coverage check does.
 
     Unless the app *opted in* (``elide_pickles``), this is byte-for-byte
     the old behaviour: pickle everything. With opt-in, each task gets a
@@ -146,16 +159,16 @@ def _persist_discovered_tasks(
 
     ``elide_pickles`` is the app's opt-in — ``task_modules`` passed
     explicitly (or ``require_pickle_free``), NOT merely inferred —
-    resolved at ``finalize()`` and baked in alongside the module list.
+    resolved at ``finalize()`` and baked in alongside the patterns.
     Inference must stay observation-only: it happens for every app,
     including apps written before the feature existed, and an SDK upgrade
     must never start dropping pickles on its own.
     """
     store = BuildTaskStore(build_id)
-    if not task_modules or not elide_pickles:
+    if not task_module_patterns or not elide_pickles:
         store.save_tasks(tasks)
         return
-    plan: PickleElisionPlan = plan_pickle_elision(tasks, task_modules)
+    plan: PickleElisionPlan = plan_pickle_elision(tasks, task_module_patterns)
     if require_pickle_free:
         error = plan.require_pickle_free_error()
         if error is not None:
@@ -220,7 +233,7 @@ def run_reactive_bootstrap(
     registry: typing.Any,
     app_name: str,
     tick_kwargs: dict[str, typing.Any] | None,
-    task_modules: typing.Sequence[str],
+    task_module_patterns: typing.Sequence[str],
     elide_pickles: bool,
     require_pickle_free: bool,
 ) -> ReactiveBootstrapResult:
@@ -265,12 +278,12 @@ def run_reactive_bootstrap(
         )
     )
     # --- task-module coverage pre-flight (see _preflight_task_modules) ---
-    _preflight_task_modules(discovery.incomplete.values(), task_modules)
+    _preflight_task_modules(discovery.incomplete.values(), task_module_patterns)
     # --- task persistence, with conditional pickle elision ---
     _persist_discovered_tasks(
         build_id,
         discovery.incomplete.values(),
-        task_modules=task_modules,
+        task_module_patterns=task_module_patterns,
         elide_pickles=elide_pickles,
         require_pickle_free=require_pickle_free,
     )

--- a/lib/stardag/src/stardag/integration/modal/_builder.py
+++ b/lib/stardag/src/stardag/integration/modal/_builder.py
@@ -1,0 +1,226 @@
+"""Default ``BuildFunction`` implementations — the resident-orchestrator side.
+
+A builder runs *inside* the app's deployed ``build`` function and drives a
+whole DAG to completion in one container, delegating each task to a
+:class:`ModalTaskExecutor`. Contrast with reactive scheduling, where no
+container is resident and short-lived ticks drive the build instead (see
+:mod:`stardag.integration.modal._tick`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import typing
+
+from stardag import BaseTask, build
+from stardag.build import BuildExitStatus, BuildSummary
+from stardag.integration.modal._executor import ModalTaskExecutor
+from stardag.integration.modal._logging import _setup_logging
+from stardag.integration.modal._protocols import BuildFunction
+from stardag.integration.modal._selector import WorkerSelector
+
+try:
+    from stardag.integration.prefect import (
+        build_flow as prefect_build_flow,
+    )
+    from stardag.integration.prefect import (
+        create_markdown,
+        upload_task_on_complete_artifacts,
+    )
+except ImportError:
+    prefect_build_flow = None
+    create_markdown = None
+    upload_task_on_complete_artifacts = None
+
+logger = logging.getLogger(__name__)
+
+
+class BuildFailedError(Exception):
+    """Raised when a build completes with failures or pending tasks."""
+
+    pass
+
+
+class Builder(BuildFunction):
+    """Default builder implementation with overridable setup/teardown.
+
+    Override ``setup()``/``teardown()``/``build()`` to customize behavior.
+    Pass an instance to ``StardagApp(build_function=MyBuilder())``.
+
+    Example:
+
+    .. code-block:: python
+
+        class MyBuilder(Builder):
+            def setup(self, tasks):
+                super().setup(tasks)
+                configure_my_environment()
+
+        stardag_app = StardagApp(
+            "my-app",
+            build_function=MyBuilder(),
+            ...
+        )
+    """
+
+    def __init__(self, *, detached: bool = True):
+        """Initialize the builder.
+
+        Args:
+            detached: Execute tasks as detached spawned Modal function calls
+                (restart-safe, re-attachable on resume, explicitly
+                cancellable). False restores the legacy blocking
+                ``remote`` calls. Passed to :class:`ModalTaskExecutor`.
+        """
+        self.detached = detached
+
+    def setup(self, tasks: typing.Sequence[BaseTask] | BaseTask) -> None:
+        """Optional setup logic before the build starts."""
+        _setup_logging()
+
+    def teardown(
+        self,
+        tasks: typing.Sequence[BaseTask] | BaseTask,
+        summary_or_exception: BuildSummary | None | Exception,
+    ) -> None:
+        """Optional teardown logic after the build finishes."""
+        if isinstance(summary_or_exception, BuildSummary):
+            summary = summary_or_exception
+            logger.info(f"Build summary:\n{repr(summary)}")
+            if summary.status != BuildExitStatus.SUCCESS:
+                raise BuildFailedError(
+                    f"Build finished with status {summary.status.value}: "
+                    f"{summary.task_count.failed} failed, "
+                    f"{summary.task_count.pending} pending"
+                )
+        elif summary_or_exception is None:
+            logger.info("Build completed without a BuildSummary.")
+        else:
+            logger.error(f"Build exception:\n{repr(summary_or_exception)}")
+
+    def __call__(
+        self,
+        tasks: typing.Sequence[BaseTask] | BaseTask,
+        worker_selector: WorkerSelector,
+        app_name: str,
+        build_kwargs: dict[str, typing.Any] | None = None,
+    ) -> BuildSummary | None:
+        """Core build logic to orchestrate the DAG build."""
+        modal_executor = ModalTaskExecutor(
+            modal_app_name=app_name,
+            worker_selector=worker_selector,
+            detached=getattr(self, "detached", True),
+        )
+        summary_or_exception: BuildSummary | None | Exception = BuildFailedError(
+            "Unknown error during build"
+        )  # Placeholder for type checking, this should never be raised
+
+        try:
+            self.setup(tasks)
+            summary = self.build(tasks, modal_executor, build_kwargs=build_kwargs)
+            summary_or_exception = summary
+            return summary
+        except Exception as exception:
+            summary_or_exception = exception
+            raise
+        finally:
+            self.teardown(tasks, summary_or_exception)
+
+    def build(
+        self,
+        tasks: typing.Sequence[BaseTask] | BaseTask,
+        task_executor: ModalTaskExecutor,
+        build_kwargs: dict[str, typing.Any] | None = None,
+    ) -> BuildSummary | None:
+        """Default build logic using stardag.build() with the ModalTaskExecutor.
+
+        ``build_kwargs`` are forwarded to :func:`stardag.build` (e.g. ``fail_mode``,
+        ``register_all``, ``global_lock_config``). Conflicting keys (``tasks``,
+        ``task_executor``) are reserved and rejected.
+        """
+        kwargs = dict(build_kwargs or {})
+        for reserved in ("tasks", "task_executor"):
+            if reserved in kwargs:
+                raise TypeError(
+                    f"build_kwargs must not contain reserved key '{reserved}'"
+                )
+        return build(tasks, task_executor=task_executor, **kwargs)
+
+
+class PrefectBuilder(Builder):
+    """Builder that uses Prefect for build orchestration.
+
+    Requires the ``stardag.integration.prefect`` package to be installed.
+    """
+
+    def __init__(
+        self,
+        on_complete_callback: typing.Callable[[BaseTask], typing.Awaitable[None]]
+        | None = None,
+        before_run_callback: typing.Callable[[BaseTask], typing.Awaitable[None]]
+        | None = None,
+    ):
+        # Prefect's build flow drives the executor via submit() only, so
+        # detached mode has no effect there — keep the legacy behavior.
+        super().__init__(detached=False)
+        self.on_complete_callback = on_complete_callback
+        self.before_run_callback = before_run_callback
+
+    def build(
+        self,
+        tasks: typing.Sequence[BaseTask] | BaseTask,
+        task_executor: ModalTaskExecutor,
+        build_kwargs: dict[str, typing.Any] | None = None,
+    ) -> BuildSummary | None:
+        if prefect_build_flow is None:
+            raise ImportError("Prefect is not installed")
+
+        _flow = prefect_build_flow  # local for pyright narrowing
+
+        # TODO: support multiple root tasks in PrefectBuilder
+        if isinstance(tasks, BaseTask):
+            task = tasks
+        else:
+            if len(tasks) != 1:
+                raise ValueError(
+                    f"PrefectBuilder currently supports only a single root task, "
+                    f"got {len(tasks)}"
+                )
+            task = tasks[0]
+
+        flow_kwargs = dict(build_kwargs or {})
+        # ``task`` is reserved because the flow is invoked as
+        # ``_flow(...)(task, ...)`` below — letting the user pass another
+        # ``task`` via build_kwargs would surface as a confusing
+        # "got multiple values for argument 'task'" TypeError.
+        for reserved in (
+            "task",
+            "task_executor",
+            "before_run_callback",
+            "on_complete_callback",
+        ):
+            if reserved in flow_kwargs:
+                raise TypeError(
+                    f"build_kwargs must not contain reserved key '{reserved}'"
+                )
+
+        async def _run():
+            await _flow.with_options(
+                name=f"stardag-build-{task.get_namespace()}:{task.get_name()}"
+            )(
+                task,
+                task_executor=task_executor,
+                before_run_callback=(self.before_run_callback or create_markdown),
+                on_complete_callback=(
+                    self.on_complete_callback or upload_task_on_complete_artifacts
+                ),
+                **flow_kwargs,
+            )
+
+        asyncio.run(_run())
+        # Prefect manages its own flow result; no BuildSummary available.
+        return None
+
+
+_default_build = Builder()

--- a/lib/stardag/src/stardag/integration/modal/_executor.py
+++ b/lib/stardag/src/stardag/integration/modal/_executor.py
@@ -1,0 +1,541 @@
+"""The orchestrator side: a ``TaskExecutorABC`` that runs tasks on Modal.
+
+Used by whatever is driving a build — a resident ``build`` function
+(:class:`stardag.integration.modal.Builder`) or a reactive scheduler tick —
+to spawn tasks onto the app's deployed ``worker_*`` functions, re-attach to
+still-running ones after a restart, and cancel them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import traceback as tb_module
+import typing
+from uuid import UUID
+
+import modal
+
+from stardag import BaseTask, TaskStruct
+from stardag.build import (
+    DetachedExecutionStatus,
+    DetachedHandle,
+    TaskExecutionError,
+    TaskExecutorABC,
+    get_current_build_id,
+)
+from stardag.build._reactive import claim_ttl_seconds
+from stardag.integration.modal._metadata import (
+    MODAL_EXECUTOR_NAME,
+    STARDAG_BUILD_ID_ENV,
+    STARDAG_CLAIM_TTL_SECONDS_ENV,
+    STARDAG_MODAL_APP_ID_ENV,
+    STARDAG_MODAL_APP_NAME_ENV,
+    STARDAG_MODAL_ENVIRONMENT_ENV,
+    STARDAG_MODAL_FUNCTION_ID_ENV,
+    STARDAG_MODAL_FUNCTION_NAME_ENV,
+    STARDAG_MODAL_WORKSPACE_ENV,
+    STARDAG_REACTIVE_ENV,
+    _get_modal_app_id_aio,
+    _get_modal_environment,
+    _get_modal_function_id_aio,
+    _get_modal_workspace_aio,
+)
+from stardag.integration.modal._selector import (
+    WorkerSelector,
+    _normalize_worker_selection,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _is_transient_modal_error(exception: BaseException) -> bool:
+    """Best-effort classification of transport-level (retryable) errors.
+
+    Anything raised by ``FunctionCall.get`` that reflects the CALL's outcome
+    (``modal.exception.RemoteError``, user exceptions re-raised from the
+    function, expired results) is terminal; connection/socket/gRPC-transport
+    failures are not — they say nothing about the call.
+    """
+    if isinstance(exception, (OSError, ConnectionError)):
+        return True
+    module = type(exception).__module__ or ""
+    if module.startswith("grpclib") or module.startswith("h2"):
+        return True
+    return type(exception).__name__ in ("ClientClosed", "StreamTerminatedError")
+
+
+class ModalTaskExecutor(TaskExecutorABC):
+    """Task executor that sends tasks to Modal for remote execution.
+
+    This executor submits tasks to Modal worker functions. Use with
+    RoutedTaskExecutor to route some tasks to Modal and others locally.
+
+    By default tasks are executed *detached* (``worker.spawn`` + a tracked
+    ``FunctionCall``): the worker invocation survives this process, its
+    function call id is recorded in the registry, and a resumed build
+    re-attaches to still-running workers instead of re-executing them.
+    Pass ``detached=False`` for the legacy blocking ``worker.remote`` mode.
+
+    Example:
+        from stardag.build import HybridConcurrentTaskExecutor, RoutedTaskExecutor
+
+        modal_executor = ModalTaskExecutor(
+            modal_app_name="my-app",
+            worker_selector=lambda task: "gpu" if needs_gpu(task) else "default",
+        )
+        local_executor = HybridConcurrentTaskExecutor()
+
+        routed = RoutedTaskExecutor(
+            executors={"modal": modal_executor, "local": local_executor},
+            router=lambda task: "modal" if run_on_modal(task) else "local",
+        )
+        build([task], task_executor=routed)
+    """
+
+    def __init__(
+        self,
+        *,
+        modal_app_name: str,
+        worker_selector: WorkerSelector,
+        detached: bool = True,
+        worker_reports_lifecycle: bool = True,
+        reactive: bool = False,
+        modal_workspace: str | None = None,
+        worker_timeouts: dict[str, int] | None = None,
+    ):
+        """Initialize Modal executor.
+
+        Args:
+            modal_app_name: Name of the Modal app with worker functions.
+            worker_selector: Function that selects which Modal worker to use per task.
+            detached: Execute tasks as detached spawned function calls
+                (restart-safe, re-attachable, explicitly cancellable).
+                False restores the legacy blocking ``remote`` calls.
+            worker_reports_lifecycle: Whether the deployed workers report the
+                task lifecycle (started/completed/suspended/failed events +
+                artifacts) themselves via the default :class:`Runner`. When
+                True the build engine skips its own completed/suspended/
+                resumed reporting for Modal-routed tasks. Set False when
+                driving an app deployed with an older stardag version whose
+                workers don't self-report, or when using a custom
+                ``run_function`` without lifecycle reporting.
+            modal_workspace: Explicit Modal workspace name for the executor
+                metadata recorded with task starts (UI deep links). Default:
+                resolved once from the configured Modal token, best-effort.
+            worker_timeouts: Per-worker Modal function ``timeout`` (seconds),
+                as declared in the app's ``worker_settings``. Only the
+                deploy process can see those settings, so they are passed in
+                rather than looked up. Used to derive the execution-claim
+                TTL recorded with every start (see
+                :meth:`execution_timeout_seconds`); an absent worker simply
+                yields no timeout and the registry's default applies.
+        """
+        self.modal_app_name = modal_app_name
+        self.worker_selector = worker_selector
+        self.detached = detached
+        self.worker_timeouts = dict(worker_timeouts or {})
+        self.worker_reports_lifecycle = worker_reports_lifecycle
+        # Reactive scheduling: forward the app name + reactive flag so
+        # workers register their dynamic deps and wake the scheduler tick.
+        self.reactive = reactive
+        self.modal_workspace = modal_workspace
+        # Executor metadata shared by every start this executor records
+        # (per-task starts add the worker function name). Resolved lazily
+        # at the first invocation, best-effort — metadata must never fail
+        # or delay a task start beyond the one cached lookup.
+        self._base_executor_metadata: dict[str, typing.Any] | None = None
+        # Cache of worker name -> modal.Function. ``modal.Function.from_name``
+        # returns a lazy handle (no network call until invoked), but it is
+        # invoked on every ``submit`` so we memoize it per worker name to avoid
+        # recreating the handle for every task.
+        self._worker_functions: dict[str, modal.Function] = {}
+        # Cache of worker name -> resolved function id (``fu-…``), best-effort.
+        # A ``None`` value is a *resolved* negative (a failed/timed-out
+        # hydration) and is kept so a persistently failing lookup is not
+        # re-paid on every task start — membership, not truthiness, marks
+        # "resolved". Mirrors the once-resolved memoization of the base
+        # metadata dict (which likewise caches a missing app id).
+        self._worker_function_ids: dict[str, str | None] = {}
+        # One-time (per executor) skew-visibility log; see reports_lifecycle.
+        self._reports_lifecycle_logged = False
+        # In-flight detached executions by task UUID, for explicit cancel().
+        # Asyncio cancellation of ``FunctionCall.get`` does NOT stop the
+        # remote call (unlike ``remote.aio``), so FAIL_FAST relies on this.
+        self._in_flight: dict[UUID, modal.FunctionCall] = {}
+
+    def _get_worker_function(self, worker_name: str) -> modal.Function:
+        """Return the (memoized) ``modal.Function`` handle for a worker."""
+        worker_function = self._worker_functions.get(worker_name)
+        if worker_function is None:
+            worker_function = modal.Function.from_name(
+                app_name=self.modal_app_name,
+                name=f"worker_{worker_name}",
+            )
+            self._worker_functions[worker_name] = worker_function
+        return worker_function
+
+    async def _get_base_executor_metadata(self) -> dict[str, typing.Any] | None:
+        """Resolve the executor metadata shared by all starts (cached).
+
+        Best-effort: resolution failures are logged at debug level and
+        yield the identity-only dict — never an exception.
+        """
+        if self._base_executor_metadata is None:
+            metadata: dict[str, typing.Any] = {
+                "kind": MODAL_EXECUTOR_NAME,
+                "app_name": self.modal_app_name,
+            }
+            environment: str | None = None
+            try:
+                workspace = self.modal_workspace or await _get_modal_workspace_aio()
+                if workspace:
+                    metadata["workspace"] = workspace
+                environment = _get_modal_environment()
+                if environment:
+                    metadata["environment"] = environment
+            except Exception:
+                logger.debug(
+                    "Failed to resolve Modal workspace/environment for "
+                    "executor metadata",
+                    exc_info=True,
+                )
+            # App id (``ap-…``): app-wide, so it lives in the base metadata
+            # alongside workspace/environment. Resolved once and cached here
+            # (the base metadata is memoized per executor). Best-effort —
+            # _get_modal_app_id_aio never raises.
+            app_id = await _get_modal_app_id_aio(self.modal_app_name, environment)
+            if app_id:
+                metadata["app_id"] = app_id
+            self._base_executor_metadata = metadata
+        return self._base_executor_metadata
+
+    async def _metadata_for_worker(
+        self, worker_name: str
+    ) -> dict[str, typing.Any] | None:
+        """Base executor metadata + the worker's function name/id (best-effort)."""
+        try:
+            base_metadata = await self._get_base_executor_metadata()
+            if base_metadata is None:
+                return None
+            metadata = {**base_metadata, "function_name": f"worker_{worker_name}"}
+            # Function id (``fu-…``): per-worker, so it lives here alongside
+            # the function name. Best-effort — hydrate the worker handle and
+            # read object_id; _get_modal_function_id_aio never raises. Cached
+            # per worker name (success *and* failure): a resolved ``None`` is
+            # kept so a broken/hung hydration is not re-attempted on every
+            # start (membership marks "resolved", not truthiness).
+            if worker_name not in self._worker_function_ids:
+                self._worker_function_ids[
+                    worker_name
+                ] = await _get_modal_function_id_aio(
+                    self._get_worker_function(worker_name)
+                )
+            function_id = self._worker_function_ids[worker_name]
+            if function_id:
+                metadata["function_id"] = function_id
+            return metadata
+        except Exception:
+            logger.debug("Failed to resolve Modal executor metadata", exc_info=True)
+            return None
+
+    async def get_executor_metadata(
+        self, task: BaseTask
+    ) -> dict[str, typing.Any] | None:
+        """Executor metadata for ``task`` without spawning anything.
+
+        Runs the worker selector (idempotent) to resolve the function
+        name — lets slot-acquiring TASK_STARTED events recorded before
+        the spawn carry the same metadata as the post-spawn start.
+        """
+        try:
+            worker_name, _ = _normalize_worker_selection(self.worker_selector(task))
+        except Exception:
+            logger.debug(
+                "Worker selection failed while resolving executor metadata",
+                exc_info=True,
+            )
+            return None
+        return await self._metadata_for_worker(worker_name)
+
+    def execution_timeout_seconds(self, task: BaseTask) -> float | None:
+        """The Modal ``timeout`` of the worker function this task routes to.
+
+        Modal kills a function call at its ``timeout``, so this is a hard
+        upper bound on how long an execution of ``task`` can be alive — the
+        one fact that makes an execution claim's expiry defensible rather
+        than a guess.
+
+        Returns None when the deployed settings were not passed in (see
+        ``worker_timeouts``), when the selected worker declares no timeout,
+        or when worker selection fails: none of those is a reason to fail a
+        start, and the registry's own default covers them.
+        """
+        if not self.worker_timeouts:
+            return None
+        try:
+            worker_name, _ = _normalize_worker_selection(self.worker_selector(task))
+        except Exception:
+            logger.debug(
+                "Worker selection failed while resolving the execution timeout",
+                exc_info=True,
+            )
+            return None
+        timeout = self.worker_timeouts.get(worker_name)
+        return float(timeout) if timeout is not None else None
+
+    async def _prepare_invocation(
+        self, task: BaseTask
+    ) -> tuple[modal.Function, dict[str, str] | None, dict[str, typing.Any] | None]:
+        """Resolve the worker function, env overrides, and executor metadata.
+
+        When ``worker_reports_lifecycle`` and an enclosing build is active,
+        the build id is injected as the ``STARDAG_BUILD_ID`` env override so
+        the worker-side :class:`Runner` can report lifecycle events. The
+        resolved executor metadata rides along the same channel
+        (``STARDAG_MODAL_*``) so worker self-reported starts carry it too —
+        as does the derived claim TTL, so the worker's own start does not
+        re-stamp the claim with the registry's generic default.
+        """
+        worker_name, env_overrides = _normalize_worker_selection(
+            self.worker_selector(task)
+        )
+        worker_function = self._get_worker_function(worker_name)
+        executor_metadata = await self._metadata_for_worker(worker_name)
+        if self.worker_reports_lifecycle:
+            build_id = get_current_build_id()
+            if build_id is not None:
+                env_overrides = {
+                    **(env_overrides or {}),
+                    STARDAG_BUILD_ID_ENV: str(build_id),
+                    STARDAG_MODAL_APP_NAME_ENV: self.modal_app_name,
+                }
+                ttl_seconds = claim_ttl_seconds(task, self)
+                if ttl_seconds is not None:
+                    env_overrides[STARDAG_CLAIM_TTL_SECONDS_ENV] = str(ttl_seconds)
+                if executor_metadata is not None:
+                    for env_name, key in (
+                        (STARDAG_MODAL_WORKSPACE_ENV, "workspace"),
+                        (STARDAG_MODAL_ENVIRONMENT_ENV, "environment"),
+                        (STARDAG_MODAL_FUNCTION_NAME_ENV, "function_name"),
+                        (STARDAG_MODAL_APP_ID_ENV, "app_id"),
+                        (STARDAG_MODAL_FUNCTION_ID_ENV, "function_id"),
+                    ):
+                        value = executor_metadata.get(key)
+                        if value:
+                            env_overrides[env_name] = value
+                if self.reactive:
+                    env_overrides[STARDAG_REACTIVE_ENV] = "1"
+        return worker_function, env_overrides, executor_metadata
+
+    def reports_lifecycle(self, task: BaseTask) -> bool:
+        """Workers self-report lifecycle when enabled and a build is active."""
+        active = self.worker_reports_lifecycle and get_current_build_id() is not None
+        if active and not self._reports_lifecycle_logged:
+            # Make the version-skew failure mode visible: nothing verifies
+            # the deployed workers actually self-report. If the app was
+            # deployed with an older stardag (or uses a custom run function
+            # without lifecycle reporting), tasks will execute fine but sit
+            # RUNNING in the registry with artifacts lost.
+            self._reports_lifecycle_logged = True
+            logger.info(
+                "Engine-side lifecycle reporting is suppressed for "
+                f"Modal-routed tasks (app {self.modal_app_name!r}): workers "
+                "are assumed to self-report started/completed/suspended/"
+                "failed events. If the deployed app predates worker "
+                "self-reporting or uses a custom run function, pass "
+                "ModalTaskExecutor(worker_reports_lifecycle=False) — "
+                "otherwise tasks will appear stuck RUNNING in the registry."
+            )
+        return active
+
+    async def submit(self, task: BaseTask) -> None | TaskStruct | TaskExecutionError:
+        """Execute task on Modal (blocking remote call)."""
+        try:
+            worker_function, env_overrides, _ = await self._prepare_invocation(task)
+            res = await worker_function.remote.aio(task, env_overrides=env_overrides)
+            return res
+        except Exception as e:
+            return TaskExecutionError(
+                exception=e,
+                traceback="".join(tb_module.format_exception(e)),
+            )
+
+    # --- Detached execution (spawn + re-attach + cancel) ---
+
+    def supports_detached(self, task: BaseTask) -> bool:
+        """Detached mode is per-executor (constructor flag), not per-task."""
+        return self.detached
+
+    def _make_handle(
+        self,
+        task: BaseTask,
+        function_call: modal.FunctionCall,
+        executor_metadata: dict[str, typing.Any] | None = None,
+    ) -> DetachedHandle:
+        """Wrap a FunctionCall in a DetachedHandle tracking in-flight state."""
+        self._in_flight[task.id] = function_call
+
+        async def wait() -> None | TaskStruct | TaskExecutionError:
+            try:
+                return await function_call.get.aio()
+            except asyncio.CancelledError:
+                # The build engine cancels the awaiting future on FAIL_FAST /
+                # user cancellation. Unlike ``remote.aio``, cancelling
+                # ``get()`` does NOT stop the detached remote call — cancel
+                # it explicitly here. This must live in wait() (not only in
+                # the executor cancel() hook): the finally below pops the
+                # in-flight entry, and the asyncio cancellation typically
+                # lands before the hook runs, so the hook would find nothing.
+                # Shielded: this coroutine is already being cancelled.
+                try:
+                    await asyncio.shield(function_call.cancel.aio())
+                except Exception as cancel_err:
+                    logger.warning(
+                        f"Failed to cancel Modal function call "
+                        f"{function_call.object_id} for task {task.id} "
+                        f"during cancellation: {cancel_err}"
+                    )
+                raise
+            except Exception as e:
+                return TaskExecutionError(
+                    exception=e,
+                    traceback="".join(tb_module.format_exception(e)),
+                )
+            finally:
+                self._in_flight.pop(task.id, None)
+
+        return DetachedHandle(
+            executor=MODAL_EXECUTOR_NAME,
+            ref=function_call.object_id,
+            wait=wait,
+            executor_metadata=executor_metadata,
+        )
+
+    async def submit_detached(self, task: BaseTask) -> DetachedHandle:
+        """Spawn the task on its worker function; return a re-attachable handle."""
+        (
+            worker_function,
+            env_overrides,
+            executor_metadata,
+        ) = await self._prepare_invocation(task)
+        function_call = await worker_function.spawn.aio(
+            task, env_overrides=env_overrides
+        )
+        return self._make_handle(task, function_call, executor_metadata)
+
+    async def reattach(
+        self, task: BaseTask, executor: str, ref: str
+    ) -> DetachedHandle | None:
+        """Re-attach to a spawned function call by id, if it is still live.
+
+        Returns None (→ normal re-execution) when the ref belongs to a
+        different backend, the call failed/was cancelled, or the result has
+        expired. A call that already finished successfully yields a handle
+        resolving immediately to its result.
+
+        Known ambiguity (accepted): Modal's ``get(timeout=0)`` poll timeout
+        raises the *builtin* ``TimeoutError`` (modal 1.5), and a task body
+        that itself raised ``TimeoutError`` re-raises the same type — such
+        a failed call classifies as still-running here. Not narrowable:
+        ``modal.exception.TimeoutError`` is not what the poll raises, and
+        ``FunctionCall.get_call_graph()`` does not reliably surface input
+        status (verified live: stays PENDING after success/cancel). The
+        re-attach path self-corrects: awaiting the returned handle's
+        ``wait()`` re-raises the failure and the task is recorded failed.
+        """
+        if executor != MODAL_EXECUTOR_NAME or not self.detached:
+            return None
+        try:
+            function_call = modal.FunctionCall.from_id(ref)
+        except Exception:
+            return None
+        try:
+            result = await function_call.get.aio(timeout=0)
+        except TimeoutError:
+            # Still running (or queued) — the interesting case. Base
+            # metadata only: the worker function behind a bare ref isn't
+            # known here.
+            return self._make_handle(
+                task, function_call, await self._get_base_executor_metadata()
+            )
+        except Exception:
+            # Failed, cancelled, expired result, or unknown id — re-execute.
+            return None
+
+        async def resolved() -> None | TaskStruct | TaskExecutionError:
+            return result
+
+        return DetachedHandle(executor=MODAL_EXECUTOR_NAME, ref=ref, wait=resolved)
+
+    async def detached_status(
+        self, task: BaseTask, executor: str, ref: str
+    ) -> DetachedExecutionStatus:
+        """Non-blocking probe of a spawned function call's state.
+
+        Note: an expired result (>~7 days) and an unknown id also classify
+        as FAILED — callers (scheduler ticks) check target existence first,
+        so a successfully-finished-long-ago execution is already resolved
+        as complete before this is consulted.
+
+        Known ambiguity (accepted, see also ``reattach``): the poll timeout
+        is the builtin ``TimeoutError``, indistinguishable from a task body
+        that raised ``TimeoutError`` — such a failed execution classifies
+        as RUNNING here. In practice the worker's own TASK_FAILED report
+        resolves the task first; only a registry-less worker raising
+        builtin TimeoutError hits the ambiguity.
+        """
+        if executor != MODAL_EXECUTOR_NAME or not self.detached:
+            return DetachedExecutionStatus.UNKNOWN
+        try:
+            function_call = modal.FunctionCall.from_id(ref)
+            await function_call.get.aio(timeout=0)
+        except TimeoutError:
+            return DetachedExecutionStatus.RUNNING
+        except Exception as e:
+            # Transient transport/infrastructure errors must NOT classify as
+            # FAILED: callers (claim loser-resolution, tick healing) treat
+            # FAILED as proof of death — a network blip mistaken for a dead
+            # winner would let a racer record a live execution as failed and
+            # spawn the duplicate the claim exists to prevent. UNKNOWN is
+            # the safe degradation (leave/wait and re-probe later).
+            if _is_transient_modal_error(e):
+                logger.warning(
+                    f"Transient error probing Modal call {ref!r}; treating "
+                    f"as unknown: {e}"
+                )
+                return DetachedExecutionStatus.UNKNOWN
+            return DetachedExecutionStatus.FAILED
+        return DetachedExecutionStatus.SUCCEEDED
+
+    async def cancel_detached(self, task: BaseTask, executor: str, ref: str) -> None:
+        """Cancel a spawned function call by its recorded id."""
+        if executor != MODAL_EXECUTOR_NAME:
+            return
+        try:
+            await modal.FunctionCall.from_id(ref).cancel.aio()
+        except Exception as e:
+            logger.warning(
+                f"Failed to cancel Modal function call {ref!r} for task {task.id}: {e}"
+            )
+
+    async def cancel(self, task: BaseTask) -> None:
+        """Cancel the tracked in-flight function call for ``task``, if any."""
+        function_call = self._in_flight.pop(task.id, None)
+        if function_call is None:
+            return
+        try:
+            await function_call.cancel.aio()
+        except Exception as e:
+            logger.warning(
+                f"Failed to cancel Modal function call "
+                f"{function_call.object_id} for task {task.id}: {e}"
+            )
+
+    async def setup(self) -> None:
+        """No setup needed for Modal executor."""
+        pass
+
+    async def teardown(self) -> None:
+        """No teardown needed for Modal executor."""
+        pass

--- a/lib/stardag/src/stardag/integration/modal/_logging.py
+++ b/lib/stardag/src/stardag/integration/modal/_logging.py
@@ -1,0 +1,15 @@
+"""Logging setup for stardag code running inside Modal containers.
+
+Its own module because every entry point into a Modal container calls it —
+the build function, the workers, the scheduler ticks, the bootstrap and the
+watchdog — and those live in different modules of this package.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def _setup_logging() -> None:
+    """Setup logging for the modal app."""
+    logging.basicConfig(level=logging.INFO)

--- a/lib/stardag/src/stardag/integration/modal/_metadata.py
+++ b/lib/stardag/src/stardag/integration/modal/_metadata.py
@@ -1,0 +1,244 @@
+"""Executor metadata, and the env-var channel that carries it to workers.
+
+Two things live here, because they are two halves of one mechanism:
+
+- **The env-var names** through which an orchestrator (a resident build
+  function or a scheduler tick) tells a Modal worker what build it is running
+  for and what it should report about itself. They ride on the worker
+  invocation's ``env_overrides``, which keeps the deployed worker function
+  signature unchanged — an older deployed worker simply applies them as
+  harmless env vars.
+- **The resolution of the Modal coordinates** that metadata consists of
+  (workspace, environment, app id, function id), all best-effort and cached:
+  the UI turns them into Modal dashboard deep links, and nothing about a task
+  may fail or be delayed because a link could not be built.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import typing
+
+import modal
+
+logger = logging.getLogger(__name__)
+
+MODAL_EXECUTOR_NAME = "modal"
+"""Executor name recorded with detached executions (see DetachedHandle)."""
+
+STARDAG_BUILD_ID_ENV = "STARDAG_BUILD_ID"
+"""Env var through which the build id reaches Modal workers.
+
+Injected into ``env_overrides`` by :class:`ModalTaskExecutor` (so it is also
+set as a process env var around the task's run) and read by
+:class:`Runner` to report the task's lifecycle events from inside the
+worker. Riding on ``env_overrides`` keeps the worker function signature
+unchanged — older deployed workers simply apply it as a harmless env var.
+"""
+
+STARDAG_MODAL_APP_NAME_ENV = "STARDAG_MODAL_APP_NAME"
+"""Env var carrying the Modal app name to workers (reactive scheduling).
+
+Lets a worker wake the scheduler by spawning the app's ``tick`` function
+when it finishes a task. Transported like ``STARDAG_BUILD_ID``.
+"""
+
+STARDAG_REACTIVE_ENV = "STARDAG_REACTIVE"
+"""Env var flagging reactive scheduling to workers ("1" when reactive).
+
+In reactive mode the worker additionally registers dynamically yielded
+deps (with task-store persistence) and wakes the scheduler after terminal
+events — there is no resident orchestrator to do either.
+"""
+
+STARDAG_CLAIM_TTL_SECONDS_ENV = "STARDAG_CLAIM_TTL_SECONDS"
+"""Env var carrying the claim TTL the orchestrator derived for this task.
+
+The worker's own TASK_STARTED is a start like any other, so without this
+it would re-stamp the claim with the registry's generic default and undo
+the orchestrator's derivation (see
+``stardag.build._reactive.claim_ttl_seconds``). Forwarding it also *improves*
+the bound: the worker's start is recorded when execution actually begins, so
+the expiry is re-based off the real start rather than off the pre-spawn
+claim, which absorbed however long the call sat queued.
+"""
+
+STARDAG_MODAL_WORKSPACE_ENV = "STARDAG_MODAL_WORKSPACE"
+"""Env var carrying the resolved Modal workspace name to workers.
+
+Part of the executor-metadata channel: the orchestrator resolves the
+workspace once (token lookup or explicit override) and forwards it so the
+worker's self-reported TASK_STARTED carries the same metadata dict.
+Transported like ``STARDAG_BUILD_ID``.
+"""
+
+STARDAG_MODAL_ENVIRONMENT_ENV = "STARDAG_MODAL_ENVIRONMENT"
+"""Env var carrying the Modal environment name to workers (see
+``STARDAG_MODAL_WORKSPACE``)."""
+
+STARDAG_MODAL_FUNCTION_NAME_ENV = "STARDAG_MODAL_FUNCTION_NAME"
+"""Env var carrying the Modal function name (``worker_<name>``) to workers
+(see ``STARDAG_MODAL_WORKSPACE``)."""
+
+STARDAG_MODAL_APP_ID_ENV = "STARDAG_MODAL_APP_ID"
+"""Env var carrying the resolved Modal app id (``ap-…``) to workers.
+
+Part of the executor-metadata channel: the orchestrator resolves the app
+id once (best-effort ``modal.App.lookup``) and forwards it so the worker's
+self-reported start carries it too. Lets the UI build stable, stop/
+redeploy-proof dashboard deep links (the app-id URL form outlives a given
+deployed app version). Transported like ``STARDAG_BUILD_ID``."""
+
+STARDAG_MODAL_FUNCTION_ID_ENV = "STARDAG_MODAL_FUNCTION_ID"
+"""Env var carrying the Modal function id (``fu-…``) to workers (see
+``STARDAG_MODAL_APP_ID``)."""
+
+
+# Cache for the token-derived Modal workspace name. Resolved at most once
+# per process (including failed lookups — metadata is best-effort and a
+# broken token shouldn't re-pay the lookup timeout on every task).
+_MODAL_WORKSPACE_UNRESOLVED = object()
+_modal_workspace_cache: typing.Any = _MODAL_WORKSPACE_UNRESOLVED
+# Serialises cold-start lookups so a burst of concurrent starts performs
+# one network lookup instead of N parallel ones. Safe to share across
+# sequential event loops: it is never held across loop boundaries.
+_modal_workspace_lock = asyncio.Lock()
+
+
+async def _get_modal_workspace_aio() -> str | None:
+    """Best-effort Modal workspace name for the configured token (cached)."""
+    global _modal_workspace_cache
+    if _modal_workspace_cache is not _MODAL_WORKSPACE_UNRESOLVED:
+        return typing.cast("str | None", _modal_workspace_cache)
+    async with _modal_workspace_lock:
+        if _modal_workspace_cache is _MODAL_WORKSPACE_UNRESOLVED:
+            # Prefer the workspace baked into the container env at deploy
+            # time. The token lookup below only works where a Modal token is
+            # configured — the local triggering/deploy process — NOT inside a
+            # Modal container (worker/tick/build), which is exactly where
+            # task-level executor metadata is produced. finalize() resolves
+            # the workspace locally and injects it as STARDAG_MODAL_WORKSPACE
+            # so containers read it here instead of failing the token lookup.
+            env_workspace = os.environ.get(STARDAG_MODAL_WORKSPACE_ENV)
+            if env_workspace:
+                _modal_workspace_cache = env_workspace
+            else:
+                try:
+                    _modal_workspace_cache = await _lookup_modal_workspace_aio()
+                except Exception as e:
+                    # Cache the failure too: metadata is best-effort and a
+                    # broken token / unreachable Modal API must neither raise
+                    # into a task start nor re-pay the lookup on every start.
+                    _modal_workspace_cache = None
+                    logger.debug(
+                        f"Modal workspace lookup failed (metadata omitted): {e}"
+                    )
+    return typing.cast("str | None", _modal_workspace_cache)
+
+
+async def _lookup_modal_workspace_aio() -> str | None:
+    from modal.config import _lookup_workspace
+    from modal.config import config as modal_config
+
+    server_url = modal_config.get("server_url")
+    token_id = modal_config.get("token_id")
+    token_secret = modal_config.get("token_secret")
+    if not (server_url and token_id and token_secret):
+        return None
+    response = await _lookup_workspace(server_url, token_id, token_secret)
+    # `workspace_name` is the org/display name and is empty for personal
+    # workspaces; `username` is the account slug used in dashboard URLs
+    # (what `modal token info` prints as "Workspace"). Prefer the explicit
+    # workspace name when present, else fall back to the username — else the
+    # (common) personal-workspace case resolves to nothing.
+    return response.workspace_name or response.username or None
+
+
+def _get_modal_workspace() -> str | None:
+    """Sync wrapper for :func:`_get_modal_workspace_aio` (cached).
+
+    Returns None (without caching a failure) when called from inside a
+    running event loop where ``asyncio.run`` is unavailable.
+    """
+    global _modal_workspace_cache
+    if _modal_workspace_cache is not _MODAL_WORKSPACE_UNRESOLVED:
+        return typing.cast("str | None", _modal_workspace_cache)
+    # The deploy-baked env works regardless of an event loop (no lookup).
+    env_workspace = os.environ.get(STARDAG_MODAL_WORKSPACE_ENV)
+    if env_workspace:
+        _modal_workspace_cache = env_workspace
+        return env_workspace
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_get_modal_workspace_aio())
+    return None
+
+
+def _get_modal_environment() -> str | None:
+    """The active Modal environment name from Modal config, if any."""
+    from modal.config import config as modal_config
+
+    return modal_config.get("environment") or None
+
+
+# Upper bound (seconds) on the best-effort Modal id lookups performed on the
+# critical path before ``spawn``. Matches the 3 s deadline Modal's own
+# ``_lookup_workspace`` gRPC call uses: a *hung* (not merely refused) Modal
+# API must not stall the first task start beyond this cap. On timeout the id
+# is treated as an ordinary best-effort failure (key omitted, debug-logged).
+_MODAL_ID_LOOKUP_TIMEOUT_SECONDS = 3.0
+
+
+async def _get_modal_app_id_aio(
+    app_name: str, environment_name: str | None
+) -> str | None:
+    """Best-effort Modal app id (``ap-…``) for the deployed app.
+
+    Unlike the token workspace lookup, ``modal.App.lookup`` resolves both
+    locally and *inside a Modal container* (worker/tick/build) — which is
+    where task-level executor metadata is produced — so it needs no
+    deploy-baked env fallback. Never raises: on any failure (including the
+    bounded-timeout expiry) the id is omitted from the executor metadata and
+    the failure logged at debug. Bounded by ``_MODAL_ID_LOOKUP_TIMEOUT_SECONDS``
+    so a hung Modal API cannot stall a task start. Resolution is cached by the
+    once-resolved base executor metadata dict.
+
+    Caveat: with ``environment_name=None`` the lookup resolves against the
+    *config-default* Modal environment. If the app is deployed to one
+    environment but local config defaults to another that happens to hold a
+    same-named app, the id (like the ``environment`` metadata key in that same
+    scenario) will be that of the wrong app. Pass the resolved environment to
+    avoid this.
+    """
+    try:
+        app = await asyncio.wait_for(
+            modal.App.lookup.aio(app_name, environment_name=environment_name),
+            timeout=_MODAL_ID_LOOKUP_TIMEOUT_SECONDS,
+        )
+        return app.app_id
+    except Exception as e:
+        logger.debug(f"Modal app id lookup failed (metadata omitted): {e}")
+        return None
+
+
+async def _get_modal_function_id_aio(function: modal.Function) -> str | None:
+    """Best-effort Modal function id (``fu-…``) for a worker function.
+
+    Hydrates the (lazy) ``modal.Function`` handle if needed and reads
+    ``object_id``. ``hydrate`` is a no-op when already hydrated. Never
+    raises: on failure (including the bounded-timeout expiry) the id is
+    omitted and the failure logged at debug. Bounded by
+    ``_MODAL_ID_LOOKUP_TIMEOUT_SECONDS`` so a hung Modal API cannot stall a
+    task start.
+    """
+    try:
+        await asyncio.wait_for(
+            function.hydrate.aio(), timeout=_MODAL_ID_LOOKUP_TIMEOUT_SECONDS
+        )
+        return function.object_id
+    except Exception as e:
+        logger.debug(f"Modal function id resolution failed (metadata omitted): {e}")
+        return None

--- a/lib/stardag/src/stardag/integration/modal/_profile.py
+++ b/lib/stardag/src/stardag/integration/modal/_profile.py
@@ -1,0 +1,112 @@
+"""Stardag profile configuration for Modal deployments.
+
+Turns the active (or a named) stardag profile into the environment variables
+that configure the SDK *inside* Modal containers, and into the
+``modal.Secret`` that carries them there.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import typing
+
+import modal
+
+from stardag.config import clear_config_cache, config_provider, load_config
+from stardag.registry._base import get_git_commit_hash
+
+
+def get_profile_env_vars(profile: str | None = None) -> dict[str, str]:
+    """Get environment variables from a stardag profile for Modal deployment.
+
+    These environment variables configure the stardag SDK inside Modal containers
+    to connect to the correct registry, workspace, and environment.
+
+    Args:
+        profile: Profile name to use. If None, uses the active profile
+            (from STARDAG_PROFILE env var or default profile in config).
+
+    Returns:
+        Dict of environment variables to inject into Modal functions:
+        - STARDAG_API_URL: API endpoint
+        - STARDAG_WORKSPACE_ID: Workspace UUID
+        - STARDAG_ENVIRONMENT_ID: Environment UUID
+        - STARDAG_TARGET_ROOTS: JSON dict of target roots (pydantic-settings parses this)
+        - COMMIT_HASH: Current git commit (for traceability)
+
+    Example:
+        >>> env_vars = get_profile_env_vars("production")
+        >>> print(env_vars)
+        {
+            'STARDAG_API_URL': 'https://api.stardag.com',
+            'STARDAG_WORKSPACE_ID': '...',
+            'STARDAG_ENVIRONMENT_ID': '...',
+            'STARDAG_TARGET_ROOTS': '{"default": "s3://bucket/prefix"}',
+            'COMMIT_HASH': 'abc123...'
+        }
+    """
+    # Load config for specific profile if provided
+    if profile:
+        # Temporarily set STARDAG_PROFILE to load that profile's config
+        old_profile = os.environ.get("STARDAG_PROFILE")
+        os.environ["STARDAG_PROFILE"] = profile
+        try:
+            clear_config_cache()
+            config = load_config()
+        finally:
+            if old_profile is not None:
+                os.environ["STARDAG_PROFILE"] = old_profile
+            else:
+                os.environ.pop("STARDAG_PROFILE", None)
+            clear_config_cache()
+    else:
+        config = config_provider.get()
+
+    env_vars: dict[str, str] = {}
+
+    reg = config.registry
+    if reg:
+        env_vars["STARDAG_API_URL"] = reg.url
+        if reg.workspace_id:
+            env_vars["STARDAG_WORKSPACE_ID"] = reg.workspace_id
+        if reg.environment_id:
+            env_vars["STARDAG_ENVIRONMENT_ID"] = reg.environment_id
+
+    # Add target roots as JSON (pydantic-settings parses JSON for nested fields)
+    if config.target.roots:
+        env_vars["STARDAG_TARGET_ROOTS"] = json.dumps(config.target.roots)
+
+    # Add git commit for traceability
+    commit_hash = get_git_commit_hash()
+    if commit_hash:
+        env_vars["COMMIT_HASH"] = commit_hash
+
+    return env_vars
+
+
+def get_profile_secret(profile: str | None = None) -> modal.Secret:
+    """Create a Modal secret from a stardag profile's environment variables.
+
+    This is the recommended way to inject profile configuration into Modal
+    functions at runtime, rather than baking them into the image.
+
+    Args:
+        profile: Profile name to use. If None, uses the active profile.
+
+    Returns:
+        A modal.Secret that can be passed to FunctionSettings.secrets.
+
+    Example:
+        >>> secret = get_profile_secret("production")
+        >>> stardag_app = StardagApp(
+        ...     "my-app",
+        ...     builder_settings=FunctionSettings(
+        ...         image=my_image,
+        ...         secrets=[secret],  # Injected at runtime
+        ...     ),
+        ...     ...
+        ... )
+    """
+    env_vars = get_profile_env_vars(profile)
+    return modal.Secret.from_dict(typing.cast(dict[str, str | None], env_vars))

--- a/lib/stardag/src/stardag/integration/modal/_protocols.py
+++ b/lib/stardag/src/stardag/integration/modal/_protocols.py
@@ -1,0 +1,120 @@
+"""The two callables a StardagApp deploys: the build function and the run function.
+
+Declared as protocols so an app can supply anything call-compatible.
+:class:`stardag.integration.modal.Builder` and
+:class:`stardag.integration.modal.Runner` are the default implementations and
+the recommended starting point (they add overridable ``setup``/``teardown``
+hooks on top of the protocol).
+"""
+
+from __future__ import annotations
+
+import inspect
+import typing
+
+from stardag import BaseTask, TaskStruct
+from stardag.build import BuildSummary
+from stardag.integration.modal._selector import WorkerSelector
+
+
+class BuildFunction(typing.Protocol):
+    """Protocol for the function registered as the Modal "build" function.
+
+    This function is called remotely on Modal to orchestrate a DAG build.
+    It receives one or more root tasks, a worker selector, the Modal app
+    name, and an optional ``build_kwargs`` dict, then coordinates task
+    execution across Modal worker functions.
+
+    Args (of ``__call__``):
+        tasks: A single root ``BaseTask`` or a sequence of root tasks.
+        worker_selector: Function picking a worker name per task.
+        app_name: Name of the Modal app hosting the worker functions.
+        build_kwargs: Optional dict of extra kwargs forwarded to the
+            underlying build engine (the default ``Builder`` splats them
+            into :func:`stardag.build`). ``None`` means "no extra kwargs".
+
+    The default implementation (``Builder``) creates a ``ModalTaskExecutor``
+    and calls ``stardag.build()``. Custom implementations can subclass
+    ``Builder`` to override ``setup()``/``teardown()``/``build()``, or
+    implement this protocol directly for full control.
+
+    Any module-level code in the module where a custom build function is
+    defined will execute inside the Modal container before the function is
+    called — use this for container-level setup (imports, config, etc.).
+    """
+
+    def __call__(
+        self,
+        tasks: typing.Sequence[BaseTask] | BaseTask,
+        worker_selector: WorkerSelector,
+        app_name: str,
+        build_kwargs: dict[str, typing.Any] | None = None,
+    ) -> BuildSummary | None: ...
+
+
+class RunFunction(typing.Protocol):
+    """Protocol for the function registered as Modal "worker_*" functions.
+
+    This function is called remotely on Modal to execute a single task.
+    It receives a task instance and returns either ``None`` (task completed)
+    or the ``TaskStruct`` yielded at the first incomplete dynamic-deps yield
+    (which may include deps that are already complete — the caller is
+    expected to filter if that matters). This enables idempotent
+    re-execution: the build system schedules the yielded deps, then
+    re-invokes the task. On re-execution the generator advances past
+    previously-yielded batches whose deps are now complete.
+
+    The default implementation (``Runner``) handles sync, async, and dynamic
+    deps tasks. Custom implementations can subclass ``Runner`` to override
+    ``setup()``/``teardown()``/``run()``, or implement this protocol directly.
+
+    Any module-level code in the module where a custom run function is
+    defined will execute inside the Modal container before the function is
+    called — use this for container-level setup (imports, config, etc.).
+
+    Args (of ``__call__``):
+        task: The task instance to execute.
+
+    Implementations *may* additionally accept an optional
+    ``env_overrides: dict[str, str] | None`` keyword argument (the framework
+    always forwards it by keyword). When the ``worker_selector`` returns
+    ``(worker_name, env_overrides)`` (see :data:`WorkerSelection`), the
+    framework forwards those overrides to run functions that accept the
+    parameter; for run functions written against the older ``(task)``-only
+    signature the framework instead applies the overrides to the process
+    environment around the call. The default :class:`Runner` accepts
+    ``env_overrides`` and applies them around its ``run`` call.
+    """
+
+    def __call__(self, task: BaseTask) -> None | TaskStruct: ...
+
+
+class _RunFunctionWithEnv(typing.Protocol):
+    """Internal protocol for run functions that accept ``env_overrides``.
+
+    Used to type the call site that forwards selector-provided environment
+    overrides (see :meth:`StardagApp.finalize`'s ``_modal_run`` wrapper).
+    """
+
+    def __call__(
+        self, task: BaseTask, *, env_overrides: dict[str, str] | None = None
+    ) -> None | TaskStruct: ...
+
+
+def _callable_accepts_env_overrides(fn: typing.Callable[..., typing.Any]) -> bool:
+    """Whether ``fn`` accepts an ``env_overrides`` argument.
+
+    Used to stay backward-compatible with custom ``RunFunction`` implementations
+    written against the older ``(task)``-only signature (before the optional
+    ``env_overrides`` parameter was added).
+    """
+    try:
+        signature = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return False
+    for param in signature.parameters.values():
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+        if param.name == "env_overrides":
+            return True
+    return False

--- a/lib/stardag/src/stardag/integration/modal/_runner.py
+++ b/lib/stardag/src/stardag/integration/modal/_runner.py
@@ -432,10 +432,16 @@ def _drive_sync_generator(
     """Drive a sync generator result for idempotent re-execution.
 
     Advances the generator past yield batches whose deps are all complete.
-    Stops at the first yield with any incomplete dep and returns that yield's
-    full ``TaskStruct`` (which may also include already-complete deps — the
-    caller is expected to filter for incomplete ones when scheduling). If
-    the generator completes, returns ``None``.
+    Stops at the first yield with any incomplete dep and returns **all** of
+    that yield's deps — including the already-complete ones, which the
+    caller is expected to filter out when scheduling. If the generator
+    completes, returns ``None``.
+
+    The returned ``TaskStruct`` is the yielded one **flattened** to a tuple
+    of tasks, not its original shape: a task that yields a nested structure
+    (a list of lists, a dict of tasks) gets a flat tuple of the same tasks
+    back. Nothing downstream needs the nesting — the build engine flattens
+    to schedule — and the flat form is what survives the Modal boundary.
 
     If ``result`` is ``None`` (no dynamic deps) returns ``None``. If
     ``result`` is already a ``TaskStruct`` (unusual but possible when a
@@ -464,8 +470,8 @@ async def _drive_async_generator(task: BaseTask) -> None | TaskStruct:
 
     Same contract as ``_drive_sync_generator``: advances past fully-complete
     yield batches and returns the first batch that contains any incomplete
-    dep as a ``TaskStruct`` (may include already-complete deps). Returns
-    ``None`` when the generator finishes.
+    dep, flattened to a tuple of tasks and including the already-complete
+    ones. Returns ``None`` when the generator finishes.
     """
     agen = typing.cast(
         typing.AsyncGenerator[TaskStruct, None],

--- a/lib/stardag/src/stardag/integration/modal/_runner.py
+++ b/lib/stardag/src/stardag/integration/modal/_runner.py
@@ -1,0 +1,485 @@
+"""Default ``RunFunction`` implementation — what runs inside a worker container.
+
+:class:`Runner` executes one task (sync, async, or dynamic-deps generator) and,
+when an orchestrator forwarded a build id, reports that task's whole lifecycle
+to the registry from inside the worker via :class:`_WorkerLifecycleReporter`.
+Reporting from here rather than from the orchestrator is what makes the events
+independent of the orchestrator's lifetime — and it is the only option under
+reactive scheduling, where there is no resident orchestrator at all.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import os
+import typing
+from uuid import UUID
+
+import modal
+
+from stardag import BaseTask, TaskStruct, flatten_task_struct
+from stardag._core.base_task import _has_custom_run, _has_custom_run_aio
+from stardag.build import BuildTaskStore, discover_and_register_aio
+from stardag.build._task_modules import (
+    declared_task_module_patterns,
+    format_uncovered_message,
+    plan_pickle_elision,
+    uncovered_task_classes,
+)
+from stardag.integration.modal._logging import _setup_logging
+from stardag.integration.modal._metadata import (
+    MODAL_EXECUTOR_NAME,
+    STARDAG_BUILD_ID_ENV,
+    STARDAG_CLAIM_TTL_SECONDS_ENV,
+    STARDAG_MODAL_APP_ID_ENV,
+    STARDAG_MODAL_APP_NAME_ENV,
+    STARDAG_MODAL_ENVIRONMENT_ENV,
+    STARDAG_MODAL_FUNCTION_ID_ENV,
+    STARDAG_MODAL_FUNCTION_NAME_ENV,
+    STARDAG_MODAL_WORKSPACE_ENV,
+    STARDAG_REACTIVE_ENV,
+)
+from stardag.integration.modal._protocols import RunFunction
+from stardag.registry._base import NoOpRegistry, registry_provider
+from stardag.utils.env import temp_env_vars
+
+logger = logging.getLogger(__name__)
+
+
+class _WorkerLifecycleReporter:
+    """Reports a task's lifecycle events from inside a Modal worker.
+
+    Created by :class:`Runner` when a build id was forwarded (see
+    ``STARDAG_BUILD_ID_ENV``) and the container has a configured registry.
+    Reporting from the worker makes the events independent of the
+    orchestrator's lifetime: completion/failure land even if the build
+    function died mid-await, and each (re-)invocation's TASK_STARTED
+    carries its own function call id for re-attach.
+
+    All reporting is best-effort: a registry hiccup must never fail a task
+    whose actual work succeeded — failures are logged loudly and the
+    engine-side self-heal (target-existence check on the next build) covers
+    a lost completion event.
+    """
+
+    def __init__(
+        self,
+        registry: typing.Any,
+        build_id: UUID,
+        task: BaseTask,
+        *,
+        reactive: bool = False,
+        app_name: str | None = None,
+        executor_metadata: dict[str, typing.Any] | None = None,
+        claim_ttl_seconds: int | None = None,
+    ):
+        self.registry = registry
+        self.build_id = build_id
+        self.task = task
+        self.reactive = reactive
+        self.app_name = app_name
+        self.executor_metadata = executor_metadata
+        self.claim_ttl_seconds = claim_ttl_seconds
+
+    @classmethod
+    def create(
+        cls, task: BaseTask, env_overrides: dict[str, str] | None
+    ) -> "_WorkerLifecycleReporter | None":
+        def _get(key: str) -> str | None:
+            return (env_overrides or {}).get(key) or os.environ.get(key)
+
+        raw_build_id = _get(STARDAG_BUILD_ID_ENV)
+        if not raw_build_id:
+            return None
+        try:
+            build_id = UUID(raw_build_id)
+        except ValueError:
+            logger.warning(f"Invalid {STARDAG_BUILD_ID_ENV}: {raw_build_id!r}")
+            return None
+        registry = registry_provider.get()
+        # Exact-type check: only the literal do-nothing default suppresses
+        # reporting — NoOpRegistry *subclasses* may implement real behavior.
+        if type(registry) is NoOpRegistry:
+            return None
+        app_name = _get(STARDAG_MODAL_APP_NAME_ENV)
+        # Executor metadata forwarded by the orchestrator's executor (same
+        # dict it records on its own starts). Values missing on older
+        # orchestrators are simply omitted.
+        executor_metadata: dict[str, typing.Any] = {"kind": MODAL_EXECUTOR_NAME}
+        if app_name:
+            executor_metadata["app_name"] = app_name
+        for key, env_name in (
+            ("workspace", STARDAG_MODAL_WORKSPACE_ENV),
+            ("environment", STARDAG_MODAL_ENVIRONMENT_ENV),
+            ("function_name", STARDAG_MODAL_FUNCTION_NAME_ENV),
+            ("app_id", STARDAG_MODAL_APP_ID_ENV),
+            ("function_id", STARDAG_MODAL_FUNCTION_ID_ENV),
+        ):
+            value = _get(env_name)
+            if value:
+                executor_metadata[key] = value
+        # The orchestrator's derived claim TTL, if it sent one. Malformed
+        # values are ignored rather than raised on: this is a bound on an
+        # expiry, and no worker should fail to report its own start over it.
+        raw_ttl = _get(STARDAG_CLAIM_TTL_SECONDS_ENV)
+        try:
+            ttl_seconds = int(raw_ttl) if raw_ttl else None
+        except ValueError:
+            logger.warning(f"Invalid {STARDAG_CLAIM_TTL_SECONDS_ENV}: {raw_ttl!r}")
+            ttl_seconds = None
+        # A syntactically valid but out-of-range value is the same problem
+        # as a malformed one, and worse in effect: the server rejects it
+        # (422) on `task_start`, so the worker loses its whole lifecycle
+        # report over a bound on an expiry. Drop it and let the server pick
+        # its default.
+        if ttl_seconds is not None and ttl_seconds <= 0:
+            logger.warning(
+                f"Ignoring {STARDAG_CLAIM_TTL_SECONDS_ENV}={raw_ttl!r}: a claim "
+                "TTL must be positive. The server's default applies instead."
+            )
+            ttl_seconds = None
+        return cls(
+            registry,
+            build_id,
+            task,
+            reactive=_get(STARDAG_REACTIVE_ENV) == "1",
+            app_name=app_name,
+            executor_metadata=executor_metadata,
+            claim_ttl_seconds=ttl_seconds,
+        )
+
+    def _guard(self, fn: typing.Callable[[], None], what: str) -> None:
+        try:
+            fn()
+        except Exception:
+            logger.exception(
+                f"Worker lifecycle report ({what}) failed for task {self.task.id}"
+            )
+
+    def started(self) -> None:
+        def _do() -> None:
+            ref: str | None = None
+            try:
+                ref = modal.current_function_call_id()
+            except Exception:
+                pass
+            self.registry.task_start(
+                self.build_id,
+                self.task,
+                executor=MODAL_EXECUTOR_NAME,
+                executor_ref=ref,
+                executor_metadata=self.executor_metadata,
+                claim_ttl_seconds=self.claim_ttl_seconds,
+            )
+
+        self._guard(_do, "start")
+
+    def completed(self) -> None:
+        self._guard(
+            lambda: self.registry.task_complete(self.build_id, self.task),
+            "complete",
+        )
+
+        def _artifacts() -> None:
+            artifacts = self.task.artifacts()
+            if artifacts:
+                self.registry.task_upload_artifacts(self.build_id, self.task, artifacts)
+
+        self._guard(_artifacts, "artifacts")
+        self._wake_scheduler()
+
+    def suspended(self, task_struct: TaskStruct | None = None) -> None:
+        if self.reactive and task_struct is not None:
+            # No resident orchestrator to pick up the yielded deps: register
+            # them (with their requires() subtrees), persist their pickles
+            # for the scheduler, and record the dynamic edges — BEFORE the
+            # suspend event, so the frontier is consistent when a tick runs.
+            self._guard(
+                lambda: self._register_dynamic_deps(task_struct), "dynamic-deps"
+            )
+        self._guard(
+            lambda: self.registry.task_suspend(self.build_id, self.task),
+            "suspend",
+        )
+        self._wake_scheduler()
+
+    def failed(self, exception: Exception) -> None:
+        self._guard(
+            lambda: self.registry.task_fail(
+                self.build_id, self.task, error_message=str(exception)
+            ),
+            "fail",
+        )
+        self._wake_scheduler()
+
+    def _register_dynamic_deps(self, task_struct: TaskStruct) -> None:
+        result = asyncio.run(
+            discover_and_register_aio(self.registry, self.build_id, task_struct)
+        )
+        store = BuildTaskStore(self.build_id)
+        # The trigger's pre-flight structurally cannot see dynamically
+        # yielded deps — they don't exist until their parent runs — so the
+        # coverage check is re-run here, on the app's patterns as published
+        # by the deployed worker wrapper. Once per class per process: this
+        # runs on every suspending worker invocation.
+        #
+        # The same elision applies (see
+        # :func:`stardag.integration.modal._bootstrap._persist_discovered_tasks`):
+        # without it the pickle-free property would hold only until a task
+        # yielded its first dynamic dependency, and a build with dynamic
+        # deps would still need target-root write access.
+        patterns = declared_task_module_patterns()
+        if patterns:
+            uncovered = uncovered_task_classes(
+                result.incomplete.values(), patterns, only_unwarned=True
+            )
+            if uncovered:
+                logger.warning(
+                    format_uncovered_message(
+                        uncovered,
+                        patterns,
+                        remedy=(
+                            "These were registered as dynamic dependencies, "
+                            "so the trigger's pre-flight could not see them."
+                        ),
+                    )
+                )
+            plan = plan_pickle_elision(result.incomplete.values(), patterns)
+            store.save_tasks(task for task, _ in plan.pickled)
+            logger.info(
+                f"Build {self.build_id} dynamic deps of task "
+                f"{self.task.id}: {plan.summary()}"
+            )
+        else:
+            store.save_tasks(result.incomplete.values())
+        deps = flatten_task_struct(task_struct)
+        self.registry.task_add_dependencies(
+            self.build_id, self.task, deps, is_dynamic=True
+        )
+
+    def _wake_scheduler(self) -> None:
+        """Reactive wake-up: flag the build dirty, then spawn a tick.
+
+        Order matters: the flag is set *before* the spawn, so if the tick
+        finds the scheduler lease held, the holder's linger re-check is
+        guaranteed to observe the wake-up.
+        """
+        if not self.reactive:
+            return
+        self._guard(lambda: self.registry.build_notify(self.build_id), "notify")
+        app_name = self.app_name
+        if app_name is None:
+            logger.warning(
+                "Reactive build without an app name — cannot spawn a "
+                "scheduler tick (relying on the watchdog)."
+            )
+            return
+
+        def _spawn_tick() -> None:
+            modal.Function.from_name(app_name=app_name, name="tick").spawn(
+                build_id=str(self.build_id)
+            )
+
+        self._guard(_spawn_tick, "tick-spawn")
+
+
+class Runner(RunFunction):
+    """Default runner implementation with overridable setup/teardown.
+
+    Override ``setup()``/``teardown()``/``run()`` to customize behavior.
+    Pass an instance to ``StardagApp(run_function=MyRunner())``.
+
+    Example:
+
+    .. code-block:: python
+
+        class MyRunner(Runner):
+            def setup(self, task):
+                super().setup(task)
+                torch.cuda.set_device(0)
+
+        stardag_app = StardagApp(
+            "my-app",
+            run_function=MyRunner(),
+            ...
+        )
+    """
+
+    def __init__(self, *, report_lifecycle: bool = True):
+        """Initialize the runner.
+
+        Args:
+            report_lifecycle: Report the task's lifecycle events
+                (started/completed/suspended/failed + artifacts) to the
+                registry from inside the worker, when a build id was
+                forwarded by the executor and the container has registry
+                credentials. See :class:`_WorkerLifecycleReporter`.
+        """
+        self.report_lifecycle = report_lifecycle
+
+    def setup(self, task: BaseTask) -> None:
+        """Optional setup logic before the task runs."""
+        _setup_logging()
+
+    def teardown(self, task: BaseTask, exception: Exception | None) -> None:
+        """Optional teardown logic after the task runs."""
+        if exception:
+            logger.error(f"Task {repr(task)} raised an exception: {repr(exception)}")
+
+    def __call__(
+        self, task: BaseTask, *, env_overrides: dict[str, str] | None = None
+    ) -> None | TaskStruct:
+        """Core logic to execute a single task.
+
+        Returns ``None`` when the task completed, or a ``TaskStruct`` of
+        dynamic dependencies that were not yet complete (idempotent
+        re-execution pattern — see ``run``).
+
+        Args:
+            task: The task instance to execute.
+            env_overrides: Optional environment variable overrides (selected by
+                the ``worker_selector`` — see :data:`WorkerSelection`). When
+                provided, they are set temporarily around the ``run`` call and
+                the previous environment is restored afterwards.
+        """
+        # getattr: tolerate subclasses overriding __init__ without super()
+        result: None | TaskStruct = None
+        exception: Exception | None = None
+        try:
+            self.setup(task)
+            # All lifecycle reporting happens inside the env-overrides
+            # context, so overrides carrying environment-sensitive config
+            # apply to reporting exactly as they do to run(). (Caveat:
+            # stardag's config/registry providers cache on first access —
+            # registry connection settings should come from the container's
+            # process environment, i.e. deployment secrets, not overrides.)
+            with temp_env_vars(env_overrides or {}):
+                # getattr: tolerate subclasses overriding __init__ w/o super()
+                reporter: _WorkerLifecycleReporter | None = None
+                if getattr(self, "report_lifecycle", True):
+                    try:
+                        reporter = _WorkerLifecycleReporter.create(task, env_overrides)
+                    except Exception:
+                        # Best-effort contract covers creation too: a broken
+                        # registry config must not fail a task before it runs.
+                        logger.exception(
+                            "Worker lifecycle reporter creation failed; "
+                            "running without lifecycle reporting."
+                        )
+                if reporter is not None:
+                    reporter.started()
+                try:
+                    result = self.run(task)
+                except Exception as e:
+                    if reporter is not None:
+                        reporter.failed(e)
+                    raise
+                if reporter is not None:
+                    if result is None:
+                        reporter.completed()
+                    else:
+                        reporter.suspended(result)
+        except Exception as e:
+            exception = e
+            raise
+        finally:
+            self.teardown(task, exception)
+        return result
+
+    def run(self, task: BaseTask) -> None | TaskStruct:
+        """Default run logic — handles sync, async, and dynamic deps tasks.
+
+        Dispatch policy:
+
+        - **Async-only** (``run_aio`` defined, ``run`` not overridden):
+          async generator ``run_aio`` is driven via ``_drive_async_generator``;
+          otherwise ``asyncio.run(task.run_aio())``.
+        - **Sync-only and dual** (``run`` defined, with or without ``run_aio``):
+          ``task.run()`` is called. If it returns a sync generator it is
+          driven via ``_drive_sync_generator``. Dual tasks intentionally
+          prefer the sync path here because the Modal worker invocation is
+          itself synchronous — if you need async execution for a dual task,
+          implement it in ``run()`` (e.g. via ``asyncio.run`` internally).
+
+        Generators cannot be serialized across the Modal boundary, so we
+        mirror ``_run_task_in_process``: drive forward while yielded batches
+        are fully complete, and at the first yield with any incomplete dep
+        return the entire yielded ``TaskStruct``. The ``ModalTaskExecutor``
+        builds those deps (filtering for incomplete ones) and re-invokes this
+        function — on re-execution the generator advances past the
+        now-complete batch.
+        """
+        has_run_aio = _has_custom_run_aio(task)
+        has_run = _has_custom_run(task)
+
+        if has_run_aio and not has_run:
+            # Async-only task
+            if inspect.isasyncgenfunction(type(task).run_aio):
+                return asyncio.run(_drive_async_generator(task))
+            asyncio.run(task.run_aio())
+            return None
+
+        # Sync (or dual) task — run and drive generator if returned.
+        # Dual tasks deliberately take the sync path; see method docstring.
+        return _drive_sync_generator(task.run())
+
+
+def _drive_sync_generator(
+    result: None | typing.Generator[TaskStruct, None, None] | TaskStruct,
+) -> None | TaskStruct:
+    """Drive a sync generator result for idempotent re-execution.
+
+    Advances the generator past yield batches whose deps are all complete.
+    Stops at the first yield with any incomplete dep and returns that yield's
+    full ``TaskStruct`` (which may also include already-complete deps — the
+    caller is expected to filter for incomplete ones when scheduling). If
+    the generator completes, returns ``None``.
+
+    If ``result`` is ``None`` (no dynamic deps) returns ``None``. If
+    ``result`` is already a ``TaskStruct`` (unusual but possible when a
+    user's ``run()`` returns deps directly) it is returned as-is.
+    """
+    if result is None:
+        return None
+    if not hasattr(result, "__next__"):
+        # Already a TaskStruct (unusual, but handle it)
+        return typing.cast(TaskStruct, result)
+
+    gen = typing.cast(typing.Generator[TaskStruct, None, None], result)
+    try:
+        while True:
+            yielded = next(gen)
+            deps = flatten_task_struct(yielded)
+            incomplete = [dep for dep in deps if not dep.complete()]
+            if incomplete:
+                return tuple(deps)
+    except StopIteration:
+        return None
+
+
+async def _drive_async_generator(task: BaseTask) -> None | TaskStruct:
+    """Drive an async generator ``run_aio`` for idempotent re-execution.
+
+    Same contract as ``_drive_sync_generator``: advances past fully-complete
+    yield batches and returns the first batch that contains any incomplete
+    dep as a ``TaskStruct`` (may include already-complete deps). Returns
+    ``None`` when the generator finishes.
+    """
+    agen = typing.cast(
+        typing.AsyncGenerator[TaskStruct, None],
+        task.run_aio(),  # type: ignore[assignment]
+    )
+    try:
+        async for yielded in agen:
+            deps = flatten_task_struct(yielded)
+            incomplete = [dep for dep in deps if not dep.complete()]
+            if incomplete:
+                return tuple(deps)
+    except StopAsyncIteration:
+        pass
+    return None
+
+
+_default_run = Runner()

--- a/lib/stardag/src/stardag/integration/modal/_selector.py
+++ b/lib/stardag/src/stardag/integration/modal/_selector.py
@@ -1,0 +1,79 @@
+"""Worker selection: which Modal worker function a task routes to.
+
+A selector is deployed-app configuration — every scheduler tick and every
+resident build of an app uses the same one, so routing cannot change
+mid-build.
+"""
+
+from __future__ import annotations
+
+import typing
+
+from stardag import BaseTask
+
+WorkerSelection = typing.Union[str, tuple[str, dict[str, str]]]
+"""Return type of a :data:`WorkerSelector`.
+
+Either a worker name (``str``), or a ``(worker_name, env_overrides)`` tuple
+where ``env_overrides`` is a dict of environment variables to set temporarily
+around the task's ``run`` call inside the worker container (e.g. to tune
+task-specific execution knobs such as worker/thread counts or batch sizes).
+See :meth:`stardag.integration.modal.Runner.__call__`.
+"""
+
+WorkerSelector = typing.Callable[[BaseTask], WorkerSelection]
+"""Type for functions that select which worker to use for a task.
+
+A selector returns either a worker name, or a ``(worker_name, env_overrides)``
+tuple (see :data:`WorkerSelection`).
+"""
+
+
+def _normalize_worker_selection(
+    selection: WorkerSelection,
+) -> tuple[str, dict[str, str] | None]:
+    """Split a :data:`WorkerSelection` into ``(worker_name, env_overrides)``.
+
+    Accepts either a bare worker name or a ``(worker_name, env_overrides)``
+    tuple and always returns the two-tuple form (``env_overrides`` is ``None``
+    when the selector returned a bare name).
+    """
+    if isinstance(selection, tuple):
+        worker_name, env_overrides = selection
+        return worker_name, env_overrides
+    return selection, None
+
+
+def _default_worker_selector(task: BaseTask) -> WorkerSelection:
+    """Default worker selector - always returns 'default'."""
+    return "default"
+
+
+class WorkerSelectorByName:
+    """Worker selector that routes tasks based on task name.
+
+    Example:
+        selector = WorkerSelectorByName(
+            name_to_worker={"heavy_task": "gpu", "io_task": "high_memory"},
+            default_worker="default",
+        )
+        stardag_app = StardagApp(..., worker_selector=selector)
+    """
+
+    def __init__(self, name_to_worker: dict[str, str], default_worker: str):
+        """Initialize the selector.
+
+        Args:
+            name_to_worker: Dict mapping task names to worker names.
+            default_worker: Worker name to use for tasks not in the mapping.
+        """
+        self.name_to_worker = name_to_worker
+        self.default_worker = default_worker
+
+    def __call__(self, task: BaseTask) -> str:
+        return self.name_to_worker.get(task.get_name(), self.default_worker)
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}({self.name_to_worker}, {self.default_worker})"
+        )

--- a/lib/stardag/src/stardag/integration/modal/_settings.py
+++ b/lib/stardag/src/stardag/integration/modal/_settings.py
@@ -1,0 +1,99 @@
+"""Modal function settings: the declaration and how it is merged at deploy.
+
+:class:`FunctionSettings` is what a user writes when configuring an app's
+builder/worker/tick functions. :func:`_prepare_function_settings` is what
+:meth:`stardag.integration.modal.StardagApp.finalize` applies to it before
+handing the result to ``modal.App.function()``.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import typing
+
+import modal
+
+
+class FunctionSettings(typing.TypedDict, total=False):
+    """Settings for Modal function configuration.
+
+    These settings are passed to modal.App.function() when creating
+    builder and worker functions.
+
+    Attributes:
+        image: Required. The Modal image to use for the function.
+        gpu: GPU configuration (e.g., "A10G", "T4", or list for fallback).
+        cpu: CPU cores (float or (min, max) tuple).
+        memory: Memory in MB (int or (min, max) tuple).
+        timeout: Function timeout in seconds.
+        volumes: Dict of mount path to Volume or CloudBucketMount.
+        secrets: List of Modal secrets to inject.
+        concurrency_limit: Max number of concurrent containers.
+        allow_concurrent_inputs: Max concurrent inputs per container.
+        container_idle_timeout: Seconds before idle container shuts down.
+        keep_warm: Number of containers to keep warm.
+        ephemeral_disk: Ephemeral disk size in MB.
+        retries: Number of retries on failure.
+    """
+
+    image: typing.Required[modal.Image]
+    gpu: str | list[str]
+    cpu: float | tuple[float, float]
+    memory: int | tuple[int, int]
+    timeout: int
+    volumes: dict[
+        typing.Union[str, pathlib.PurePosixPath],
+        typing.Union[modal.Volume, modal.CloudBucketMount],
+    ]
+    secrets: list[modal.Secret]
+    concurrency_limit: int
+    allow_concurrent_inputs: int
+    container_idle_timeout: int
+    keep_warm: int
+    ephemeral_disk: int
+    retries: int
+
+
+def _dedupe_secrets(secrets: list[modal.Secret]) -> list[modal.Secret]:
+    """De-duplicate Modal secrets by name, preserving order.
+
+    Named secrets (``Secret.from_name``) dedupe by name so a secret
+    propagated from the builder to a worker that also declares it is applied
+    once. Secrets without a usable name (e.g. ``Secret.from_dict``) fall back
+    to object identity.
+    """
+    seen: set[str | int] = set()
+    result: list[modal.Secret] = []
+    for secret in secrets:
+        key: str | int = getattr(secret, "name", None) or id(secret)
+        if key in seen:
+            continue
+        seen.add(key)
+        result.append(secret)
+    return result
+
+
+def _prepare_function_settings(
+    settings: FunctionSettings,
+    *,
+    extra_secrets: list[modal.Secret],
+    auto_volumes: dict[str, modal.Volume],
+) -> dict[str, typing.Any]:
+    """Merge extra secrets and auto-volumes into function settings.
+
+    Auto-mounted volumes are merged with user volumes, where user-specified
+    volumes at the same mount path take precedence over auto-mounted ones.
+    Secrets are de-duplicated by name (a named secret propagated from the
+    builder plus one the function already declares should apply once).
+    """
+    result: dict[str, typing.Any] = dict(settings)
+
+    # Merge secrets: existing + extra, de-duplicated by name.
+    existing_secrets: list[modal.Secret] = list(result.get("secrets") or [])
+    result["secrets"] = _dedupe_secrets(existing_secrets + extra_secrets)
+
+    # Merge volumes: auto-mounted (lower priority) + user (higher priority)
+    user_volumes = dict(result.get("volumes") or {})
+    result["volumes"] = {**auto_volumes, **user_volumes}
+
+    return result

--- a/lib/stardag/src/stardag/integration/modal/_tick.py
+++ b/lib/stardag/src/stardag/integration/modal/_tick.py
@@ -1,0 +1,433 @@
+"""Reactive scheduling: the tick body, its configuration, and the watchdog.
+
+A *tick* is one short-lived pass over a reactive build's frontier. Ticks are
+spawned by the bootstrap, by workers finishing tasks, and by the optional
+watchdog; they are idempotent and single-flighted, so invoking one at any time
+is safe and a tick on a non-reactive build no-ops.
+
+The tick is deployed as a Modal function, so it runs in a container with no
+access to the ``StardagApp`` object that configured it. Everything it needs
+from deploy time is therefore captured in a :class:`_TickDeployment` at
+``finalize()`` and closed over by the registered wrapper — which keeps that
+wrapper a two-line delegation to :func:`_run_tick` here.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+import typing
+from uuid import UUID
+
+import modal
+
+from stardag import BaseTask
+from stardag.build import (
+    BuildTaskStore,
+    FailMode,
+    TickConfig,
+    run_tick_aio,
+)
+from stardag.build._base import GlobalLockConfig
+from stardag.build._task_modules import (
+    import_task_modules,
+    set_declared_task_module_patterns,
+)
+from stardag.exceptions import NotFoundError, is_missing_route_error
+from stardag.integration.modal._executor import ModalTaskExecutor
+from stardag.integration.modal._logging import _setup_logging
+from stardag.integration.modal._selector import WorkerSelector
+from stardag.integration.modal._settings import FunctionSettings
+from stardag.registry._base import NoOpRegistry, registry_provider
+from stardag.registry._lock import RegistryGlobalConcurrencyLockManager
+
+logger = logging.getLogger(__name__)
+
+LimitKeySelector = typing.Callable[[BaseTask], typing.Sequence[str]]
+"""Maps a task to the named registry concurrency-limit keys it runs under."""
+
+
+# --- Per-build tick configuration ---
+
+
+_TICK_KWARGS_ALLOWED = (
+    "linger_seconds",
+    "poll_interval_seconds",
+    "fail_mode",
+    # Fan-out throttles. Both default to something derived (see TickConfig
+    # and stardag.build._reactive._spawn_cap) and both are here because the
+    # thing the derivation cannot see — how the *tick* function is sized
+    # relative to its workers, and how much concurrency the registry
+    # deployment behind it will take — is per-deployment, and a build
+    # triggered against that deployment is where it can be said.
+    "max_concurrent_actions",
+    "max_spawns_per_tick",
+    # Per-build attempt budget. Belongs here more than most: the budget is
+    # per build by definition, and a build that has exhausted it is
+    # unblocked by re-triggering *with a raised* max_attempts — which only
+    # works if a re-trigger can say it.
+    "max_attempts",
+)
+
+
+def _tick_function_timeout_seconds(
+    tick_settings: FunctionSettings | None,
+    builder_settings: FunctionSettings | None,
+) -> float | None:
+    """The Modal ``timeout`` the deployed ``tick`` function will carry.
+
+    Resolved from **whichever settings actually register the function** —
+    ``tick_settings`` when given, otherwise ``builder_settings``, which is
+    the same fallback ``finalize`` applies. Reading ``tick_settings`` alone
+    would silently yield "unknown" for every app that does not configure
+    the tick separately (the common case), and a spawn cap derived from a
+    timeout the function was not registered with is precisely the mistake
+    this plumbing exists to remove.
+
+    ``None`` when neither declares one: Modal's own default is not a
+    promise this SDK should encode, and the cap has further rungs to fall
+    back to (see ``stardag.build._reactive._spawn_cap``).
+    """
+    # An empty `tick_settings` falls back deliberately — it declares
+    # nothing, and `finalize` resolves it the same way.
+    settings = tick_settings if tick_settings else builder_settings
+    # `is not None`, not truthiness: `timeout=0` is a value someone
+    # configured, and reporting it as "not declared" would hand the spawn
+    # cap a different rung to fall back to than the one the function was
+    # actually registered with.
+    timeout = (settings or {}).get("timeout")
+    return float(timeout) if timeout is not None else None
+
+
+def _build_tick_config(
+    stored_tick_kwargs: dict[str, typing.Any] | None,
+    tick_kwargs: dict[str, typing.Any] | None,
+    limit_key_selector: LimitKeySelector | None,
+    tick_timeout_seconds: float | None = None,
+) -> TickConfig:
+    """Assemble a TickConfig for one tick invocation.
+
+    Precedence: explicit ``tick_kwargs`` (manual/ops invocations) over the
+    build's stored ``reactive_tick_kwargs`` (set at trigger time in the
+    registry — shared by all ticks) over TickConfig defaults. The
+    concurrency-limit key selector is deployed-app configuration (callables
+    can't ride in the JSON tick config).
+
+    ``tick_timeout_seconds`` is the deployed ``tick`` function's own Modal
+    ``timeout`` — how long this container may live, which is what the
+    per-pass spawn cap is derived from. It is applied as a *default* rather
+    than an override so a caller that runs several ticks in one container
+    can pass its own share of the budget (the watchdog sweep does), and it
+    is deliberately absent from ``_TICK_KWARGS_ALLOWED``: persisting it in
+    a build's stored tick config would freeze a deploy-time fact into
+    per-build state and go stale on the next redeploy.
+    """
+    config_kwargs: dict[str, typing.Any] = {
+        **(stored_tick_kwargs or {}),
+        **(tick_kwargs or {}),
+    }
+    if "fail_mode" in config_kwargs:
+        config_kwargs["fail_mode"] = FailMode(config_kwargs["fail_mode"])
+    config_kwargs.setdefault("tick_timeout_seconds", tick_timeout_seconds)
+    return TickConfig(limit_key_selector=limit_key_selector, **config_kwargs)
+
+
+def _validate_tick_kwargs(
+    tick_kwargs: dict[str, typing.Any] | None,
+) -> dict[str, typing.Any] | None:
+    """Validate + JSON-normalize reactive tick_kwargs.
+
+    They are persisted in the build's ``reactive_tick_kwargs`` in the
+    registry (JSON) so all ticks of the build share them — hence only
+    JSON-scalar TickConfig fields are allowed here. ``fail_mode`` may be
+    passed as a FailMode and is stored as its string value.
+    """
+    if not tick_kwargs:
+        return tick_kwargs
+    unknown = set(tick_kwargs) - set(_TICK_KWARGS_ALLOWED)
+    if unknown:
+        raise TypeError(
+            f"Unsupported tick_kwargs {sorted(unknown)}; allowed (JSON-"
+            f"persistable TickConfig fields): {list(_TICK_KWARGS_ALLOWED)}. "
+            "Callables like a concurrency-limit key selector belong in the "
+            "deployed app configuration, not per-trigger kwargs."
+        )
+    normalized = dict(tick_kwargs)
+    if "fail_mode" in normalized:
+        normalized["fail_mode"] = str(FailMode(normalized["fail_mode"]))
+    return normalized
+
+
+# --- The deployed tick ---
+
+
+@dataclasses.dataclass(frozen=True)
+class _TickDeployment:
+    """The deploy-time facts a scheduler tick needs, captured at ``finalize()``.
+
+    A tick runs in a deployed container with no access to the
+    ``StardagApp`` that configured it, so every one of these has to be
+    carried across the Modal boundary in the registered wrapper's closure.
+    Bundling them keeps that closure a single variable and gives the facts
+    one documented home instead of eight free ones.
+
+    Attributes:
+        app_name: The Modal app the tick belongs to — also the ownership
+            check against a build's recorded ``reactive_app_name``.
+        worker_selector: The app's deployed selector. Always the app's own:
+            per-trigger overrides are rejected precisely because later ticks
+            could not honour them.
+        limit_key_selector: Named registry concurrency-limit keys per task.
+            Deployed-app configuration because a callable cannot be
+            persisted in the build's JSON tick config.
+        modal_workspace: Explicit Modal workspace for executor metadata, or
+            None to resolve it best-effort.
+        worker_timeouts: Per-worker Modal ``timeout`` (seconds), which is
+            what the execution claim's expiry is derived from. Only the
+            deploy process can see the app's ``worker_settings``.
+        tick_timeout_seconds: The ``tick`` function's own Modal ``timeout``
+            — how long this container may live, from which the per-pass
+            spawn cap is derived.
+        task_modules: The concrete module list expanded at ``finalize()``,
+            imported here so a tick can rebuild task objects from registry
+            data. Empty when the app opted out.
+        task_module_patterns: The declared patterns behind that list,
+            published for the coverage checks that report against patterns
+            rather than expansions.
+    """
+
+    app_name: str
+    worker_selector: WorkerSelector
+    limit_key_selector: LimitKeySelector | None
+    modal_workspace: str | None
+    worker_timeouts: dict[str, int]
+    tick_timeout_seconds: float | None
+    task_modules: tuple[str, ...]
+    task_module_patterns: tuple[str, ...]
+
+
+def _run_tick(
+    build_id: str,
+    tick_kwargs: dict[str, typing.Any] | None = None,
+    *,
+    deployment: _TickDeployment,
+) -> dict[str, typing.Any]:
+    """One scheduler pass over a reactive build's frontier.
+
+    The body of the deployed ``tick`` function (see
+    :meth:`StardagApp.finalize`), and also what the watchdog sweep invokes
+    in-process for each build it adopts. Returns a JSON-able outcome: the
+    ``run_tick_aio`` summary, or a short ``{"outcome": ...}`` record for
+    the two cases that stop before the scheduler lease is even acquired —
+    a build that is not reactively scheduled, and one owned by another app.
+    """
+    _setup_logging()
+    app_name = deployment.app_name
+    build_uuid = UUID(build_id)
+    task_store = BuildTaskStore(build_uuid)
+    registry = registry_provider.get()
+    # The reactive marker/owner/config live in the registry (not on
+    # the target root): read them with the lighter GET /builds/{id}
+    # for this pre-lease gate — the full frontier is only fetched
+    # once the tick actually processes it (run_tick_aio). Reactive
+    # scheduling against a server predating the build_get shape 404s
+    # only on a genuine missing route; a resource-level 404 (build
+    # deleted) must propagate as a real not-found.
+    try:
+        build_info = registry.build_get(build_uuid)
+    except NotFoundError as e:
+        if not is_missing_route_error(e):
+            raise
+        raise RuntimeError(
+            "The registry server does not support reactive "
+            "scheduling (build endpoint too old). Upgrade "
+            "stardag-api to a version matching this SDK."
+        ) from e
+    reactive_app_name = build_info.reactive_app_name
+    if reactive_app_name is None:
+        # Not a reactively-scheduled build (e.g. a resident-
+        # orchestrator build swept by the watchdog): never schedule
+        # on top of it, and don't even acquire the scheduler lease.
+        logger.info(
+            f"Tick for build {build_id}: not reactively scheduled "
+            "(no reactive_app_name); skipping."
+        )
+        return {"outcome": "not_reactive"}
+    # App ownership: with multiple StardagApps in one environment,
+    # every app's watchdog sweeps ALL running reactive builds — but
+    # only the app recorded at trigger time may drive a build.
+    # A foreign app's tick would schedule with ITS commit (its
+    # workers, its selectors) and unpickle the owning app's task
+    # store (pickle skew across commits), so it must not run the
+    # tick loop itself. Instead it FORWARDS: best-effort spawn of
+    # the owner's tick, so wake-ups that land on the wrong app
+    # (e.g. a still-running worker of the previous owner after a
+    # takeover) are not dropped, and every app's watchdog sweep
+    # doubles as cross-app coverage. The owner-side single-flight
+    # lease collapses duplicate forwards. Explicit takeover =
+    # re-trigger from the new app (updates reactive_app_name and
+    # re-persists the task objects under the new code).
+    owner_app = reactive_app_name
+    if owner_app != app_name:
+        forwarded = False
+        try:
+            modal.Function.from_name(app_name=owner_app, name="tick").spawn(
+                build_id=build_id
+            )
+            forwarded = True
+        except Exception as e:
+            # Owner app deleted/renamed: the build is orphaned —
+            # surfaced in logs; remedy is a re-trigger from a live
+            # app (see the how-to's app-ownership section).
+            logger.info(
+                f"Tick for build {build_id}: could not forward to "
+                f"owner app {owner_app!r} (deleted?): {e}"
+            )
+        logger.info(
+            f"Tick for build {build_id}: owned by app "
+            f"{owner_app!r}, not {app_name!r}; "
+            f"{'forwarded to owner' if forwarded else 'skipping'}."
+        )
+        return {
+            "outcome": "foreign_app",
+            "owner_app": owner_app,
+            "forwarded": forwarded,
+        }
+    # Per-build tick configuration persisted at trigger time in the
+    # registry — every tick (worker wake-ups and watchdog sweeps
+    # spawn with only the build id) runs with the same settings.
+    # Explicit tick_kwargs (tests/manual invocations) win over
+    # persisted ones; the limit key selector is deployed-app config.
+    config = _build_tick_config(
+        build_info.reactive_tick_kwargs,
+        tick_kwargs,
+        deployment.limit_key_selector,
+        tick_timeout_seconds=deployment.tick_timeout_seconds,
+    )
+
+    # Register the app's task classes in THIS container before the
+    # tick reconstructs anything: rehydrating a task from registry
+    # data is a dict lookup in the polymorphic registry, which is
+    # populated only as a side effect of importing the defining
+    # modules (unlike pickle, which self-imports). The list was
+    # expanded and frozen at deploy time; the import is cached per
+    # module list, so a container serving many ticks pays it once.
+    # Failures warn rather than abort — and are retained, so a
+    # later "could not rehydrate" error can name them.
+    if deployment.task_modules:
+        set_declared_task_module_patterns(deployment.task_module_patterns)
+        import_task_modules(deployment.task_modules)
+
+    executor = ModalTaskExecutor(
+        modal_app_name=app_name,
+        worker_selector=deployment.worker_selector,
+        reactive=True,
+        modal_workspace=deployment.modal_workspace,
+        worker_timeouts=deployment.worker_timeouts,
+    )
+    lock_manager = RegistryGlobalConcurrencyLockManager(
+        # No waiting on the scheduler lease: a held lease means
+        # another tick is active and will observe the wake-up flag.
+        config=GlobalLockConfig(lock_wait_timeout_seconds=None),
+    )
+    summary = asyncio.run(
+        run_tick_aio(
+            build_uuid,
+            registry=registry,
+            task_executor=executor,
+            lock_manager=lock_manager,
+            task_store=task_store,
+            config=config,
+        )
+    )
+    logger.info(f"Tick for build {build_id}: {summary}")
+    return dataclasses.asdict(summary)
+
+
+# --- The watchdog sweep ---
+
+
+def _run_watchdog_sweep(
+    registry: typing.Any,
+    tick: typing.Callable[..., typing.Any],
+    sweep_limit: int = 100,
+    tick_timeout_seconds: float | None = None,
+    reactive_app_name: str | None = None,
+) -> None:
+    """One watchdog pass: tick every running build this app owns.
+
+    ``reactive_app_name`` scopes the listing to this app's own reactive
+    builds. Without it, ``sweep_limit`` is spent on whatever RUNNING builds
+    happen to be most recently active in the environment — including builds
+    no tick of this app can advance (resident builds, and builds whose
+    orchestrator died without emitting a terminal event, which stay RUNNING
+    forever). Once those exceed the limit the safety net stops reaching
+    genuine reactive builds entirely, and silently.
+
+    The trade-off is losing the incidental cross-app coverage a sweep used to
+    provide. That was accidental and competed for the same limit; an app's own
+    watchdog is the supported mechanism, and ``build_trigger`` already warns
+    when a reactive build is triggered on an app without one.
+
+    ``linger_seconds=0`` (one frontier pass per build) is essential: the
+    sweep runs ticks sequentially in one function call — persisted linger
+    settings (default 120 s) would blow through the function timeout after
+    a couple of builds and starve the rest of the safety-net tick.
+
+    The same "one container, many builds" property applies to the per-pass
+    spawn cap, which is derived from how long the container may live: every
+    build in the sweep would otherwise size its fan-out as though it had
+    the whole container to itself, and the first wide build would spend the
+    entire timeout while the rest of the sweep never ran. Each build is
+    therefore handed its **share** of the budget. Truncating here is
+    cheap and self-correcting — the watchdog is a safety net, builds are
+    normally driven by their own ticks, and a truncated pass re-acts on a
+    fresh frontier immediately.
+    """
+    if type(registry) is NoOpRegistry:
+        logger.warning("Tick watchdog: no registry configured; nothing to do.")
+        return
+    # Scoping is server-side now that `build_list_running` is expressed in
+    # terms of `build_list`, so every RegistryABC gets it and the signature
+    # shim this used to need went with it. `scoped` still exists because
+    # the truncation remedy below differs by it.
+    scoped = reactive_app_name is not None
+    running_builds = registry.build_list_running(
+        limit=sweep_limit, reactive_app_name=reactive_app_name
+    )
+    scope = (
+        f"reactive builds owned by {reactive_app_name!r}"
+        if scoped
+        else "running builds"
+    )
+    if len(running_builds) >= sweep_limit:
+        # The remedy follows `scoped`, not whether a name was *asked* for:
+        # a scoping request the registry cannot honour still yields a
+        # listing capped by RUNNING builds of every kind, and "run fewer
+        # reactive builds per app" would then be advice about the wrong
+        # population.
+        remedy = (
+            "Cancel or clean up builds that are RUNNING but abandoned, or "
+            "reduce the number of concurrent reactive builds for this app."
+            if scoped
+            else "This listing was not scoped to a reactive app, so the cap "
+            "was consumed by RUNNING builds of every kind — most likely "
+            "abandoned ones. Clean those up (`stardag builds cleanup`); an "
+            "upgraded registry would also scope this listing."
+        )
+        logger.warning(
+            f"Tick watchdog: {sweep_limit}+ {scope}; only the {sweep_limit} "
+            "most recently active are swept, so a less-recently-active build "
+            f"may not be ticked this period. {remedy}"
+        )
+    sweep_kwargs: dict[str, typing.Any] = {"linger_seconds": 0}
+    if tick_timeout_seconds is not None and running_builds:
+        sweep_kwargs["tick_timeout_seconds"] = tick_timeout_seconds / len(
+            running_builds
+        )
+    for running_build_id in running_builds:
+        try:
+            tick(str(running_build_id), tick_kwargs=dict(sweep_kwargs))
+        except Exception:
+            logger.exception(f"Watchdog tick failed for build {running_build_id}")

--- a/lib/stardag/src/stardag/integration/modal/_volumes.py
+++ b/lib/stardag/src/stardag/integration/modal/_volumes.py
@@ -1,0 +1,73 @@
+"""Modal volumes derived from the configured target roots.
+
+A ``modalvol://`` target root names a Modal Volume. This module resolves
+those names to ``modal.Volume`` objects so
+:meth:`stardag.integration.modal.StardagApp.finalize` can auto-mount them
+into every deployed function (which is what makes target I/O inside a
+container a filesystem call rather than a Volume API call).
+"""
+
+from __future__ import annotations
+
+import typing
+
+import modal
+
+from stardag.config import config_provider
+from stardag.integration.modal._target import (
+    MODAL_VOLUME_URI_PREFIX,
+    get_volume_name_and_path,
+)
+
+
+class TargetRootsVolumes(typing.NamedTuple):
+    """Result of get_target_roots_volumes().
+
+    Attributes:
+        by_root_key: Dict of target root key to Modal Volume instance.
+        by_volume_name: Dict of volume name to Modal Volume instance (deduped).
+    """
+
+    by_root_key: dict[str, modal.Volume]
+    by_volume_name: dict[str, modal.Volume]
+
+
+def get_target_roots_volumes(
+    target_roots: dict[str, str] | None = None,
+    create_if_missing: bool = True,
+) -> TargetRootsVolumes:
+    """Get Modal volumes for configured target roots.
+
+    Scans target roots for ``modalvol://`` URIs and returns the corresponding
+    Modal Volume objects, both keyed by target root name and deduped by
+    volume name.
+
+    Args:
+        target_roots: Dict of target root key to URI or None (default from config).
+        create_if_missing: Whether to create the Modal volume if it doesn't exist.
+            When True, volumes are eagerly hydrated to trigger creation.
+            When False, volumes are lazy references (hydrated by Modal at deploy time).
+
+    Returns:
+        TargetRootsVolumes with volumes keyed by root key and by volume name.
+    """
+    if target_roots is None:
+        config = config_provider.get()
+        target_roots = config.target.roots
+
+    by_root_key: dict[str, modal.Volume] = {}
+    by_volume_name: dict[str, modal.Volume] = {}
+    for key, uri in target_roots.items():
+        if not uri.startswith(MODAL_VOLUME_URI_PREFIX):
+            continue
+        volume_name, _ = get_volume_name_and_path(uri)
+        if volume_name not in by_volume_name:
+            vol = modal.Volume.from_name(
+                volume_name, create_if_missing=create_if_missing
+            )
+            if create_if_missing:
+                vol.hydrate()
+            by_volume_name[volume_name] = vol
+        by_root_key[key] = by_volume_name[volume_name]
+
+    return TargetRootsVolumes(by_root_key=by_root_key, by_volume_name=by_volume_name)

--- a/lib/stardag/tests/test_integration/test_modal/conftest.py
+++ b/lib/stardag/tests/test_integration/test_modal/conftest.py
@@ -59,7 +59,7 @@ def hermetic_modal_executor_metadata(monkeypatch):
     Tests exercising the resolution logic itself override these
     monkeypatches explicitly.
     """
-    from stardag.integration.modal import _app as modal_app_module
+    from stardag.integration.modal import _app, _executor, _metadata
 
     async def _fake_workspace_aio():
         return "test-workspace"
@@ -73,23 +73,28 @@ def hermetic_modal_executor_metadata(monkeypatch):
     # The real (pre-patch) functions, for tests exercising the resolution
     # logic itself.
     originals = {
-        "get_modal_workspace_aio": modal_app_module._get_modal_workspace_aio,
-        "get_modal_app_id_aio": modal_app_module._get_modal_app_id_aio,
-        "get_modal_function_id_aio": modal_app_module._get_modal_function_id_aio,
+        "get_modal_workspace_aio": _metadata._get_modal_workspace_aio,
+        "get_modal_app_id_aio": _metadata._get_modal_app_id_aio,
+        "get_modal_function_id_aio": _metadata._get_modal_function_id_aio,
     }
 
-    monkeypatch.setattr(
-        modal_app_module, "_get_modal_workspace_aio", _fake_workspace_aio
-    )
-    monkeypatch.setattr(
-        modal_app_module, "_get_modal_workspace", lambda: "test-workspace"
-    )
-    monkeypatch.setattr(modal_app_module, "_get_modal_environment", lambda: "test-env")
+    def patch_everywhere(name, value):
+        """Patch ``name`` in ``_metadata`` and in every module that calls it.
+
+        The helpers are defined in ``_metadata`` but imported *by name* into
+        their callers, so patching only the definition site would leave
+        those call sites resolving the real function.
+        """
+        for module in (_metadata, _executor, _app):
+            if hasattr(module, name):
+                monkeypatch.setattr(module, name, value)
+
+    patch_everywhere("_get_modal_workspace_aio", _fake_workspace_aio)
+    patch_everywhere("_get_modal_workspace", lambda: "test-workspace")
+    patch_everywhere("_get_modal_environment", lambda: "test-env")
     # Pin the app-id / function-id resolution too, so the unit tier never
     # attempts a real ``modal.App.lookup`` / handle hydration over the
     # network. Tests exercising these helpers override them explicitly.
-    monkeypatch.setattr(modal_app_module, "_get_modal_app_id_aio", _fake_app_id_aio)
-    monkeypatch.setattr(
-        modal_app_module, "_get_modal_function_id_aio", _fake_function_id_aio
-    )
+    patch_everywhere("_get_modal_app_id_aio", _fake_app_id_aio)
+    patch_everywhere("_get_modal_function_id_aio", _fake_function_id_aio)
     return originals

--- a/lib/stardag/tests/test_integration/test_modal/test__app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test__app.py
@@ -33,8 +33,9 @@ try:
         StardagApp,
         get_default_volume_mount_path,
     )
-    from stardag.integration.modal._app import ModalTaskExecutor
     from stardag.integration.modal._config import with_stardag_on_image
+    from stardag.integration.modal._executor import ModalTaskExecutor
+    from stardag.integration.modal._settings import _prepare_function_settings
     from stardag.testing.modal import live_modal_guard
     from stardag.testing.modal._tasks import (
         AsyncDoubleTask,
@@ -244,7 +245,7 @@ class TestUserVolumesOverride:
         )
 
         # Verify _prepare_function_settings merges correctly
-        settings = StardagApp._prepare_function_settings(
+        settings = _prepare_function_settings(
             FunctionSettings(
                 image=TEST_IMAGE,
                 volumes={EXPECTED_MOUNT_PATH: user_volume},
@@ -270,7 +271,7 @@ class TestUserVolumesOverride:
         assert EXPECTED_MOUNT_PATH in result.volume_mounts
 
         # Verify _prepare_function_settings includes auto volumes
-        settings = StardagApp._prepare_function_settings(
+        settings = _prepare_function_settings(
             FunctionSettings(image=TEST_IMAGE),
             extra_secrets=[],
             auto_volumes=result.auto_volumes,

--- a/lib/stardag/tests/test_integration/test_modal/test_detached_executor.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_detached_executor.py
@@ -17,7 +17,8 @@ except ImportError:
 
 from stardag import BaseTask
 from stardag.build import TaskExecutionError
-from stardag.integration.modal._app import MODAL_EXECUTOR_NAME, ModalTaskExecutor
+from stardag.integration.modal._executor import ModalTaskExecutor
+from stardag.integration.modal._metadata import MODAL_EXECUTOR_NAME
 
 
 class FakeFunctionCall:
@@ -256,7 +257,7 @@ class TestBuildIdInjection:
 
     async def test_injected_inside_build_context(self):
         from stardag.build._base import current_build_id_var
-        from stardag.integration.modal._app import STARDAG_BUILD_ID_ENV
+        from stardag.integration.modal._metadata import STARDAG_BUILD_ID_ENV
 
         build_id = __import__("uuid").uuid4()
         function_call = FakeFunctionCall()
@@ -273,7 +274,7 @@ class TestBuildIdInjection:
         assert env_overrides[STARDAG_BUILD_ID_ENV] == str(build_id)
 
     async def test_not_injected_outside_build_context(self):
-        from stardag.integration.modal._app import STARDAG_BUILD_ID_ENV
+        from stardag.integration.modal._metadata import STARDAG_BUILD_ID_ENV
 
         worker = FakeWorkerFunction(FakeFunctionCall())
         executor = _make_executor(worker)
@@ -285,7 +286,7 @@ class TestBuildIdInjection:
 
     async def test_not_injected_when_worker_reporting_disabled(self):
         from stardag.build._base import current_build_id_var
-        from stardag.integration.modal._app import STARDAG_BUILD_ID_ENV
+        from stardag.integration.modal._metadata import STARDAG_BUILD_ID_ENV
 
         worker = FakeWorkerFunction(FakeFunctionCall())
         executor = ModalTaskExecutor(

--- a/lib/stardag/tests/test_integration/test_modal/test_env_overrides.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_env_overrides.py
@@ -24,12 +24,10 @@ except ImportError:
     pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
 
 import stardag as sd
-from stardag.integration.modal._app import (
-    ModalTaskExecutor,
-    Runner,
-    _callable_accepts_env_overrides,
-    _normalize_worker_selection,
-)
+from stardag.integration.modal._executor import ModalTaskExecutor
+from stardag.integration.modal._protocols import _callable_accepts_env_overrides
+from stardag.integration.modal._runner import Runner
+from stardag.integration.modal._selector import _normalize_worker_selection
 from stardag.testing.modal._tasks import make_range
 
 _UNSET = "<unset>"

--- a/lib/stardag/tests/test_integration/test_modal/test_executor_metadata.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_executor_metadata.py
@@ -21,7 +21,8 @@ except ImportError:
 
 from stardag import BaseTask
 from stardag.build._base import current_build_id_var
-from stardag.integration.modal._app import (
+from stardag.integration.modal._executor import ModalTaskExecutor
+from stardag.integration.modal._metadata import (
     MODAL_EXECUTOR_NAME,
     STARDAG_BUILD_ID_ENV,
     STARDAG_CLAIM_TTL_SECONDS_ENV,
@@ -31,9 +32,8 @@ from stardag.integration.modal._app import (
     STARDAG_MODAL_FUNCTION_ID_ENV,
     STARDAG_MODAL_FUNCTION_NAME_ENV,
     STARDAG_MODAL_WORKSPACE_ENV,
-    ModalTaskExecutor,
-    _WorkerLifecycleReporter,
 )
+from stardag.integration.modal._runner import _WorkerLifecycleReporter
 from stardag.registry import NoOpRegistry
 
 EXPECTED_BASE_METADATA = {
@@ -116,7 +116,7 @@ class TestDetachedHandleMetadata:
         function id) fail here; the spawn still succeeds and the handle
         carries only the identity fields the executor always knows.
         """
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _executor as executor_module
 
         async def _boom():
             raise ConnectionError("no network")
@@ -129,15 +129,15 @@ class TestDetachedHandleMetadata:
         async def _no_function_id(function):
             return None
 
-        monkeypatch.setattr(modal_app_module, "_get_modal_workspace_aio", _boom)
+        monkeypatch.setattr(executor_module, "_get_modal_workspace_aio", _boom)
         monkeypatch.setattr(
-            modal_app_module,
+            executor_module,
             "_get_modal_environment",
             lambda: (_ for _ in ()).throw(ConnectionError("also broken")),
         )
-        monkeypatch.setattr(modal_app_module, "_get_modal_app_id_aio", _no_app_id)
+        monkeypatch.setattr(executor_module, "_get_modal_app_id_aio", _no_app_id)
         monkeypatch.setattr(
-            modal_app_module, "_get_modal_function_id_aio", _no_function_id
+            executor_module, "_get_modal_function_id_aio", _no_function_id
         )
         worker = FakeWorkerFunction(FakeFunctionCall())
         executor = _make_executor(worker)
@@ -157,7 +157,7 @@ class TestDetachedHandleMetadata:
         """A raising token lookup is cached as None: no raise reaches the
         caller and the lookup (and its timeout) is not re-paid on every
         task start."""
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _metadata as metadata_module
 
         real_get = hermetic_modal_executor_metadata["get_modal_workspace_aio"]
         calls = {"n": 0}
@@ -167,12 +167,12 @@ class TestDetachedHandleMetadata:
             raise TimeoutError("modal api unreachable")
 
         monkeypatch.setattr(
-            modal_app_module, "_lookup_modal_workspace_aio", _raising_lookup
+            metadata_module, "_lookup_modal_workspace_aio", _raising_lookup
         )
         monkeypatch.setattr(
-            modal_app_module,
+            metadata_module,
             "_modal_workspace_cache",
-            modal_app_module._MODAL_WORKSPACE_UNRESOLVED,
+            metadata_module._MODAL_WORKSPACE_UNRESOLVED,
         )
 
         assert await real_get() is None
@@ -185,7 +185,7 @@ class TestDetachedHandleMetadata:
         """Inside a Modal container there is no token, so the workspace is
         baked into STARDAG_MODAL_WORKSPACE at deploy; the resolver must read
         that env var instead of attempting (and failing) a token lookup."""
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _metadata as metadata_module
 
         real_get = hermetic_modal_executor_metadata["get_modal_workspace_aio"]
 
@@ -193,15 +193,15 @@ class TestDetachedHandleMetadata:
             raise AssertionError("token lookup must not run when env is set")
 
         monkeypatch.setattr(
-            modal_app_module, "_lookup_modal_workspace_aio", _must_not_be_called
+            metadata_module, "_lookup_modal_workspace_aio", _must_not_be_called
         )
         monkeypatch.setattr(
-            modal_app_module,
+            metadata_module,
             "_modal_workspace_cache",
-            modal_app_module._MODAL_WORKSPACE_UNRESOLVED,
+            metadata_module._MODAL_WORKSPACE_UNRESOLVED,
         )
         monkeypatch.setenv(
-            modal_app_module.STARDAG_MODAL_WORKSPACE_ENV, "baked-workspace"
+            metadata_module.STARDAG_MODAL_WORKSPACE_ENV, "baked-workspace"
         )
 
         assert await real_get() == "baked-workspace"
@@ -214,10 +214,10 @@ class TestDetachedHandleMetadata:
         and UI deep links break."""
         import types
 
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _metadata as metadata_module
 
         monkeypatch.setattr(
-            modal_app_module.modal.config,
+            metadata_module.modal.config,
             "config",
             types.SimpleNamespace(
                 get=lambda k: {
@@ -233,26 +233,26 @@ class TestDetachedHandleMetadata:
             return types.SimpleNamespace(workspace_name="", username="andhus")
 
         monkeypatch.setattr(
-            modal_app_module.modal.config,
+            metadata_module.modal.config,
             "_lookup_workspace",
             _fake_lookup,
             raising=False,
         )
-        assert await modal_app_module._lookup_modal_workspace_aio() == "andhus"
+        assert await metadata_module._lookup_modal_workspace_aio() == "andhus"
 
         async def _fake_lookup_named(server_url, token_id, token_secret):
             return types.SimpleNamespace(workspace_name="my-org", username="u")
 
         monkeypatch.setattr(
-            modal_app_module.modal.config,
+            metadata_module.modal.config,
             "_lookup_workspace",
             _fake_lookup_named,
             raising=False,
         )
-        assert await modal_app_module._lookup_modal_workspace_aio() == "my-org"
+        assert await metadata_module._lookup_modal_workspace_aio() == "my-org"
 
     async def test_base_metadata_resolved_once(self, monkeypatch):
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _executor as executor_module
 
         calls = {"n": 0}
 
@@ -260,7 +260,7 @@ class TestDetachedHandleMetadata:
             calls["n"] += 1
             return "counted-ws"
 
-        monkeypatch.setattr(modal_app_module, "_get_modal_workspace_aio", _counting)
+        monkeypatch.setattr(executor_module, "_get_modal_workspace_aio", _counting)
         worker = FakeWorkerFunction(FakeFunctionCall())
         executor = _make_executor(worker)
 
@@ -504,7 +504,7 @@ class TestWorkspaceLookupColdBurst:
         one network lookup, everyone gets the cached result."""
         import asyncio
 
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _metadata as metadata_module
 
         real_get = hermetic_modal_executor_metadata["get_modal_workspace_aio"]
         calls = {"n": 0}
@@ -515,12 +515,12 @@ class TestWorkspaceLookupColdBurst:
             return "burst-ws"
 
         monkeypatch.setattr(
-            modal_app_module, "_lookup_modal_workspace_aio", _slow_lookup
+            metadata_module, "_lookup_modal_workspace_aio", _slow_lookup
         )
         monkeypatch.setattr(
-            modal_app_module,
+            metadata_module,
             "_modal_workspace_cache",
-            modal_app_module._MODAL_WORKSPACE_UNRESOLVED,
+            metadata_module._MODAL_WORKSPACE_UNRESOLVED,
         )
 
         results = await asyncio.gather(*[real_get() for _ in range(10)])
@@ -604,10 +604,10 @@ class TestAppAndFunctionIdResolution:
         timeout — it must not stall the caller; the id is omitted."""
         import asyncio
 
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _metadata as metadata_module
 
         real = hermetic_modal_executor_metadata["get_modal_app_id_aio"]
-        monkeypatch.setattr(modal_app_module, "_MODAL_ID_LOOKUP_TIMEOUT_SECONDS", 0.01)
+        monkeypatch.setattr(metadata_module, "_MODAL_ID_LOOKUP_TIMEOUT_SECONDS", 0.01)
 
         async def _hang(name, environment_name=None):
             await asyncio.sleep(10)
@@ -626,10 +626,10 @@ class TestAppAndFunctionIdResolution:
         timeout; the id is omitted rather than stalling the start."""
         import asyncio
 
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _metadata as metadata_module
 
         real = hermetic_modal_executor_metadata["get_modal_function_id_aio"]
-        monkeypatch.setattr(modal_app_module, "_MODAL_ID_LOOKUP_TIMEOUT_SECONDS", 0.01)
+        monkeypatch.setattr(metadata_module, "_MODAL_ID_LOOKUP_TIMEOUT_SECONDS", 0.01)
 
         class _Fn:
             def __init__(self):
@@ -649,7 +649,7 @@ class TestFunctionIdCaching:
     eliminated, now also for function ids)."""
 
     async def test_resolved_function_id_cached_per_worker(self, monkeypatch):
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _executor as executor_module
 
         calls = {"n": 0}
 
@@ -657,7 +657,7 @@ class TestFunctionIdCaching:
             calls["n"] += 1
             return "fu-counted"
 
-        monkeypatch.setattr(modal_app_module, "_get_modal_function_id_aio", _counting)
+        monkeypatch.setattr(executor_module, "_get_modal_function_id_aio", _counting)
         worker = FakeWorkerFunction(FakeFunctionCall())
         executor = _make_executor(worker)
 
@@ -669,7 +669,7 @@ class TestFunctionIdCaching:
     async def test_failed_function_id_cached_per_worker(self, monkeypatch):
         """A resolved-but-``None`` (failed hydration) is a resolution: it is
         cached and not retried on the next start, and the key stays omitted."""
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _executor as executor_module
 
         calls = {"n": 0}
 
@@ -677,7 +677,7 @@ class TestFunctionIdCaching:
             calls["n"] += 1
             return None
 
-        monkeypatch.setattr(modal_app_module, "_get_modal_function_id_aio", _failing)
+        monkeypatch.setattr(executor_module, "_get_modal_function_id_aio", _failing)
         worker = FakeWorkerFunction(FakeFunctionCall())
         executor = _make_executor(worker)
 

--- a/lib/stardag/tests/test_integration/test_modal/test_live_claim_e2e.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_live_claim_e2e.py
@@ -31,10 +31,8 @@ try:
     live_modal_guard(VOLUME_NAME)
 
     from stardag.build import BuildExitStatus, ClaimConfig, build_aio
-    from stardag.integration.modal._app import (
-        MODAL_EXECUTOR_NAME,
-        ModalTaskExecutor,
-    )
+    from stardag.integration.modal._executor import ModalTaskExecutor
+    from stardag.integration.modal._metadata import MODAL_EXECUTOR_NAME
     from stardag.registry import NoOpRegistry, StartClaimResult
     from stardag.testing.modal._tasks import SleepAndSaveCallId
 

--- a/lib/stardag/tests/test_integration/test_modal/test_live_detached_e2e.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_live_detached_e2e.py
@@ -38,10 +38,8 @@ try:
     live_modal_guard(VOLUME_NAME)
 
     from stardag.build import BuildExitStatus, build
-    from stardag.integration.modal._app import (
-        MODAL_EXECUTOR_NAME,
-        ModalTaskExecutor,
-    )
+    from stardag.integration.modal._executor import ModalTaskExecutor
+    from stardag.integration.modal._metadata import MODAL_EXECUTOR_NAME
     from stardag.registry import NoOpRegistry, RegisteredTaskInfo
     from stardag.testing.modal._tasks import SleepAndSaveCallId
 
@@ -90,7 +88,7 @@ import json
 import sys
 
 from stardag.build import build_aio
-from stardag.integration.modal._app import ModalTaskExecutor
+from stardag.integration.modal._executor import ModalTaskExecutor
 from stardag.registry import NoOpRegistry
 from stardag.testing.modal._tasks import SleepAndSaveCallId
 

--- a/lib/stardag/tests/test_integration/test_modal/test_live_reactive_e2e.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_live_reactive_e2e.py
@@ -54,10 +54,8 @@ try:
         LockAcquisitionResult,
         LockAcquisitionStatus,
     )
-    from stardag.integration.modal._app import (
-        MODAL_EXECUTOR_NAME,
-        ModalTaskExecutor,
-    )
+    from stardag.integration.modal._executor import ModalTaskExecutor
+    from stardag.integration.modal._metadata import MODAL_EXECUTOR_NAME
     from stardag.registry import BuildFrontier, FrontierTaskRef, NoOpRegistry
     from stardag.testing.modal._tasks import SleepAndSaveCallId
 

--- a/lib/stardag/tests/test_integration/test_modal/test_runner.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_runner.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
 
-from stardag.integration.modal._app import Runner
+from stardag.integration.modal._runner import Runner
 from stardag.testing.modal._tasks import (
     AsyncDoubleTask,
     AsyncDynamicRangeSumTask,

--- a/lib/stardag/tests/test_integration/test_modal/test_runner_lifecycle.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_runner_lifecycle.py
@@ -18,12 +18,11 @@ try:
 except ImportError:
     pytest.skip("Skipping modal tests (import not available)", allow_module_level=True)
 
-from stardag.integration.modal._app import (
+from stardag.integration.modal._metadata import (
     MODAL_EXECUTOR_NAME,
     STARDAG_BUILD_ID_ENV,
-    Runner,
-    _WorkerLifecycleReporter,
 )
+from stardag.integration.modal._runner import Runner, _WorkerLifecycleReporter
 from stardag.registry import NoOpRegistry, registry_provider
 from stardag.testing.modal._tasks import SyncDynamicRangeSumTask, make_range
 
@@ -226,13 +225,15 @@ class TestReporterCreationGuard:
     ):
         """The best-effort contract covers creation itself: a broken registry
         config in the worker env must not fail a task before it runs."""
-        from stardag.integration.modal import _app as app_module
+        from stardag.integration.modal import _runner as runner_module
 
         def broken_create(task, env_overrides):
             raise RuntimeError("malformed registry config")
 
         monkeypatch.setattr(
-            app_module._WorkerLifecycleReporter, "create", staticmethod(broken_create)
+            runner_module._WorkerLifecycleReporter,
+            "create",
+            staticmethod(broken_create),
         )
         task = make_range(limit=3)
 
@@ -247,7 +248,7 @@ class TestReactiveWorkerBehavior:
     and registers dynamically yielded deps itself (no resident orchestrator)."""
 
     def _reactive_env(self, build_id: UUID, app_name: str = "wake-app") -> dict:
-        from stardag.integration.modal._app import (
+        from stardag.integration.modal._metadata import (
             STARDAG_MODAL_APP_NAME_ENV,
             STARDAG_REACTIVE_ENV,
         )

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -23,7 +23,8 @@ from stardag.integration.modal import (
     Runner,
     StardagApp,
 )
-from stardag.integration.modal._app import _default_build, _default_run
+from stardag.integration.modal._builder import _default_build
+from stardag.integration.modal._runner import _default_run
 from stardag.registry import NoOpRegistry, RegistryABC, registry_provider
 
 
@@ -494,7 +495,7 @@ class TestBuilderBuildKwargs:
 
     def test_default_build_forwards_build_kwargs(self, monkeypatch):
         from stardag.build import FailMode
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _builder as builder_module
 
         captured: dict = {}
 
@@ -503,9 +504,9 @@ class TestBuilderBuildKwargs:
             captured["kwargs"] = kwargs
             return None
 
-        monkeypatch.setattr(modal_app_module, "build", fake_build)
+        monkeypatch.setattr(builder_module, "build", fake_build)
 
-        builder = modal_app_module.Builder()
+        builder = builder_module.Builder()
         executor = MagicMock()
         root = MagicMock()
         builder.build(
@@ -523,7 +524,7 @@ class TestBuilderBuildKwargs:
 
     def test_default_build_no_build_kwargs(self, monkeypatch):
         """Backwards-compat: omitting build_kwargs still works."""
-        from stardag.integration.modal import _app as modal_app_module
+        from stardag.integration.modal import _builder as builder_module
 
         captured: dict = {}
 
@@ -531,9 +532,9 @@ class TestBuilderBuildKwargs:
             captured["kwargs"] = kwargs
             return None
 
-        monkeypatch.setattr(modal_app_module, "build", fake_build)
+        monkeypatch.setattr(builder_module, "build", fake_build)
 
-        builder = modal_app_module.Builder()
+        builder = builder_module.Builder()
         builder.build(MagicMock(), MagicMock())
         # Only task_executor — no leaked kwargs from a None build_kwargs.
         assert set(captured["kwargs"].keys()) == {"task_executor"}
@@ -1450,13 +1451,13 @@ class TestFinalizeBakesTaskModules:
             return TickSummary(outcome="noop")
 
         with (
-            patch("stardag.integration.modal._app.run_tick_aio", stub_tick_aio),
-            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch("stardag.integration.modal._tick.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
             patch(
-                "stardag.integration.modal._app.RegistryGlobalConcurrencyLockManager"
+                "stardag.integration.modal._tick.RegistryGlobalConcurrencyLockManager"
             ),
             patch(
-                "stardag.integration.modal._app.import_task_modules"
+                "stardag.integration.modal._tick.import_task_modules"
             ) as import_modules,
         ):
             rp.get.return_value = registry
@@ -1464,7 +1465,10 @@ class TestFinalizeBakesTaskModules:
 
         # Exactly the list frozen at deploy time — not re-derived in the
         # container, where the filesystem walk would cost cold-start time.
-        import_modules.assert_called_once_with(result.task_modules)
+        # (The deployment record holds it as a tuple; import_task_modules
+        # keys its cache on ``tuple(modules)`` either way.)
+        import_modules.assert_called_once()
+        assert list(import_modules.call_args.args[0]) == result.task_modules
 
     def test_opted_out_tick_imports_nothing(self, default_in_memory_fs_target):
         from stardag.build import TickSummary
@@ -1481,13 +1485,13 @@ class TestFinalizeBakesTaskModules:
             return TickSummary(outcome="noop")
 
         with (
-            patch("stardag.integration.modal._app.run_tick_aio", stub_tick_aio),
-            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch("stardag.integration.modal._tick.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
             patch(
-                "stardag.integration.modal._app.RegistryGlobalConcurrencyLockManager"
+                "stardag.integration.modal._tick.RegistryGlobalConcurrencyLockManager"
             ),
             patch(
-                "stardag.integration.modal._app.import_task_modules"
+                "stardag.integration.modal._tick.import_task_modules"
             ) as import_modules,
         ):
             rp.get.return_value = registry
@@ -1803,7 +1807,7 @@ class TestDynamicDepPickleElision:
     its first dynamic dependency."""
 
     def _reporter(self, build_id):
-        from stardag.integration.modal._app import _WorkerLifecycleReporter
+        from stardag.integration.modal._runner import _WorkerLifecycleReporter
         from stardag.utils.testing.helper_tasks import SyncOnlyTask
 
         registry = MagicMock(spec=RegistryABC)
@@ -1999,7 +2003,7 @@ class TestApiKeySecretPropagation:
         # containers, so finalize resolves the workspace locally (mocked to
         # "test-workspace" by the hermetic fixture) and bakes it into the
         # function env so container-side executor metadata has it.
-        from stardag.integration.modal._app import STARDAG_MODAL_WORKSPACE_ENV
+        from stardag.integration.modal._metadata import STARDAG_MODAL_WORKSPACE_ENV
 
         captured: list[dict] = []
         real_from_dict = modal.Secret.from_dict
@@ -2097,6 +2101,90 @@ class TestFinalizeRegistersTick:
         assert registered["bootstrap"]["timeout"] == 900
 
 
+class TestDeployedFunctionsAreSerializable:
+    """Every function finalize() registers is registered ``serialized=True``,
+    i.e. Modal cloudpickles the closure at deploy time and reconstructs it in
+    the container. Whatever those closures capture must therefore survive
+    ``modal._serialization``: a capture that doesn't is a deploy-time failure
+    with nothing in the unit tier to catch it.
+    """
+
+    def _finalize_capturing_functions(self, **app_kwargs):
+        app = StardagApp(
+            "test-serializable",
+            builder_settings=FunctionSettings(image=_make_image(), timeout=1800),
+            worker_settings={"default": FunctionSettings(image=_make_image())},
+            **app_kwargs,
+        )
+        captured: dict = {}
+
+        def capture_function(**kwargs):
+            def decorator(fn):
+                captured[kwargs["name"]] = fn
+                return fn
+
+            return decorator
+
+        app.modal_app.function = capture_function  # type: ignore[assignment]
+        with patch("stardag.integration.modal._app.get_target_roots_volumes") as mv:
+            mv.return_value = MagicMock(by_volume_name={}, by_root_key={})
+            app.finalize()
+        return captured
+
+    def test_every_registered_function_round_trips(self):
+        # Modal's own serializer (its vendored cloudpickle), not the
+        # standalone package — that is what a deploy actually runs.
+        from modal._serialization import serialize
+
+        captured = self._finalize_capturing_functions(
+            watchdog_period_minutes=5,
+            task_modules=["stardag.utils.*"],
+            limit_key_selector=lambda task: ["some-limit"],
+        )
+
+        assert set(captured) == {
+            "build",
+            "worker_default",
+            "tick",
+            "bootstrap",
+            "tick_watchdog",
+        }
+        for name, fn in captured.items():
+            assert serialize(fn), f"{name} serialized to nothing"
+
+    def test_round_tripped_tick_still_reads_its_deploy_time_config(self):
+        """The tick's deploy-time captures (app name, selectors, worker
+        timeouts, baked module list) have to arrive intact on the other side
+        of serialization — the container never sees the StardagApp."""
+        from uuid import uuid4
+
+        from modal._serialization import deserialize, serialize
+        from stardag.registry import BuildInfo
+
+        captured = self._finalize_capturing_functions(watchdog_period_minutes=5)
+        tick = deserialize(serialize(captured["tick"]), None)
+
+        build_id = uuid4()
+        registry = MagicMock(spec=RegistryABC)
+        registry.build_get.return_value = BuildInfo(
+            id=build_id, reactive_app_name="another-app", reactive_tick_kwargs=None
+        )
+        with (
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
+            patch("modal.Function.from_name", side_effect=Exception("no such app")),
+        ):
+            rp.get.return_value = registry
+            result = tick(str(build_id))
+
+        # It compared the build's owner against the app name it was
+        # deployed with, which means that capture survived the round trip.
+        assert result == {
+            "outcome": "foreign_app",
+            "owner_app": "another-app",
+            "forwarded": False,
+        }
+
+
 class TestTickAppOwnership:
     """Only the app recorded as the build's reactive_app_name (in the
     registry) may drive its ticks — read via the lighter build_get."""
@@ -2155,8 +2243,8 @@ class TestTickAppOwnership:
 
         # Patch the tick loop to assert it is never entered on a foreign app.
         with (
-            patch("stardag.integration.modal._app.registry_provider") as rp,
-            patch("stardag.integration.modal._app.run_tick_aio") as tick_aio,
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
+            patch("stardag.integration.modal._tick.run_tick_aio") as tick_aio,
         ):
             rp.get.return_value = registry
             result = tick(str(build_id))
@@ -2184,8 +2272,8 @@ class TestTickAppOwnership:
         registry = self._registry_with_reactive_app(build_id, "app-gone")
 
         with (
-            patch("stardag.integration.modal._app.registry_provider") as rp,
-            patch("stardag.integration.modal._app.run_tick_aio") as tick_aio,
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
+            patch("stardag.integration.modal._tick.run_tick_aio") as tick_aio,
             patch(
                 "modal.Function.from_name",
                 side_effect=Exception("app not found"),
@@ -2211,8 +2299,8 @@ class TestTickAppOwnership:
         registry = self._registry_with_reactive_app(build_id, None)
 
         with (
-            patch("stardag.integration.modal._app.registry_provider") as rp,
-            patch("stardag.integration.modal._app.run_tick_aio") as tick_aio,
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
+            patch("stardag.integration.modal._tick.run_tick_aio") as tick_aio,
         ):
             rp.get.return_value = registry
             result = tick(str(build_id))
@@ -2240,10 +2328,10 @@ class TestTickAppOwnership:
         # construction requires configured credentials (present on dev
         # machines, absent in CI — the guard itself must not need them).
         with (
-            patch("stardag.integration.modal._app.run_tick_aio", stub_tick_aio),
-            patch("stardag.integration.modal._app.registry_provider") as rp,
+            patch("stardag.integration.modal._tick.run_tick_aio", stub_tick_aio),
+            patch("stardag.integration.modal._tick.registry_provider") as rp,
             patch(
-                "stardag.integration.modal._app.RegistryGlobalConcurrencyLockManager"
+                "stardag.integration.modal._tick.RegistryGlobalConcurrencyLockManager"
             ),
         ):
             rp.get.return_value = own_registry
@@ -2340,7 +2428,7 @@ class TestReactiveRetrigger:
 
 class TestWatchdogSweep:
     def test_sweep_ticks_each_running_build_without_linger(self):
-        from stardag.integration.modal._app import _run_watchdog_sweep
+        from stardag.integration.modal._tick import _run_watchdog_sweep
 
         build_ids = [uuid4(), uuid4()]
         registry = MagicMock(spec=RegistryABC)
@@ -2362,7 +2450,7 @@ class TestWatchdogSweep:
         so each build gets a share of its wall clock — otherwise the first
         wide build would size its fan-out as though it owned the whole
         timeout and the rest of the sweep would never run."""
-        from stardag.integration.modal._app import _run_watchdog_sweep
+        from stardag.integration.modal._tick import _run_watchdog_sweep
 
         build_ids = [uuid4(), uuid4(), uuid4(), uuid4()]
         registry = MagicMock(spec=RegistryABC)
@@ -2381,7 +2469,7 @@ class TestWatchdogSweep:
     def test_sweep_omits_the_budget_when_the_timeout_is_unknown(self):
         """No declared tick timeout — nothing to split, and the spawn cap
         falls to its next rung rather than being handed a made-up number."""
-        from stardag.integration.modal._app import _run_watchdog_sweep
+        from stardag.integration.modal._tick import _run_watchdog_sweep
 
         registry = MagicMock(spec=RegistryABC)
         registry.build_list_running.return_value = [uuid4()]
@@ -2394,7 +2482,7 @@ class TestWatchdogSweep:
         assert ticked == [{"linger_seconds": 0}]
 
     def test_sweep_survives_individual_tick_failures(self):
-        from stardag.integration.modal._app import _run_watchdog_sweep
+        from stardag.integration.modal._tick import _run_watchdog_sweep
 
         build_ids = [uuid4(), uuid4()]
         registry = MagicMock(spec=RegistryABC)
@@ -2411,7 +2499,7 @@ class TestWatchdogSweep:
         assert ticked == [str(build_ids[1])]  # second build still swept
 
     def test_sweep_noop_without_registry(self):
-        from stardag.integration.modal._app import _run_watchdog_sweep
+        from stardag.integration.modal._tick import _run_watchdog_sweep
 
         _run_watchdog_sweep(NoOpRegistry(), lambda *a, **k: 1 / 0)  # no raise
 
@@ -2419,7 +2507,7 @@ class TestWatchdogSweep:
         """The listing — not the tick — is where irrelevant builds must be
         dropped: a tick on a non-reactive build is a whole (wasted) function
         invocation, and unrelated builds otherwise consume the sweep limit."""
-        from stardag.integration.modal._app import _run_watchdog_sweep
+        from stardag.integration.modal._tick import _run_watchdog_sweep
 
         registry = MagicMock(spec=RegistryABC)
         registry.build_list_running.return_value = []
@@ -2433,7 +2521,7 @@ class TestWatchdogSweep:
     def test_truncation_warning_names_the_scope_and_the_remedy(self, caplog):
         import logging
 
-        from stardag.integration.modal._app import _run_watchdog_sweep
+        from stardag.integration.modal._tick import _run_watchdog_sweep
 
         registry = MagicMock(spec=RegistryABC)
         registry.build_list_running.return_value = [uuid4(), uuid4()]
@@ -2497,7 +2585,7 @@ class TestTickFunctionTimeout:
         return typing.cast("FunctionSettings", kwargs)
 
     def test_reads_tick_settings_when_given(self):
-        from stardag.integration.modal._app import _tick_function_timeout_seconds
+        from stardag.integration.modal._tick import _tick_function_timeout_seconds
 
         assert (
             _tick_function_timeout_seconds(
@@ -2511,7 +2599,7 @@ class TestTickFunctionTimeout:
         timeout must follow the same fallback — otherwise every app that
         does not configure the tick separately (the common case) would
         report "unknown"."""
-        from stardag.integration.modal._app import _tick_function_timeout_seconds
+        from stardag.integration.modal._tick import _tick_function_timeout_seconds
 
         builder = self._settings(timeout=3600)
         assert _tick_function_timeout_seconds(None, builder) == 3600.0
@@ -2521,12 +2609,12 @@ class TestTickFunctionTimeout:
         """`timeout=0` was reported as "not declared", which sends the spawn
         cap to a different fallback rung than the one the function was
         registered with."""
-        from stardag.integration.modal._app import _tick_function_timeout_seconds
+        from stardag.integration.modal._tick import _tick_function_timeout_seconds
 
         assert _tick_function_timeout_seconds(self._settings(timeout=0), None) == 0.0
 
     def test_none_when_neither_declares_one(self):
-        from stardag.integration.modal._app import _tick_function_timeout_seconds
+        from stardag.integration.modal._tick import _tick_function_timeout_seconds
 
         assert _tick_function_timeout_seconds(None, None) is None
         assert (
@@ -2540,7 +2628,7 @@ class TestBuildTickConfig:
     ticks, explicit kwargs win, app-level limit key selector injected."""
 
     def test_stored_kwargs_applied(self):
-        from stardag.integration.modal._app import _build_tick_config
+        from stardag.integration.modal._tick import _build_tick_config
 
         config = _build_tick_config(
             {"linger_seconds": 42, "fail_mode": "continue"},
@@ -2552,7 +2640,7 @@ class TestBuildTickConfig:
         assert config.limit_key_selector is None
 
     def test_explicit_kwargs_win_and_selector_injected(self):
-        from stardag.integration.modal._app import _build_tick_config
+        from stardag.integration.modal._tick import _build_tick_config
 
         selector = lambda t: ["gpu"]  # noqa: E731
         config = _build_tick_config(
@@ -2565,7 +2653,7 @@ class TestBuildTickConfig:
 
     def test_defaults_without_stored_kwargs(self):
         from stardag.build import TickConfig
-        from stardag.integration.modal._app import _build_tick_config
+        from stardag.integration.modal._tick import _build_tick_config
 
         config = _build_tick_config(None, None, None)
         assert config.linger_seconds == TickConfig().linger_seconds
@@ -2575,7 +2663,7 @@ class TestBuildTickConfig:
         """The deployed tick's own Modal ``timeout`` — how long this
         container may live — is what the per-pass spawn cap is derived
         from, so it has to reach the TickConfig."""
-        from stardag.integration.modal._app import _build_tick_config
+        from stardag.integration.modal._tick import _build_tick_config
 
         config = _build_tick_config(None, None, None, tick_timeout_seconds=300.0)
 
@@ -2584,7 +2672,7 @@ class TestBuildTickConfig:
     def test_caller_supplied_budget_wins_over_the_function_timeout(self):
         """A default, not an override: the watchdog sweep runs several
         ticks in one container and passes on its own share of the budget."""
-        from stardag.integration.modal._app import _build_tick_config
+        from stardag.integration.modal._tick import _build_tick_config
 
         config = _build_tick_config(
             None,
@@ -2599,6 +2687,6 @@ class TestBuildTickConfig:
         """It is a deploy-time fact about the container, not per-build
         config: persisting it in a build's stored tick_kwargs would go
         stale on the next redeploy."""
-        from stardag.integration.modal._app import _TICK_KWARGS_ALLOWED
+        from stardag.integration.modal._tick import _TICK_KWARGS_ALLOWED
 
         assert "tick_timeout_seconds" not in _TICK_KWARGS_ALLOWED


### PR DESCRIPTION
## Why

`integration/modal/_app.py` had grown to **3606 lines** holding the entire Modal
integration: the app, the task executor, the builder, the runner, the reactive
bootstrap, the scheduler tick, worker selection, executor metadata, profile
config and volume discovery. It was well-commented but no longer navigable, and
`finalize()` alone was ~450 lines with a 135-line function body nested inside it.

## What

Split along the seams the code already had, leaving `_app.py` with `StardagApp`
alone:

| module | lines | contents |
| --- | --- | --- |
| `_logging` | 15 | container logging setup |
| `_volumes` | 73 | `modalvol://` target roots → `modal.Volume` |
| `_selector` | 79 | worker routing (`WorkerSelector`, `WorkerSelectorByName`) |
| `_settings` | 99 | `FunctionSettings` + the deploy-time merge |
| `_profile` | 112 | stardag profile → container env vars / `Secret` |
| `_protocols` | 120 | `BuildFunction` / `RunFunction` contracts |
| `_builder` | 226 | `Builder`, `PrefectBuilder` (resident orchestrator) |
| `_metadata` | 244 | Modal coordinates + the env-var channel to workers |
| `_bootstrap` | 296 | reactive bootstrap: discover, persist, arm, first tick |
| `_tick` | 433 | tick body, tick config, watchdog sweep |
| `_runner` | 485 | `Runner` + worker-side lifecycle self-reporting |
| `_executor` | 541 | `ModalTaskExecutor` (spawn / re-attach / cancel) |
| `_app` | 1239 | `StardagApp` |

**Behaviour is unchanged.** Beyond the moves:

- **`finalize()` drops from ~450 to ~190 lines.** The 135-line `_modal_tick`
  body moved to `_tick._run_tick`, and its eight deploy-time captures are
  bundled in a frozen `_TickDeployment` — so the registered wrapper is a
  two-line delegation, and the facts a tick needs get one documented home
  instead of eight free variables. Secret assembly, volume auto-mounting, the
  API-key check and per-worker timeouts became named helpers, and one local
  `register()` replaces five repetitions of the prepare-settings/name/
  serialized dance.
- The **module map and usage example moved to the package `__init__`** — the
  front door a reader actually lands on — instead of a private module's header.
- **`ModalTaskExecutor` is now exported** from `stardag.integration.modal`. It
  is the documented first-class executor, and both the docs and a docstring
  example already tell users to import it from there, but it was never in
  `__all__`. Additive.
- Dropped a redundant `import asyncio` inside `PrefectBuilder.build`.

Public API is otherwise untouched; everything still resolves through
`stardag.integration.modal`.

## Verifying it is really a pure refactor

A green suite felt insufficient for a move this size, so:

1. **AST diff, old vs new.** 136 of 144 symbols are byte-identical modulo
   docstrings. The 8 that differ are `finalize` plus five annotation-only
   changes (a `-> None`, and type aliases replacing inline/quoted annotations)
   and the redundant-import removal.
2. **`finalize()` output equivalence.** A probe capturing every
   `modal_app.function(**kwargs)` call `finalize()` makes — for a minimal app
   and a fully-configured one (multiple workers with timeouts, separate tick and
   bootstrap settings, watchdog, task modules, limit key selector) — produces
   byte-identical output on both checkouts: same registration order, function
   names, secrets, mounted volumes, timeouts and schedule, and the same
   `FinalizeResult`.
3. **New test for an uncovered invariant.** Every registered function carries
   `serialized=True`, i.e. Modal cloudpickles the closure at deploy time.
   Nothing tested that, and bundling the tick's captures into a dataclass is
   exactly what could break it. `TestDeployedFunctionsAreSerializable` round-
   trips all five closures through `modal._serialization` (Modal's own vendored
   cloudpickle, not the standalone package) and drives the restored tick through
   its ownership check to prove the captures survived. Confirmed non-vacuous:
   the assertion fails on an unserializable capture.

## Tests

`1263 passed, 29 deselected` — the pre-existing `1261` plus the 2 new
serialization tests, in both fixed and random order. Same 17 live-tier gate
errors as before when the `modal_live` marker is included. `pre-commit`
(prettier, ruff, ruff-format, pyright over `src` and `tests`) passes.

Test-side changes are import-path updates: patch targets moved with the code
that reads them, and the hermetic-metadata fixture now patches each helper in
every module that calls it rather than only where it is defined.

🤖 Generated with [Claude Code](https://claude.com/claude-code)