### PR TITLE
fix(targets): a user package named `modal` should not break target resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.19.1] — 2026-08-14
+
+### Fixed
+
+- **`0.19.0` could fail at import for anyone who had `modal` installed but
+  was not using it.** `stardag.integration.modal._runner` read
+  `modal.exception.InputCancellation` with only a bare `import modal` in
+  scope, at module level. `exception` is not in modal's `__all__`, and
+  modal's package `__getattr__` raises for anything it does not export, so
+  that attribute exists only when something else in the process has already
+  imported the submodule — an accident of the import graph. Where nothing
+  had, importing the integration raised
+
+  ```
+  AttributeError: module 'modal' has no attribute 'exception'
+  ```
+
+  This was not confined to Modal users.
+  `get_default_prefix_to_target_prototype()` imports the Modal integration to
+  register the `modalvol://` prefix, so the failure landed on the ordinary
+  target-factory path — `get_file_target` / `get_directory_target` — in any
+  process where `modal` was merely present, typically as a transitive
+  dependency. Services that never touched Modal crashed at import.
+
+  Fixed by importing the name out of the submodule
+  (`from modal.exception import InputCancellation`), which does not depend on
+  the parent-package attribute. `_app.py` had the same latent pattern in an
+  `except` clause and is fixed the same way. Affects `0.19.0` only.
+
+- **A broken optional integration no longer takes down the target factory.**
+  The guards in `get_default_prefix_to_target_prototype()` caught only
+  `ImportError` — the "not installed" case — so anything else raised while
+  importing an integration propagated and killed target resolution for every
+  prefix, including purely local ones. They now also catch and log an
+  unexpected failure: the affected prefix drops out of the mapping (using it
+  gives the ordinary unsupported-prefix error) and a warning names the real
+  cause. A genuinely absent dependency stays silent, as before.
+
 ## [0.19.0] — 2026-08-13
 
 ### Registry API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,42 +10,46 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### Fixed
 
-- **A failing optional integration no longer takes down the target factory.**
-  `get_default_prefix_to_target_prototype()` imports `stardag.integration.*`
-  to register the `s3://` and `modalvol://` prefixes, and its guards caught
-  only `ImportError` — the "not installed" case. Anything else raised while
-  importing an integration therefore propagated and killed target resolution
-  for **every** prefix, including purely local ones. A process that merely had
-  `modal` or `boto3` installed, typically as a transitive dependency, and
-  never used either backend, could fail on the ordinary
-  `get_file_target` / `get_directory_target` path.
-
-  The guards now also catch and log an unexpected failure: the affected prefix
-  drops out of the mapping (using it gives the ordinary unsupported-prefix
-  error), and a warning names the real cause. A genuinely absent optional
-  dependency stays silent, as before.
-
-### Changed
-
-- **The Modal integration no longer reaches for `modal.exception` through a
-  bare `import modal`.** `_runner.py` resolved
-  `modal.exception.InputCancellation` at module level, and `_app.py` used
-  `except modal.exception.NotFoundError`. Both relied on the submodule being
-  bound as an attribute of the `modal` package — which it is on every
-  currently supported modal release, but only as a side effect of modal's own
-  `__init__` importing it. `exception` is not in modal's `__all__`, and
-  modal's package `__getattr__` rejects anything it does not export, so the
-  form is a private implementation detail away from
+- **A user package named `modal` no longer breaks target resolution.**
+  Reported from a deployment running `0.19.0`, where `get_directory_target()`
+  failed at import with
 
   ```
   AttributeError: module 'modal' has no attribute 'exception'
   ```
 
-  Both sites now import the name out of the submodule directly, which never
-  consults the parent-package attribute. No behaviour change on any modal
-  version stardag supports (`>=1.0.0`) — this removes a latent dependency on
-  modal's import graph, it does not fix an observed failure on those
-  versions.
+  in a service that did not use Modal at all. Two independent defects had to
+  line up.
+
+  First, the trigger. The service's entrypoint was launched as a script path
+  (`python pkg/service/main.py`, not `python -m`), which puts the script's own
+  directory on `sys.path[0]`. That directory contained a first-party
+  `modal/` subpackage, so **every** `import modal` in the process — stardag's
+  included — resolved to it instead of the installed distribution. `import
+modal` therefore _succeeded_ and returned the wrong module; the failure
+  surfaced only on first attribute access. Nothing on that service's code
+  path had ever imported `stardag.integration.modal` before, which is why the
+  shadowing had been latent and `0.19.0` appeared to cause it.
+
+  Second, why it escalated. `get_default_prefix_to_target_prototype()` imports
+  the optional `stardag.integration.*` backends to register the `s3://` and
+  `modalvol://` prefixes, and guarded those imports against `ImportError` —
+  the "not installed" case — and nothing else. A shadowed `modal` does not
+  raise `ImportError`, so the `AttributeError` propagated out of the factory
+  and killed target resolution for **every** prefix, local paths included.
+
+  Both are fixed. `_runner.py` and `_app.py` no longer resolve
+  `modal.exception` off the parent package — `exception` is not in modal's
+  `__all__`, and the attribute is bound only as a side effect of modal's own
+  `__init__` — so a shadowed or partial `modal` now fails as a plain
+  `ImportError`, which is both accurate and catchable. And the factory's
+  guards now also catch and log an unexpected failure: the affected prefix
+  drops out of the mapping, using it gives the ordinary unsupported-prefix
+  error, and a warning names the cause. A genuinely absent optional dependency
+  stays silent, as before.
+
+  Note the attribute form worked on every modal release stardag supports
+  (`>=1.0.0`); it was the shadowing, not a modal version, that exposed it.
 
 ## [0.19.0] — 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,39 +10,42 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ### Fixed
 
