### PR TITLE
fix(modal): don't swallow StopAsyncIteration from the async driver's loop body

### DIFF
--- a/lib/stardag/src/stardag/integration/modal/_runner.py
+++ b/lib/stardag/src/stardag/integration/modal/_runner.py
@@ -477,14 +477,20 @@ async def _drive_async_generator(task: BaseTask) -> None | TaskStruct:
         typing.AsyncGenerator[TaskStruct, None],
         task.run_aio(),  # type: ignore[assignment]
     )
-    try:
-        async for yielded in agen:
-            deps = flatten_task_struct(yielded)
-            incomplete = [dep for dep in deps if not dep.complete()]
-            if incomplete:
-                return tuple(deps)
-    except StopAsyncIteration:
-        pass
+    # No `except StopAsyncIteration` here, unlike the sync driver's
+    # `except StopIteration`: `async for` consumes the generator's
+    # exhaustion itself and never propagates it, so such a handler could
+    # not do the job it appears to do. The only way to reach it would be a
+    # StopAsyncIteration raised by the loop *body* — `complete()`, say —
+    # and swallowing that would return None, which the caller reads as
+    # "task completed" and reports as such. An error must propagate
+    # instead. (A generator that raises it internally already surfaces as
+    # RuntimeError, so that path never reached the handler either.)
+    async for yielded in agen:
+        deps = flatten_task_struct(yielded)
+        incomplete = [dep for dep in deps if not dep.complete()]
+        if incomplete:
+            return tuple(deps)
     return None
 
 

--- a/lib/stardag/tests/test_integration/test_modal/test_runner.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_runner.py
@@ -163,3 +163,27 @@ class TestRunnerAsyncDynamicDeps:
         assert second is None
         assert task.complete()
         assert task.target().load() == 10  # sum(range(5))
+
+    def test_stop_async_iteration_from_the_loop_body_propagates(
+        self, runner: Runner, default_in_memory_fs_target, monkeypatch
+    ):
+        """A ``StopAsyncIteration`` escaping the driver's loop body must not
+        be mistaken for "the generator finished".
+
+        ``async for`` consumes a generator's own exhaustion, so the only way
+        this exception reaches the driver is from the body — e.g. a
+        ``complete()`` override raising it. Swallowing it would return
+        ``None``, which the caller reads as a completed task and reports as
+        such to the registry, losing the error entirely.
+        """
+        task = AsyncDynamicRangeSumTask(limit=5)
+
+        def _boom(self):
+            raise StopAsyncIteration("from complete()")
+
+        # Patch the *dependency* class, whose complete() the driver calls on
+        # each yielded batch, not the task under test.
+        monkeypatch.setattr(type(make_range(limit=5)), "complete", _boom)
+
+        with pytest.raises(StopAsyncIteration):
+            runner(task)


### PR DESCRIPTION
Follow-up to a Copilot review note on #247, which flagged
`except StopAsyncIteration: pass` in `_drive_async_generator` as dead code. It
is *slightly worse than dead*, which is why this is a fix rather than a tidy-up.

## The mirror that doesn't hold

The async driver wrapped its `async for` in `except StopAsyncIteration: pass`,
mirroring the sync driver's `except StopIteration`. The two loops aren't alike:

- `_drive_sync_generator` calls `next(gen)` itself, so its handler **is** what
  detects exhaustion — load-bearing.
- `async for` consumes the generator's exhaustion internally and never
  propagates it, so the async handler cannot do the job it appears to do.

## But it wasn't unreachable

Verified behaviour of all three paths:

| path | reaches the handler? |
| --- | --- |
| generator exhausts normally | **no** — `async for` absorbs it |
| generator raises `StopAsyncIteration` internally | **no** — surfaces as `RuntimeError: async generator raised StopAsyncIteration` |
| the loop **body** raises it | **yes** — and it was swallowed |

That third path is the problem. The body calls `flatten_task_struct(yielded)`
and `dep.complete()`; a `complete()` override raising `StopAsyncIteration` was
caught and fell through to `return None`. `Runner.__call__` reads `None` as
"the task completed" and reports **TASK_COMPLETED** to the registry — turning an
error into a false success and losing it entirely.

## Change

Remove the handler so such an error propagates, and leave a comment recording
why the async driver deliberately does *not* mirror the sync one — otherwise
this looks like an oversight and invites re-adding.

The sync driver is **deliberately untouched**: its handler is required for
exhaustion detection. Narrowing its scope to just the `next(gen)` call would
close the same latent hole there, but that is a separate change with its own
risk, not a follow-up to this review note.

## Tests

Added `test_stop_async_iteration_from_the_loop_body_propagates`, which patches
the dependency class's `complete()` to raise and asserts the error escapes
`Runner`. **Confirmed non-vacuous**: against the previous implementation it
fails with `Failed: DID NOT RAISE <class 'StopAsyncIteration'>`.

`1264 passed, 29 deselected` (the 1263 on `main` plus this one). `pre-commit`
(prettier, ruff, ruff-format, pyright over `src` and `tests`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)