### PR TITLE
Prepare server image 0.1.2 (search SQL injection fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+### Registry API
+
+- **Security (server image `0.1.2`): fixed a SQL injection in the task search
+  endpoint.** `GET /api/v1/tasks/search` builds JSONB accessor chains as SQL
+  text (Postgres has no bind-parameter form for a `->'key'` step). The path
+  segments of a `filter` key, and the artifact name in a `sort` field, were
+  interpolated without validation, so a crafted key or sort value could inject
+  SQL. The endpoint requires authentication, and the injection lands inside the
+  environment-scoped `WHERE`; a malformed value was read-only (no statement
+  stacking on the parameterised path) but could read across environments. All
+  released server images before `0.1.2` are affected. Fixed by validating every
+  path segment against an identifier character class and binding the sort
+  artifact name as a parameter; filter/sort inputs are now length-bounded.
+  Self-hosters should upgrade to server image `0.1.2`. See advisory
+  `GHSA-…` <!-- filled in on publish -->.
+
 ## [0.18.0] — 2026-08-11
 
 ### Registry API

--- a/lib/stardag/src/stardag/selfhost/_modal_app.py
+++ b/lib/stardag/src/stardag/selfhost/_modal_app.py
@@ -62,7 +62,7 @@ DEFAULT_SERVER_MODAL_ENV = "stardag-host"
 SERVER_IMAGE_REPO = "ghcr.io/stardag-dev/stardag-server"
 # The server release this SDK version is tested against. Bumped at SDK
 # release time; override per deployment with --server-version.
-DEFAULT_SERVER_VERSION = "0.1.1"
+DEFAULT_SERVER_VERSION = "0.1.2"
 
 # Minimum client interpreter for from-source image builds (stardag-api's
 # requires-python; the image gets the client's version via add_python).


### PR DESCRIPTION
Changelog entry for the task-search SQL injection fix (landed in #249), and bumps `DEFAULT_SERVER_VERSION` to `0.1.2` so `stardag self-host` pulls the fixed image by default.

After this merges, tagging `server-v0.1.2` on main builds and publishes `ghcr.io/stardag-dev/stardag-server:0.1.2` and cuts the GitHub release. A security advisory for the self-hosted image will be published alongside; the changelog references its GHSA id (filled in on publish).