-- **`0.19.0` could fail at import for anyone who had `modal` installed but
-  was not using it.** `stardag.integration.modal._runner` read
-  `modal.exception.InputCancellation` with only a bare `import modal` in
-  scope, at module level. `exception` is not in modal's `__all__`, and
-  modal's package `__getattr__` raises for anything it does not export, so
-  that attribute exists only when something else in the process has already
-  imported the submodule — an accident of the import graph. Where nothing
-  had, importing the integration raised
+- **A failing optional integration no longer takes down the target factory.**
+  `get_default_prefix_to_target_prototype()` imports `stardag.integration.*`
+  to register the `s3://` and `modalvol://` prefixes, and its guards caught
+  only `ImportError` — the "not installed" case. Anything else raised while
+  importing an integration therefore propagated and killed target resolution
+  for **every** prefix, including purely local ones. A process that merely had
+  `modal` or `boto3` installed, typically as a transitive dependency, and
+  never used either backend, could fail on the ordinary
+  `get_file_target` / `get_directory_target` path.
+
+  The guards now also catch and log an unexpected failure: the affected prefix
+  drops out of the mapping (using it gives the ordinary unsupported-prefix
+  error), and a warning names the real cause. A genuinely absent optional
+  dependency stays silent, as before.
+
+### Changed
+
+- **The Modal integration no longer reaches for `modal.exception` through a
+  bare `import modal`.** `_runner.py` resolved
+  `modal.exception.InputCancellation` at module level, and `_app.py` used
+  `except modal.exception.NotFoundError`. Both relied on the submodule being
+  bound as an attribute of the `modal` package — which it is on every
+  currently supported modal release, but only as a side effect of modal's own
+  `__init__` importing it. `exception` is not in modal's `__all__`, and
+  modal's package `__getattr__` rejects anything it does not export, so the
+  form is a private implementation detail away from
 
   ```
   AttributeError: module 'modal' has no attribute 'exception'
   ```
 
-  This was not confined to Modal users.
-  `get_default_prefix_to_target_prototype()` imports the Modal integration to
-  register the `modalvol://` prefix, so the failure landed on the ordinary
-  target-factory path — `get_file_target` / `get_directory_target` — in any
-  process where `modal` was merely present, typically as a transitive
-  dependency. Services that never touched Modal crashed at import.
-
-  Fixed by importing the name out of the submodule
-  (`from modal.exception import InputCancellation`), which does not depend on
-  the parent-package attribute. `_app.py` had the same latent pattern in an
-  `except` clause and is fixed the same way. Affects `0.19.0` only.
-
-- **A broken optional integration no longer takes down the target factory.**
-  The guards in `get_default_prefix_to_target_prototype()` caught only
-  `ImportError` — the "not installed" case — so anything else raised while
-  importing an integration propagated and killed target resolution for every
-  prefix, including purely local ones. They now also catch and log an
-  unexpected failure: the affected prefix drops out of the mapping (using it
-  gives the ordinary unsupported-prefix error) and a warning names the real
-  cause. A genuinely absent dependency stays silent, as before.
+  Both sites now import the name out of the submodule directly, which never
+  consults the parent-package attribute. No behaviour change on any modal
+  version stardag supports (`>=1.0.0`) — this removes a latent dependency on
+  modal's import graph, it does not fix an observed failure on those
+  versions.
 
 ## [0.19.0] — 2026-08-13
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,32 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.19.1 — Import fix for `0.19.0`
+
+**Upgrade if you are on `0.19.0`.** No API changes, nothing to migrate.
+
+`0.19.0` could raise at import time:
+
+```
+AttributeError: module 'modal' has no attribute 'exception'
+```
+
+You did not have to be using Modal to hit it. The Modal integration read
+`modal.exception` off a bare `import modal`, and the target factory imports
+that integration to register the `modalvol://` prefix — so the crash landed
+on `get_file_target` / `get_directory_target`, the ordinary path every task
+with a target goes through. Any environment with the `modal` package merely
+present, often as a transitive dependency, could be affected. Whether it
+actually raised came down to import order: `modal.exception` is bound on the
+`modal` package only if something else imported the submodule first, so the
+same code worked in one environment and failed in the next.
+
+Also in this release: an optional integration that fails to import for an
+unexpected reason no longer takes the target factory with it. Only that
+integration's prefix drops out, with a logged warning naming the cause — the
+guard previously handled "not installed" and nothing else, which is what
+turned the bug above into a hard crash instead of a degraded `modalvol://`.
+
 ## v0.19.0 — A task can survive being interrupted
 
 Modal takes containers away. It reclaims preemptible instances, and it kills

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -51,6 +51,31 @@ prefix drops out of the mapping, asking for it afterwards gives the ordinary
 optional dependency stays silent, as before, so the warning means something
 when you see it.
 
+### Recognising this in your own code
+
+The generalisable part has nothing to do with modal. When a local package
+shadows an installed distribution, `import x` **succeeds** — it just returns
+the wrong module. So there is no `ImportError` anywhere, nothing fails at
+import time, and the first symptom is an `AttributeError` at whatever line
+first touches the real package's API. That line is usually deep inside a
+library, so the traceback blames the dependency, and CPython's message for a
+missing module attribute is often identical to what the real package's own
+`__getattr__` would have produced.
+
+If you are staring at an `AttributeError` on a dependency that makes no
+sense, check what you actually imported:
+
+```python
+import x
+print(x.__file__, getattr(x, "__version__", None))
+```
+
+A path outside `site-packages` is the answer. The usual cause is running an
+entrypoint as a script path (`python pkg/service/main.py`), which puts that
+script's own directory on `sys.path[0]` — so any sibling module or package
+of your entrypoint can shadow any installed distribution. `python -m
+pkg.service.main` does not do this.
+
 Worth saying plainly: the old attribute form worked on every modal release
 stardag supports. No modal version is implicated — it was the name collision
 that exposed the assumption.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,33 +6,54 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
