### PR TITLE
Modal: an app-supplied container setup hook that runs in every container

### DIFF
--- a/.claude/skills/stardag/sdk-advanced.md
+++ b/.claude/skills/stardag/sdk-advanced.md
@@ -323,6 +323,7 @@ app = StardagApp(
     worker_settings={"default": FunctionSettings(image=image)},
     watchdog_period_minutes=5,          # recommended with reactive mode
     limit_key_selector=lambda t: [],    # named concurrency-limit keys per task
+    container_setup=my_container_setup, # runs once in EVERY container
 )
 
 # After `stardag modal deploy`:
@@ -334,6 +335,16 @@ result = app.build_trigger(root_task, reactive=True)  # experimental: no
                                                    # scheduler ticks drive it
 app.build_spawn(root_task)                         # legacy fire-and-forget
 ```
+
+**Container setup**: `container_setup` (a zero-arg callable, `ContainerSetup`)
+runs once per container at the top of all five registered functions —
+`build`, `worker_*`, `tick`, `bootstrap`, `tick_watchdog` — before stardag's
+logging default. It is the only setup hook that reaches the reactive
+functions (a `tick`/`bootstrap`/`tick_watchdog` container has no `Builder`
+or `Runner` in it). It complements rather than replaces `Builder.setup(tasks)`
+(per build, `build` container only) and `Runner.setup(task)` (per task).
+Define it in a module importable inside the container — it is pickled by
+reference, like `worker_selector`.
 
 Worker executions are **detached** Modal function calls by default: they
 survive orchestrator restarts (resumed builds re-attach instead of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,19 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   Additive — an app that passes nothing behaves exactly as before. The new
   `ContainerSetup` type alias is exported from `stardag.integration.modal`.
 
+- **`finalize()` now warns about workers nothing can route to.** An app that
+  declares several `worker_settings` but no `worker_selector` sends every task
+  to `"default"`, so its other tiers are deployed and never reached — and the
+  symptom is indistinguishable from a healthy deployment, because the build
+  succeeds, just entirely on the wrong worker. The warning names the
+  unreachable workers and fires at deploy, not on the app object the
+  triggering process constructs. Passing a selector explicitly — even one that
+  always returns `"default"` — silences it. Per-trigger overrides
+  (`build_spawn`/`build_trigger(worker_selector=...)`) remain a valid way to
+  route a **resident** build; reactive builds reject them, since later ticks
+  could not honour them, which is why the app-level selector is what the
+  warning points at.
+
 ## [0.19.1] — 2026-08-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,13 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
   Additive — an app that passes nothing behaves exactly as before. The new
   `ContainerSetup` type alias is exported from `stardag.integration.modal`.
 
+- **`finalize()` now fails an app with no `"default"` worker and no
+  `worker_selector`.** Every task would route to a `worker_default` function
+  the app does not deploy, so the deployment is dead on arrival — previously
+  it deployed cleanly and failed at the first task. Scoped to the
+  no-selector case: an app that declares a selector may omit `"default"` and
+  route everything to its own tiers, which works today and keeps working.
+
 - **`finalize()` now warns about workers nothing can route to.** An app that
   declares several `worker_settings` but no `worker_selector` sends every task
   to `"default"`, so its other tiers are deployed and never reached — and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,58 @@ For detailed SDK migration guides, see [RELEASE_NOTES.md](RELEASE_NOTES.md).
 
 ## [Unreleased]
 
+## [0.20.0] — 2026-08-14
+
+### SDK
+
+- **`StardagApp(container_setup=...)` — one declared place for setup that
+  every Modal container of an app needs.** A zero-argument callable, run once
+  per container at the top of **all five** registered functions: `build`, each
+  `worker_*`, and the reactive `tick`, `bootstrap` and `tick_watchdog`.
+
+  It closes a real gap rather than adding sugar. `finalize()` registers every
+  function with `serialized=True`, so a container unpickles a closure instead
+  of importing the module the app was declared in — and which of the app's
+  modules _do_ get imported was decided by what each closure happened to
+  reference. `build` and `worker_*` close over the app's `build_function` /
+  `run_function`, so their modules are imported and their module-level setup
+  runs; that is the behaviour `StardagApp.__init__` has always documented. But
+  a `bootstrap` container closes over nothing of the app's at all (just the app
+  name, the task-module patterns and two flags), and `tick` / `tick_watchdog`
+  import app code only as a side effect of a supplied `worker_selector` /
+  `limit_key_selector` or of the expanded `task_modules`. Setup that appears to
+  "run everywhere" because it runs in the workers could therefore be silently
+  absent from exactly the containers that drive a reactive build — reported
+  from a deployed app whose storage credentials were prepared by such a
+  routine, whose reactive builds then failed in `bootstrap` at the first
+  completion check.
+
+  Semantics:
+
+  - **Once per container, not once per input** — a worker serves many tasks and
+    a tick container may be reused; the guard lives in stardag so apps do not
+    each write one.
+  - **A hook that raises propagates and is retried on the next input.** It is
+    deliberately not remembered as done on failure, so a container's remaining
+    inputs cannot run silently un-set-up; a deterministic failure fails every
+    input, loudly.
+  - **Runs before stardag's own `logging.basicConfig` default.** `basicConfig`
+    no-ops once the root logger has handlers, so an app that configures root
+    logging in the hook owns log formatting in these containers, and an app
+    that does not still gets the default.
+  - Pickled by reference like `worker_selector`, so **define it in a module
+    importable inside the container** — which is also what makes module-level
+    code in the hook's own module run in every container.
+
+  It complements, and does not replace, `Builder.setup(tasks)` (per build,
+  `build` container only) and `Runner.setup(task)` (per task). For the reactive
+  functions there is no choice to make: a `tick` / `bootstrap` /
+  `tick_watchdog` container holds neither a `Builder` nor a `Runner`, so this
+  is the only hook that reaches them.
+
+  Additive — an app that passes nothing behaves exactly as before. The new
+  `ContainerSetup` type alias is exported from `stardag.integration.modal`.
+
 ## [0.19.1] — 2026-08-14
 
 ### Fixed

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -102,7 +102,17 @@ again for the rest of that container's inputs.
 See [Integrate with Modal](https://stardag-dev.github.io/stardag/how-to/integrate-modal/)
 for the full section.
 
-### Also: a warning for workers nothing can reach
+### Also: worker routing is checked at deploy
+
+An app with **no `"default"` worker and no `worker_selector`** now fails
+`finalize()` instead of deploying. Every task would route to a
+`worker_default` function the app does not deploy, so nothing would have
+worked; previously it deployed cleanly and failed at the first task. This is
+scoped to the no-selector case — an app that declares a selector may omit
+`"default"` and route everything to its own tiers, which works today and
+keeps working.
+
+The softer case gets a warning instead.
 
 `finalize()` now warns when an app declares several `worker_settings` but no
 `worker_selector`. Every task then routes to `"default"`, so the other tiers

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -100,6 +100,20 @@ again for the rest of that container's inputs.
 See [Integrate with Modal](https://stardag-dev.github.io/stardag/how-to/integrate-modal/)
 for the full section.
 
+### Also: a warning for workers nothing can reach
+
+`finalize()` now warns when an app declares several `worker_settings` but no
+`worker_selector`. Every task then routes to `"default"`, so the other tiers
+are deployed and never reached — and nothing looks wrong, because the build
+succeeds, just entirely on the wrong worker. The warning names the unreachable
+workers, and passing a selector explicitly — even one that always returns
+`"default"` — silences it.
+
+Per-trigger overrides (`build_spawn`/`build_trigger(worker_selector=...)`)
+remain a valid way to route a _resident_ build. Reactive builds reject them,
+because later ticks (worker wake-ups, watchdog sweeps) could not honour them,
+which is why the app-level selector is what the warning points at.
+
 ---
 
 ## v0.19.1 — A user package named `modal` no longer breaks target resolution

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,102 @@ For changes to the Registry API, UI, and other components, see [CHANGELOG.md](CH
 
 ---
 
+## v0.20.0 — Container setup you can actually rely on, in every Modal container
+
+Additive. Nothing to migrate: an app that does not pass `container_setup`
+behaves exactly as before.
+
+**If your Modal app has setup code that must run before anything else —
+credentials written to disk, your own log formatter, an environment check —
+move it to `container_setup`.** It may not be running where you think it is.
+
+```python
+# my_app/setup.py — an importable module, not the deploy script
+def container_setup() -> None:
+    configure_logging()
+    write_credentials()
+
+
+# my_app/app.py
+app = StardagApp(
+    "my-app",
+    container_setup=container_setup,
+    builder_settings=FunctionSettings(image=image),
+    worker_settings={"default": FunctionSettings(image=image)},
+)
+```
+
+### Why it was needed
+
+`StardagApp.finalize()` registers every function with `serialized=True`. A
+container therefore unpickles a closure rather than importing the module your
+app was declared in, and which of your modules get imported is decided by what
+each function's closure happens to reference.
+
+That worked out for two of the five. `build` closes over your `build_function`
+and `worker_*` over your `run_function`, so those modules are imported and
+their module-level code runs — the behaviour `StardagApp.__init__` documents
+and that apps have relied on. The other three were never covered. A
+`bootstrap` container closes over the app name, the task-module patterns and
+two booleans: nothing of yours, so none of your modules are imported at all. A
+`tick` or `tick_watchdog` container imports your code only as a side effect —
+of a `worker_selector` or `limit_key_selector` if you passed one, and of
+whatever the expanded `task_modules` pull in.
+
+The failure mode this produces is a quiet one. Setup that plainly works —
+because you see it working in your workers — is simply absent from the
+containers that drive a reactive build, and the first symptom is somewhere
+else entirely. It was reported by a deployed app whose object-store
+credentials are prepared by exactly such a routine: its reactive builds failed
+in `bootstrap`, at the first completion check of discovery, with a storage
+error that said nothing about setup.
+
+`container_setup` turns that accident into a contract. It runs at the top of
+all five functions, so where your setup runs is no longer a property of your
+import graph.
+
+### Semantics worth knowing
+
+- **Once per container, not once per input.** A worker serves many tasks and a
+  tick container may be reused. The guard lives in stardag so you do not have
+  to write one.
+- **A hook that raises propagates, and is retried on the next input.** It is
+  deliberately not remembered as done on failure — the alternative is a
+  container whose remaining inputs run silently un-set-up. A hook that fails
+  deterministically fails every input, loudly.
+- **It runs before stardag's own logging default**, a plain
+  `logging.basicConfig(level=INFO)`. `basicConfig` no-ops once the root logger
+  has handlers, so a hook that configures root logging wins and an app that
+  does not still gets the default. A hook that configures a _non-root_ logger
+  will still see stardag add a root `StreamHandler`.
+- **Define it in an importable module.** Like `worker_selector`, it is pickled
+  by reference, so its defining module must be importable inside the container
+  — part of the source you add via `add_local_python_source(...)`, not a loose
+  deploy script. That is also what makes module-level code in the hook's own
+  module run in every container.
+
+### How it relates to a custom `Builder` or `Runner`
+
+It does not replace them, and they do not replace it. The three hooks have
+different scopes and are meant to be used together:
+
+| Hook                   | Scope         | Runs                                                            | For                                                                                                |
+| ---------------------- | ------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `container_setup()`    | the container | once per container, before anything else, in all five functions | credentials, logging, environment checks — nothing build- or task-specific (it takes no arguments) |
+| `Builder.setup(tasks)` | one build     | once per `build` invocation, in the `build` container only      | preparation that depends on the roots being built                                                  |
+| `Runner.setup(task)`   | one task      | before every input a worker container serves                    | preparation that depends on that task                                                              |
+
+For the reactive functions there is nothing to weigh up: a `tick`, `bootstrap`
+or `tick_watchdog` container contains no `Builder` and no `Runner`, so
+`container_setup` is the only hook that reaches them. In the other direction,
+moving per-task work into `container_setup` would run it once and then never
+again for the rest of that container's inputs.
+
+See [Integrate with Modal](https://stardag-dev.github.io/stardag/how-to/integrate-modal/)
+for the full section.
+
+---
+
 ## v0.19.1 — A user package named `modal` no longer breaks target resolution
 
 No API changes, nothing to migrate.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -43,10 +43,12 @@ and `worker_*` over your `run_function`, so those modules are imported and
 their module-level code runs — the behaviour `StardagApp.__init__` documents
 and that apps have relied on. The other three were never covered. A
 `bootstrap` container closes over the app name, the task-module patterns and
-two booleans: nothing of yours, so none of your modules are imported at all. A
-`tick` or `tick_watchdog` container imports your code only as a side effect —
-of a `worker_selector` or `limit_key_selector` if you passed one, and of
-whatever the expanded `task_modules` pull in.
+two booleans — nothing of yours, so nothing pulls in the module your setup
+lives in. (Its root tasks arrive by value, so unpickling them does import
+_their_ modules; that is not the same thing, and is no help if your setup
+lives anywhere else.) A `tick` or `tick_watchdog` container imports your code
+only as a side effect — of a `worker_selector` or `limit_key_selector` if you
+passed one, and of whatever the expanded `task_modules` pull in.
 
 The failure mode this produces is a quiet one. Setup that plainly works —
 because you see it working in your workers — is simply absent from the

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -1194,6 +1194,22 @@ and then never again for the rest of that container's inputs.
   logger has handlers, so a hook that configures root logging wins, and an
   app that does not still gets the default. A hook that configures a
   _non-root_ logger will still see stardag add a root `StreamHandler`.
+- **Only containers this app deploys.** `reactive_discovery="local"` runs
+  discovery in the _triggering_ process, which is not a container of this
+  app, so the hook does not run there — writing credentials or
+  reconfiguring root logging in someone's shell would be the wrong call.
+  An app that relies on the hook and also triggers with `"local"` has to
+  prepare the triggering process itself.
+- **It runs outside per-task `env_overrides`.** A `worker_selector`
+  returning `(worker_name, env_overrides)` applies those around the task's
+  `run` call only, so a hook that reads the environment sees the
+  container's base environment, not the per-task overrides. Correct by
+  scope — the container is set up once, the overrides vary per task — but
+  worth knowing if you route credentials through both.
+- **A failing hook is visible in Modal, not in the registry.** It runs
+  before the worker's lifecycle reporter exists, so it does not record a
+  `TASK_FAILED`; a reactive build sees the execution claim lapse and the
+  next tick re-spawn. Same shape as a raising `Runner.setup()`.
 
 <!-- TODO below needs significant cleanup.
 ## Running the `stardag-examples` Examples

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -1176,7 +1176,8 @@ and then never again for the rest of that container's inputs.
 
 - **Define it in an importable module.** Like `worker_selector` and your
   build/run functions, the hook is captured by the serialized Modal
-  functions and pickled _by reference_, so its defining module must be
+  functions and pickled _by reference_ (via its class, if you pass a
+  callable instance rather than a plain function), so its defining module must be
   importable in the container — part of the source you add via
   `add_local_python_source(...)`, not a loose deploy script. That is also
   what makes any module-level code in the hook's own module run in every

--- a/docs/docs/how-to/integrate-modal.md
+++ b/docs/docs/how-to/integrate-modal.md
@@ -1114,6 +1114,86 @@ app = sd_modal.StardagApp(
 )
 ```
 
