### PR TITLE
Release v0.19.0 — a task can survive being interrupted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.19.0] — 2026-08-13
+
 ### Registry API
 
 - **Security (server image `0.1.2`): fixed a SQL injection in the task search
@@ -50,11 +52,25 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### UI
 
+- **A build whose work is done no longer says it needs intervention.** A
+  build that failed waiting on a shared task, which another build later
+  completed, kept showing "Nothing runnable, and no wake-up pending — needs
+  intervention" alongside a status count taken when it failed. The panel now
+  recognises that every root is complete.
+
 - `INTERRUPTED` renders as its own status (orange, beside skipped's amber
   rather than failed's red), is filterable, and offers Retry but not
   Release — an interrupted task holds no claim to release.
 
 ### SDK
+
+- **A `StopAsyncIteration` raised by an async task's loop body is no longer
+  swallowed.** `_drive_async_generator` wrapped its `async for` in
+  `except StopAsyncIteration: pass`, mirroring the sync driver — but `async
+for` consumes the generator's own exhaustion, so the handler could only
+  ever catch one raised by the _loop body_ (a `complete()` check, say).
+  Swallowing that returned `None`, which the caller reads as "task
+  completed" and reports as such. It now propagates.
 
 - **A task can survive preemption and function timeouts** (closes
   [#245](https://github.com/stardag-dev/stardag/issues/245)). The two ways
@@ -107,6 +123,23 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   through `StardagApp`. `nonpreemptible=True` is the direct answer to
   "this task must not be preempted" (3× CPU/memory price, not supported
   for GPU functions).
+
+### Deployment
+
+- **Cognito self-signup now defaults to off** (AWS CDK templates). The user
+  pool was created with `selfSignUpEnabled: true`, so a deployment reachable
+  from the public internet let anyone register — and the Registry API
+  auto-provisions an internal user and personal workspace on first login.
+  It is now a config flag, `COGNITO_ALLOW_SELF_SIGNUP`, defaulting to
+  `false`. **Self-hosters who rely on open registration must set it
+  explicitly.** Note this governs _native_ registration only: with a
+  federated IdP, Cognito still auto-provisions on first login regardless —
+  the README covers the pre-sign-up-Lambda and IdP-side options.
+
+- **Dependency security floors raised** across the API's transitive
+  dependencies, the UI's dev/build tooling, and `aws-cdk-lib`
+  (2.215 → 2.264, picking up a critical handlebars advisory and CDK
+  tooling CVEs). Dev lockfiles relocked and Dependabot configured.
 
 ## [0.18.0] — 2026-08-11
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -26,7 +26,7 @@ import stardag as sd
 from stardag.integration.modal import MODAL_INTERRUPTIONS
 
 
-class TrainModel(sd.Task[None]):
+class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
     def target(self) -> sd.DirectoryTarget:
         return sd.get_directory_target(sd.get_default_relpath(self))
 
@@ -65,6 +65,11 @@ it, so that handler does nothing at all on a timeout.
 completion is a `._DONE` flag written by `mark_done()`, so a checkpoint
 written inside the directory sits beside the result without being mistaken
 for one.
+
+Note the base class: `sd.TargetTask[sd.DirectoryTarget]`, not `sd.Task`.
+`Task` picks your target from its serializer and types `target()`
+accordingly, so returning a bare `DirectoryTarget` from it does not
+typecheck; `TargetTask` is the base for a task that owns its target.
 
 ### What you will see
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,100 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.19.0 — A task can survive being interrupted
+
+Modal takes containers away. It reclaims preemptible instances, and it kills
+a function that hits its timeout. Neither means the task was wrong — but
+until now the SDK had no way to say so, and the way you would naturally
+write the handler made things worse.
+
+To checkpoint, you catch the interruption. Do that and re-raise anything
+derived from `Exception` — a `RuntimeError`, say — and stardag recorded a
+permanent failure and, under `FAIL_FAST`, killed the build. The same task
+with a bare `raise` was restarted and succeeded. One keyword apart, and
+nothing warned you.
+
+**The rule is now: the task decides whether it is resumable.**
+
+```python
+import stardag as sd
+from stardag.integration.modal import MODAL_INTERRUPTIONS
+
+
+class TrainModel(sd.Task[None]):
+    def target(self) -> sd.DirectoryTarget:
+        return sd.get_directory_target(sd.get_default_relpath(self))
+
+    def run(self):
+        checkpoint = self.target() / "checkpoint.json"
+        try:
+            train(resume_from=checkpoint)
+        except MODAL_INTERRUPTIONS:        # preemption OR the function timeout
+            save_checkpoint(checkpoint)
+            raise sd.ResumableInterruption("checkpointed") from None
+        self.target().mark_done()
+```
+
+`sd.ResumableInterruption` is the only way a task gets resumed. An
+interruption you let propagate stays a failure, retried under the ordinary
+`TickConfig.max_attempts` — which is the right answer for both things an
+uncaught interruption can mean: the task hung, or its worker's `timeout` is
+too small. So there is **no configuration** deciding whether a timeout was
+"expected". The task answers that by raising, or by not raising.
+
+Resumption is bounded by the new `TickConfig.max_interruptions` (default
+20), a budget separate from `max_attempts`. It has to be separate: a trainer
+designed to be killed and resumed would otherwise exhaust a budget meant for
+genuine failures and fail the build for the one reason it was built to
+survive.
+
+**Catch `MODAL_INTERRUPTIONS`, never `BaseException`.** It is exactly
+`KeyboardInterrupt` (preemption) and `modal.exception.InputCancellation`
+(the timeout). A blanket catch sweeps up ordinary bugs — a `NameError` is a
+`BaseException` too — and answering one with "resume me" runs a
+deterministic failure until the budget is gone. `except KeyboardInterrupt:`
+is wrong in the other direction: `InputCancellation` is not a subclass of
+it, so that handler does nothing at all on a timeout.
+
+**The checkpoint must not be the task's result.** `DirectoryTarget`
+completion is a `._DONE` flag written by `mark_done()`, so a checkpoint
+written inside the directory sits beside the result without being mistaken
+for one.
+
+### What you will see
+
+The task cycles RUNNING → INTERRUPTED → RUNNING and finishes COMPLETED.
+`INTERRUPTED` is a new task status — non-terminal, holds no execution claim,
+and rendered in the UI as its own thing rather than as a failure. It does
+not spend an attempt: a task resumed three times still reports
+`attempt_count == 1`.
+
+### Scope
+
+**Reactive builds only.** `sd.build` / `build_aio` have no resumption path —
+a timed-out execution fails the task there, as it always did, because only a
+scheduler tick can respawn one.
+
+**Requires a Registry API serving `POST /builds/{id}/tasks/{id}/interrupt`.**
+Against an older server the SDK logs a warning and records nothing, which is
+exactly its behaviour before this existed — a version skew degrades to the
+old recovery path, never to a failed build. Deploy the server before
+upgrading the SDK, as usual.
+
+### Also
+
+`FunctionSettings` gains **`nonpreemptible`** (the direct answer to "this
+task must not be preempted" — 3x CPU/memory price, no GPU support) and
+**`startup_timeout`**.
+
+An interruption is now reported by the worker inside the grace window the
+platform allows, rather than being inferred later by a scheduler probing a
+corpse. That releases the execution claim and its concurrency-limit slots
+immediately and wakes the scheduler directly — so recovery no longer depends
+on having configured the watchdog.
+
+---
+
 ## v0.18.0 — Builds collaborate, and triggering got fast
 
 Reactive scheduling worked until something went wrong. Then a build sat at


### PR DESCRIPTION
> **For review — do not merge without approval.**

Cuts `[Unreleased]` as **0.19.0** and adds the SDK release notes. No version
bump: `hatch-vcs` derives it from the `v0.19.0` tag, which is pushed after
this merges.

## The headline

`sd.ResumableInterruption` — a task that catches a platform interruption,
checkpoints, and asks to be resumed. Full write-up in `RELEASE_NOTES.md`;
the short version is that the previous behaviour turned the *correct* way to
write a checkpoint handler into a permanently failed build, and one keyword
separated that from a task that resumed and succeeded.

## What I added beyond the interruption work

Six changes have merged since `v0.18.0` with no changelog entry. All are now
covered:

| | where it landed |
| --- | --- |
| #248 async driver no longer swallows `StopAsyncIteration` from the loop body | SDK |
| #243 a build whose roots are complete stops claiming it needs intervention | UI |
| #254 **Cognito self-signup now defaults to off** | Deployment |
| #255–258 dependency security floors (API transitives, UI tooling, `aws-cdk-lib` 2.215 → 2.264) | Deployment |

Two I deliberately left out: #247 (the `_app.py` module split) and #251
(`mkstemp` in the integration-test harness). Both are internal — no public
surface changed, and neither is something a reader of this file is looking
for. Say the word if you'd rather they were listed.

## The one an upgrader has to act on

**#254 changes a default.** The AWS CDK templates created the Cognito user
pool with `selfSignUpEnabled: true`, so a publicly reachable deployment let
anyone register — and the Registry API auto-provisions a user and personal
workspace on first login. It is now `COGNITO_ALLOW_SELF_SIGNUP`, defaulting
to `false`.

A self-hoster who *relied* on open registration will find it closed after
redeploying, so the entry says so explicitly. It also carries the caveat
from that PR: the flag governs native registration only — with a federated
IdP, Cognito still auto-provisions on first login regardless.

Note this reaches people through the CDK templates, not through
`pip install stardag`, which is why it is in the changelog's Deployment
section and not in the release notes.

## Scope split

`RELEASE_NOTES.md` says on its own first line that it is the SDK
(`pip install stardag`) and that everything else lives in `CHANGELOG.md`. So
the release notes cover only the interruption feature, and the API/UI/
Deployment changes are changelog-only. That is also why the notes spend
their space on what a *user writes* — catch `MODAL_INTERRUPTIONS`, raise
`ResumableInterruption`, keep the checkpoint out of the result — rather than
on the internals.

Two boundaries are stated there because they will otherwise be found the
hard way:

- **Resumption is reactive-only.** `sd.build` / `build_aio` have no
  resumption path; only a scheduler tick can respawn.
- **The server needs `POST /builds/{id}/tasks/{id}/interrupt`.** Against an
  older one the SDK logs a warning and records nothing — its pre-existing
  behaviour, never a failed build. Deploy the server first, as usual.

## Follow-ups already open

- #263 — three `TASK_STARTED` events per execution, now multiplied by every
  resumption.
- #264 — the runnable checkpoint-and-resume example, held until this
  publishes so it can use the PyPI build (its CI is red on exactly the two
  unpublished symbols until then).
