### PR TITLE
Default Cognito self-signup to off; make it opt-in

### DIFF
--- a/infra/aws-cdk/.env.deploy.example
+++ b/infra/aws-cdk/.env.deploy.example
@@ -14,6 +14,11 @@ GOOGLE_CLIENT_SECRET=GOCSPX-xxx
 
 # Optional Features (opt-in)
 # SES_ENABLED=true  # Enable AWS SES for transactional emails (invites, etc.)
+# Allow anyone to self-register in the Cognito user pool. Off by default
+# (a public deployment with open signup lets anyone get an account). See
+# README "Restricting who can sign up" — note this does not gate federated
+# (e.g. Google) sign-up on its own.
+# COGNITO_ALLOW_SELF_SIGNUP=true
 
 # Prebuilt public images (opt-in) — see README "Use prebuilt public images"
 # Pin the API service to a prebuilt release image instead of the locally

--- a/infra/aws-cdk/README.md
+++ b/infra/aws-cdk/README.md
@@ -336,11 +336,47 @@ SES_ENABLED=true  # Enable AWS SES for transactional emails
 
 ### Optional Features
 
-| Feature     | Env Var       | Default | Description                                      |
-| ----------- | ------------- | ------- | ------------------------------------------------ |
-| SES (Email) | `SES_ENABLED` | `false` | AWS SES for transactional emails (invites, etc.) |
+| Feature             | Env Var                     | Default | Description                                       |
+| ------------------- | --------------------------- | ------- | ------------------------------------------------- |
+| SES (Email)         | `SES_ENABLED`               | `false` | AWS SES for transactional emails (invites, etc.)  |
+| Self-service signup | `COGNITO_ALLOW_SELF_SIGNUP` | `false` | Allow anyone to register in the Cognito user pool |
 
 **SES (Email):** When enabled, creates an SES email identity for your domain with automatic DKIM DNS records. Requires the domain to be configured in Route 53. After deployment, you'll need to request SES production access in the AWS Console (sandbox mode only allows sending to verified emails).
+
+### Restricting who can sign up
+
+This deployment is reachable from the public internet, so **who can obtain an
+account is a security decision**. The Registry API auto-provisions an internal
+user and a personal workspace on first login for any principal Cognito
+authenticates, so account creation in the pool is effectively account creation
+in Stardag.
+
+**Default is closed.** `COGNITO_ALLOW_SELF_SIGNUP` defaults to `false`, which
+sets the user pool's `selfSignUpEnabled: false` — the public `SignUp` API is
+disabled and native (email/password) users can only be created by an admin
+(`aws cognito-idp admin-create-user`, or the Cognito console). Set
+`COGNITO_ALLOW_SELF_SIGNUP=true` only for a deployment that deliberately offers
+open registration (e.g. a hosted trial).
+
+> **Important — federated (Google) sign-up is a separate door.** Disabling
+> self-signup blocks the _native_ `SignUp` API only. When a Google (or other
+> federated) IdP is configured, Cognito **still auto-provisions a pool user on
+> first federated login**, regardless of `selfSignUpEnabled`. So with the
+> default Google IdP, `COGNITO_ALLOW_SELF_SIGNUP=false` alone does **not** stop
+> anyone with a Google account from signing in and getting an account.
+>
+> To actually restrict federated sign-up, do one (or both) of:
+>
+> - **Add a pre-sign-up Lambda trigger** on the user pool that rejects sign-ups
+>   whose email is outside an allowlist/domain. The trigger fires for federated
+>   sign-ups too (`triggerSource == "PreSignUp_ExternalProvider"`); `throw` to
+>   deny. This is the robust, IdP-independent control.
+> - **Restrict at the IdP** — e.g. set the Google OAuth consent screen to
+>   _Internal_ for a Workspace org, or limit it to explicit test users, so only
+>   your org's Google accounts can complete the flow.
+>
+> If neither is in place, treat the deployment as open-registration regardless
+> of the `COGNITO_ALLOW_SELF_SIGNUP` value.
 
 ## CDK Commands
 

--- a/infra/aws-cdk/lib/config.ts
+++ b/infra/aws-cdk/lib/config.ts
@@ -46,6 +46,17 @@ export interface StardagConfig {
 
   // Optional features
   sesEnabled: boolean;
+
+  // Whether the Cognito user pool allows self-service sign-up. Off by
+  // default: a self-hosted instance is typically reachable from the public
+  // internet, and open sign-up there means anyone can obtain an account.
+  // Opt in (COGNITO_ALLOW_SELF_SIGNUP=true) for a deployment that
+  // deliberately offers open registration (e.g. a hosted trial).
+  //
+  // NOTE: this governs Cognito *native* self-registration only. It does not
+  // by itself stop account creation via a federated IdP (e.g. Google) — see
+  // infra/aws-cdk/README.md ("Restricting who can sign up").
+  allowSelfSignUp: boolean;
 }
 
 export function loadConfig(): StardagConfig {
@@ -74,6 +85,7 @@ export function loadConfig(): StardagConfig {
 
     // Optional features (opt-in)
     sesEnabled: optionalBoolEnv("SES_ENABLED", false),
+    allowSelfSignUp: optionalBoolEnv("COGNITO_ALLOW_SELF_SIGNUP", false),
   };
 }
 