+## Container setup: code that runs in every container
+
+Some setup is a property of the _container_, not of a build or a task:
+materialising credentials onto disk, installing your own log formatter,
+validating that the environment is what you think it is. Pass it as
+`container_setup` and stardag runs it once per container, at the top of
+**every** function the app registers — `build`, each `worker_*`, and the
+reactive `tick`, `bootstrap` and `tick_watchdog`.
+
+```{.python notest}
+# my_app/setup.py — an importable module, not the deploy script (see below)
+def container_setup() -> None:
+    configure_logging()
+    write_credentials()
+
+
+# my_app/app.py
+from my_app.setup import container_setup
+
+app = sd_modal.StardagApp(
+    "stardag-poc",
+    container_setup=container_setup,
+    builder_settings=sd_modal.FunctionSettings(image=image),
+    worker_settings={"default": sd_modal.FunctionSettings(image=image)},
+    watchdog_period_minutes=5,
+)
+```
+
+**Why this exists.** `StardagApp` registers its functions with
+`serialized=True`, so a container unpickles a closure rather than importing
+the module your app was declared in. Which of your modules get imported is
+therefore decided by what each function's closure happens to reference:
+`build` and `worker_*` close over your `build_function` / `run_function`,
+so their modules are imported — but a `bootstrap` container closes over
+nothing of yours at all, and `tick` / `tick_watchdog` import your code only
+as a side effect of a `worker_selector` or the expanded `task_modules`.
+Setup that "obviously runs everywhere" because it runs in your workers can
+therefore be silently absent from the containers that drive a reactive
+build. `container_setup` is the contract that replaces that accident.
+
+### Which hook does what
+
+`container_setup` does **not** replace a custom `Builder` or `Runner`, and
+they do not replace it — the three have different scopes and are meant to
+be used together:
+
+| Hook                   | Scope         | Runs                                                            | For                                                                                                |
+| ---------------------- | ------------- | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `container_setup()`    | the container | once per container, before anything else, in all five functions | credentials, logging, environment checks — nothing build- or task-specific (it takes no arguments) |
+| `Builder.setup(tasks)` | one build     | once per `build` invocation, in the `build` container only      | preparation that depends on the roots being built                                                  |
+| `Runner.setup(task)`   | one task      | before every input a worker container serves                    | preparation that depends on that task                                                              |
+
+For the reactive functions this is not a matter of taste: a `tick`,
+`bootstrap` or `tick_watchdog` container contains no `Builder` and no
+`Runner`, so `container_setup` is the only hook that reaches them.
+Conversely, moving per-task work into `container_setup` would run it once
+and then never again for the rest of that container's inputs.
+
+### Details worth knowing
+
+- **Define it in an importable module.** Like `worker_selector` and your
+  build/run functions, the hook is captured by the serialized Modal
+  functions and pickled _by reference_, so its defining module must be
+  importable in the container — part of the source you add via
+  `add_local_python_source(...)`, not a loose deploy script. That is also
+  what makes any module-level code in the hook's own module run in every
+  container of the app.
+- **Once per container, not once per input.** A worker serves many tasks
+  and a tick container may be reused; stardag holds the guard so you do
+  not have to write one.
+- **A hook that raises propagates, and is retried on the next input.** It
+  is deliberately not remembered as done on failure — the alternative is a
+  container whose remaining inputs run silently un-set-up. A hook that
+  fails deterministically therefore fails every input, loudly.
+- **It runs before stardag's own logging default**, which is a plain
+  `logging.basicConfig(level=INFO)`. `basicConfig` no-ops once the root
+  logger has handlers, so a hook that configures root logging wins, and an
+  app that does not still gets the default. A hook that configures a
+  _non-root_ logger will still see stardag add a root `StreamHandler`.
+
 <!-- TODO below needs significant cleanup.
 ## Running the `stardag-examples` Examples
 

--- a/lib/stardag/src/stardag/integration/modal/__init__.py
+++ b/lib/stardag/src/stardag/integration/modal/__init__.py
@@ -39,6 +39,9 @@ modules directly. Roughly in the order a build passes through them:
   declaration and the merge applied to it.
 - :mod:`._protocols`, :mod:`._selector` — the contracts of the two
   callables an app deploys, and worker routing.