-## v0.19.1 — A broken optional integration no longer takes the process down
+## v0.19.1 — A user package named `modal` no longer breaks target resolution
 
 No API changes, nothing to migrate.
 
-`get_file_target` and `get_directory_target` go through the target factory,
-which imports the optional `stardag.integration.*` backends to find out which
-URI prefixes it can serve. Those imports were guarded against the backend not
-being _installed_ — and against nothing else. So if an integration was
-installed but failed to import for any other reason, the exception propagated
-out of the factory and took **every** prefix with it, including plain local
-paths. A process that had `modal` or `boto3` present as a transitive
-dependency, and used neither, could fail on the ordinary target path because
-of a backend it never asked for.
+**If you have a package or module of your own named `modal` (or `boto3`),
+upgrade.** On `0.19.0` that could make `get_file_target` and
+`get_directory_target` fail at import — in a service that never used Modal or
+S3 — with
 
-Now the integration's own prefix simply drops out of the mapping and a warning
-names the cause. Asking for that prefix afterwards gives the ordinary
-"unsupported prefix" error rather than an import traceback, and everything
-else keeps working. A genuinely absent optional dependency stays silent, as
-before — so the warning means something when you see it.
+```
+AttributeError: module 'modal' has no attribute 'exception'
+```
 
-Also in this release, and the reason the above got looked at: the Modal
-integration used to reach `modal.exception` through a bare `import modal`,
-which works only because modal's own `__init__` happens to import that
-submodule. It is not part of modal's public surface, and modal's package
-`__getattr__` rejects anything outside `__all__`. Both call sites now import
-the name from the submodule directly. This is hardening, not a fix for an
-observed failure: the old form works on every modal release stardag supports.
+Here is the whole shape of it, because the interesting part is how ordinary
+each half is.
+
+A deployment launched its entrypoint as a script path — `python
+pkg/service/main.py` rather than `python -m pkg.service.main`. CPython puts
+that script's own directory on `sys.path[0]`, and that directory happened to
+contain a first-party `modal/` subpackage. From then on every `import modal`
+anywhere in the process resolved to it, stardag's included. Note this does
+not raise: the import _succeeds_ and hands back the wrong module, so nothing
+notices until something touches an attribute.
+
+What made it stardag's problem is the target factory. It imports the optional
+`stardag.integration.*` backends to find out which URI prefixes it can serve,
+and guarded those imports against the backend not being _installed_ —
+`ImportError` — and nothing else. A shadowed `modal` is not an `ImportError`.
+So the `AttributeError` came up through the factory and took **every** prefix
+with it, plain local paths included. The service could not build a target at
+all, because of a backend it never asked for. It had simply never imported
+`stardag.integration.modal` before; `0.19.0` reaches it to register
+`modalvol://`, which is why a long-latent name collision surfaced as a
+version bump.
+
+Both halves are fixed. The Modal integration no longer reaches
+`modal.exception` through the parent package, so a shadowed or partial modal
+now fails as a plain `ImportError` — accurate, and catchable by everything
+that already guards these imports. And the factory's guards catch and log an
+unexpected failure rather than only a missing dependency: that integration's
+prefix drops out of the mapping, asking for it afterwards gives the ordinary
+"unsupported prefix" error, and a warning names the cause. A genuinely absent
+optional dependency stays silent, as before, so the warning means something
+when you see it.
+
+Worth saying plainly: the old attribute form worked on every modal release
+stardag supports. No modal version is implicated — it was the name collision
+that exposed the assumption.
 
 ## v0.19.0 — A task can survive being interrupted
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,31 +6,33 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
-## v0.19.1 — Import fix for `0.19.0`
+## v0.19.1 — A broken optional integration no longer takes the process down
 
-**Upgrade if you are on `0.19.0`.** No API changes, nothing to migrate.
+No API changes, nothing to migrate.
 
-`0.19.0` could raise at import time:
+`get_file_target` and `get_directory_target` go through the target factory,
+which imports the optional `stardag.integration.*` backends to find out which
+URI prefixes it can serve. Those imports were guarded against the backend not
+being _installed_ — and against nothing else. So if an integration was
+installed but failed to import for any other reason, the exception propagated
+out of the factory and took **every** prefix with it, including plain local
+paths. A process that had `modal` or `boto3` present as a transitive
+dependency, and used neither, could fail on the ordinary target path because
+of a backend it never asked for.
 
-```
-AttributeError: module 'modal' has no attribute 'exception'
-```
+Now the integration's own prefix simply drops out of the mapping and a warning
+names the cause. Asking for that prefix afterwards gives the ordinary
+"unsupported prefix" error rather than an import traceback, and everything
+else keeps working. A genuinely absent optional dependency stays silent, as
+before — so the warning means something when you see it.
 
-You did not have to be using Modal to hit it. The Modal integration read
-`modal.exception` off a bare `import modal`, and the target factory imports
-that integration to register the `modalvol://` prefix — so the crash landed
-on `get_file_target` / `get_directory_target`, the ordinary path every task
-with a target goes through. Any environment with the `modal` package merely
-present, often as a transitive dependency, could be affected. Whether it
-actually raised came down to import order: `modal.exception` is bound on the
-`modal` package only if something else imported the submodule first, so the
-same code worked in one environment and failed in the next.
-
-Also in this release: an optional integration that fails to import for an
-unexpected reason no longer takes the target factory with it. Only that
-integration's prefix drops out, with a logged warning naming the cause — the
-guard previously handled "not installed" and nothing else, which is what
-turned the bug above into a hard crash instead of a degraded `modalvol://`.
+Also in this release, and the reason the above got looked at: the Modal
+integration used to reach `modal.exception` through a bare `import modal`,
+which works only because modal's own `__init__` happens to import that
+submodule. It is not part of modal's public surface, and modal's package
+`__getattr__` rejects anything outside `__all__`. Both call sites now import
+the name from the submodule directly. This is hardening, not a fix for an
+observed failure: the old form works on every modal release stardag supports.
 
 ## v0.19.0 — A task can survive being interrupted
 

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -20,6 +20,7 @@ import typing
 from uuid import UUID
 
 import modal
