### PR TITLE
docs(examples): a task that survives preemption and function timeouts

### DIFF
--- a/lib/stardag-examples/src/stardag_examples/modal/README.md
+++ b/lib/stardag-examples/src/stardag_examples/modal/README.md
@@ -9,6 +9,9 @@ Includes examples for:
   triggering and reactive scheduling), detached execution, dynamic deps, and
   registry-backed named concurrency limits — see
   [walkthrough/README.md](walkthrough/README.md)
+- **checkpointing/** - Surviving preemption and function timeouts: a task
+  that checkpoints, raises `sd.ResumableInterruption`, and is resumed by the
+  scheduler until it converges
 - **ml_pipeline/** - ML pipeline on Modal
 - **prefect/** - Modal + Prefect for observability
 

--- a/lib/stardag-examples/src/stardag_examples/modal/checkpointing/app.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/checkpointing/app.py
@@ -1,0 +1,47 @@
+"""Modal app for the checkpoint-and-resume example.
+
+Deliberately configured so the interruption path actually runs: the worker's
+``timeout`` is far shorter than the task needs, so every attempt is cut off
+and resumed until the work is done.
+
+Usage:
+    stardag modal deploy app.py
+    python main.py
+"""
+
+import sys
+
+import modal
+import stardag.integration.modal as sd_modal
+
+# Must match local Python version for Modal serialization compatibility.
+python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+image = (
+    modal.Image.debian_slim(python_version=python_version)
+    .uv_sync()
+    .add_local_python_source("stardag_examples")
+)
+
+app = sd_modal.StardagApp(
+    "stardag_examples-checkpointing",
+    task_modules=["stardag_examples.modal.checkpointing.task"],
+    builder_settings=sd_modal.FunctionSettings(image=image),
+    worker_settings={
+        # 15s against a task that wants ~40s of work: three or four
+        # interruptions before it converges. `retries=0` on purpose — this
+        # example is about the *scheduler* resuming the task, so letting
+        # Modal retry the input as well would muddy what you see in the UI.
+        #
+        # A real deployment would size `timeout` to the platform maximum and
+        # let the task take as many resumes as it takes; small numbers here
+        # only make the behaviour observable in under a minute.
+        "default": sd_modal.FunctionSettings(image=image, timeout=15, retries=0),
+    },
+    # Nothing to configure for the interruption behaviour: the task asks
+    # to be resumed by raising sd.ResumableInterruption, and the scheduler
+    # obliges up to TickConfig.max_interruptions (default 20).
+    # Reactive scheduling is what resumes the task, and the watchdog is the
+    # backstop if a wake-up is ever lost.
+    watchdog_period_minutes=5,
+)

--- a/lib/stardag-examples/src/stardag_examples/modal/checkpointing/main.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/checkpointing/main.py
@@ -1,0 +1,14 @@
+"""Trigger the checkpointing example.
+
+Watch the task go RUNNING → INTERRUPTED → RUNNING several times in the UI
+before it completes. Each INTERRUPTED is the worker saying "the platform
+took my container, I checkpointed" — not a failure, and it does not spend
+the task's retry budget.
+"""
+
+from stardag_examples.modal.checkpointing.app import app
+from stardag_examples.modal.checkpointing.task import TrainModel
+
+if __name__ == "__main__":
+    result = app.build_trigger(TrainModel(seed=0), reactive=True)
+    print(f"build_id={result.build_id}")

--- a/lib/stardag-examples/src/stardag_examples/modal/checkpointing/task.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/checkpointing/task.py
@@ -30,13 +30,6 @@ class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
     def target(self) -> sd.DirectoryTarget:
         """A directory, so progress and the result can live side by side.
 
-        ``TargetTask`` rather than ``Task`` because this task owns its
-        target rather than letting a serializer pick one: ``Task.target()``
-        is typed to return the serializer's ``LoadableSaveableFileSystemTarget``,
-        so overriding it with a bare ``DirectoryTarget`` does not typecheck.
-        ``TargetTask[DirectoryTarget]`` is the base for exactly this — a
-        typed target you define, with ``complete()`` derived from it.
-
         ``DirectoryTarget.exists()`` is backed by a ``._DONE`` flag file
         written by ``mark_done()``, so writing a checkpoint inside it does
         **not** make the task look complete. That is the whole reason to
@@ -46,10 +39,6 @@ class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
         return sd.get_directory_target(sd.get_default_relpath(self))
 
     def run(self) -> None:
-        # Bind the directory once. ``target()`` builds a fresh
-        # ``DirectoryTarget`` per call, and each one tracks the sub-targets
-        # *it* handed out, so ``mark_done()`` on a second instance would
-        # write an empty ``._SUB_KEYS`` manifest next to real files.
         directory = self.target()
         checkpoint = directory / "checkpoint.json"
 

--- a/lib/stardag-examples/src/stardag_examples/modal/checkpointing/task.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/checkpointing/task.py
@@ -1,0 +1,84 @@
+"""A task that expects to be killed and resumed until it converges.
+
+The canonical "expected timeout" workload: work that needs more wall-clock
+than the platform's maximum function timeout allows, so it checkpoints and
+is *supposed* to be interrupted repeatedly. See
+``docs/how-to/integrate-modal.md#preemption-and-timeouts``.
+"""
+
+import json
+import time
+
+import stardag as sd
+from stardag.integration.modal import MODAL_INTERRUPTIONS
+
+TOTAL_STEPS = 20
+SECONDS_PER_STEP = 2.0
+
+
+class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
+    """"Trains" for ``TOTAL_STEPS``, surviving any number of interruptions.
+
+    Deliberately slower than the worker's ``timeout`` (see ``app.py``), so
+    a real run *will* be interrupted and resumed several times. That is the
+    whole point of the example — a task like this is not misconfigured, and
+    the platform ending it is not an error.
+    """
+
+    seed: int = 0
+
+    def target(self) -> sd.DirectoryTarget:
+        """A directory, so progress and the result can live side by side.
+
+        ``TargetTask`` rather than ``Task`` because this task owns its
+        target rather than letting a serializer pick one: ``Task.target()``
+        is typed to return the serializer's ``LoadableSaveableFileSystemTarget``,
+        so overriding it with a bare ``DirectoryTarget`` does not typecheck.
+        ``TargetTask[DirectoryTarget]`` is the base for exactly this — a
+        typed target you define, with ``complete()`` derived from it.
+
+        ``DirectoryTarget.exists()`` is backed by a ``._DONE`` flag file
+        written by ``mark_done()``, so writing a checkpoint inside it does
+        **not** make the task look complete. That is the whole reason to
+        use one here: a checkpoint is the opposite of a result — it says
+        "not done, but do not start over".
+        """
+        return sd.get_directory_target(sd.get_default_relpath(self))
+
+    def run(self) -> None:
+        checkpoint = self.target() / "checkpoint.json"
+
+        state = {"step": 0, "loss": 10.0}
+        if checkpoint.exists():
+            with checkpoint.open("r") as handle:
+                state = json.load(handle)
+        print(f"TrainModel(seed={self.seed}): resuming from step {state['step']}")
+
+        try:
+            while state["step"] < TOTAL_STEPS:
+                time.sleep(SECONDS_PER_STEP)
+                state = {"step": state["step"] + 1, "loss": state["loss"] * 0.9}
+                print(f"  step {state['step']}/{TOTAL_STEPS}, loss {state['loss']:.4f}")
+        except MODAL_INTERRUPTIONS:
+            # Exactly the two exceptions the platform ends an execution
+            # with: KeyboardInterrupt when it reclaims the container, and
+            # modal.exception.InputCancellation when the function timeout
+            # fires. Catching this tuple rather than BaseException is
+            # load-bearing — a NameError is a BaseException too, and
+            # answering one with "resume me" would run a deterministic bug
+            # until the interruption budget is gone.
+            with checkpoint.open("w") as handle:
+                json.dump(state, handle)
+            print(f"  interrupted at step {state['step']}; checkpointed")
+            # The load-bearing line. Raising this is the ONLY way a task
+            # asks to be resumed — an interruption left to propagate is a
+            # failure, on the reading that a task with no plan for being
+            # interrupted either hung or has too small a timeout.
+            raise sd.ResumableInterruption(
+                f"checkpointed at step {state['step']}"
+            ) from None
+
+        with (self.target() / "result.json").open("w") as handle:
+            json.dump({"steps": state["step"], "loss": state["loss"]}, handle)
+        # Only now is the task complete.
+        self.target().mark_done()

--- a/lib/stardag-examples/src/stardag_examples/modal/checkpointing/task.py
+++ b/lib/stardag-examples/src/stardag_examples/modal/checkpointing/task.py
@@ -17,7 +17,7 @@ SECONDS_PER_STEP = 2.0
 
 
 class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
-    """"Trains" for ``TOTAL_STEPS``, surviving any number of interruptions.
+    """Pretends to train for ``TOTAL_STEPS``, surviving any interruptions.
 
     Deliberately slower than the worker's ``timeout`` (see ``app.py``), so
     a real run *will* be interrupted and resumed several times. That is the
@@ -46,7 +46,12 @@ class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
         return sd.get_directory_target(sd.get_default_relpath(self))
 
     def run(self) -> None:
-        checkpoint = self.target() / "checkpoint.json"
+        # Bind the directory once. ``target()`` builds a fresh
+        # ``DirectoryTarget`` per call, and each one tracks the sub-targets
+        # *it* handed out, so ``mark_done()`` on a second instance would
+        # write an empty ``._SUB_KEYS`` manifest next to real files.
+        directory = self.target()
+        checkpoint = directory / "checkpoint.json"
 
         state = {"step": 0, "loss": 10.0}
         if checkpoint.exists():
@@ -78,7 +83,7 @@ class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
                 f"checkpointed at step {state['step']}"
             ) from None
 
-        with (self.target() / "result.json").open("w") as handle:
+        with (directory / "result.json").open("w") as handle:
             json.dump({"steps": state["step"], "loss": state["loss"]}, handle)
         # Only now is the task complete.
-        self.target().mark_done()
+        directory.mark_done()

--- a/lib/stardag-examples/uv.lock
+++ b/lib/stardag-examples/uv.lock
@@ -4306,7 +4306,7 @@ wheels = [
 
 [[package]]
 name = "stardag"
-version = "0.18.0"
+version = "0.19.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4319,9 +4319,9 @@ dependencies = [
     { name = "typer" },
     { name = "uuid6" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/44/4e/6849bacaf9f622b93f50e196493912b05d953efff142e1648834232aef68/stardag-0.18.0.tar.gz", hash = "sha256:a8781e97a13adc8cee6518589b3c7cc4e7e3b472481992c715a8f8bf4741d1c9", size = 797703, upload-time = "2026-08-11T17:50:36.437Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/3f/7d4dccd0a125f01ee1922895207ab93a9853e1150c3513971824f47ec03e/stardag-0.19.0.tar.gz", hash = "sha256:a9525257548a00b3ecf034b8cd94f681595b3ad8ca97dda92423201b6dfb33c9", size = 848286, upload-time = "2026-08-13T06:59:51.572Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/a9/d1828c89a4e773c3fbe66c531c4994123719bdc90d905583c154c0fd0200/stardag-0.18.0-py3-none-any.whl", hash = "sha256:dedaa1eec217e50efc064dc3c9c89f7792d3d633d226fe3e48a6a40414aac9fe", size = 371096, upload-time = "2026-08-11T17:50:34.709Z" },
+    { url = "https://files.pythonhosted.org/packages/db/01/c945e2ba0cc2f3eed83f11052cc5b25dce13f13356f9ff65c1ef895012bc/stardag-0.19.0-py3-none-any.whl", hash = "sha256:f33dc9449919b835cbaa042953f49e6fadc3666d54bb5421f1a1f484fd251594", size = 399192, upload-time = "2026-08-13T06:59:49.717Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The runnable counterpart to the recipe added in #245 / #250.

> **Do not merge until v0.19.0 is on PyPI.** See "Why CI is red", below.

## What it demonstrates

A "trainer" that wants ~40s of work against a worker with a **15s** timeout,
so it is genuinely interrupted three or four times and genuinely has to
resume to finish. Demonstrating the API on a task that completes first time
would show nothing.

```python
except MODAL_INTERRUPTIONS:            # preemption OR the function timeout
    with checkpoint.open("w") as f:
        json.dump(state, f)
    raise sd.ResumableInterruption(f"checkpointed at step {state['step']}") from None
```

Three things it exists to get right, each the thing people get wrong:

- **Catch `MODAL_INTERRUPTIONS`, not `BaseException`.** A `NameError` is a
  `BaseException` too, and answering one with "resume me" runs a
  deterministic failure until the budget is gone. Commented at the line
  where it bites.
- **Raise `sd.ResumableInterruption`.** It is the only way a task gets
  resumed; an interruption left to propagate stays a failure, which is the
  right answer for a task that hung or has too small a `timeout`.
- **The checkpoint is not the result.** It lives inside the task's
  `DirectoryTarget`, whose completion is the `._DONE` flag that
  `mark_done()` writes — so progress written beside the result cannot be
  mistaken for it.

`retries=0` on the worker on purpose: this example is about the *scheduler*
resuming the task, and letting Modal retry the input too would muddy what
you see in the UI.

## Verified end-to-end, not just imported

Deployed to a self-hosted Modal+Neon stack and run twice (once after a
base-class correction, below). The build's frontier over time:

```
[  10.1s] running      attempts=1 interrupts=0
[  31.1s] interrupted  attempts=1 interrupts=1
[  35.3s] running      attempts=1 interrupts=1
[  52.3s] interrupted  attempts=1 interrupts=2
[  56.5s] running      attempts=1 interrupts=2
[  73.3s] interrupted  attempts=1 interrupts=3
[  81.9s] running      attempts=1 interrupts=3
BUILD STATUS: completed
```

and the task's event log:

```
task_pending × 1   task_started × 12   task_interrupted × 3   task_completed × 1
task_failed  × 0
```

Two things worth reading off that:

- **`attempts` stays at 1** across three interruptions — interruptions do
  not spend the retry budget, which is the property the separate
  `max_interruptions` budget exists for.
- **Completion is itself the proof that resumption works.** Each attempt
  gets 15s against 40s of work, so a task restarting from zero could never
  finish.

(The 12 starts are 3 per execution — claim, ref-recording, worker
self-report. Expected and pre-existing; see #263.)

## A real bug this caught

The first version subclassed `sd.Task[None]` and overrode `target()` to
return a `DirectoryTarget`. It ran fine, and pyright rejected it:
`Task.target()` is typed to return the serializer's
`LoadableSaveableFileSystemTarget[LoadedT]`, so a bare `DirectoryTarget` is
an incompatible override. The right base is
**`sd.TargetTask[sd.DirectoryTarget]`** — a task that owns its target, with
`complete()` derived from it. Corrected, redeployed and re-run; the trace
above is from the corrected version.

Worth knowing because the how-to's inline recipe shows the `try/except`
without the class declaration, so it is easy to reach for `sd.Task`.

## Why CI is red, and when it goes green

`lib/stardag-examples` installs the **published** stardag from PyPI, so
`pyright-stardag-examples` cannot see APIs that only exist on main:

```
task.py:13 - "MODAL_INTERRUPTIONS" is unknown import symbol
task.py:77 - "ResumableInterruption" is not a known attribute of module "stardag"
```

Those two, and only those two — everything else is clean.

Landing it before the release would mean temporarily switching
`.pre-commit-config.yaml` and `tox.ini` to editable installs (the workflow
the repo documents for exactly this) and reverting afterwards: churn in both
directions for no gain, when the release is imminent.

**To merge, after v0.19.0 publishes:** `cd lib/stardag-examples && uv lock
--upgrade-package stardag`, push, CI goes green.