+- :mod:`._container_setup`, :mod:`._logging` — what runs at the top of
+  every container the app deploys: the app's own ``container_setup`` hook,
+  then stardag's logging default.
 - :mod:`._app` — ``StardagApp`` itself: registering those functions
   (``finalize``) and triggering builds on them.
 - :mod:`._builder` — the resident ``build`` function (``Builder``).
@@ -66,6 +69,7 @@ from stardag.integration.modal._builder import (
     PrefectBuilder,
 )
 from stardag.integration.modal._config import get_package_deps, with_stardag_on_image
+from stardag.integration.modal._container_setup import ContainerSetup
 from stardag.integration.modal._executor import ModalTaskExecutor
 from stardag.integration.modal._profile import get_profile_env_vars, get_profile_secret
 from stardag.integration.modal._protocols import BuildFunction, RunFunction
@@ -89,6 +93,7 @@ __all__ = [
     "BuildFailedError",
     "BuildFunction",
     "BuildTriggerResult",
+    "ContainerSetup",
     "ReactiveDiscovery",
     "RunFunction",
     "StardagApp",

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -348,7 +348,12 @@ class StardagApp:
             worker_settings: Dict of worker name to settings. Must include
                 "default". Fully independent per worker.
             worker_selector: Function to select the worker name for each task.
-                Defaults to always returning "default".
+                Defaults to always returning "default" — which means an app
+                that declares more than one worker and leaves this unset
+                deploys workers nothing can reach, so ``finalize()`` warns
+                about it. Passing a selector explicitly, even one that
+                always returns ``"default"``, is how to say that is
+                intended.
             tick_settings: Settings for the reactive-scheduling ``tick`` /
                 ``tick_watchdog`` functions. Defaults to ``builder_settings``
                 when not given.
@@ -479,6 +484,12 @@ class StardagApp:
             self.modal_app = modal_app_or_name
 
         self.worker_selector = worker_selector or _default_worker_selector
+        # Whether a selector was *declared*, as opposed to defaulted. Only
+        # used for the deploy-time reachability warning in finalize(): an
+        # app with several workers and no selector routes everything to
+        # "default". Explicitly passing one — even one that always returns
+        # "default" — is the way to say that is intended.
+        self._worker_selector_declared = worker_selector is not None
         self._build_function = build_function
         self._run_function = run_function
         # The app's container-level setup, closed over by every registered
@@ -680,6 +691,41 @@ class StardagApp:
             extra_secrets.append(self.stardag_api_key_secret)
         return extra_secrets
 
+    def _warn_if_workers_unreachable(self) -> None:
+        """Warn at deploy when extra workers cannot be routed to.
+
+        Without a ``worker_selector`` every task routes to ``"default"``,
+        so an app that went to the trouble of declaring a ``gpu`` worker
+        deploys one that nothing will ever reach. The symptom is
+        indistinguishable from a working deployment — the build succeeds,
+        just entirely on the wrong tier — so it is worth one line at the
+        only moment someone is watching: the deploy.
+
+        Deliberately in ``finalize()`` rather than ``__init__``: the app
+        object is also constructed in the *triggering* process, which has
+        no business being warned about the deployment's configuration.
+
+        Not an error, because per-trigger overrides
+        (``build_spawn(tasks, worker_selector=...)``) are a legitimate way
+        to route a resident build. They are not available to reactive
+        builds, though, which is why the app-level selector is the answer
+        being pointed at.
+        """
+        if self._worker_selector_declared or len(self._worker_settings) <= 1:
+            return
+        extra = sorted(name for name in self._worker_settings if name != "default")
+        logger.warning(
+            f"StardagApp {self.name!r} declares {len(self._worker_settings)} "
+            f"workers but no worker_selector, so every task routes to "
+            f"'default' and these are unreachable: {', '.join(extra)}. Pass "
+            f"worker_selector=... to StardagApp (see WorkerSelectorByName). "
+            f"Per-trigger overrides — build_spawn/build_trigger("
+            f"worker_selector=...) — cover resident builds only; reactive "
+            f"builds reject them, because later ticks could not honour "
+            f"them. If routing everything to 'default' is intended, pass a "
+            f"selector that says so to silence this."
+        )
+
     def _worker_timeouts(self) -> dict[str, int]:
         """Per-worker Modal ``timeout``, as declared in ``worker_settings``.
 
@@ -729,6 +775,8 @@ class StardagApp:
         """
         if self._is_finalized:
             raise RuntimeError("StardagApp has already been finalized")
+
+        self._warn_if_workers_unreachable()
 
         # Discover and create Modal volumes from target roots
         target_roots_volumes = get_target_roots_volumes(

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -38,6 +38,10 @@ from stardag.integration.modal._bootstrap import (
     run_reactive_bootstrap,
 )
 from stardag.integration.modal._builder import _default_build
+from stardag.integration.modal._container_setup import (
+    ContainerSetup,
+    _run_container_setup,
+)
 from stardag.integration.modal._logging import _setup_logging
 from stardag.integration.modal._metadata import (
     MODAL_EXECUTOR_NAME,
@@ -218,6 +222,8 @@ class StardagApp:
         modal_app: The underlying modal.App instance.
         name: The app name.
         is_finalized: Whether finalize() has been called.
+        container_setup: The app's container-level setup hook, or None
+            (see the ``container_setup`` argument).
         task_modules: The validated task-module patterns (see the
             ``task_modules`` argument); empty when opted out.
         require_pickle_free: Whether a reactive build refuses to fall
@@ -232,6 +238,7 @@ class StardagApp:
         *,
         build_function: BuildFunction = _default_build,
         run_function: RunFunction = _default_run,
+        container_setup: ContainerSetup | None = None,
         builder_settings: FunctionSettings,
         worker_settings: dict[str, FunctionSettings],
         worker_selector: WorkerSelector | None = None,
@@ -258,18 +265,82 @@ class StardagApp:
                 ``Builder`` for customization, or implement the protocol
                 directly.
 
-                Any module-level code in the module where this callable is
-                defined will run inside the Modal container at import time —
-                use this for container-level setup.
+                Because this callable is pickled by reference, the module
+                defining it is imported inside the ``build`` container, so
+                its module-level code runs there. That is a property of
+                the ``build`` container only — for setup that must run in
+                *every* container the app deploys, pass
+                ``container_setup``.
             run_function: Callable registered as the Modal worker functions.
                 Must match the ``RunFunction`` protocol:
                 ``(task) -> None``.
                 Defaults to ``Runner()`` which provides overridable
                 ``setup()``/``teardown()`` hooks.
 
-                Any module-level code in the module where this callable is
-                defined will run inside the Modal container at import time —
-                use this for worker-level setup (GPU init, library preloading).
+                As with ``build_function``, the module defining this
+                callable is imported inside every ``worker_*`` container —
+                use that (or ``Runner.setup()``) for worker-specific setup
+                such as GPU init or library preloading, and
+                ``container_setup`` for setup every container needs.
+            container_setup: Called once per container, at the top of
+                **every** function this app registers — ``build``, each
+                ``worker_*``, and the reactive ``tick``, ``bootstrap`` and
+                ``tick_watchdog`` — before any stardag work and before the
+                per-build/per-task ``Builder.setup()`` / ``Runner.setup()``
+                hooks. Takes no arguments. Default: nothing to run.
+
+                This is the hook for state a container must have before it
+                does anything: credentials materialised onto disk, log
+                formatting, environment validation. Without it, whether an
+                app's setup code runs at all depends on which of its
+                modules a given function's closure happens to drag in —
+                dependable for ``build`` and ``worker_*``, which close over
+                the callables above, but not for the reactive functions,
+                and not at all for ``bootstrap``.
+
+                **It does not replace a custom builder or runner, and they
+                do not replace it.** The three hooks have different scopes
+                and all three are expected to be used together:
+
+                - ``container_setup`` — the *container*. Once, before
+                  anything else, in all five functions. Nothing about a
+                  build or a task is in scope here (it takes no arguments).
+                - ``Builder.setup(tasks)`` — one *build*, in the ``build``
+                  container only. Prep that depends on the roots being
+                  built.
+                - ``Runner.setup(task)`` — one *task*, before each input a
+                  worker serves. Prep that depends on that task.
+
+                The split is not a matter of taste for the reactive
+                functions: a ``tick``, ``bootstrap`` or ``tick_watchdog``
+                container has no ``Builder`` and no ``Runner`` in it at
+                all, so ``container_setup`` is the *only* hook that reaches
+                them. Conversely, moving per-task work into
+                ``container_setup`` would run it once and then never again
+                for the rest of that container's inputs.
+
+                **Once per container, not once per input.** A worker
+                serves many tasks and a tick container may be reused;
+                stardag holds the guard so apps do not each have to write
+                one. A hook that raises propagates and is *not* remembered
+                as done — the next input tries again — so a hook that
+                fails deterministically fails every input rather than
+                letting later ones run un-set-up.
+
+                **Ordering with logging.** The hook runs before stardag's
+                own ``logging.basicConfig`` default, and ``basicConfig``
+                no-ops once the root logger has handlers, so a hook that
+                configures root logging wins and an app that does not still
+                gets the default. A hook that instead configures a
+                non-root logger will still see stardag add a root
+                ``StreamHandler``.
+
+                Like ``worker_selector`` and the callables above, this is
+                captured by the serialized Modal functions, so **define it
+                in a module that is importable inside the container**
+                (source added via ``add_local_python_source(...)``, not a
+                loose deploy script). That is also what makes module-level
+                code in the hook's own module run in every container.
             builder_settings: Settings for the "build" function. Each
                 function's settings are independent — nothing is propagated
                 between them, except ``stardag_api_key_secret`` (below) and
@@ -410,6 +481,16 @@ class StardagApp:
         self.worker_selector = worker_selector or _default_worker_selector
         self._build_function = build_function
         self._run_function = run_function
+        # The app's container-level setup, closed over by every registered
+        # wrapper in finalize(). Deployed-app configuration exactly like
+        # worker_selector: captured here, pickled by reference into the
+        # serialized functions, run once per container.
+        if container_setup is not None and not callable(container_setup):
+            raise TypeError(
+                f"container_setup must be callable, got "
+                f"{type(container_setup).__name__}"
+            )
+        self.container_setup = container_setup
         self._builder_settings = builder_settings
         self._worker_settings = worker_settings
         # Reactive scheduling: the "tick" function's settings (defaults to
@@ -683,6 +764,13 @@ class StardagApp:
         # Modal's is_async() only accepts inspect.isfunction()-compatible objects,
         # not callable class instances. The wrappers delegate to the actual callable
         # and are what get serialized/sent to Modal.
+        #
+        # Every wrapper below opens with _run_container_setup(container_setup):
+        # it is the app's one chance to prepare a container, and the top of
+        # the wrapper is the only place common to all five functions that
+        # runs before any stardag work. _run_container_setup no-ops when the
+        # app supplied no hook, and after the first input in this container.
+        container_setup = self.container_setup
         build_fn = self._build_function
 
         def _modal_build(
@@ -691,6 +779,7 @@ class StardagApp:
             app_name: str,
             build_kwargs: dict[str, typing.Any] | None = None,
         ) -> BuildSummary | None:
+            _run_container_setup(container_setup)
             return build_fn(tasks, worker_selector, app_name, build_kwargs=build_kwargs)
 
         run_fn = self._run_function
@@ -703,6 +792,7 @@ class StardagApp:
         def _modal_run(
             task: BaseTask, *, env_overrides: dict[str, str] | None = None
         ) -> typing.Any:
+            _run_container_setup(container_setup)
             # Publish the app's task-module patterns for the worker-side
             # code that needs them but is nowhere near the app object:
             # _WorkerLifecycleReporter._register_dynamic_deps checks the
@@ -751,6 +841,7 @@ class StardagApp:
             build_id: str,
             tick_kwargs: dict[str, typing.Any] | None = None,
         ) -> dict[str, typing.Any]:
+            _run_container_setup(container_setup)
             return _run_tick(build_id, tick_kwargs, deployment=tick_deployment)
 
         # tick/watchdog default to builder_settings when tick_settings is
@@ -773,6 +864,7 @@ class StardagApp:
             tasks: typing.Sequence[BaseTask] | BaseTask,
             tick_kwargs: dict[str, typing.Any] | None = None,
         ) -> dict[str, typing.Any]:
+            _run_container_setup(container_setup)
             _setup_logging()
             build_uuid = UUID(build_id)
             task_list = [tasks] if isinstance(tasks, BaseTask) else list(tasks)
@@ -812,6 +904,7 @@ class StardagApp:
         if self.watchdog_period_minutes is not None:
 
             def _modal_tick_watchdog() -> None:
+                _run_container_setup(container_setup)
                 _setup_logging()
                 # The watchdog runs on the same settings as `tick`, so its
                 # container has the same timeout — which it then splits

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -265,11 +265,13 @@ class StardagApp:
                 ``Builder`` for customization, or implement the protocol
                 directly.
 
-                Because this callable is pickled by reference, the module
-                defining it is imported inside the ``build`` container, so
-                its module-level code runs there. That is a property of
-                the ``build`` container only — for setup that must run in
-                *every* container the app deploys, pass
+                Unpickling the serialized ``build`` wrapper in a container
+                reaches this callable's defining module — the function
+                itself for a plain function, its class for a callable
+                instance such as a ``Builder`` subclass — so that module is
+                imported there and its module-level code runs. That is a
+                property of the ``build`` container only; for setup that
+                must run in *every* container the app deploys, pass
                 ``container_setup``.
             run_function: Callable registered as the Modal worker functions.
                 Must match the ``RunFunction`` protocol:
@@ -277,11 +279,12 @@ class StardagApp:
                 Defaults to ``Runner()`` which provides overridable
                 ``setup()``/``teardown()`` hooks.
 
-                As with ``build_function``, the module defining this
-                callable is imported inside every ``worker_*`` container —
-                use that (or ``Runner.setup()``) for worker-specific setup
-                such as GPU init or library preloading, and
-                ``container_setup`` for setup every container needs.
+                As with ``build_function``, unpickling the serialized
+                worker wrapper imports this callable's defining module (or
+                its class's) inside every ``worker_*`` container — use that,
+                or ``Runner.setup()``, for worker-specific setup such as
+                GPU init or library preloading, and ``container_setup``
+                for setup every container needs.
             container_setup: Called once per container, at the top of
                 **every** function this app registers — ``build``, each
                 ``worker_*``, and the reactive ``tick``, ``bootstrap`` and
@@ -494,8 +497,8 @@ class StardagApp:
         self._run_function = run_function
         # The app's container-level setup, closed over by every registered
         # wrapper in finalize(). Deployed-app configuration exactly like
-        # worker_selector: captured here, pickled by reference into the
-        # serialized functions, run once per container.
+        # worker_selector: captured here, carried into the serialized
+        # functions, run once per container.
         if container_setup is not None and not callable(container_setup):
             raise TypeError(
                 f"container_setup must be callable, got "

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -486,7 +486,14 @@ class StardagApp:
             assert modal_app_or_name.name is not None
             self.modal_app = modal_app_or_name
 
-        self.worker_selector = worker_selector or _default_worker_selector
+        # `is not None` rather than truthiness: a selector is an arbitrary
+        # callable, and one whose class defines __bool__/__len__ falsey
+        # would otherwise be silently swapped for the default — and, since
+        # the warning below keys off declaration, swapped *without* the
+        # warning that is supposed to catch exactly that outcome.
+        self.worker_selector = (
+            worker_selector if worker_selector is not None else _default_worker_selector
+        )
         # Whether a selector was *declared*, as opposed to defaulted. Only
         # used for the deploy-time reachability warning in finalize(): an
         # app with several workers and no selector routes everything to

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -713,27 +713,51 @@ class StardagApp:
             extra_secrets.append(self.stardag_api_key_secret)
         return extra_secrets
 
-    def _warn_if_workers_unreachable(self) -> None:
-        """Warn at deploy when extra workers cannot be routed to.
+    def _check_worker_routing(self) -> None:
+        """Check at deploy that tasks can reach the workers being deployed.
 
-        Without a ``worker_selector`` every task routes to ``"default"``,
-        so an app that went to the trouble of declaring a ``gpu`` worker
-        deploys one that nothing will ever reach. The symptom is
-        indistinguishable from a working deployment — the build succeeds,
-        just entirely on the wrong tier — so it is worth one line at the
-        only moment someone is watching: the deploy.
+        Two failure shapes, and the difference in severity is the whole
+        point. With no ``worker_selector`` every task routes to
+        ``"default"``:
+
+        - **No ``"default"`` worker at all** — nothing works. Every task
+          routes to a function this app does not deploy, so the deployment
+          is dead on arrival. Raises.
+        - **A ``"default"`` plus other tiers** — everything works, on the
+          wrong worker. The build succeeds, so the symptom is
+          indistinguishable from a healthy deployment, which is exactly
+          why it is worth one line at the only moment someone is watching.
+          Warns.
+
+        The error is scoped to the case where no selector was declared. An
+        app that declares one is free to omit ``"default"`` and route
+        everything to its own tiers — that works today, and refusing it
+        would break a working deployment to enforce a naming convention.
 
         Deliberately in ``finalize()`` rather than ``__init__``: the app
         object is also constructed in the *triggering* process, which has
-        no business being warned about the deployment's configuration.
+        no business being told about the deployment's configuration.
 
-        Not an error, because per-trigger overrides
+        The warning is not an error because per-trigger overrides
         (``build_spawn(tasks, worker_selector=...)``) are a legitimate way
         to route a resident build. They are not available to reactive
         builds, though, which is why the app-level selector is the answer
         being pointed at.
         """
-        if self._worker_selector_declared or len(self._worker_settings) <= 1:
+        if self._worker_selector_declared:
+            return
+        if "default" not in self._worker_settings:
+            declared = sorted(self._worker_settings) or ["<none>"]
+            raise StardagError(
+                f"StardagApp {self.name!r} has no 'default' worker and no "
+                f"worker_selector, so every task would route to a "
+                f"'worker_default' function this app does not deploy. "
+                f"Declared workers: {', '.join(declared)}. Either add a "
+                f"'default' entry to worker_settings, or pass "
+                f"worker_selector=... so tasks are routed to the workers "
+                f"that do exist (see WorkerSelectorByName)."
+            )
+        if len(self._worker_settings) <= 1:
             return
         extra = sorted(name for name in self._worker_settings if name != "default")
         logger.warning(
@@ -798,7 +822,7 @@ class StardagApp:
         if self._is_finalized:
             raise RuntimeError("StardagApp has already been finalized")
 
-        self._warn_if_workers_unreachable()
+        self._check_worker_routing()
 
         # Discover and create Modal volumes from target roots
         target_roots_volumes = get_target_roots_volumes(

--- a/lib/stardag/src/stardag/integration/modal/_app.py
+++ b/lib/stardag/src/stardag/integration/modal/_app.py
@@ -41,6 +41,7 @@ from stardag.integration.modal._builder import _default_build
 from stardag.integration.modal._container_setup import (
     ContainerSetup,
     _run_container_setup,
+    _validate_container_setup,
 )
 from stardag.integration.modal._logging import _setup_logging
 from stardag.integration.modal._metadata import (
@@ -330,6 +331,14 @@ class StardagApp:
                 fails deterministically fails every input rather than
                 letting later ones run un-set-up.
 
+                **Only containers this app deploys.** It is not run by
+                ``reactive_discovery="local"``, where discovery happens in
+                the *triggering* process: that machine is not a container
+                of this app, and writing credentials or reconfiguring root
+                logging in someone's shell would be the wrong call. An app
+                that both relies on the hook and triggers with
+                ``"local"`` has to prepare the triggering process itself.
+
                 **Ordering with logging.** The hook runs before stardag's
                 own ``logging.basicConfig`` default, and ``basicConfig``
                 no-ops once the root logger has handlers, so a hook that
@@ -391,15 +400,21 @@ class StardagApp:
                 ``"modal"`` is the default because discovery is target-root
                 I/O — one existence check per task — and inside Modal a
                 ``modalvol://`` root is a mounted filesystem rather than a
-                rate-limited API. Only the placement changes: the same code
-                runs, in the same order, with the same failure handling.
+                rate-limited API. The same discovery code runs either way,
+                in the same order and with the same failure handling; what
+                differs is the machine, and therefore the container-level
+                preparation around it (see ``container_setup`` below).
 
                 Reach for ``"local"`` when the deployed app predates the
                 ``bootstrap`` function, or when the target root is
                 reachable from the triggering process but not from the
                 Modal app. Note that ``"local"`` also puts the coverage
                 pre-flight on the *local* ``task_modules`` rather than the
-                deployed one, reinstating the stale-deploy blind spot.
+                deployed one, reinstating the stale-deploy blind spot —
+                and that ``container_setup`` does **not** run, because the
+                triggering process is not a container this app deployed
+                (see that argument). Discovery there runs against whatever
+                the triggering process is already configured with.
             watchdog_period_minutes: If set, register a scheduled watchdog
                 that periodically re-ticks running reactive builds (the
                 safety net for lost wake-ups, UI-cancelled builds, and stale
@@ -506,11 +521,8 @@ class StardagApp:
         # wrapper in finalize(). Deployed-app configuration exactly like
         # worker_selector: captured here, carried into the serialized
         # functions, run once per container.
-        if container_setup is not None and not callable(container_setup):
-            raise TypeError(
-                f"container_setup must be callable, got "
-                f"{type(container_setup).__name__}"
-            )
+        if container_setup is not None:
+            _validate_container_setup(container_setup)
         self.container_setup = container_setup
         self._builder_settings = builder_settings
         self._worker_settings = worker_settings

--- a/lib/stardag/src/stardag/integration/modal/_builder.py
+++ b/lib/stardag/src/stardag/integration/modal/_builder.py
@@ -76,7 +76,12 @@ class Builder(BuildFunction):
         self.detached = detached
 
     def setup(self, tasks: typing.Sequence[BaseTask] | BaseTask) -> None:
-        """Optional setup logic before the build starts."""
+        """Optional setup logic before the build starts.
+
+        Per *build*, and scoped to the ``build`` container. Setup that
+        every container of the app needs, once per container, belongs in
+        ``StardagApp(container_setup=...)`` instead — it runs before this.
+        """
         _setup_logging()
 
     def teardown(

--- a/lib/stardag/src/stardag/integration/modal/_container_setup.py
+++ b/lib/stardag/src/stardag/integration/modal/_container_setup.py
@@ -40,9 +40,24 @@ every container of the app.
 
 # Process-local, and therefore container-local: the closure is unpickled
 # per container, but this module is imported from the image like any
-# other, so the flag is exactly "has this container run setup yet".
-_setup_done = False
+# other, so this records exactly "what has this container already set up".
+#
+# Per *hook* rather than a single flag. A deployed container only ever
+# unpickles one app's closure, so in production there is one entry — but a
+# process that holds two StardagApps (a test, or a script deploying
+# several apps) would otherwise have the first app's hook silence the
+# second's, which is a silent wrong answer rather than a missing
+# optimisation.
+#
+# A list compared by identity, not a set: it avoids requiring the hook to
+# be hashable, and holding the objects keeps them alive, so an id() cannot
+# be recycled onto a different hook after a garbage collection.
+_setup_done: list[ContainerSetup] = []
 _setup_lock = threading.Lock()
+
+
+def _already_run(container_setup: ContainerSetup) -> bool:
+    return any(done is container_setup for done in _setup_done)
 
 
 def _run_container_setup(container_setup: ContainerSetup | None) -> None:
@@ -54,26 +69,24 @@ def _run_container_setup(container_setup: ContainerSetup | None) -> None:
     inputs on threads, and setup that runs twice concurrently is exactly
     what the app is being spared from writing itself.
 
-    Failures propagate and are **not** memoised: the "done" flag is set
-    only on success, so a hook that raised is attempted again on the next
-    input rather than leaving the rest of the container's inputs running
-    silently un-set-up. A hook that fails deterministically therefore
-    fails every input, loudly — which is the honest outcome when the
-    container is not in the state the app requires.
+    Failures propagate and are **not** memoised: the hook is recorded as
+    done only on success, so one that raised is attempted again on the
+    next input rather than leaving the rest of the container's inputs
+    running silently un-set-up. A hook that fails deterministically
+    therefore fails every input, loudly — which is the honest outcome when
+    the container is not in the state the app requires.
     """
-    global _setup_done
-    if container_setup is None or _setup_done:
+    if container_setup is None or _already_run(container_setup):
         return
     with _setup_lock:
-        if _setup_done:
+        if _already_run(container_setup):
             return
         logger.debug(f"Running container setup: {container_setup!r}")
         container_setup()
-        _setup_done = True
+        _setup_done.append(container_setup)
 
 
 def _reset_container_setup_for_testing() -> None:
     """Forget that setup ran, so a test can exercise a "fresh container"."""
-    global _setup_done
     with _setup_lock:
-        _setup_done = False
+        _setup_done.clear()

--- a/lib/stardag/src/stardag/integration/modal/_container_setup.py
+++ b/lib/stardag/src/stardag/integration/modal/_container_setup.py
@@ -17,6 +17,7 @@ reactive ``tick`` / ``bootstrap`` / ``tick_watchdog``. Passing
 
 from __future__ import annotations
 
+import inspect
 import logging
 import threading
 import typing
@@ -56,6 +57,39 @@ _setup_done: list[ContainerSetup] = []
 _setup_lock = threading.Lock()
 
 
+def _validate_container_setup(container_setup: typing.Any) -> None:
+    """Reject a hook that cannot be called the way containers will call it.
+
+    Raised where the app is declared rather than surfacing in every
+    container of a deployed app. ``callable()`` alone would miss the
+    likelier mistake: passing a function that takes an argument, which
+    deploys cleanly and then raises ``TypeError`` on every input.
+
+    Signature introspection is best-effort — some callables (C builtins,
+    exotic wrappers) have no inspectable signature, and those are let
+    through rather than rejected on the strength of a failed guess.
+    """
+    if not callable(container_setup):
+        raise TypeError(
+            f"container_setup must be callable, got {type(container_setup).__name__}"
+        )
+    try:
+        signature = inspect.signature(container_setup)
+    except (TypeError, ValueError):
+        return
+    try:
+        signature.bind()
+    except TypeError as e:
+        raise TypeError(
+            f"container_setup must be callable with no arguments; "
+            f"{getattr(container_setup, '__name__', container_setup)!r} has "
+            f"signature {signature}. It is invoked as container_setup() at "
+            f"the top of every function the app deploys, with nothing to "
+            f"pass it — bind any configuration it needs at the call site "
+            f"(a closure or functools.partial)."
+        ) from e
+
+
 def _already_run(container_setup: ContainerSetup) -> bool:
     return any(done is container_setup for done in _setup_done)
 
@@ -73,8 +107,17 @@ def _run_container_setup(container_setup: ContainerSetup | None) -> None:
     done only on success, so one that raised is attempted again on the
     next input rather than leaving the rest of the container's inputs
     running silently un-set-up. A hook that fails deterministically
-    therefore fails every input, loudly — which is the honest outcome when
-    the container is not in the state the app requires.
+    therefore fails every input — the honest outcome when the container is
+    not in the state the app requires.
+
+    Note where that failure is visible. Running before the wrapper's own
+    body means running before a worker's lifecycle reporter exists, so a
+    raising hook surfaces in the Modal logs and *not* as a TASK_FAILED in
+    the registry; a reactive build sees the execution claim lapse and the
+    next tick re-spawn. That is the same shape as a raising
+    ``Runner.setup()`` and is the right layering — the hook is what makes
+    the container able to talk to the registry in the first place — but it
+    does mean the registry is not where you will see it.
     """
     if container_setup is None or _already_run(container_setup):
         return

--- a/lib/stardag/src/stardag/integration/modal/_container_setup.py
+++ b/lib/stardag/src/stardag/integration/modal/_container_setup.py
@@ -1,0 +1,79 @@
+"""The app-supplied setup hook every Modal container of an app runs.
+
+Its own module for the same reason :mod:`._logging` is: every entry point
+into a Modal container invokes it — the build function, the workers, the
+scheduler ticks, the bootstrap and the watchdog — and those live in
+different modules of this package.
+
+The hook exists because a ``StardagApp`` registers its functions with
+``serialized=True``, so a container unpickles a closure instead of
+importing the module the app was declared in. Which of the app's modules
+get imported is therefore decided by what each closure happens to
+reference — reliable for ``build`` and ``worker_*`` (they close over the
+app's ``build_function`` / ``run_function``), and an accident for the
+reactive ``tick`` / ``bootstrap`` / ``tick_watchdog``. Passing
+``StardagApp(container_setup=...)`` makes it a contract for all five.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import typing
+
+logger = logging.getLogger(__name__)
+
+ContainerSetup = typing.Callable[[], None]
+"""Type for an app's container-level setup callable.
+
+Takes no arguments and returns nothing. Run once per container, before
+anything else in the Modal function that invoked it — see
+``StardagApp(container_setup=...)``.
+
+Like ``worker_selector`` and the app's build/run functions, this is
+captured by the serialized Modal functions and so must be defined in a
+module that is importable *inside the container* (part of the source added
+via ``add_local_python_source(...)``, not a loose deploy script). That is
+also what makes any module-level code in the hook's own module run in
+every container of the app.
+"""
+
+# Process-local, and therefore container-local: the closure is unpickled
+# per container, but this module is imported from the image like any
+# other, so the flag is exactly "has this container run setup yet".
+_setup_done = False
+_setup_lock = threading.Lock()
+
+
+def _run_container_setup(container_setup: ContainerSetup | None) -> None:
+    """Run ``container_setup`` at most once in this container.
+
+    A no-op when the app supplied no hook.
+
+    Under a lock because a worker with ``allow_concurrent_inputs`` serves
+    inputs on threads, and setup that runs twice concurrently is exactly
+    what the app is being spared from writing itself.
+
+    Failures propagate and are **not** memoised: the "done" flag is set
+    only on success, so a hook that raised is attempted again on the next
+    input rather than leaving the rest of the container's inputs running
+    silently un-set-up. A hook that fails deterministically therefore
+    fails every input, loudly — which is the honest outcome when the
+    container is not in the state the app requires.
+    """
+    global _setup_done
+    if container_setup is None or _setup_done:
+        return
+    with _setup_lock:
+        if _setup_done:
+            return
+        logger.debug(f"Running container setup: {container_setup!r}")
+        container_setup()
+        _setup_done = True
+
+
+def _reset_container_setup_for_testing() -> None:
+    """Forget that setup ran, so a test can exercise a "fresh container"."""
+    global _setup_done
+    with _setup_lock:
+        _setup_done = False

--- a/lib/stardag/src/stardag/integration/modal/_logging.py
+++ b/lib/stardag/src/stardag/integration/modal/_logging.py
@@ -3,6 +3,12 @@
 Its own module because every entry point into a Modal container calls it —
 the build function, the workers, the scheduler ticks, the bootstrap and the
 watchdog — and those live in different modules of this package.
+
+Always runs *after* the app's own ``container_setup`` hook (see
+:mod:`._container_setup`), which is what lets an app own logging in these
+containers: ``basicConfig`` returns early once the root logger has
+handlers, so a hook that configured root logging wins and an app that did
+not still gets this default.
 """
 
 from __future__ import annotations

--- a/lib/stardag/src/stardag/integration/modal/_protocols.py
+++ b/lib/stardag/src/stardag/integration/modal/_protocols.py
@@ -40,9 +40,11 @@ class BuildFunction(typing.Protocol):
 
     Any module-level code in the module where a custom build function is
     defined will execute inside the ``build`` container before the function
-    is called, because the callable is pickled by reference. That covers
-    the ``build`` container only; for setup every container of the app
-    needs — workers and the reactive functions included — pass
+    is called: unpickling the serialized wrapper there reaches the
+    callable's defining module — the function itself for a plain function,
+    its class for a callable instance — and imports it. That covers the
+    ``build`` container only; for setup every container of the app needs —
+    workers and the reactive functions included — pass
     ``StardagApp(container_setup=...)``.
     """
 
@@ -73,8 +75,8 @@ class RunFunction(typing.Protocol):
 
     Any module-level code in the module where a custom run function is
     defined will execute inside every ``worker_*`` container before the
-    function is called, because the callable is pickled by reference — use
-    it for worker-specific setup. For setup every container of the app
+    function is called, by the same mechanism as ``BuildFunction`` above —
+    use it for worker-specific setup. For setup every container of the app
     needs, pass ``StardagApp(container_setup=...)``.
 
     Args (of ``__call__``):

--- a/lib/stardag/src/stardag/integration/modal/_protocols.py
+++ b/lib/stardag/src/stardag/integration/modal/_protocols.py
@@ -39,8 +39,11 @@ class BuildFunction(typing.Protocol):
     implement this protocol directly for full control.
 
     Any module-level code in the module where a custom build function is
-    defined will execute inside the Modal container before the function is
-    called — use this for container-level setup (imports, config, etc.).
+    defined will execute inside the ``build`` container before the function
+    is called, because the callable is pickled by reference. That covers
+    the ``build`` container only; for setup every container of the app
+    needs — workers and the reactive functions included — pass
+    ``StardagApp(container_setup=...)``.
     """
 
     def __call__(
@@ -69,8 +72,10 @@ class RunFunction(typing.Protocol):
     ``setup()``/``teardown()``/``run()``, or implement this protocol directly.
 
     Any module-level code in the module where a custom run function is
-    defined will execute inside the Modal container before the function is
-    called — use this for container-level setup (imports, config, etc.).
+    defined will execute inside every ``worker_*`` container before the
+    function is called, because the callable is pickled by reference — use
+    it for worker-specific setup. For setup every container of the app
+    needs, pass ``StardagApp(container_setup=...)``.
 
     Args (of ``__call__``):
         task: The task instance to execute.

--- a/lib/stardag/src/stardag/integration/modal/_runner.py
+++ b/lib/stardag/src/stardag/integration/modal/_runner.py
@@ -533,7 +533,12 @@ class Runner(RunFunction):
         self.report_lifecycle = report_lifecycle
 
     def setup(self, task: BaseTask) -> None:
-        """Optional setup logic before the task runs."""
+        """Optional setup logic before the task runs.
+
+        Per *task*, so it runs again for every input a worker container
+        serves. Setup that need only happen once per container belongs in
+        ``StardagApp(container_setup=...)`` instead — it runs before this.
+        """
         _setup_logging()
 
     def teardown(self, task: BaseTask, exception: BaseException | None) -> None:

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -2824,6 +2824,29 @@ class TestContainerSetup:
 
         assert order == ["container_setup", "stardag_logging"]
 
+    def test_two_apps_in_one_process_each_run_their_own_hook(self):
+        """The guard is per hook, not one global flag.
+
+        A deployed container only ever unpickles one app's closure, so in
+        production there is one hook — but a process holding two apps
+        would otherwise have the first app's hook silence the second's,
+        which is a wrong answer rather than a missed optimisation.
+        """
+        first, second = [], []
+        app_a = self._app(lambda: first.append("a"))
+        app_b = self._app(lambda: second.append("b"))
+        registered_a = _finalize_capturing_functions(app_a)
+        registered_b = _finalize_capturing_functions(app_b)
+
+        with self._stubbed_bodies(), registry_provider.override(NoOpRegistry()):
+            registered_a["worker_default"]("task")
+            registered_b["worker_default"]("task")
+            registered_a["worker_default"]("task")
+            registered_b["worker_default"]("task")
+
+        assert first == ["a"]
+        assert second == ["b"]
+
     def test_defaults_to_none_and_is_a_no_op(self):
         """Additive: an app that passes nothing behaves exactly as before."""
         app = StardagApp(

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -2841,3 +2841,51 @@ class TestContainerSetup:
         """Caught where the app is declared, not in a container hours later."""
         with pytest.raises(TypeError, match="container_setup must be callable"):
             self._app("not-callable")  # type: ignore[arg-type]
+
+
+class TestUnreachableWorkerWarning:
+    """finalize() flags workers no task can be routed to.
+
+    Without a ``worker_selector`` everything routes to ``"default"``, so a
+    declared ``gpu`` worker is deployed and never reached — a deployment
+    that looks entirely healthy while running on the wrong tier.
+    """
+
+    @staticmethod
+    def _app(workers, worker_selector=None) -> StardagApp:
+        return StardagApp(
+            "test-app",
+            worker_selector=worker_selector,
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={
+                name: FunctionSettings(image=_make_image()) for name in workers
+            },
+        )
+
+    def test_warns_when_extra_workers_have_no_selector(self, caplog):
+        app = self._app(["default", "gpu", "high_memory"])
+
+        with caplog.at_level("WARNING", logger="stardag.integration.modal._app"):
+            _finalize_capturing_functions(app)
+
+        assert "no worker_selector" in caplog.text
+        # Names the workers that are actually unreachable, not "default".
+        assert "gpu, high_memory" in caplog.text
+
+    def test_no_warning_when_a_selector_is_declared(self, caplog):
+        """Explicit is intent — even a selector that returns 'default'."""
+        app = self._app(["default", "gpu"], worker_selector=lambda task: "default")
+
+        with caplog.at_level("WARNING", logger="stardag.integration.modal._app"):
+            _finalize_capturing_functions(app)
+
+        assert "worker_selector" not in caplog.text
+
+    def test_no_warning_for_a_single_worker(self, caplog):
+        """The default routing is correct by construction here."""
+        app = self._app(["default"])
+
+        with caplog.at_level("WARNING", logger="stardag.integration.modal._app"):
+            _finalize_capturing_functions(app)
+
+        assert "worker_selector" not in caplog.text

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1,6 +1,8 @@
 """Tests for StardagApp build_function and run_function customization."""
 
 import contextlib
+import threading
+import time
 import typing
 
 import pytest
@@ -25,6 +27,7 @@ from stardag.integration.modal import (
     StardagApp,
 )
 from stardag.integration.modal._builder import _default_build
+from stardag.integration.modal import _container_setup as _container_setup_module
 from stardag.integration.modal._container_setup import (
     _reset_container_setup_for_testing,
 )
@@ -2860,10 +2863,135 @@ class TestContainerSetup:
         with self._stubbed_bodies(), registry_provider.override(NoOpRegistry()):
             registered["tick"](str(uuid4()), None)
 
+        # Nothing recorded, so nothing was run and nothing is retained.
+        assert _container_setup_module._setup_done == []
+
     def test_rejects_a_non_callable(self):
         """Caught where the app is declared, not in a container hours later."""
         with pytest.raises(TypeError, match="container_setup must be callable"):
             self._app("not-callable")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize("function_name", list(_INVOCATIONS))
+    def test_runs_before_the_wrapper_body(self, function_name):
+        """Not merely *that* it ran — that it ran FIRST.
+
+        Everything the feature claims rests on this: the hook has to
+        precede the wrapper's own body, which is what puts it ahead of
+        ``Builder.setup`` / ``Runner.setup`` / ``_run_tick`` and therefore
+        ahead of stardag's ``logging.basicConfig`` default. Asserting only
+        that the hook ran would pass with the call moved to the bottom of
+        every wrapper.
+        """
+        order: list[str] = []
+
+        def body(*args, **kwargs):
+            order.append("body")
+            return None
+
+        app = StardagApp(
+            "test-app",
+            container_setup=lambda: order.append("container_setup"),
+            build_function=body,
+            run_function=body,
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={
+                "default": FunctionSettings(image=_make_image()),
+                "gpu": FunctionSettings(image=_make_image()),
+            },
+            watchdog_period_minutes=5,
+        )
+        registered = _finalize_capturing_functions(app)
+
+        with contextlib.ExitStack() as stack:
+            tick = stack.enter_context(
+                patch("stardag.integration.modal._app._run_tick")
+            )
+            bootstrap = stack.enter_context(
+                patch("stardag.integration.modal._app.run_reactive_bootstrap")
+            )
+            sweep = stack.enter_context(
+                patch("stardag.integration.modal._app._run_watchdog_sweep")
+            )
+            stack.enter_context(registry_provider.override(NoOpRegistry()))
+            tick.side_effect = lambda *a, **kw: (order.append("body"), {})[1]
+            bootstrap.side_effect = lambda *a, **kw: (
+                order.append("body"),
+                MagicMock(summary={}),
+            )[1]
+            sweep.side_effect = lambda *a, **kw: order.append("body")
+            self._INVOCATIONS[function_name](registered[function_name])
+
+        assert order == ["container_setup", "body"]
+
+    def test_watchdog_reentering_tick_does_not_rerun_or_deadlock(self):
+        """The watchdog sweep calls the tick wrapper in-process.
+
+        The guard's lock is a plain ``threading.Lock``, so a path that
+        re-entered it while holding it would deadlock the container rather
+        than fail it. The outer call has already released the lock and
+        recorded the hook by then, so the inner call short-circuits — pin
+        that, because a future change here fails silently until a watchdog
+        container hangs.
+        """
+        calls = []
+        app = self._app(lambda: calls.append("setup"))
+        registered = _finalize_capturing_functions(app)
+
+        with contextlib.ExitStack() as stack:
+            tick = stack.enter_context(
+                patch("stardag.integration.modal._app._run_tick")
+            )
+            sweep = stack.enter_context(
+                patch("stardag.integration.modal._app._run_watchdog_sweep")
+            )
+            stack.enter_context(registry_provider.override(NoOpRegistry()))
+            tick.return_value = {}
+            # Mimic the real sweep: invoke the tick wrapper it was handed.
+            sweep.side_effect = lambda registry, tick_fn, **kw: tick_fn("bid", None)
+            registered["tick_watchdog"]()
+
+        assert calls == ["setup"]
+        assert tick.call_count == 1
+
+    def test_concurrent_inputs_run_the_hook_exactly_once(self):
+        """``allow_concurrent_inputs`` serves inputs on threads.
+
+        Sparing every app from writing this guard is the stated reason it
+        lives in stardag, so the double-checked lock is worth pinning: a
+        regression to a bare check would let several threads through.
+        """
+        calls = []
+        barrier = threading.Barrier(8)
+
+        def slow_setup():
+            calls.append("setup")
+            time.sleep(0.05)
+
+        app = self._app(slow_setup)
+        registered = _finalize_capturing_functions(app)
+        errors: list[BaseException] = []
+
+        def invoke():
+            try:
+                barrier.wait(timeout=5)
+                registered["worker_default"]("task")
+            except BaseException as e:  # noqa: BLE001 - reported below
+                errors.append(e)
+
+        threads = [threading.Thread(target=invoke) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        assert errors == []
+        assert calls == ["setup"]
+
+    def test_rejects_a_hook_that_takes_arguments(self):
+        """The likelier mistake than a non-callable, and it would
+        otherwise deploy cleanly and raise in every container."""
+        with pytest.raises(TypeError, match="no arguments"):
+            self._app(lambda config: None)  # type: ignore[arg-type,misc]
 
 
 class TestUnreachableWorkerWarning:

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -1,5 +1,6 @@
 """Tests for StardagApp build_function and run_function customization."""
 
+import contextlib
 import typing
 
 import pytest
@@ -24,6 +25,9 @@ from stardag.integration.modal import (
     StardagApp,
 )
 from stardag.integration.modal._builder import _default_build
+from stardag.integration.modal._container_setup import (
+    _reset_container_setup_for_testing,
+)
 from stardag.integration.modal._runner import _default_run
 from stardag.registry import NoOpRegistry, RegistryABC, registry_provider
 
@@ -2690,3 +2694,150 @@ class TestBuildTickConfig:
         from stardag.integration.modal._tick import _TICK_KWARGS_ALLOWED
 
         assert "tick_timeout_seconds" not in _TICK_KWARGS_ALLOWED
+
+
+class TestContainerSetup:
+    """``StardagApp(container_setup=...)``: the app's per-container hook.
+
+    The point of the hook is that it reaches all five registered
+    functions. ``build`` and ``worker_*`` already import the app's code
+    (they close over its build/run functions); ``tick``, ``bootstrap`` and
+    ``tick_watchdog`` did not, and ``bootstrap`` closed over nothing of the
+    app's at all — so those three are what these tests are really about.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _fresh_container(self):
+        """Each test starts as a container that has not run setup yet."""
+        _reset_container_setup_for_testing()
+        yield
+        _reset_container_setup_for_testing()
+
+    @staticmethod
+    def _app(container_setup) -> StardagApp:
+        return StardagApp(
+            "test-app",
+            container_setup=container_setup,
+            build_function=lambda *args, **kwargs: None,
+            run_function=lambda task, **kwargs: None,
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={
+                "default": FunctionSettings(image=_make_image()),
+                "gpu": FunctionSettings(image=_make_image()),
+            },
+            watchdog_period_minutes=5,
+        )
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _stubbed_bodies():
+        """Stub out what the wrappers delegate to, leaving only the hook."""
+        with contextlib.ExitStack() as stack:
+            tick = stack.enter_context(
+                patch("stardag.integration.modal._app._run_tick")
+            )
+            bootstrap = stack.enter_context(
+                patch("stardag.integration.modal._app.run_reactive_bootstrap")
+            )
+            stack.enter_context(
+                patch("stardag.integration.modal._app._run_watchdog_sweep")
+            )
+            tick.return_value = {}
+            bootstrap.return_value = MagicMock(summary={})
+            yield
+
+    # One invocation of each registered function, with dummy arguments.
+    _INVOCATIONS: dict[str, typing.Callable[[typing.Any], typing.Any]] = {
+        "build": lambda fn: fn("task", "selector", "test-app", None),
+        "worker_default": lambda fn: fn("task"),
+        "worker_gpu": lambda fn: fn("task"),
+        "tick": lambda fn: fn(str(uuid4()), None),
+        "bootstrap": lambda fn: fn(str(uuid4()), [], None),
+        "tick_watchdog": lambda fn: fn(),
+    }
+
+    @pytest.mark.parametrize("function_name", list(_INVOCATIONS))
+    def test_runs_in_every_registered_function(self, function_name):
+        """Including the three that import nothing of the app's own."""
+        calls = []
+        app = self._app(lambda: calls.append("setup"))
+        registered = _finalize_capturing_functions(app)
+
+        assert function_name in registered
+        with self._stubbed_bodies(), registry_provider.override(NoOpRegistry()):
+            self._INVOCATIONS[function_name](registered[function_name])
+
+        assert calls == ["setup"]
+
+    def test_runs_once_per_container_not_once_per_input(self):
+        """A worker serves many tasks and a tick container may be reused —
+        stardag holds the guard so apps need not write one."""
+        calls = []
+        app = self._app(lambda: calls.append("setup"))
+        registered = _finalize_capturing_functions(app)
+
+        with self._stubbed_bodies(), registry_provider.override(NoOpRegistry()):
+            registered["worker_default"]("task")
+            registered["worker_default"]("task")
+            registered["worker_gpu"]("task")
+            registered["build"]("task", "selector", "test-app", None)
+            registered["tick"](str(uuid4()), None)
+
+        assert calls == ["setup"]
+
+    def test_failure_propagates_and_is_retried_on_the_next_input(self):
+        """Not memoised on failure: the alternative is a container whose
+        remaining inputs run silently un-set-up."""
+        attempts = []
+
+        def flaky():
+            attempts.append("attempt")
+            if len(attempts) == 1:
+                raise RuntimeError("setup boom")
+
+        app = self._app(flaky)
+        registered = _finalize_capturing_functions(app)
+
+        with pytest.raises(RuntimeError, match="setup boom"):
+            registered["worker_default"]("task")
+        registered["worker_default"]("task")  # retried, and succeeds
+        registered["worker_default"]("task")  # now remembered as done
+
+        assert attempts == ["attempt", "attempt"]
+
+    def test_runs_before_stardag_logging_default(self):
+        """The whole reason an app can own its log formatter in these
+        containers: ``basicConfig`` no-ops once root has handlers."""
+        order = []
+        app = self._app(lambda: order.append("container_setup"))
+        registered = _finalize_capturing_functions(app)
+
+        with (
+            self._stubbed_bodies(),
+            registry_provider.override(NoOpRegistry()),
+            patch(
+                "stardag.integration.modal._app._setup_logging",
+                side_effect=lambda: order.append("stardag_logging"),
+            ),
+        ):
+            registered["bootstrap"](str(uuid4()), [], None)
+
+        assert order == ["container_setup", "stardag_logging"]
+
+    def test_defaults_to_none_and_is_a_no_op(self):
+        """Additive: an app that passes nothing behaves exactly as before."""
+        app = StardagApp(
+            "test-app",
+            builder_settings=FunctionSettings(image=_make_image()),
+            worker_settings={"default": FunctionSettings(image=_make_image())},
+        )
+        assert app.container_setup is None
+
+        registered = _finalize_capturing_functions(app)
+        with self._stubbed_bodies(), registry_provider.override(NoOpRegistry()):
+            registered["tick"](str(uuid4()), None)
+
+    def test_rejects_a_non_callable(self):
+        """Caught where the app is declared, not in a container hours later."""
+        with pytest.raises(TypeError, match="container_setup must be callable"):
+            self._app("not-callable")  # type: ignore[arg-type]

--- a/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
+++ b/lib/stardag/tests/test_integration/test_modal/test_stardag_app.py
@@ -18,6 +18,7 @@ from uuid import uuid4
 import stardag as _sd
 from stardag import BaseTask
 from stardag.build._base import BuildSummary
+from stardag.exceptions import StardagError
 from stardag.integration.modal import (
     Builder,
     BuildFunction,
@@ -3031,6 +3032,24 @@ class TestUnreachableWorkerWarning:
             _finalize_capturing_functions(app)
 
         assert "worker_selector" not in caplog.text
+
+    def test_raises_when_there_is_no_default_worker_and_no_selector(self):
+        """Nothing works at all here, so it is an error, not a warning:
+        every task routes to a function the app does not deploy."""
+        app = self._app(["gpu", "high_memory"])
+
+        with pytest.raises(StardagError, match="no 'default' worker"):
+            _finalize_capturing_functions(app)
+
+    def test_no_default_worker_is_fine_with_a_declared_selector(self):
+        """An app routing everything to its own tiers works today —
+        refusing it would break a working deployment over a name."""
+        app = self._app(["gpu"], worker_selector=lambda task: "gpu")
+
+        registered = _finalize_capturing_functions(app)
+
+        assert "worker_gpu" in registered
+        assert "worker_default" not in registered
 
     def test_no_warning_for_a_single_worker(self, caplog):
         """The default routing is correct by construction here."""


### PR DESCRIPTION
## The problem

`StardagApp.finalize()` registers every function with `serialized=True`, so
a container unpickles a closure rather than importing the module the app was
declared in. Which of the app's modules get imported is therefore decided by
what each closure happens to reference:

| Function        | What imports the app's code                                                        |
| --------------- | ---------------------------------------------------------------------------------- |
| `build`         | closes over `build_function` → its defining module is imported. **Contractual.**    |
| `worker_*`      | closes over `run_function` → same. **Contractual.**                                 |
| `tick`          | `worker_selector` / `limit_key_selector` pickle by reference *if supplied*, plus whatever the expanded `task_modules` pull in. **Accidental.** |
| `tick_watchdog` | same as `tick`. **Accidental.**                                                     |
| `bootstrap`     | closes over `app_name` (str), `task_module_patterns` (tuple) and two bools. **Nothing of the app's is imported.** |

`StardagApp.__init__` has always sold that first row as the mechanism — "any
module-level code in the module where this callable is defined will run
inside the Modal container at import time — use this for container-level
setup". There was no equivalent for the other three, and no way to get one.

The failure mode is a quiet one: setup that plainly works, because you watch
it work in your workers, is simply absent from the containers that drive a
reactive build. Reported by a deployed app whose object-store credentials are
prepared by exactly such a routine — its reactive builds failed in
`bootstrap`, at the first completion check of discovery, with a storage error
that said nothing about setup.

`_logging.py` already states the underlying concept in its module docstring —
"every entry point into a Modal container calls it — the build function, the
workers, the scheduler ticks, the bootstrap and the watchdog". The notion that
all five need setup existed in the code; it just was not extensible by the app.

## The change

`StardagApp(container_setup: ContainerSetup | None = None)` — a zero-argument
callable run **once per container** at the top of all five registered
wrappers.

- **Once per container, not once per input.** A worker serves many tasks and a
  tick container may be reused; the guard lives in stardag so apps do not each
  write one. Under a lock, since `allow_concurrent_inputs` serves inputs on
  threads.
- **A hook that raises propagates and is retried on the next input.** It is
  deliberately not remembered as done on failure — the alternative is a
  container whose remaining inputs run silently un-set-up. A deterministic
  failure therefore fails every input, loudly.
- **Runs before stardag's own `logging.basicConfig` default.** `basicConfig`
  no-ops once the root logger has handlers, so an app that configures root
  logging in the hook owns log formatting in these containers, and one that
  does not still gets the default.
- **Pickled by reference like `worker_selector`**, so it must be defined in a
  module importable inside the container — which is also what makes
  module-level code in the hook's own module run in every container, turning
  today's accident into the contract.

Additive: an app that passes nothing behaves exactly as before.

### How it relates to a custom `Builder` / `Runner`

It does not replace them and they do not replace it — documented in both
directions, in the docstrings and the how-to:

| Hook                   | Scope         | Runs                                                            | For                                                          |
| ---------------------- | ------------- | --------------------------------------------------------------- | ------------------------------------------------------------ |
| `container_setup()`    | the container | once per container, before anything else, in all five functions | credentials, logging, environment checks — nothing build- or task-specific |
| `Builder.setup(tasks)` | one build     | once per `build` invocation, in the `build` container only      | preparation that depends on the roots being built            |
| `Runner.setup(task)`   | one task      | before every input a worker container serves                     | preparation that depends on that task                        |

For the reactive functions there is nothing to weigh up: a `tick`,
`bootstrap` or `tick_watchdog` container holds neither a `Builder` nor a
`Runner`, so this is the only hook that reaches them. In the other direction,
per-task work moved into `container_setup` would run once and then never again
for the rest of that container's inputs.

## Second commit: a warning for unreachable workers

An app that declares several `worker_settings` but no `worker_selector` routes
every task to `"default"`, so its other tiers are deployed and never reached —
and nothing looks wrong afterwards, because the build succeeds, just entirely
on the wrong worker. `finalize()` now names them once, at the deploy.

Deliberately in `finalize()` rather than `__init__` (which also runs in the
triggering process), and a warning rather than an error: per-trigger overrides
are a legitimate way to route a **resident** build. They are rejected for
reactive builds, since later ticks could not honour them, which is why the
app-level selector is what the message points at. Passing a selector
explicitly — even one that always returns `"default"` — records the intent and
silences it.

## Design notes

The hook is a plain callable held on the app and closed over by the wrappers,
which is exactly the existing `worker_selector` / `limit_key_selector` pattern
— deploy-time configuration captured at `finalize()`. That means the how-to's
existing rule ("define the callables you pass to `StardagApp` in an importable
module") covers it verbatim, with no new caveat to teach.

Alternatives considered and rejected:

- **A `FunctionSettings` key**, for per-function setup. That TypedDict is
  documented as "passed to `modal.App.function()`" and
  `_prepare_function_settings` splats it wholesale; a non-Modal key would have
  to be filtered out and would break the contract. Per-function differentiation
  stays available inside the hook and via `Builder.setup` / `Runner.setup`.
- **`@modal.enter()` on `@app.cls()`** — the Modal-native container lifecycle
  hook, but it requires registering classes rather than functions, changing the
  deployed shape (`Function.from_name` lookups, function naming, `schedule=` on
  the watchdog). Not additive for already-deployed apps.
- **`resource_provider`** — stardag's lazy-singleton pattern resolves resources
  in-process from config; its state does not cross the deploy → container
  boundary, which is the entire requirement here.
- **`tick_function` / `bootstrap_function` overridables** mirroring
  `build_function` / `run_function` — would deliver the import side effect, but
  promotes scheduler internals to a public contract to solve a problem that is
  only about setup.

The hook takes no arguments. Role-awareness ("am I a worker or a tick?") is
available from Modal's own environment, and a parameter can be added
compatibly later via the signature-inspection route already used for
`env_overrides` in `_protocols.py`.

## Tests

14 new in `test_stardag_app.py`:

- `TestContainerSetup` — fires in all five wrappers (parametrized, so
  `bootstrap` and the ticks are covered explicitly); once per container across
  repeated inputs and across functions; retried after a raise; ordering against
  stardag's logging default; `None` is a no-op; non-callable rejected at
  construction.
- `TestUnreachableWorkerWarning` — warns and names the unreachable workers;
  silent with a declared selector; silent for a single worker.

Full suite: 1323 passed. `ruff` / `pyright` / `prettier` clean.

Docs: a new section in `how-to/integrate-modal.md`, the `StardagApp` /
`BuildFunction` / `RunFunction` / `Builder.setup` / `Runner.setup` docstrings,
the skill bundle, and `CHANGELOG.md` + `RELEASE_NOTES.md` under 0.20.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
