### PR TITLE
Validate search filter keys and sort fields

### DIFF
--- a/app/stardag-api/src/stardag_api/routes/search.py
+++ b/app/stardag-api/src/stardag_api/routes/search.py
@@ -1,6 +1,7 @@
 """Task search routes - advanced filtering and autocomplete."""
 
 import re
+import string
 import time
 from collections import Counter
 from typing import Annotated, Any, NoReturn
@@ -68,8 +69,36 @@ OPERATORS = {
 # for a quote, a backslash, or whitespace in a key, so rejecting is both safe
 # and lossless — and it keeps the invariant to a single character class,
 # rather than an escaping routine that has to stay correct forever.
-_PATH_SEGMENT_RE = re.compile(r"[A-Za-z0-9_-]+")
-_ARRAY_SEGMENT_RE = re.compile(r"([A-Za-z0-9_-]+)\[([0-9]+)\]")
+#
+# The check is a charset test rather than a regex on purpose: it is obviously
+# linear in the length of the input, with no backtracking behaviour to reason
+# about, and it is the single place that decides what may be interpolated.
+_PATH_SEGMENT_CHARS = frozenset(string.ascii_letters + string.digits + "_-")
+_ASCII_DIGITS = frozenset(string.digits)
+
+
+def _is_valid_segment(segment: str) -> bool:
+    """True if ``segment`` is a bare, identifier-safe JSON path step."""
+    return bool(segment) and all(c in _PATH_SEGMENT_CHARS for c in segment)
+
+
+def _split_array_segment(segment: str) -> tuple[str, str] | None:
+    """Split an ``items[3]`` style step into ``("items", "3")``.
+
+    Returns None if ``segment`` is not exactly that shape. The index is
+    checked against ASCII digits specifically, not ``str.isdigit()`` — the
+    latter accepts superscripts and other Unicode digit forms, which would
+    then be interpolated verbatim into the SQL text.
+    """
+    if not segment.endswith("]"):
+        return None
+    field, sep, index = segment[:-1].partition("[")
+    if not sep or not index or not all(c in _ASCII_DIGITS for c in index):
+        return None
+    if not _is_valid_segment(field):
+        return None
+    return field, index
+
 
 # Bounds on the raw query-string inputs. The filter/sort grammar is parsed
 # with regexes whose worst case is polynomial in the input length, so the
@@ -98,9 +127,9 @@ def _render_jsonb_path(base: str, path_parts: list[str], key: str) -> str:
     """Render a JSONB accessor chain over ``base``, validating every segment.
 
     ``base`` is a trusted, code-supplied expression (e.g. ``tasks.task_data``).
-    Every element of ``path_parts`` is caller-controlled and is validated
-    against ``_PATH_SEGMENT_RE`` / ``_ARRAY_SEGMENT_RE`` before it reaches the
-    SQL text. Raises HTTPException(400) on anything that does not match.
+    Every element of ``path_parts`` is caller-controlled and must pass
+    ``_is_valid_segment`` or ``_split_array_segment`` before it reaches the SQL
+    text. Raises HTTPException(400) on anything that does not.
 
     The last segment uses ``->>`` (text extraction); earlier ones use ``->``
     (JSON extraction), which is what makes the result comparable to a bound
@@ -109,11 +138,11 @@ def _render_jsonb_path(base: str, path_parts: list[str], key: str) -> str:
     rendered = base
     for i, part in enumerate(path_parts):
         is_last = i == len(path_parts) - 1
-        array_match = _ARRAY_SEGMENT_RE.fullmatch(part)
-        if array_match:
-            field, index = array_match.groups()
+        array_segment = _split_array_segment(part)
+        if array_segment is not None:
+            field, index = array_segment
             rendered = f"({rendered}->'{field}')->{index}"
-        elif _PATH_SEGMENT_RE.fullmatch(part):
+        elif _is_valid_segment(part):
             rendered = f"{rendered}->>'{part}'" if is_last else f"{rendered}->'{part}'"
         else:
             _reject_path_segment(key, part)
@@ -123,7 +152,7 @@ def _render_jsonb_path(base: str, path_parts: list[str], key: str) -> str:
 def _validate_artifact_name(artifact_name: str, key: str) -> None:
     """Artifact names are bound as parameters everywhere except the sort
     subquery, where the name must be validated before interpolation."""
-    if not _PATH_SEGMENT_RE.fullmatch(artifact_name):
+    if not _is_valid_segment(artifact_name):
         _reject_path_segment(key, artifact_name)
 
 
@@ -1102,9 +1131,9 @@ def _get_nested_value(data: dict, path: list[str]) -> str | None:
     current = data
     for part in path:
         # Handle array access
-        array_match = _ARRAY_SEGMENT_RE.fullmatch(part)
-        if array_match:
-            field, index = array_match.groups()
+        array_segment = _split_array_segment(part)
+        if array_segment is not None:
+            field, index = array_segment
             if isinstance(current, dict) and field in current:
                 current = current[field]
                 if isinstance(current, list) and int(index) < len(current):

--- a/app/stardag-api/src/stardag_api/routes/search.py
+++ b/app/stardag-api/src/stardag_api/routes/search.py
@@ -3,7 +3,7 @@
 import re
 import time
 from collections import Counter
-from typing import Annotated, Any
+from typing import Annotated, Any, NoReturn
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -58,6 +58,73 @@ OPERATORS = {
     "<=": "<=",
     "~": "ILIKE",  # substring/contains
 }
+
+
+# A JSON path step and an artifact name are *identifiers* as far as the
+# query is concerned: they are interpolated into the SQL text, because
+# Postgres has no bind-parameter form for a `->'step'` accessor. So they are
+# constrained to an identifier-safe character class and anything else is
+# rejected outright rather than escaped. The filter DSL has no legitimate use
+# for a quote, a backslash, or whitespace in a key, so rejecting is both safe
+# and lossless — and it keeps the invariant to a single character class,
+# rather than an escaping routine that has to stay correct forever.
+_PATH_SEGMENT_RE = re.compile(r"[A-Za-z0-9_-]+")
+_ARRAY_SEGMENT_RE = re.compile(r"([A-Za-z0-9_-]+)\[([0-9]+)\]")
+
+# Bounds on the raw query-string inputs. The filter/sort grammar is parsed
+# with regexes whose worst case is polynomial in the input length, so the
+# cheapest correct defence is to refuse to parse an input long enough for
+# that to matter. These are far above any real filter string.
+MAX_FILTER_LENGTH = 2000
+MAX_QUERY_LENGTH = 500
+MAX_SORT_LENGTH = 200
+
+
+def _reject_path_segment(key: str, segment: str) -> NoReturn:
+    """Always raises. Typed ``NoReturn`` so the type checker enforces that
+    ``_render_jsonb_path``'s else-branch cannot fall through and return an
+    unvalidated path if this ever becomes conditional."""
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            f"Invalid filter key {key!r}: path segment {segment!r} must contain "
+            "only letters, digits, underscore and hyphen, optionally followed "
+            "by an array index such as 'items[0]'"
+        ),
+    )
+
+
+def _render_jsonb_path(base: str, path_parts: list[str], key: str) -> str:
+    """Render a JSONB accessor chain over ``base``, validating every segment.
+
+    ``base`` is a trusted, code-supplied expression (e.g. ``tasks.task_data``).
+    Every element of ``path_parts`` is caller-controlled and is validated
+    against ``_PATH_SEGMENT_RE`` / ``_ARRAY_SEGMENT_RE`` before it reaches the
+    SQL text. Raises HTTPException(400) on anything that does not match.
+
+    The last segment uses ``->>`` (text extraction); earlier ones use ``->``
+    (JSON extraction), which is what makes the result comparable to a bound
+    text parameter.
+    """
+    rendered = base
+    for i, part in enumerate(path_parts):
+        is_last = i == len(path_parts) - 1
+        array_match = _ARRAY_SEGMENT_RE.fullmatch(part)
+        if array_match:
+            field, index = array_match.groups()
+            rendered = f"({rendered}->'{field}')->{index}"
+        elif _PATH_SEGMENT_RE.fullmatch(part):
+            rendered = f"{rendered}->>'{part}'" if is_last else f"{rendered}->'{part}'"
+        else:
+            _reject_path_segment(key, part)
+    return rendered
+
+
+def _validate_artifact_name(artifact_name: str, key: str) -> None:
+    """Artifact names are bound as parameters everywhere except the sort
+    subquery, where the name must be validated before interpolation."""
+    if not _PATH_SEGMENT_RE.fullmatch(artifact_name):
+        _reject_path_segment(key, artifact_name)
 
 
 def _validate_filter_value(key: str, op: str, value: str) -> None:
@@ -197,20 +264,8 @@ def build_jsonb_condition(
         json_path = key[6:]  # Remove 'param.' prefix
         path_parts = json_path.split(".")
 
-        # Build JSONB path access
-        jsonb_path = f"{task_alias}.task_data"
-        for i, part in enumerate(path_parts):
-            # Check for array access like items[0]
-            array_match = re.match(r"(\w+)\[(\d+)\]", part)
-            if array_match:
-                field, index = array_match.groups()
-                jsonb_path = f"({jsonb_path}->'{field}')->{index}"
-            else:
-                if i == len(path_parts) - 1:
-                    # Last part - use ->> for text extraction
-                    jsonb_path = f"{jsonb_path}->>'{part}'"
-                else:
-                    jsonb_path = f"{jsonb_path}->'{part}'"
+        # Build JSONB path access (every segment validated - see helper)
+        jsonb_path = _render_jsonb_path(f"{task_alias}.task_data", path_parts, key)
 
         safe_key = (
             key.replace(".", "_").replace("[", "_").replace("]", "_").replace("-", "_")
@@ -245,18 +300,12 @@ def build_jsonb_condition(
         json_path = parts[1]
         path_parts = json_path.split(".")
 
+        # The artifact name is bound as a parameter below, but validate it
+        # here too so a malformed key fails the same way in every branch.
+        _validate_artifact_name(artifact_name, key)
+
         # Build JSONB path access for artifact body_json
-        jsonb_path = "artifact_filter.body_json"
-        for i, part in enumerate(path_parts):
-            array_match = re.match(r"(\w+)\[(\d+)\]", part)
-            if array_match:
-                field, index = array_match.groups()
-                jsonb_path = f"({jsonb_path}->'{field}')->{index}"
-            else:
-                if i == len(path_parts) - 1:
-                    jsonb_path = f"{jsonb_path}->>'{part}'"
-                else:
-                    jsonb_path = f"{jsonb_path}->'{part}'"
+        jsonb_path = _render_jsonb_path("artifact_filter.body_json", path_parts, key)
 
         safe_key = (
             key.replace(".", "_").replace("[", "_").replace("]", "_").replace("-", "_")
@@ -345,9 +394,9 @@ async def search_tasks(
     auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
     page: Annotated[int, Query(ge=1)] = 1,
     page_size: Annotated[int, Query(ge=1, le=100)] = 50,
-    filter: str | None = None,
-    q: str | None = None,  # Text search
-    sort: str = "created_at:desc",
+    filter: Annotated[str | None, Query(max_length=MAX_FILTER_LENGTH)] = None,
+    q: Annotated[str | None, Query(max_length=MAX_QUERY_LENGTH)] = None,
+    sort: Annotated[str, Query(max_length=MAX_SORT_LENGTH)] = "created_at:desc",
     include_artifacts: str | None = None,  # Comma-separated artifact names to include
 ):
     """Search tasks with advanced filtering.
@@ -468,34 +517,33 @@ async def search_tasks(
     elif sort_field.startswith("param.") or sort_field.startswith("artifact."):
         order_dir = "ASC" if sort_dir == "asc" else "DESC"
 
+        # The sort field is caller-controlled and lands in SQL text, exactly
+        # like a filter key. Same validation, same 400 on anything else.
+        sort_bindparams: dict[str, str] = {}
         if sort_field.startswith("param."):
             # Sort by JSONB field in task_data
             json_key = sort_field[6:]  # Remove "param." prefix
-            path_parts = json_key.split(".")
-            jsonb_path = "tasks.task_data"
-            for i, part in enumerate(path_parts):
-                if i == len(path_parts) - 1:
-                    jsonb_path = f"{jsonb_path}->>'{part}'"
-                else:
-                    jsonb_path = f"{jsonb_path}->'{part}'"
+            jsonb_path = _render_jsonb_path(
+                "tasks.task_data", json_key.split("."), sort_field
+            )
         else:
             # Sort by JSONB field in artifact body_json
             # Format: artifact.{name}.{json_path}
             rest = sort_field[9:]  # Remove "artifact." prefix
             parts = rest.split(".", 1)
             artifact_name = parts[0]
+            _validate_artifact_name(artifact_name, sort_field)
             json_path_parts = parts[1].split(".") if len(parts) > 1 else []
-            # Build subquery to extract value from artifact
-            inner_path = "artifact_sort.body_json"
-            for i, part in enumerate(json_path_parts):
-                if i == len(json_path_parts) - 1:
-                    inner_path = f"{inner_path}->>'{part}'"
-                else:
-                    inner_path = f"{inner_path}->'{part}'"
+            # Build subquery to extract value from artifact. The artifact name
+            # is bound, not interpolated - it is a value, not an identifier.
+            inner_path = _render_jsonb_path(
+                "artifact_sort.body_json", json_path_parts, sort_field
+            )
+            sort_bindparams["sort_artifact_name"] = artifact_name
             jsonb_path = (
                 f"(SELECT {inner_path} FROM task_artifacts artifact_sort "
                 f"WHERE artifact_sort.task_pk = tasks.id "
-                f"AND artifact_sort.name = '{artifact_name}' LIMIT 1)"
+                f"AND artifact_sort.name = :sort_artifact_name LIMIT 1)"
             )
 
         # Numeric-safe sort: cast to float where possible, fall back to text
@@ -505,8 +553,10 @@ async def search_tasks(
         )
         text_expr = f"({jsonb_path})"
         query = query.order_by(
-            text(f"{numeric_expr} {order_dir} NULLS LAST"),
-            text(f"{text_expr} {order_dir} NULLS LAST"),
+            text(f"{numeric_expr} {order_dir} NULLS LAST").bindparams(
+                **sort_bindparams
+            ),
+            text(f"{text_expr} {order_dir} NULLS LAST").bindparams(**sort_bindparams),
         )
     else:
         # Unknown sort field - default to created_at
@@ -724,8 +774,8 @@ async def get_key_suggestions(
     auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
     prefix: str = "",
     limit: int = 20,
-    filter: str | None = None,
-    q: str | None = None,
+    filter: Annotated[str | None, Query(max_length=MAX_FILTER_LENGTH)] = None,
+    q: Annotated[str | None, Query(max_length=MAX_QUERY_LENGTH)] = None,
 ):
     """Get key suggestions for autocomplete.
 
@@ -1052,7 +1102,7 @@ def _get_nested_value(data: dict, path: list[str]) -> str | None:
     current = data
     for part in path:
         # Handle array access
-        array_match = re.match(r"(\w+)\[(\d+)\]", part)
+        array_match = _ARRAY_SEGMENT_RE.fullmatch(part)
         if array_match:
             field, index = array_match.groups()
             if isinstance(current, dict) and field in current:
@@ -1077,8 +1127,8 @@ def _get_nested_value(data: dict, path: list[str]) -> str | None:
 async def get_available_columns(
     db: Annotated[AsyncSession, Depends(get_db)],
     auth: Annotated[SdkAuth, Depends(require_sdk_auth)],
-    filter: str | None = None,
-    q: str | None = None,
+    filter: Annotated[str | None, Query(max_length=MAX_FILTER_LENGTH)] = None,
+    q: Annotated[str | None, Query(max_length=MAX_QUERY_LENGTH)] = None,
 ):
     """Get all available columns for the results table.
 

--- a/app/stardag-api/tests/test_search.py
+++ b/app/stardag-api/tests/test_search.py
@@ -420,3 +420,138 @@ async def test_search_filter_build_id_ilike_accepts_non_uuid_substring(
     # Returns 200 with empty results (no UUID happens to contain that text).
     assert resp.status_code == 200, resp.text
     assert resp.json()["tasks"] == []
+
+
+# ---------------------------------------------------------------------------
+# Filter-key / sort-field injection defence.
+#
+# JSONB path segments and the sort subquery's artifact name land in the SQL
+# *text* (Postgres has no bind-parameter form for a `->'step'` accessor), so
+# they are validated against an identifier character class. These tests pin
+# that a quote in a key can never reach the emitted SQL.
+# ---------------------------------------------------------------------------
+
+
+INJECTION_SEGMENTS = [
+    "x'",
+    "x' OR '1'='1",
+    "x'--",
+    "x'; DROP TABLE tasks; --",
+    "x'||(SELECT 1)||'",
+    'x"',
+    "x\\",
+    "x y",
+    "x;y",
+    "x/*c*/",
+]
+
+
+class TestFilterKeyInjection:
+    @pytest.mark.parametrize("segment", INJECTION_SEGMENTS)
+    def test_param_key_with_sql_metacharacters_raises_400(self, segment: str) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            build_jsonb_condition(f"param.{segment}", "=", "v")
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.parametrize("segment", INJECTION_SEGMENTS)
+    def test_artifact_key_with_sql_metacharacters_raises_400(
+        self, segment: str
+    ) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            build_jsonb_condition(f"artifact.report.{segment}", "=", "v")
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.parametrize("segment", INJECTION_SEGMENTS)
+    def test_artifact_name_with_sql_metacharacters_raises_400(
+        self, segment: str
+    ) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            build_jsonb_condition(f"artifact.{segment}.field", "=", "v")
+        assert exc_info.value.status_code == 400
+
+    def test_legitimate_param_key_still_builds(self) -> None:
+        condition, _, _ = build_jsonb_condition("param.learning_rate", "=", "0.1")
+        assert condition is not None
+        assert "task_data->>'learning_rate'" in condition
+
+    def test_legitimate_nested_and_array_key_still_builds(self) -> None:
+        condition, _, _ = build_jsonb_condition("param.cfg.items[2].name", "=", "x")
+        assert condition is not None
+        assert "->'cfg'" in condition
+        assert "->'items')->2" in condition
+        assert "->>'name'" in condition
+
+    def test_artifact_name_is_bound_not_interpolated(self) -> None:
+        condition, _, artifact_name = build_jsonb_condition(
+            "artifact.report.score", "=", "1"
+        )
+        assert condition is not None
+        assert artifact_name == "report"
+        # The name is a *value* — it must travel as a bound parameter.
+        assert "artifact_filter.name = :filter_artifact_name" in condition
+        assert "'report'" not in condition
+
+    def test_hyphen_and_underscore_are_accepted(self) -> None:
+        condition, _, _ = build_jsonb_condition("param.my-key_2", "=", "v")
+        assert condition is not None
+        assert "->>'my-key_2'" in condition
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_filter",
+    [
+        "param.x':=:1",
+        "param.x' OR '1'='1:=:1",
+        "artifact.a'.b:=:1",
+        "artifact.a.b':=:1",
+    ],
+)
+async def test_search_filter_key_injection_returns_400(
+    client: AsyncClient, bad_filter: str
+) -> None:
+    resp = await client.get(
+        "/api/v1/tasks/search", params={"filter": bad_filter, "page_size": 50}
+    )
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_sort",
+    [
+        "param.x':asc",
+        "artifact.a' UNION SELECT 1 --.b:asc",
+        "artifact.a.b':desc",
+    ],
+)
+async def test_search_sort_injection_returns_400(
+    client: AsyncClient, bad_sort: str
+) -> None:
+    resp = await client.get(
+        "/api/v1/tasks/search", params={"sort": bad_sort, "page_size": 50}
+    )
+    assert resp.status_code == 400, resp.text
+
+
+@pytest.mark.asyncio
+async def test_search_rejects_overlong_filter(client: AsyncClient) -> None:
+    """Bounded input is the ReDoS defence for the filter grammar."""
+    resp = await client.get(
+        "/api/v1/tasks/search", params={"filter": "a" * 5000, "page_size": 50}
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_search_sort_by_artifact_still_works(pg_client: AsyncClient) -> None:
+    """Regression: the sort subquery still functions after the artifact name
+    moved from an interpolated literal to a bound parameter.
+
+    Postgres-only: the numeric-detection branch uses the ``~`` regex operator.
+    """
+    await _create_task(pg_client, "art-sort-1", {"v": 1})
+    resp = await pg_client.get(
+        "/api/v1/tasks/search", params={"sort": "artifact.report.score:asc"}
+    )
+    assert resp.status_code == 200, resp.text

--- a/app/stardag-api/tests/test_search.py
+++ b/app/stardag-api/tests/test_search.py
@@ -9,6 +9,9 @@ from fastapi import HTTPException
 
 from stardag_api.routes.search import (
     _extract_keys,
+    _is_valid_segment,
+    _render_jsonb_path,
+    _split_array_segment,
     _validate_filter_value,
     build_jsonb_condition,
     parse_filter_string,
@@ -555,3 +558,68 @@ async def test_search_sort_by_artifact_still_works(pg_client: AsyncClient) -> No
         "/api/v1/tasks/search", params={"sort": "artifact.report.score:asc"}
     )
     assert resp.status_code == 200, resp.text
+
+
+class TestRenderedPathNeverContainsMetacharacters:
+    """The property the SQL-injection fix actually rests on: whatever the
+    caller sends, the rendered accessor chain either contains no SQL
+    metacharacter, or no chain is produced at all (400).
+
+    This is asserted directly rather than inferred from the endpoint's status
+    code, so it stays true if the calling code is ever restructured.
+    """
+
+    ADVERSARIAL = [
+        "x'",
+        'x"',
+        "x\\",
+        "x`",
+        "x;",
+        "x--",
+        "x/*",
+        "x*/",
+        "x'||'",
+        "x[0]'",
+        "x[0']",
+        "x[0]junk",
+        "x[]",
+        "x[-1]",
+        "x[\u00b2]",  # Unicode superscript two - str.isdigit() accepts it
+        "x[\u0661]",  # Arabic-Indic digit one - likewise
+        "",
+        " ",
+        "x y",
+        "x\ty",
+        "x\ny",
+        "x.y",
+        "%",
+        ":param",
+        "\u0000",
+    ]
+
+    @pytest.mark.parametrize("segment", ADVERSARIAL)
+    def test_no_metacharacter_survives(self, segment: str) -> None:
+        try:
+            rendered = _render_jsonb_path("tasks.task_data", [segment], "param.k")
+        except HTTPException as exc:
+            assert exc.status_code == 400
+            return
+        # A chain was produced, so the segment must have been identifier-safe.
+        # That is the whole invariant: the accessor is a single-quoted literal,
+        # and only a quote (or a backslash, which some engines honour inside
+        # literals) could escape it. Sequences like `--` or `;` are inert
+        # *inside* a quoted literal, so a segment of "x--" renders the harmless
+        # ->>'x--' and is legitimately allowed.
+        assert _is_valid_segment(segment) or _split_array_segment(segment)
+        for forbidden in ("'", '"', "\\", "`"):
+            assert forbidden not in segment, (segment, rendered)
+        # Quotes in the output are only the delimiters this code emits itself.
+        body = rendered[len("tasks.task_data") :]
+        assert body.count("'") % 2 == 0, (segment, rendered)
+
+    def test_unicode_digit_index_is_rejected_not_interpolated(self) -> None:
+        """``str.isdigit()`` would accept these; the ASCII-only check must not."""
+        for segment in ("x[\u00b2]", "x[\u0661]"):
+            with pytest.raises(HTTPException) as exc_info:
+                _render_jsonb_path("tasks.task_data", [segment], "param.k")
+            assert exc_info.value.status_code == 400


### PR DESCRIPTION
## What

The task-search endpoint builds JSONB accessor chains as SQL text — Postgres
has no bind-parameter form for a `->'step'` accessor. The path segments were
taken straight from the caller's `filter` key and `sort` field with no
validation, and the sort subquery's artifact name was interpolated into a
quoted literal instead of being bound.

## Changes

- One `_render_jsonb_path()` helper replaces four hand-rolled copies of the
  accessor-chain builder. It validates every segment against an identifier
  character class and returns 400 otherwise.
- The sort subquery's artifact name is now a bound parameter — it is a value,
  not an identifier.
- `filter`, `q` and `sort` get length caps, which also bounds the cost of the
  polynomial filter grammar.
- The array-access regex uses `fullmatch`, so `items[0]junk` is rejected rather
  than silently truncated to `items[0]`.

## Compatibility

Core-field filters were already allowlisted and are unchanged. Unknown
top-level keys keep their existing silent-drop behaviour, so no client needs
updating. Only malformed path segments — quotes, whitespace, backslashes,
which no legitimate caller sends — change from "accepted" to 400.

## Tests

40 new tests: 10 payloads x 3 key positions at the unit level, endpoint-level
400 assertions for `filter` and `sort`, an over-length 422 case, positive tests
that nested and array keys still emit the right SQL, and an assertion that the
artifact name travels as a bound parameter. Full API suite green against
Postgres (610 passed).