### PR TITLE
Replace python-jose with PyJWT for token auth

### DIFF
--- a/app/stardag-api/pyproject.toml
+++ b/app/stardag-api/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "alembic>=1.14.0",
     "pydantic>=2.8.2",
     "pydantic-settings>=2.7.1",
-    "python-jose[cryptography]>=3.3.0",
+    "pyjwt[crypto]>=2.10.0",
     "httpx>=0.27.0",
     "bcrypt>=4.0.0",
     "uuid_utils>=0.9.0",
@@ -33,11 +33,8 @@ dependencies = [
     # parent above; the floor is the first patched version.
     "starlette>=1.3.1",  # via fastapi — StaticFiles UNC SSRF, form() DoS
     "urllib3>=2.7.0",  # via boto3 — decompression-bomb / cross-origin headers
-    "cryptography>=50.0.0",  # via python-jose[cryptography] — several CVEs
+    "cryptography>=50.0.0",  # via pyjwt[crypto] (and used directly) — several CVEs
     "mako>=1.3.12",  # via alembic — TemplateLookup path traversal
-    # via python-jose -> rsa — decoder DoS. Remove together with python-jose
-    # if/when it is replaced (see the security-scanning follow-ups).
-    "pyasn1>=0.6.4",
 ]
 
 [dependency-groups]

--- a/app/stardag-api/src/stardag_api/auth/jwt.py
+++ b/app/stardag-api/src/stardag_api/auth/jwt.py
@@ -1,13 +1,15 @@
 """JWT validation using JWKS from OIDC provider."""
 
+import json
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 import httpx
-from jose import JWTError, jwt
-from jose.exceptions import ExpiredSignatureError, JWTClaimsError
+import jwt
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+from jwt.algorithms import RSAAlgorithm
 
 from stardag_api.config import oidc_settings
 
@@ -164,24 +166,37 @@ class JWTValidator:
             if key is None:
                 raise AuthenticationError(f"Unable to find key with ID: {kid}")
 
-            # Decode and validate the token
-            # Note: python-jose will validate exp, iat, and signature
-            # We handle audience verification manually to support multiple audiences
+            # Convert the JWK to a public key object PyJWT can verify with.
+            # from_jwk's return type is the RSA public|private union; a signing
+            # JWK (kty=RSA, n/e, no d) yields a public key.
+            public_key = cast(RSAPublicKey, RSAAlgorithm.from_jwk(json.dumps(key)))
+
+            # Decode and validate the token. PyJWT verifies the signature and
+            # expiry; algorithms=["RS256"] is what prevents an "alg":"none" or
+            # HS256 key-confusion attack. Issuer and audience are verified
+            # manually below: we allow multiple of each, which PyJWT's single
+            # `issuer`/`audience` parameters don't express directly. PyJWT does
+            # not validate at_hash at all, so no option is needed to skip it
+            # (jose required one — some ID tokens carry at_hash without the
+            # matching access token).
             payload = jwt.decode(
                 token,
-                key,
+                public_key,
                 algorithms=["RS256"],
-                issuer=self.allowed_issuers,
                 options={
-                    "verify_aud": False,  # We verify manually below
-                    "verify_iss": True,
+                    "verify_signature": True,
                     "verify_exp": True,
-                    # Skip at_hash validation - ID tokens contain at_hash but we
-                    # may receive ID tokens without the corresponding access token
-                    # (e.g., for bootstrap endpoints that need user claims)
-                    "verify_at_hash": False,
+                    "verify_aud": False,  # verified manually below
+                    "verify_iss": False,  # verified manually below
                 },
             )
+
+            # Manually verify issuer against the allowed set
+            if payload.get("iss") not in self.allowed_issuers:
+                raise AuthenticationError(
+                    f"Invalid issuer. Expected one of {self.allowed_issuers}, "
+                    f"got {payload.get('iss')!r}"
+                )
 
             # Manually verify audience
             token_aud = payload.get("aud")
@@ -198,11 +213,11 @@ class JWTValidator:
 
             return TokenPayload.from_dict(payload)
 
-        except ExpiredSignatureError as e:
+        except jwt.ExpiredSignatureError as e:
             raise AuthenticationError("Token has expired") from e
-        except JWTClaimsError as e:
-            raise AuthenticationError(f"Invalid token claims: {e}") from e
-        except JWTError as e:
+        except jwt.InvalidTokenError as e:
+            # Base class for every other PyJWT failure (bad signature, wrong
+            # algorithm, missing/invalid claim, malformed token).
             raise AuthenticationError(f"Invalid token: {e}") from e
         except httpx.HTTPError as e:
             logger.error("Failed to fetch JWKS: %s", e)

