### PR TITLE
Bump aws-cdk CLI to 2.1136.0 to match aws-cdk-lib 2.264

### DIFF
--- a/infra/aws-cdk/package-lock.json
+++ b/infra/aws-cdk/package-lock.json
@@ -20,7 +20,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "22.7.9",
         "@types/source-map-support": "^0.5.10",
-        "aws-cdk": "2.1030.0",
+        "aws-cdk": "2.1136.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -1256,9 +1256,9 @@
       }
     },
     "node_modules/aws-cdk": {
-      "version": "2.1030.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1030.0.tgz",
-      "integrity": "sha512-jYgOy1Hqx8cOTWW9On9xpypXLecjOqSZ4X2q5U0Gzd14xI+HLmpaRJV5ILJ8vYrLKVbqjhiog0pdxAC7vwF9uQ==",
+      "version": "2.1136.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1136.0.tgz",
+      "integrity": "sha512-n6kCL9R9uuvb7WXEwiSs3rYGwnTy9AHHmxOT5Pj5/++E4PYz2bLDXIxzoiOMIj5maoyC52PTe/0GezFV+O0ILQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1266,9 +1266,6 @@
       },
       "engines": {
         "node": ">= 18.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
       }
     },
     "node_modules/aws-cdk-lib": {

--- a/infra/aws-cdk/package.json
+++ b/infra/aws-cdk/package.json
@@ -14,7 +14,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "22.7.9",
     "@types/source-map-support": "^0.5.10",
-    "aws-cdk": "2.1030.0",
+    "aws-cdk": "2.1136.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",


### PR DESCRIPTION
The `aws-cdk-lib` bump to 2.264 (handlebars critical + CDK tooling CVEs)
raised the cloud assembly schema this package emits to **54.0.0**, but
left the `aws-cdk` CLI pinned at **2.1030.0**, which reads at most
**48.x.x**.

The pairing is unusable. Any deployment from this package dies at
`cdk synth`, before a single stack is touched:

```
This CDK CLI is not compatible with the CDK library used by your application.
(Cloud assembly schema version mismatch: Maximum schema version supported is
48.x.x, but found 54.0.0. You need at least CLI version 2.1135.1 to read this
manifest.)
```

A deployment hit exactly this. It failed closed — synth is the first
step, so nothing was deployed and no stack was left half-updated — but
the deploy path is blocked until the CLI catches up.

## The fix

`aws-cdk` 2.1030.0 → **2.1136.0**, the newest 2.x CLI, with the lockfile
regenerated. Staying on the 2.x line is deliberate: 3.0 is a major CLI
release, and this is a compatibility fix, not an upgrade.

## Verification

- `npx cdk synth` now gets past the manifest read and all the way
  through template validation on all four stacks. (It still stops at a
  context lookup without credentials, which is expected off-CI.)
- The synthesized templates require **bootstrap stack version 6** — the
  same as before this bump, and far below what a bootstrapped account
  carries — so **no re-bootstrap is needed**.
- `aws-cdk-lib` itself is untouched at 2.264.0; this only moves the CLI.