--- a/infra/aws-cdk/lib/constructs/cognito.ts
+++ b/infra/aws-cdk/lib/constructs/cognito.ts
@@ -19,6 +19,23 @@ export interface StardagCognitoProps {
    * @default "stardag"
    */
   domainPrefix?: string;
+
+  /**
+   * Whether users may self-register in the Cognito user pool.
+   *
+   * Off by default: a self-hosted instance is typically reachable from the
+   * public internet, and open sign-up there lets anyone obtain an account.
+   *
+   * NOTE: this maps to Cognito's `selfSignUpEnabled`, which governs *native*
+   * (email/password) self-registration only. It does NOT prevent account
+   * creation via a federated identity provider such as Google — Cognito
+   * auto-provisions a pool user on first federated login regardless. To
+   * restrict federated sign-up, add a pre-sign-up Lambda trigger (email
+   * allowlist) or restrict the upstream IdP. See the README.
+   *
+   * @default false
+   */
+  allowSelfSignUp?: boolean;
 }
 
 export class StardagCognito extends Construct {
@@ -35,6 +52,7 @@ export class StardagCognito extends Construct {
       googleClientId,
       googleClientSecret,
       domainPrefix = "stardag",
+      allowSelfSignUp = false,
     } = props;
 
     // =============================================================
@@ -43,8 +61,10 @@ export class StardagCognito extends Construct {
     this.userPool = new cognito.UserPool(this, "UserPool", {
       userPoolName: "stardag-users",
 
-      // Self sign-up enabled (users can register)
-      selfSignUpEnabled: true,
+      // Native self-registration. Off by default (see props docs); a hosted
+      // deployment that wants open registration opts in via config. Does not
+      // affect federated (e.g. Google) sign-up — see the README.
+      selfSignUpEnabled: allowSelfSignUp,
 
       // Sign-in options
       signInAliases: {

--- a/infra/aws-cdk/lib/foundation-stack.ts
+++ b/infra/aws-cdk/lib/foundation-stack.ts
@@ -98,6 +98,7 @@ export class FoundationStack extends cdk.Stack {
       googleClientId: config.googleClientId,
       googleClientSecret: config.googleClientSecret,
       domainPrefix: "stardag",
+      allowSelfSignUp: config.allowSelfSignUp,
     });
 
     this.cognitoIssuerUrl = cognito.issuerUrl;

--- a/infra/aws-cdk/lib/stardag-stack.ts
+++ b/infra/aws-cdk/lib/stardag-stack.ts
@@ -61,6 +61,7 @@ export class StardagStack extends cdk.Stack {
       googleClientId: config.googleClientId,
       googleClientSecret: config.googleClientSecret,
       domainPrefix: "stardag", // Must be globally unique
+      allowSelfSignUp: config.allowSelfSignUp,
     });
 
     // =============================================================

--- a/infra/aws-cdk/test/stardag.test.ts
+++ b/infra/aws-cdk/test/stardag.test.ts
@@ -21,6 +21,7 @@ const mockConfig = {
   googleClientId: "test-client-id.apps.googleusercontent.com",
   googleClientSecret: "test-client-secret",
   sesEnabled: false, // Opt-in feature, disabled by default
+  allowSelfSignUp: false, // Secure default: no open self-registration
 };
 
 describe("StardagStack", () => {
@@ -76,6 +77,14 @@ describe("StardagStack", () => {
         UserPoolName: "stardag-users",
         UsernameAttributes: ["email"],
         AutoVerifiedAttributes: ["email"],
+      });
+    });
+
+    test("disables native self-signup by default (allowSelfSignUp=false)", () => {
+      // selfSignUpEnabled:false synthesizes AllowAdminCreateUserOnly:true.
+      // mockConfig has allowSelfSignUp:false, the secure default.
+      template.hasResourceProperties("AWS::Cognito::UserPool", {
+        AdminCreateUserConfig: { AllowAdminCreateUserOnly: true },
       });
     });
 


### PR DESCRIPTION
The AWS CDK templates created the Cognito user pool with `selfSignUpEnabled: true`, so a deployment reachable from the public internet let anyone register — and the Registry API auto-provisions an internal user + personal workspace on first login. This makes self-signup a config flag, **defaulting to off**.

## Changes
- `config.ts`: new `allowSelfSignUp` (env `COGNITO_ALLOW_SELF_SIGNUP`, default `false`).
- `constructs/cognito.ts`: `selfSignUpEnabled` now follows the flag.
- Threaded through `foundation-stack.ts` (active) and `stardag-stack.ts` (legacy).
- README: "Restricting who can sign up" section + config table row + `.env.deploy.example`.
- Test asserting the secure default synthesizes `AllowAdminCreateUserOnly: true`.

## Honest caveat (documented)
This governs **native** self-registration only. With the default Google IdP, Cognito still auto-provisions a pool user on first *federated* login regardless of `selfSignUpEnabled`. A true lockdown needs a pre-sign-up Lambda allowlist or an IdP-side restriction — the README explains both. A follow-up could add an optional pre-sign-up allowlist trigger.

Build + 38 jest tests pass.