--- a/app/stardag-api/src/stardag_api/auth/jwt.py
+++ b/app/stardag-api/src/stardag_api/auth/jwt.py
@@ -168,8 +168,21 @@ class JWTValidator:
 
             # Convert the JWK to a public key object PyJWT can verify with.
             # from_jwk's return type is the RSA public|private union; a signing
-            # JWK (kty=RSA, n/e, no d) yields a public key.
-            public_key = cast(RSAPublicKey, RSAAlgorithm.from_jwk(json.dumps(key)))
+            # JWK (kty=RSA, n/e, no d) yields a public key. A malformed JWK
+            # raises InvalidKeyError/ValueError (neither is a
+            # jwt.InvalidTokenError), so map them here — otherwise a bad key in
+            # the JWKS would surface as a 500 instead of an auth failure.
+            try:
+                public_key = cast(RSAPublicKey, RSAAlgorithm.from_jwk(json.dumps(key)))
+            except (
+                jwt.exceptions.InvalidKeyError,
+                ValueError,
+                TypeError,
+                KeyError,
+            ) as e:
+                raise AuthenticationError(
+                    f"Malformed signing key in JWKS for kid {kid!r}: {e}"
+                ) from e
 
             # Decode and validate the token. PyJWT verifies the signature and
             # expiry; algorithms=["RS256"] is what prevents an "alg":"none" or
@@ -198,7 +211,15 @@ class JWTValidator:
                     f"got {payload.get('iss')!r}"
                 )
 
-            # Manually verify audience
+            # Manually verify audience. Note the deliberate `if token_aud:`:
+            # a token with no `aud` is NOT rejected here. Cognito *access*
+            # tokens legitimately omit `aud` (they scope via `client_id` /
+            # `scope`), so requiring `aud` would break SDK auth against a
+            # Cognito-backed deployment. Such tokens are still gated by
+            # signature + issuer above. Tightening this (e.g. checking
+            # `client_id` against an allowlist when `aud` is absent) is a
+            # possible future hardening, but must not simply reject aud-less
+            # tokens. See the security-scanning follow-ups.
             token_aud = payload.get("aud")
             if token_aud:
                 # aud can be a string or list

--- a/app/stardag-api/src/stardag_api/auth/tokens.py
+++ b/app/stardag-api/src/stardag_api/auth/tokens.py
@@ -15,8 +15,7 @@ from typing import Any
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from jose import JWTError, jwt
-from jose.exceptions import ExpiredSignatureError, JWTClaimsError
+import jwt
 
 from stardag_api.config import jwt_settings
 
@@ -164,7 +163,7 @@ class InternalTokenManager:
             )
             self._key_id = hashlib.sha256(public_key_bytes).hexdigest()[:16]
 
-        # Cache PEM representations for jose library
+        # Cache PEM representations for PyJWT (encode/decode take PEM directly)
         self._private_key_pem = self._private_key.private_bytes(
             encoding=serialization.Encoding.PEM,
             format=serialization.PrivateFormat.PKCS8,
@@ -270,11 +269,11 @@ class InternalTokenManager:
             )
             return SessionTokenPayload.from_dict(payload)
 
-        except ExpiredSignatureError as e:
+        except jwt.ExpiredSignatureError as e:
             raise TokenExpiredError("Token has expired") from e
-        except JWTClaimsError as e:
-            raise TokenInvalidError(f"Invalid token claims: {e}") from e
-        except JWTError as e:
+        except jwt.InvalidTokenError as e:
+            # Base class for every other PyJWT failure (bad signature, wrong
+            # issuer/audience, missing claim, malformed token).
             raise TokenInvalidError(f"Invalid token: {e}") from e
 
     def validate_token(self, token: str) -> InternalTokenPayload:
@@ -305,11 +304,11 @@ class InternalTokenManager:
             )
             return InternalTokenPayload.from_dict(payload)
 
-        except ExpiredSignatureError as e:
+        except jwt.ExpiredSignatureError as e:
             raise TokenExpiredError("Token has expired") from e
-        except JWTClaimsError as e:
-            raise TokenInvalidError(f"Invalid token claims: {e}") from e
-        except JWTError as e:
+        except jwt.InvalidTokenError as e:
+            # Base class for every other PyJWT failure (bad signature, wrong
+            # issuer/audience, missing claim, malformed token).
             raise TokenInvalidError(f"Invalid token: {e}") from e
 
     def get_jwks(self) -> dict[str, Any]:

--- a/app/stardag-api/tests/test_auth.py
+++ b/app/stardag-api/tests/test_auth.py
@@ -954,3 +954,52 @@ async def test_validate_rejects_unknown_kid():
         m.return_value = jwks
         with pytest.raises(AuthenticationError, match="[Kk]ey"):
             await validator.validate_token(token)
