### PR TITLE
fix(docs): the checkpoint recipe needs TargetTask, not Task

### DIFF
--- a/.claude/skills/stardag/sdk-advanced.md
+++ b/.claude/skills/stardag/sdk-advanced.md
@@ -398,7 +398,7 @@ import stardag as sd
 from stardag.integration.modal import MODAL_INTERRUPTIONS
 
 
-class TrainModel(sd.Task[None]):
+class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
     def target(self) -> sd.DirectoryTarget:
         return sd.get_directory_target(sd.get_default_relpath(self))
 

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -900,7 +900,7 @@ import stardag as sd
 from stardag.integration.modal import MODAL_INTERRUPTIONS
 
 
-class TrainModel(sd.Task[None]):
+class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
     seed: int = 0
 
     def target(self) -> sd.DirectoryTarget:
@@ -940,6 +940,11 @@ Three things carry it:
   `mark_done()` is what makes the task complete. Writing a checkpoint does
   not — `DirectoryTarget.exists()` is backed by a `._DONE` flag file — so
   progress and completion cannot be confused.
+- **`TargetTask`, not `Task`.** `sd.Task` picks your target from its
+  serializer and types `target()` as the serializer's
+  `LoadableSaveableFileSystemTarget`, so returning a bare `DirectoryTarget`
+  from it does not typecheck. `sd.TargetTask[sd.DirectoryTarget]` is the
+  base for a task that owns its target, with `complete()` derived from it.
 
 #### What happens if you _don't_ catch it
 

--- a/docs/docs/reference/exceptions.md
+++ b/docs/docs/reference/exceptions.md
@@ -138,7 +138,7 @@ import stardag as sd
 from stardag.integration.modal import MODAL_INTERRUPTIONS
 
 
-class TrainModel(sd.Task[None]):
+class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
     def target(self) -> sd.DirectoryTarget:
         return sd.get_directory_target(sd.get_default_relpath(self))
 

--- a/lib/stardag/src/stardag/exceptions.py
+++ b/lib/stardag/src/stardag/exceptions.py
@@ -19,7 +19,10 @@ class ResumableInterruption(StardagError):
     or hitting its function timeout — and persisting whatever progress you
     had::
 
-        class TrainModel(sd.Task[None]):
+        class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
+            def target(self) -> sd.DirectoryTarget:
+                return sd.get_directory_target(sd.get_default_relpath(self))
+
             def run(self):
                 try:
                     train(resume_from=self.target() / "checkpoint.json")


### PR DESCRIPTION
Every copy of the checkpoint-and-resume recipe merged in #250 declared

```python
class TrainModel(sd.Task[None]):
    def target(self) -> sd.DirectoryTarget: ...
```

which runs but does not typecheck. `Task.target()` is typed to return the
serializer's `LoadableSaveableFileSystemTarget[LoadedT]`, so returning a bare
`DirectoryTarget` from it is an incompatible override. The right base is
**`sd.TargetTask[sd.DirectoryTarget]`** — a task that owns its target, with
`complete()` derived from it.

Four copies, all fixed:

| file | |
| --- | --- |
| `docs/how-to/integrate-modal.md` | the recipe users read first — also gains a line saying *why* `TargetTask` |
| `docs/reference/exceptions.md` | |
| `lib/stardag/src/stardag/exceptions.py` | the `ResumableInterruption` docstring, which additionally called `self.target() / "checkpoint.json"` without ever showing a `target()` returning something that supports `/` — it now does |
| `.claude/skills/stardag/sdk-advanced.md` | |

(The fifth lives in the release notes on #265 and is fixed there once this
lands.)

## How it was found, and the lesson

pyright, on the **runnable** example in #264 — which is the argument for
having written one. Four prose copies of the same snippet shipped in #250
because prose snippets are not typechecked and nobody had run it.

So this time the corrected snippet was checked rather than assumed: extracted
verbatim to a scratch module and run through pyright against the local SDK,
**0 errors**.