### PR TITLE
docs: bind the directory target once in the checkpoint recipe

### DIFF
--- a/.claude/skills/stardag/sdk-advanced.md
+++ b/.claude/skills/stardag/sdk-advanced.md
@@ -403,13 +403,14 @@ class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
         return sd.get_directory_target(sd.get_default_relpath(self))
 
     def run(self):
-        checkpoint = self.target() / "checkpoint.json"
+        directory = self.target()
+        checkpoint = directory / "checkpoint.json"
         try:
             train(resume_from=checkpoint)
         except MODAL_INTERRUPTIONS:        # preemption OR the function timeout
             save_checkpoint(checkpoint)
             raise sd.ResumableInterruption("checkpointed") from None
-        self.target().mark_done()
+        directory.mark_done()
 ```
 
 **Rules:**

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,13 +31,14 @@ class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
         return sd.get_directory_target(sd.get_default_relpath(self))
 
     def run(self):
-        checkpoint = self.target() / "checkpoint.json"
+        directory = self.target()
+        checkpoint = directory / "checkpoint.json"
         try:
             train(resume_from=checkpoint)
         except MODAL_INTERRUPTIONS:        # preemption OR the function timeout
             save_checkpoint(checkpoint)
             raise sd.ResumableInterruption("checkpointed") from None
-        self.target().mark_done()
+        directory.mark_done()
 ```
 
 `sd.ResumableInterruption` is the only way a task gets resumed. An

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -907,7 +907,8 @@ class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
         return sd.get_directory_target(sd.get_default_relpath(self))
 
     def run(self):
-        checkpoint = self.target() / "checkpoint.json"
+        directory = self.target()              # bind once, see below
+        checkpoint = directory / "checkpoint.json"
 
         state = {"step": 0}
         if checkpoint.exists():
@@ -923,9 +924,9 @@ class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
                 json.dump(state, f)
             raise sd.ResumableInterruption("checkpointed") from None
 
-        with (self.target() / "model.pkl").open("wb") as f:
+        with (directory / "model.pkl").open("wb") as f:
             f.write(serialize(model))
-        self.target().mark_done()              # only now is the task complete
+        directory.mark_done()                  # only now is the task complete
 ```
 
 Three things carry it:
@@ -945,6 +946,13 @@ Three things carry it:
   `LoadableSaveableFileSystemTarget`, so returning a bare `DirectoryTarget`
   from it does not typecheck. `sd.TargetTask[sd.DirectoryTarget]` is the
   base for a task that owns its target, with `complete()` derived from it.
+- **Bind the directory once.** `target()` builds a _new_ `DirectoryTarget`
+  every call, and each instance remembers only the sub-targets it handed
+  out via `/`. Call it once for the checkpoint and again for
+  `mark_done()`, and the instance that marks done has never seen your
+  files, so it writes an empty `._SUB_KEYS` manifest beside them.
+  Completion still works — that is the separate `._DONE` flag — but the
+  directory's own listing of its contents comes out blank.
 
 #### What happens if you _don't_ catch it
 

--- a/docs/docs/reference/exceptions.md
+++ b/docs/docs/reference/exceptions.md
@@ -143,13 +143,14 @@ class TrainModel(sd.TargetTask[sd.DirectoryTarget]):
         return sd.get_directory_target(sd.get_default_relpath(self))
 
     def run(self):
-        checkpoint = self.target() / "checkpoint.json"
+        directory = self.target()
+        checkpoint = directory / "checkpoint.json"
         try:
             train(resume_from=checkpoint)
         except MODAL_INTERRUPTIONS:        # preemption OR the function timeout
             save_checkpoint(checkpoint)
             raise sd.ResumableInterruption("checkpointed") from None
-        self.target().mark_done()
+        directory.mark_done()
 ```
 
 **An interruption you do not catch is a failure**, deliberately. Letting

--- a/lib/stardag/src/stardag/exceptions.py
+++ b/lib/stardag/src/stardag/exceptions.py
@@ -24,11 +24,14 @@ class ResumableInterruption(StardagError):
                 return sd.get_directory_target(sd.get_default_relpath(self))
 
             def run(self):
+                directory = self.target()
+                checkpoint = directory / "checkpoint.json"
                 try:
-                    train(resume_from=self.target() / "checkpoint.json")
+                    train(resume_from=checkpoint)
                 except MODAL_INTERRUPTIONS:
-                    save_checkpoint(self.target() / "checkpoint.json")
+                    save_checkpoint(checkpoint)
                     raise sd.ResumableInterruption("checkpointed") from None
+                directory.mark_done()
 
     **An interruption you do NOT catch is a failure**, deliberately. Letting
     one propagate means the task had no plan for it: either it hung, or the


### PR DESCRIPTION
Found by review on #264, and it affects the recipe as shipped in v0.19.0.

```python
checkpoint = self.target() / "checkpoint.json"   # instance A
...
self.target().mark_done()                        # instance B
```

`target()` builds a **new** `DirectoryTarget` every call, and each
instance tracks only the sub-targets it handed out via `/`. So instance
B has never seen the checkpoint, and `mark_done()` writes an empty
`._SUB_KEYS` manifest next to real files.

Verified both ways with the exact documented recipe:

| form | `._SUB_KEYS` |
| --- | --- |
| two `target()` calls | `''` |
| bound once | `'checkpoint.json\nmodel.pkl'` |

**Completion was never affected** — that rides on the separate `._DONE`
flag, and `complete()` returns `True` either way — and nothing in the SDK
reads `._SUB_KEYS` back. But a directory target that lists none of its own
contents is simply wrong, and it is what every copy of the recipe taught.

## Scope

All five copies: the Modal how-to, the exceptions reference, the skill
bundle, the `ResumableInterruption` docstring, and `RELEASE_NOTES.md`.
The how-to gets a bullet explaining why, alongside the existing
`TargetTask`-not-`Task` one — same class of trap.

Docs and one docstring only; no behaviour change, so no release needed.
Logged under `[Unreleased]`.