+
+
+@pytest.mark.asyncio
+async def test_validate_malformed_jwk_raises_auth_error_not_500():
+    """A malformed JWK in the JWKS must map to AuthenticationError, not leak a
+    raw ValueError/InvalidKeyError (which would surface as a 500)."""
+    _, jwks = _rsa_keypair_and_jwk(kid="test-kid")
+    # Corrupt the key material: non-base64 modulus.
+    jwks["keys"][0]["n"] = "!!!not-base64!!!"
+    private_pem, _ = _rsa_keypair_and_jwk()
+    token = _sign(private_pem, _base_claims(), kid="test-kid")
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks
+        with pytest.raises(AuthenticationError):
+            await validator.validate_token(token)
+
+
+@pytest.mark.asyncio
+async def test_validate_non_rsa_jwk_raises_auth_error_not_500():
+    """A non-RSA key co-published in the JWKS and selected by a hostile `kid`
+    must map to AuthenticationError (401), not a raw InvalidKeyError (500).
+    IdPs commonly publish EC keys alongside RSA ones."""
+    import base64
+
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    ec_key = ec.generate_private_key(ec.SECP256R1())
+    nums = ec_key.public_key().public_numbers()
+
+    def _b64url(n: int) -> str:
+        b = n.to_bytes(32, "big")
+        return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+    ec_jwk = {
+        "kid": "test-kid",
+        "kty": "EC",
+        "crv": "P-256",
+        "x": _b64url(nums.x),
+        "y": _b64url(nums.y),
+    }
+    jwks = {"keys": [ec_jwk]}
+    private_pem, _ = _rsa_keypair_and_jwk()
+    token = _sign(private_pem, _base_claims(), kid="test-kid")
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks
+        with pytest.raises(AuthenticationError):
+            await validator.validate_token(token)