+from modal.exception import NotFoundError as ModalNotFoundError
 
 from stardag import BaseTask
 from stardag.build import BuildSummary
@@ -530,7 +531,7 @@ class StardagApp:
         assert self.stardag_api_key_secret is not None
         try:
             self.stardag_api_key_secret.hydrate()
-        except modal.exception.NotFoundError as e:
+        except ModalNotFoundError as e:
             name = self._api_key_secret_name
             secret_name_flag = (
                 "" if name == "stardag-api-key" else f" --secret-name {name}"

--- a/lib/stardag/src/stardag/integration/modal/_runner.py
+++ b/lib/stardag/src/stardag/integration/modal/_runner.py
@@ -54,12 +54,13 @@ from stardag.utils.env import temp_env_vars
 # cancellation" instead of failing every worker import.
 #
 # Import the name out of the submodule rather than reaching for
-# ``modal.exception`` off a bare ``import modal``: ``exception`` is not in
-# modal's ``__all__``, and modal's package ``__getattr__`` raises
-# ``AttributeError`` for anything it does not export. The attribute exists
-# only when something else in the process happened to import the submodule
-# first, so the bare-``modal`` form works or not depending on import order
-# elsewhere in the environment.
+# ``modal.exception`` off a bare ``import modal``. The attribute form works
+# on every modal release we support, but only as a side effect: ``exception``
+# is not in modal's ``__all__``, and modal's package ``__getattr__`` raises
+# for anything it does not export — it resolves purely because modal's own
+# ``__init__`` imports the submodule early, which binds it on the package.
+# Depending on that is depending on a private detail of modal's import
+# graph. The from-import never consults the parent attribute at all.
 try:
     from modal.exception import InputCancellation as _InputCancellationImpl
 

--- a/lib/stardag/src/stardag/integration/modal/_runner.py
+++ b/lib/stardag/src/stardag/integration/modal/_runner.py
@@ -49,12 +49,23 @@ from stardag.exceptions import ResumableInterruption
 from stardag.registry._base import NoOpRegistry, registry_provider
 from stardag.utils.env import temp_env_vars
 
-# Modal's own "this input was cancelled" BaseException. Looked up rather
-# than imported so a client that predates or renames it degrades to "we
-# cannot recognise a cancellation" instead of failing every worker import.
-_InputCancellation: type[BaseException] | None = getattr(
-    modal.exception, "InputCancellation", None
-)
+# Modal's own "this input was cancelled" BaseException, imported so that a
+# client that predates or renames it degrades to "we cannot recognise a
+# cancellation" instead of failing every worker import.
+#
+# Import the name out of the submodule rather than reaching for
+# ``modal.exception`` off a bare ``import modal``: ``exception`` is not in
+# modal's ``__all__``, and modal's package ``__getattr__`` raises
+# ``AttributeError`` for anything it does not export. The attribute exists
+# only when something else in the process happened to import the submodule
+# first, so the bare-``modal`` form works or not depending on import order
+# elsewhere in the environment.
+try:
+    from modal.exception import InputCancellation as _InputCancellationImpl
+
+    _InputCancellation: type[BaseException] | None = _InputCancellationImpl
+except ImportError:  # pragma: no cover - depends on the installed modal
+    _InputCancellation = None
 
 MODAL_INTERRUPTIONS: tuple[type[BaseException], ...] = tuple(
     e for e in (KeyboardInterrupt, _InputCancellation) if e is not None

--- a/lib/stardag/src/stardag/target/_factory.py
+++ b/lib/stardag/src/stardag/target/_factory.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import typing
 from contextlib import contextmanager
 
@@ -6,6 +7,8 @@ from stardag.config import DEFAULT_TARGET_ROOT_KEY, config_provider
 from stardag.target import DirectoryTarget, FileTarget, LocalFileTarget
 from stardag.target._base import RemoteFileTarget
 from stardag.utils.resource_provider import resource_provider
+
+logger = logging.getLogger(__name__)
 
 # A class or callable that takes a (fully qualifed/"absolute") path (/uri) and returns
 # a FileTarget.
@@ -16,6 +19,25 @@ PrefixToFileTargetPrototype = typing.Mapping[str, FileTargetPrototype]
 
 
 def get_default_prefix_to_target_prototype() -> dict[str, FileTargetPrototype]:
+    """The built-in URI-prefix → target mapping, with optional integrations.
+
+    Every stardag process that resolves a target root goes through here, so
+    this is a load-bearing import site: it reaches into
+    ``stardag.integration.*`` for backends whose third-party dependency may
+    or may not be installed. An integration that is merely *absent* is the
+    expected case (``ImportError`` → that prefix is unsupported), but an
+    integration that is installed and **broken** must not take the process
+    with it. A user who only ever writes to local files or S3 should not
+    fail to import a target because, say, the Modal integration does not
+    like the ``modal`` version that happens to be in the environment — they
+    would get an error from a backend they never asked for, on a code path
+    that has nothing to do with it.
+
+    So each guard is deliberately broad, and logs rather than passes: the
+    prefix drops out of the mapping, and anyone who *does* use it gets the
+    ordinary "unsupported prefix" error from
+    :meth:`TargetFactory.get_target` plus a warning naming the real cause.
+    """
     prefix_to_target_prototype: dict[str, FileTargetPrototype] = {
         "/": LocalFileTarget,
     }
@@ -29,6 +51,12 @@ def get_default_prefix_to_target_prototype() -> dict[str, FileTargetPrototype]:
         prefix_to_target_prototype["s3://"] = s3_target_from_path
     except ImportError:
         pass
+    except Exception:
+        logger.warning(
+            "The stardag S3 integration is installed but failed to import; "
+            "the 's3://' target prefix is unavailable in this process.",
+            exc_info=True,
+        )
 
     # Modal integration
     try:
@@ -37,6 +65,13 @@ def get_default_prefix_to_target_prototype() -> dict[str, FileTargetPrototype]:
         prefix_to_target_prototype["modalvol://"] = get_modal_target
     except ImportError:
         pass
+    except Exception:
+        logger.warning(
+            "The stardag Modal integration is installed but failed to "
+            "import; the 'modalvol://' target prefix is unavailable in this "
+            "process.",
+            exc_info=True,
+        )
 
     return prefix_to_target_prototype
 

--- a/lib/stardag/tests/test_integration/test_modal/test_import.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_import.py
@@ -65,9 +65,8 @@ _UNBOUND_EXCEPTION_SUBMODULE = textwrap.dedent(
 
     # `exception` is not in modal's __all__, and modal's package-level
     # __getattr__ raises AttributeError for anything it does not export.
-    # So `modal.exception` is bound only when something else in the process
-    # already imported the submodule — an accident of the import graph, not
-    # a guarantee. Recreate the case where nothing did.
+    # The attribute is bound only because modal's own __init__ imports the
+    # submodule — an implementation detail, not a guarantee. Take it away.
     try:
         del modal.exception
     except AttributeError:
@@ -91,23 +90,26 @@ _UNBOUND_EXCEPTION_SUBMODULE = textwrap.dedent(
 def test_import_survives_unbound_modal_exception_submodule():
     """Importing the integration must not depend on `modal.exception` being bound.
 
-    Regression test. `_runner.py` read `modal.exception.InputCancellation`
-    with only a bare `import modal` in scope, at module level. That works
-    exactly when some other import in the process has already pulled in the
-    `modal.exception` submodule, which binds it as an attribute on the
-    parent package — and blows up with
+    `_runner.py` used to read `modal.exception.InputCancellation` with only
+    a bare `import modal` in scope. That resolves on every modal release we
+    support — but only as a side effect of modal's own `__init__` importing
+    the submodule early, which binds it as an attribute on the package.
+    `exception` is not in modal's `__all__`, and modal's package
+    `__getattr__` raises
 
         AttributeError: module 'modal' has no attribute 'exception'
 
-    when nothing has. Because `get_default_prefix_to_target_prototype()`
-    imports the Modal integration for the `modalvol://` prefix, the failure
-    landed on *any* stardag user with `modal` merely present in the
-    environment, on the ordinary target-factory path, whether or not they
-    used Modal for anything.
+    for anything it does not export. So the old form was one refactor of
+    modal's import graph away from breaking, on a code path that matters:
+    `get_default_prefix_to_target_prototype()` imports this package to
+    register the `modalvol://` prefix, so any failure here reaches users who
+    merely have `modal` installed and never touch Modal.
 
-    The ordinary tests in this file cannot catch it: the pytest process has
-    other modal-importing modules loaded, so the attribute is always bound
-    by the time they run. Hence the subprocess and the explicit unbind.
+    This test pins the property rather than the accident. It unbinds the
+    attribute to assert the import does not consult it — the unbind is
+    deliberately artificial, because no supported modal version leaves it
+    unbound on its own. A subprocess is required: by the time this module is
+    collected, pytest has modal loaded and the attribute bound.
     """
     result = subprocess.run(
         [sys.executable, "-c", _UNBOUND_EXCEPTION_SUBMODULE],

--- a/lib/stardag/tests/test_integration/test_modal/test_import.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_import.py
@@ -3,7 +3,15 @@
 Regression test for https://github.com/stardag-dev/stardag/issues/113
 where `from modal.gpu import GPU_T` broke on modal >= 1.4 because the
 `modal.gpu` module was removed.
+
+Also covers the sibling failure mode: reaching a *submodule* off a bare
+``import modal``. See
+:func:`test_import_survives_unbound_modal_exception_submodule`.
 """
+
+import subprocess
+import sys
+import textwrap
 
 import pytest
 
@@ -45,3 +53,68 @@ def test_function_settings_gpu_accepts_list():
         gpu=["A10G", "T4"],
     )
     assert settings.get("gpu") == ["A10G", "T4"]
+
+
+# Runs in a subprocess because the setup is a mutation of the interpreter's
+# `modal` package object that must precede the very first import of
+# `stardag.integration.modal` — by the time this test module is collected,
+# the pytest process has long since imported both.
+_UNBOUND_EXCEPTION_SUBMODULE = textwrap.dedent(
+    """
+    import modal
+
+    # `exception` is not in modal's __all__, and modal's package-level
+    # __getattr__ raises AttributeError for anything it does not export.
+    # So `modal.exception` is bound only when something else in the process
+    # already imported the submodule — an accident of the import graph, not
+    # a guarantee. Recreate the case where nothing did.
+    try:
+        del modal.exception
+    except AttributeError:
+        pass
+    assert not hasattr(modal, "exception"), "test setup failed to unbind it"
+
+    import stardag.integration.modal  # noqa: F401
+    from stardag.integration.modal import MODAL_INTERRUPTIONS
+
+    # Importing must not merely survive: the interruption tuple has to stay
+    # populated. Silently degrading to KeyboardInterrupt-only would mean
+    # function timeouts stop being recognised as resumable.
+    assert KeyboardInterrupt in MODAL_INTERRUPTIONS, MODAL_INTERRUPTIONS
+    assert len(MODAL_INTERRUPTIONS) == 2, MODAL_INTERRUPTIONS
+
+    print("ok")
+    """
+)
+
+
+def test_import_survives_unbound_modal_exception_submodule():
+    """Importing the integration must not depend on `modal.exception` being bound.
+
+    Regression test. `_runner.py` read `modal.exception.InputCancellation`
+    with only a bare `import modal` in scope, at module level. That works
+    exactly when some other import in the process has already pulled in the
+    `modal.exception` submodule, which binds it as an attribute on the
+    parent package — and blows up with
+
+        AttributeError: module 'modal' has no attribute 'exception'
+
+    when nothing has. Because `get_default_prefix_to_target_prototype()`
+    imports the Modal integration for the `modalvol://` prefix, the failure
+    landed on *any* stardag user with `modal` merely present in the
+    environment, on the ordinary target-factory path, whether or not they
+    used Modal for anything.
+
+    The ordinary tests in this file cannot catch it: the pytest process has
+    other modal-importing modules loaded, so the attribute is always bound
+    by the time they run. Hence the subprocess and the explicit unbind.
+    """
+    result = subprocess.run(
+        [sys.executable, "-c", _UNBOUND_EXCEPTION_SUBMODULE],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"import failed with modal.exception unbound:\n{result.stderr}"
+    )
+    assert "ok" in result.stdout

--- a/lib/stardag/tests/test_integration/test_modal/test_import.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_import.py
@@ -4,9 +4,9 @@ Regression test for https://github.com/stardag-dev/stardag/issues/113
 where `from modal.gpu import GPU_T` broke on modal >= 1.4 because the
 `modal.gpu` module was removed.
 
-Also covers the sibling failure mode: reaching a *submodule* off a bare
-``import modal``. See
-:func:`test_import_survives_unbound_modal_exception_submodule`.
+Also covers the sibling failure mode: a *consumer* package named ``modal``
+shadowing the distribution on ``sys.path``. See
+:func:`test_a_shadowed_modal_package_does_not_break_the_target_factory`.
 """
 
 import subprocess
@@ -55,68 +55,84 @@ def test_function_settings_gpu_accepts_list():
     assert settings.get("gpu") == ["A10G", "T4"]
 
 
-# Runs in a subprocess because the setup is a mutation of the interpreter's
-# `modal` package object that must precede the very first import of
-# `stardag.integration.modal` — by the time this test module is collected,
-# the pytest process has long since imported both.
-_UNBOUND_EXCEPTION_SUBMODULE = textwrap.dedent(
+# A first-party package named `modal` on `sys.path` ahead of site-packages
+# shadows the distribution for the whole process. This is not exotic: running
+# an entrypoint as a script path (`python pkg/service/main.py` rather than
+# `python -m ...`) puts that script's own directory on `sys.path[0]`, so any
+# `modal/` subpackage sitting next to it wins. `import modal` then succeeds
+# and returns the wrong thing — which is why an `except ImportError` guard
+# around the integration never fired.
+_SHADOWED_MODAL = textwrap.dedent(
     """
+    import sys
+
+    sys.path.insert(0, sys.argv[1])
+
     import modal
 
-    # `exception` is not in modal's __all__, and modal's package-level
-    # __getattr__ raises AttributeError for anything it does not export.
-    # The attribute is bound only because modal's own __init__ imports the
-    # submodule — an implementation detail, not a guarantee. Take it away.
+    assert "site-packages" not in (modal.__file__ or ""), modal.__file__
+    assert not hasattr(modal, "exception")
+
+    # 1. The integration must fail *loudly and correctly*: a shadowed modal
+    #    genuinely means "the Modal integration is unavailable here", which
+    #    is ImportError. Reaching `modal.exception` off the parent package
+    #    instead produced `AttributeError: module 'modal' has no attribute
+    #    'exception'` — a message identical to CPython's own, blamed on
+    #    modal, and invisible to every `except ImportError` in the stack.
     try:
-        del modal.exception
-    except AttributeError:
+        import stardag.integration.modal  # noqa: F401
+    except ImportError:
         pass
-    assert not hasattr(modal, "exception"), "test setup failed to unbind it"
+    except AttributeError as e:
+        raise AssertionError(f"shadowed modal must raise ImportError, got {e!r}")
+    else:
+        raise AssertionError("expected the integration import to fail")
 
-    import stardag.integration.modal  # noqa: F401
-    from stardag.integration.modal import MODAL_INTERRUPTIONS
+    # 2. And the rest of stardag must not care. This is the actual incident:
+    #    a service that never used Modal could not resolve a local or S3
+    #    target, because the target factory imports the Modal integration to
+    #    register `modalvol://`.
+    from stardag.target._factory import get_default_prefix_to_target_prototype
 
-    # Importing must not merely survive: the interruption tuple has to stay
-    # populated. Silently degrading to KeyboardInterrupt-only would mean
-    # function timeouts stop being recognised as resumable.
-    assert KeyboardInterrupt in MODAL_INTERRUPTIONS, MODAL_INTERRUPTIONS
-    assert len(MODAL_INTERRUPTIONS) == 2, MODAL_INTERRUPTIONS
+    prefixes = get_default_prefix_to_target_prototype()
+    assert "/" in prefixes, prefixes
+    assert "modalvol://" not in prefixes, prefixes
 
     print("ok")
     """
 )
 
 
-def test_import_survives_unbound_modal_exception_submodule():
-    """Importing the integration must not depend on `modal.exception` being bound.
+def test_a_shadowed_modal_package_does_not_break_the_target_factory(tmp_path):
+    """A consumer package named `modal` must cost the Modal integration, not stardag.
 
-    `_runner.py` used to read `modal.exception.InputCancellation` with only
-    a bare `import modal` in scope. That resolves on every modal release we
-    support — but only as a side effect of modal's own `__init__` importing
-    the submodule early, which binds it as an attribute on the package.
-    `exception` is not in modal's `__all__`, and modal's package
-    `__getattr__` raises
+    Regression test for a reported incident, reproduced here exactly: the
+    affected service ran its entrypoint as a script path, which put the
+    entrypoint's directory on `sys.path[0]`, and that directory contained a
+    first-party `modal/` subpackage. Every `import modal` in that process —
+    stardag's included — resolved to the empty local package.
 
-        AttributeError: module 'modal' has no attribute 'exception'
+    Two things then went wrong, and this test covers both. The integration
+    read `modal.exception` off the parent package, so the failure presented
+    as `AttributeError` rather than `ImportError`; and the target factory
+    guarded its integration imports against `ImportError` only. The
+    `AttributeError` went straight through and took down target resolution
+    for every prefix, so a service that had never used Modal for anything
+    could not build a local target.
 
-    for anything it does not export. So the old form was one refactor of
-    modal's import graph away from breaking, on a code path that matters:
-    `get_default_prefix_to_target_prototype()` imports this package to
-    register the `modalvol://` prefix, so any failure here reaches users who
-    merely have `modal` installed and never touch Modal.
-
-    This test pins the property rather than the accident. It unbinds the
-    attribute to assert the import does not consult it — the unbind is
-    deliberately artificial, because no supported modal version leaves it
-    unbound on its own. A subprocess is required: by the time this module is
-    collected, pytest has modal loaded and the attribute bound.
+    Runs in a subprocess: the shadowing has to be in place before the first
+    `import modal` in the process, and pytest imported the real one long ago.
     """
+    shadow = tmp_path / "modal"
+    shadow.mkdir()
+    (shadow / "__init__.py").write_text("")
+
     result = subprocess.run(
-        [sys.executable, "-c", _UNBOUND_EXCEPTION_SUBMODULE],
+        [sys.executable, "-c", _SHADOWED_MODAL, str(tmp_path)],
         capture_output=True,
         text=True,
     )
     assert result.returncode == 0, (
-        f"import failed with modal.exception unbound:\n{result.stderr}"
+        f"shadowed-modal handling regressed:\n{result.stdout}\n{result.stderr}"
     )
     assert "ok" in result.stdout

--- a/lib/stardag/tests/test_target/test__factory.py
+++ b/lib/stardag/tests/test_target/test__factory.py
@@ -46,12 +46,16 @@ def test_local_prefix_is_always_present():
 def test_broken_modal_integration_does_not_break_the_factory(caplog):
     """A broken Modal integration costs the `modalvol://` prefix, nothing else.
 
-    Regression test for the incident where `stardag.integration.modal`
-    raised `AttributeError` at import (reading the `modal.exception`
-    submodule off a bare `import modal`). The guard here caught only
-    `ImportError`, so the `AttributeError` propagated and killed the target
-    factory — taking down services that had `modal` installed as a
-    transitive dependency and never used a `modalvol://` root.
+    The guard here used to catch only `ImportError` — "the optional
+    dependency is not installed". Any *other* exception escaping the
+    integration's import propagated out of the factory and killed target
+    resolution for every prefix, so a fault confined to one backend took
+    down processes that had `modal` installed as a transitive dependency and
+    never used a `modalvol://` root.
+
+    `AttributeError` is used here because that is the shape reported from a
+    deployment, but the contract under test is the general one: whatever the
+    integration raises, it costs that integration's prefix and no more.
     """
     boom = AttributeError("module 'modal' has no attribute 'exception'")
 

--- a/lib/stardag/tests/test_target/test__factory.py
+++ b/lib/stardag/tests/test_target/test__factory.py
@@ -1,0 +1,102 @@
+"""Tests for the default URI-prefix → target mapping.
+
+The theme here is blast radius. ``get_default_prefix_to_target_prototype``
+is on the path of every target resolution in every stardag process, and it
+imports optional third-party integrations to populate its mapping. An
+integration that is broken in the installed environment must cost the user
+that one prefix, not the process.
+"""
+
+import logging
+from unittest import mock
+
+from stardag.target._factory import get_default_prefix_to_target_prototype
+
+_MODAL_TARGET_MODULE = "stardag.integration.modal._target"
+_S3_MODULE = "stardag.integration.aws.s3"
+
+
+def _import_raising(module_name: str, exc: BaseException):
+    """Patch ``__import__`` so importing ``module_name`` raises ``exc``.
+
+    Note this models the exception escaping *module execution*, which is
+    what a broken integration actually does — the failing statement is at
+    the top level of the imported module (or of a package ``__init__`` it
+    pulls in), and whatever it raises propagates unchanged.
+
+    A stub module in ``sys.modules`` does not model it: ``from x import y``
+    turns a missing attribute into ``ImportError``, so the stub would
+    always land in the "integration not installed" branch and the test
+    would pass against the very bug it is meant to catch.
+    """
+    real_import = __import__
+
+    def _import(name, *args, **kwargs):
+        if name == module_name:
+            raise exc
+        return real_import(name, *args, **kwargs)
+
+    return mock.patch("builtins.__import__", _import)
+
+
+def test_local_prefix_is_always_present():
+    assert "/" in get_default_prefix_to_target_prototype()
+
+
+def test_broken_modal_integration_does_not_break_the_factory(caplog):
+    """A broken Modal integration costs the `modalvol://` prefix, nothing else.
+
+    Regression test for the incident where `stardag.integration.modal`
+    raised `AttributeError` at import (reading the `modal.exception`
+    submodule off a bare `import modal`). The guard here caught only
+    `ImportError`, so the `AttributeError` propagated and killed the target
+    factory — taking down services that had `modal` installed as a
+    transitive dependency and never used a `modalvol://` root.
+    """
+    boom = AttributeError("module 'modal' has no attribute 'exception'")
+
+    with _import_raising(_MODAL_TARGET_MODULE, boom):
+        with caplog.at_level(logging.WARNING):
+            mapping = get_default_prefix_to_target_prototype()
+
+    assert "modalvol://" not in mapping
+    # The prefixes that have nothing to do with Modal are unaffected.
+    assert "/" in mapping
+    # ...and the cause is reported rather than swallowed, so a user who
+    # *did* want modalvol:// can tell a broken integration from an absent
+    # one instead of only seeing "unsupported prefix" downstream.
+    assert any("Modal integration" in record.message for record in caplog.records), (
+        caplog.text
+    )
+
+
+def test_broken_s3_integration_does_not_break_the_factory(caplog):
+    """Same contract for the S3 integration guard."""
+    boom = RuntimeError("botocore exploded on import")
+
+    with _import_raising(_S3_MODULE, boom):
+        with caplog.at_level(logging.WARNING):
+            mapping = get_default_prefix_to_target_prototype()
+
+    assert "s3://" not in mapping
+    assert "/" in mapping
+    assert any("S3 integration" in record.message for record in caplog.records), (
+        caplog.text
+    )
+
+
+def test_absent_integration_is_silent(caplog):
+    """A *missing* optional dependency is the expected case — no warning.
+
+    Distinguishing this from the broken case is the point of keeping the
+    `ImportError` branch separate: warning on every plain install would
+    train users to ignore the warning that matters.
+    """
+    absent = ImportError(f"No module named {_MODAL_TARGET_MODULE!r}")
+
+    with _import_raising(_MODAL_TARGET_MODULE, absent):
+        with caplog.at_level(logging.WARNING):
+            mapping = get_default_prefix_to_target_prototype()
+
+    assert "modalvol://" not in mapping
+    assert not [r for r in caplog.records if "Modal integration" in r.message]


### PR DESCRIPTION
## Root cause

`0.19.0` could fail at import with

```
AttributeError: module 'modal' has no attribute 'exception'
```

in a service that does not use Modal. Reported from a deployment; root cause
confirmed by reproducing the reported traceback frame for frame against the
`v0.19.0` tree (`__init__.py:57` → `_app.py:53` → `_runner.py:56`).

**A user package named `modal` was shadowing the distribution.** The
entrypoint was launched as a script path (`python pkg/service/main.py`, not
`python -m`), so CPython put the entrypoint's own directory on `sys.path[0]`
— and that directory contained a first-party `modal/` subpackage. Every
`import modal` in the process resolved to it, stardag's included.

The important property: **that import succeeds.** It returns the wrong
module, so nothing notices until an attribute is touched. And CPython's
message for a missing module attribute is character-for-character modal's own
package `__getattr__` message, which is why the log reads like a modal bug.

The service had simply never imported `stardag.integration.modal` before.
`0.19.0` reaches it from the target factory to register `modalvol://`, which
is why a long-latent name collision surfaced as a version bump.

*(An earlier revision of this description proposed a different mechanism —
that `modal.exception` is bound only if something imports the submodule
first. That was wrong: measured `True` on 1.0.0 through 1.5.3, i.e. every
version matching our floor. Thanks to the reporter for pushing back on it.)*

## What this changes

### 1. The target factory no longer dies with an optional integration

`get_default_prefix_to_target_prototype()` imports `stardag.integration.*` to
discover which URI prefixes it can serve, and guarded those imports against
`ImportError` — "the optional dependency is not installed" — and nothing
else. A shadowed `modal` is not an `ImportError`, so the `AttributeError`
propagated out of the factory and killed target resolution for **every**
prefix, plain local paths included. A service that never used Modal could not
build a target at all.

The guards now also catch and log an unexpected failure: that integration's
prefix drops out of the mapping, asking for it afterwards gives the ordinary
unsupported-prefix error, and a warning names the real cause. A genuinely
absent optional dependency stays silent as before, so the warning means
something when it appears.

### 2. `modal.exception` is no longer reached through the parent package

`_runner.py` resolved `modal.exception.InputCancellation` at module level;
`_app.py` used `except modal.exception.NotFoundError`. Both rely on the
submodule being bound as an attribute of the `modal` package — true on every
modal release we support, but only as a side effect of modal's own `__init__`
importing it. `exception` is not in modal's `__all__`.

Both now import the name from the submodule. Under a shadowed or partial
`modal` that fails as a plain `ImportError`, which is *accurate* — the Modal
integration genuinely is unavailable — and catchable by every guard that
already exists, instead of an `AttributeError` misattributed to a dependency.

No modal version is implicated in the incident. The name collision exposed
the assumption.

## Tests

`test_a_shadowed_modal_package_does_not_break_the_target_factory` puts an
empty `modal/` package on `sys.path` in a subprocess — the real thing, no
simulation — and asserts both halves: the integration import fails as
`ImportError` rather than `AttributeError`, and the target factory still
serves `/` while omitting `modalvol://`.

`tests/test_target/test__factory.py` covers broken-vs-absent for both the
Modal and S3 guards. The broken case patches `__import__` to raise, modelling
an exception escaping *module execution*. A stub module in `sys.modules` does
not model it: `from x import y` converts a missing attribute into
`ImportError`, so the stub lands in the "not installed" branch and passes
against the very bug it is meant to catch.

Verification note: these fail against the unfixed code only when all three
changed source files are reverted **together**. Reverting them one at a time
does not discriminate — the `_app.py` change raises `ImportError` earlier in
the chain and short-circuits `_runner.py`.

Full `lib/stardag` suite green (1309 passed).

## Scope

No API change, nothing to migrate. `CHANGELOG.md` and `RELEASE_NOTES.md`
updated for a `v0.19.1` patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