--- a/app/stardag-api/tests/test_auth.py
+++ b/app/stardag-api/tests/test_auth.py
@@ -789,3 +789,168 @@ async def test_auth_config_local_mode(
     assert data["oidc_client_id"] is None
     assert data["oidc_ui_client_id"] is None
     assert data["local_registration_enabled"] is False
+
+
+# --- End-to-end external OIDC validation (real RSA signature via JWKS) ---
+#
+# The caching tests above use a stub JWKS and never verify a real signature.
+# These exercise the path the python-jose -> PyJWT swap actually changed:
+# JWK -> key via RSAAlgorithm.from_jwk, RS256 signature verification, and the
+# manual issuer/audience checks.
+
+
+def _rsa_keypair_and_jwk(kid: str = "test-kid"):
+    """Return (private_key_pem, jwks_dict) for a fresh RSA keypair."""
+    import base64
+
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+
+    numbers = private_key.public_key().public_numbers()
+
+    def _b64url(n: int) -> str:
+        length = (n.bit_length() + 7) // 8
+        return base64.urlsafe_b64encode(n.to_bytes(length, "big")).rstrip(b"=").decode()
+
+    jwks = {
+        "keys": [
+            {
+                "kid": kid,
+                "kty": "RSA",
+                "alg": "RS256",
+                "use": "sig",
+                "n": _b64url(numbers.n),
+                "e": _b64url(numbers.e),
+            }
+        ]
+    }
+    return private_pem, jwks
+
+
+def _sign(private_pem: str, claims: dict, kid: str = "test-kid") -> str:
+    import jwt as pyjwt
+
+    return pyjwt.encode(claims, private_pem, algorithm="RS256", headers={"kid": kid})
+
+
+def _validator(jwks_url: str = "https://idp.example.com/jwks") -> JWTValidator:
+    return JWTValidator(
+        jwks_url=jwks_url,
+        allowed_issuers=["https://idp.example.com", "https://alt.example.com"],
+        audiences=["stardag-ui", "stardag-sdk"],
+        cache_ttl=300,
+    )
+
+
+def _base_claims() -> dict:
+    now = int(time.time())
+    return {
+        "sub": "user-123",
+        "email": "user@example.com",
+        "iss": "https://idp.example.com",
+        "aud": "stardag-ui",
+        "iat": now,
+        "exp": now + 300,
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_real_rsa_signed_token_succeeds():
+    private_pem, jwks = _rsa_keypair_and_jwk()
+    token = _sign(private_pem, _base_claims())
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks
+        payload = await validator.validate_token(token)
+    assert isinstance(payload, TokenPayload)
+    assert payload.sub == "user-123"
+    assert payload.email == "user@example.com"
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_alternate_allowed_issuer():
+    private_pem, jwks = _rsa_keypair_and_jwk()
+    claims = _base_claims() | {"iss": "https://alt.example.com"}
+    token = _sign(private_pem, claims)
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks
+        payload = await validator.validate_token(token)
+    assert payload.iss == "https://alt.example.com"
+
+
+@pytest.mark.asyncio
+async def test_validate_accepts_audience_array():
+    private_pem, jwks = _rsa_keypair_and_jwk()
+    claims = _base_claims() | {"aud": ["some-other", "stardag-sdk"]}
+    token = _sign(private_pem, claims)
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks
+        payload = await validator.validate_token(token)
+    assert payload.sub == "user-123"
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_wrong_issuer():
+    private_pem, jwks = _rsa_keypair_and_jwk()
+    token = _sign(private_pem, _base_claims() | {"iss": "https://evil.example.com"})
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks
+        with pytest.raises(AuthenticationError, match="[Ii]ssuer"):
+            await validator.validate_token(token)
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_wrong_audience():
+    private_pem, jwks = _rsa_keypair_and_jwk()
+    token = _sign(private_pem, _base_claims() | {"aud": "not-ours"})
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks
+        with pytest.raises(AuthenticationError, match="[Aa]udience"):
+            await validator.validate_token(token)
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_expired_token():
+    private_pem, jwks = _rsa_keypair_and_jwk()
+    now = int(time.time())
+    token = _sign(private_pem, _base_claims() | {"iat": now - 600, "exp": now - 300})
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks
+        with pytest.raises(AuthenticationError, match="expired"):
+            await validator.validate_token(token)
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_signature_from_different_key():
+    # Token signed by key A, JWKS advertises key B (same kid) -> bad signature.
+    private_a, _ = _rsa_keypair_and_jwk()
+    _, jwks_b = _rsa_keypair_and_jwk()
+    token = _sign(private_a, _base_claims())
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks_b
+        with pytest.raises(AuthenticationError):
+            await validator.validate_token(token)
+
+
+@pytest.mark.asyncio
+async def test_validate_rejects_unknown_kid():
+    private_pem, jwks = _rsa_keypair_and_jwk(kid="real-kid")
+    token = _sign(private_pem, _base_claims(), kid="unknown-kid")
+    validator = _validator()
+    with patch.object(validator, "_fetch_jwks", new_callable=AsyncMock) as m:
+        m.return_value = jwks
+        with pytest.raises(AuthenticationError, match="[Kk]ey"):
+            await validator.validate_token(token)

--- a/app/stardag-api/uv.lock
+++ b/app/stardag-api/uv.lock
@@ -435,18 +435,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
-]
-
-[[package]]
 name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -811,15 +799,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -983,6 +962,23 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "pyright"
 version = "1.1.411"
 source = { registry = "https://pypi.org/simple" }
@@ -1049,25 +1045,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1129,18 +1106,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]
@@ -1233,10 +1198,9 @@ dependencies = [
     { name = "httpx" },
     { name = "mako" },
     { name = "packaging" },
-    { name = "pyasn1" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "python-jose", extra = ["cryptography"] },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "starlette" },
     { name = "urllib3" },
@@ -1265,10 +1229,9 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "mako", specifier = ">=1.3.12" },
     { name = "packaging", specifier = ">=23.0" },
-    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pydantic", specifier = ">=2.8.2" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3.0" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "urllib3", specifier = ">=2.7.0" },


### PR DESCRIPTION
python-jose is unmaintained and is the sole reason `ecdsa` (Minerva timing attack, **no upstream fix**), `rsa` and `pyasn1` are in the tree. This swaps it for `PyJWT[crypto]`.

## Changes
- **`auth/tokens.py`** (internal RS256 tokens): direct substitution — PyJWT `encode`/`decode` take the PEM keys and the same issuer/audience/options.
- **`auth/jwt.py`** (external OIDC via JWKS): JWK → public key via `RSAAlgorithm.from_jwk`; issuer verified manually against the allowed set (mirroring the existing manual audience check), since PyJWT’s single `issuer`/`audience` params can’t express "one of many". `algorithms=["RS256"]` is retained — this is what blocks `alg=none` / HS256 key-confusion.
- Removes `python-jose`, `ecdsa`, `rsa`, `pyasn1` from the lock; drops the `pyasn1` floor (existed only for jose→rsa).

## Testing
The old suite **stubbed** the JWKS and never verified a real signature. Added end-to-end tests that generate an RSA keypair, sign a token, and assert:
- success (incl. alternate allowed issuer, audience-array claim)
- rejection of wrong issuer, wrong audience, expiry, a signature from a *different* key, and an unknown `kid`

Full API suite passes (644); pyright + ruff clean.

## Note
This touches the auth-critical path and feeds the prod image build. Flagged for review rather than auto-merge.